### PR TITLE
Added missing BitString.cs to .mdp for mono build

### DIFF
--- a/src/Npgsql.mdp
+++ b/src/Npgsql.mdp
@@ -84,6 +84,7 @@
     <File name="Npgsql/NpgsqlProviderManifest.cs" subtype="Code" buildaction="Compile" />
     <File name="NpgsqlTypes/ArrayHandling.cs" subtype="Code" buildaction="Compile" />
     <File name="NpgsqlTypes/DateDatatypes.cs" subtype="Code" buildaction="Compile" />
+    <File name="NpgsqlTypes/BitString.cs" subtype="Code" buildaction="Compile" />
   </Contents>
   <References>
     <ProjectReference type="Gac" localcopy="True" refto="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />


### PR DESCRIPTION
The monodevelop .mdp was missing this file, breaking the build...
