### PR TITLE
NpgsqlSchema: Use InvariantCulture on all return DataTables with schema ...

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -56,6 +57,7 @@ namespace Npgsql
 		internal static DataTable GetMetaDataCollections()
         {
             DataSet ds = new DataSet();
+            ds.Locale = CultureInfo.InvariantCulture;
             using (Stream xmlStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Npgsql.NpgsqlMetaData.xml"))
             {
                 ds.ReadXml(xmlStream);
@@ -70,6 +72,7 @@ namespace Npgsql
 		internal static DataTable GetRestrictions()
         {
             DataSet ds = new DataSet();
+            ds.Locale = CultureInfo.InvariantCulture;
             using (Stream xmlStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Npgsql.NpgsqlMetaData.xml"))
             {
                 ds.ReadXml(xmlStream);
@@ -129,6 +132,7 @@ namespace Npgsql
 		internal DataTable GetDatabases(string[] restrictions)
 		{
 			DataTable databases = new DataTable("Databases");
+			databases.Locale = CultureInfo.InvariantCulture;
 
 			databases.Columns.AddRange(
 				new DataColumn[] {new DataColumn("database_name"), new DataColumn("owner"), new DataColumn("encoding")});
@@ -157,6 +161,7 @@ namespace Npgsql
 		internal DataTable GetTables(string[] restrictions)
 		{
 			DataTable tables = new DataTable("Tables");
+			tables.Locale = CultureInfo.InvariantCulture;
 
 			tables.Columns.AddRange(
 				new DataColumn[]
@@ -190,6 +195,7 @@ namespace Npgsql
 		internal DataTable GetColumns(string[] restrictions)
 		{
 			DataTable columns = new DataTable("Columns");
+			columns.Locale = CultureInfo.InvariantCulture;
 
 			columns.Columns.AddRange(
 				new DataColumn[]
@@ -230,6 +236,7 @@ namespace Npgsql
 		internal DataTable GetViews(string[] restrictions)
 		{
 			DataTable views = new DataTable("Views");
+			views.Locale = CultureInfo.InvariantCulture;
 
 			views.Columns.AddRange(
 				new DataColumn[]
@@ -262,6 +269,7 @@ namespace Npgsql
 		internal DataTable GetUsers(string[] restrictions)
 		{
 			DataTable users = new DataTable("Users");
+			users.Locale = CultureInfo.InvariantCulture;
 
 			users.Columns.AddRange(new DataColumn[] {new DataColumn("user_name"), new DataColumn("user_sysid", typeof (int))});
 
@@ -283,6 +291,7 @@ namespace Npgsql
         internal DataTable GetIndexes(string[] restrictions)
         {
             DataTable indexes = new DataTable("Indexes");
+            indexes.Locale = CultureInfo.InvariantCulture;
 
             indexes.Columns.AddRange(
                 new DataColumn[]
@@ -328,6 +337,7 @@ where
         internal DataTable GetIndexColumns(string[] restrictions)
         {
             DataTable indexColumns = new DataTable("IndexColumns");
+            indexColumns.Locale = CultureInfo.InvariantCulture;
 
             indexColumns.Columns.AddRange(
                 new DataColumn[]
@@ -418,6 +428,7 @@ where pgc.contype='f'
 	    public static DataTable GetReservedWords()
 	    {
 	        DataTable table = new DataTable("ReservedWords");
+	        table.Locale = CultureInfo.InvariantCulture;
 	        table.Columns.Add("ReservedWord", typeof (string));
             // List of keywords taken from PostgreSQL 9.0 reserved words documentation.
 	        string[] keywords = new[]


### PR DESCRIPTION
...data. This matches what MS' SqlClient does. This matters e.g. on Turkish culture where 'i' is not lower case for 'I'.
