### PR TITLE
Refactored pool/connection + pool timer on demand

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -547,8 +547,22 @@ namespace Npgsql
 											NpgsqlConnectionStringBuilder.GetKeyName(Keywords.UserName));
 			}
 
-			// Get a Connector.  The connector returned is guaranteed to be connected and ready to go.
-			connector = NpgsqlConnectorPool.ConnectorPoolMgr.RequestConnector(this);
+			// Get a Connector, either from the pool or creating one ourselves.
+            if (Pooling)
+            {
+                connector = NpgsqlConnectorPool.ConnectorPoolMgr.RequestConnector(this);                
+            }
+            else
+            {
+                connector = new NpgsqlConnector(this);
+
+                connector.ProvideClientCertificatesCallback += ProvideClientCertificatesCallbackDelegate;
+                connector.CertificateSelectionCallback += CertificateSelectionCallbackDelegate;
+                connector.CertificateValidationCallback += CertificateValidationCallbackDelegate;
+                connector.PrivateKeySelectionCallback += PrivateKeySelectionCallbackDelegate;
+
+                connector.Open();
+            }
 
 			connector.Notice += NoticeDelegate;
 			connector.Notification += NotificationDelegate;
@@ -635,7 +649,24 @@ namespace Npgsql
                 connector.RemoveNotificationThread();
             }
 
-            NpgsqlConnectorPool.ConnectorPoolMgr.ReleaseConnector(this, connector);
+            if (Pooling)
+            {
+                NpgsqlConnectorPool.ConnectorPoolMgr.ReleaseConnector(this, connector);                
+            }
+            else
+            {
+                Connector.ProvideClientCertificatesCallback -= ProvideClientCertificatesCallbackDelegate;
+                Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
+                Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
+                Connector.PrivateKeySelectionCallback -= PrivateKeySelectionCallbackDelegate;
+
+                if (Connector.Transaction != null)
+                {
+                    Connector.Transaction.Cancel();
+                }
+
+                Connector.Close();
+            }
 
             connector = null;
         }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -167,6 +167,9 @@ namespace Npgsql
 
 #endif
 
+        public NpgsqlConnector(NpgsqlConnection Connection)
+            : this(Connection.ConnectionStringValues.Clone(), Connection.Pooling, false)
+        {}
 
         /// <summary>
         /// Constructor.

--- a/src/Npgsql/NpgsqlConnectorPool.cs
+++ b/src/Npgsql/NpgsqlConnectorPool.cs
@@ -70,23 +70,21 @@ namespace Npgsql
         public NpgsqlConnectorPool()
         {
             PooledConnectors = new Dictionary<string, ConnectorQueue>();
+        }
+        
+        private void StartTimer()
+        {
             Timer = new Timer(1000);
             Timer.AutoReset = false;
             Timer.Elapsed += new ElapsedEventHandler(TimerElapsedHandler);
-            Timer.Start();
-            
-        }
-        
-        ~NpgsqlConnectorPool()
-        {
-            Timer.Stop();
-
+            Timer.Start();            
         }
 
         private void TimerElapsedHandler(object sender, ElapsedEventArgs e)
         {
             NpgsqlConnector Connector;
-            
+            var activeConnectionsExist = false;
+
             try
             {
                 lock (locker)
@@ -127,6 +125,8 @@ namespace Npgsql
                                 {
                                     Queue.InactiveTime = 0;
                                 }
+                                if (Queue.Available.Count > 0 || Queue.Busy.Count > 0)
+                                    activeConnectionsExist = true;
                             }
                             else
                             {
@@ -138,7 +138,10 @@ namespace Npgsql
             }
             finally
             {
-                Timer.Start();
+                if (activeConnectionsExist)
+                    Timer.Start();
+                else
+                    Timer = null;
             }
         }
 
@@ -160,7 +163,7 @@ namespace Npgsql
         /// <value>Timer for tracking unused connections in pools.</value>
         // I used System.Timers.Timer because of bad experience with System.Threading.Timer
         // on Windows - it's going mad sometimes and don't respect interval was set.
-        private readonly Timer Timer;
+        private Timer Timer;
 
         /// <summary>
         /// Searches the shared and pooled connector lists for a
@@ -171,25 +174,6 @@ namespace Npgsql
         /// pool for available connectors.</param>
         /// <returns>A connector object.</returns>
         public NpgsqlConnector RequestConnector(NpgsqlConnection Connection)
-        {
-            NpgsqlConnector Connector;
-
-            if (Connection.Pooling)
-            {
-                Connector = RequestPooledConnector(Connection);
-            }
-            else
-            {
-                Connector = GetNonPooledConnector(Connection);
-            }
-
-            return Connector;
-        }
-
-        /// <summary>
-        /// Find a pooled connector.  Handle locking and timeout here.
-        /// </summary>
-        private NpgsqlConnector RequestPooledConnector(NpgsqlConnection Connection)
         {
             NpgsqlConnector Connector;
             Int32 timeoutMilliseconds = Connection.Timeout * 1000;
@@ -226,6 +210,9 @@ namespace Npgsql
                     throw new Exception("Connection pool exceeds maximum size.");
                 }
             }
+
+            if (Timer == null)
+                StartTimer();
 
             return Connector;
         }
@@ -290,35 +277,23 @@ namespace Npgsql
             {
                 CleanUpConnector(Connection, Connector);
             }
-            else if (Connector.Pooled)
-            {
-                ReleasePooledConnector(Connection, Connector);
-            }
             else
             {
-                UngetNonPooledConnector(Connection, Connector);
-            }
-        }
-
-        /// <summary>
-        /// Release a pooled connector.  Handle locking here.
-        /// </summary>
-        private void ReleasePooledConnector(NpgsqlConnection Connection, NpgsqlConnector Connector)
-        {
-            //lock (this)
-            {
-                ReleasePooledConnectorInternal(Connection, Connector);
+                //lock (this)
+                {
+                    ReleaseConnectorInternal(Connection, Connector);
+                }
             }
         }
 
         /// <summary>
         /// Release a pooled connector.  Handle shared/non-shared here.
         /// </summary>
-        private void ReleasePooledConnectorInternal(NpgsqlConnection Connection, NpgsqlConnector Connector)
+        private void ReleaseConnectorInternal(NpgsqlConnection Connection, NpgsqlConnector Connector)
         {
             if (!Connector.Shared)
             {
-                UngetPooledConnector(Connection, Connector);
+                UngetConnector(Connection, Connector);
             }
             else
             {
@@ -326,26 +301,6 @@ namespace Npgsql
                 throw new NotImplementedException("Internal: Shared pooling not implemented");
             }
         }
-
-        /// <summary>
-        /// Create a connector without any pooling functionality.
-        /// </summary>
-        private static NpgsqlConnector GetNonPooledConnector(NpgsqlConnection Connection)
-        {
-            NpgsqlConnector Connector;
-
-            Connector = CreateConnector(Connection);
-
-            Connector.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
-            Connector.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
-            Connector.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
-            Connector.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
-
-            Connector.Open();
-
-            return Connector;
-        }
-
 
         /// <summary>
         /// Find an available pooled connector in the non-shared pool, or create
@@ -413,7 +368,7 @@ namespace Npgsql
 
                 if (Queue.Available.Count + Queue.Busy.Count < Connection.MaxPoolSize)
                 {
-                    Connector = CreateConnector(Connection);
+                    Connector = new NpgsqlConnector(Connection);
                     Queue.Busy.Add(Connector, null);
 
                 }
@@ -455,7 +410,7 @@ namespace Npgsql
 
                         while (Queue.Available.Count + Queue.Busy.Count < Connection.MinPoolSize)
                         {
-                            NpgsqlConnector Spare = CreateConnector(Connection);
+                            NpgsqlConnector Spare = new NpgsqlConnector(Connection);
 
                             Spare.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
                             Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
@@ -492,36 +447,11 @@ namespace Npgsql
                 }
         */
 
-        private static NpgsqlConnector CreateConnector(NpgsqlConnection Connection)
-        {
-            return new NpgsqlConnector(Connection.ConnectionStringValues.Clone(), Connection.Pooling, false);
-        }
-
-        /// <summary>
-        /// Close the connector.
-        /// </summary>
-        /// <param name="Connection"></param>
-        /// <param name="Connector">Connector to release</param>
-        private static void UngetNonPooledConnector(NpgsqlConnection Connection, NpgsqlConnector Connector)
-        {
-            Connector.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
-            Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
-            Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
-            Connector.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
-
-            if (Connector.Transaction != null)
-            {
-                Connector.Transaction.Cancel();
-            }
-
-            Connector.Close();
-        }
-
         /// <summary>
         /// Put a pooled connector into the pool queue.
         /// </summary>
         /// <param name="Connector">Connector to pool</param>
-        private void UngetPooledConnector(NpgsqlConnection Connection, NpgsqlConnector Connector)
+        private void UngetConnector(NpgsqlConnection Connection, NpgsqlConnector Connector)
         {
             ConnectorQueue queue;
 
@@ -671,7 +601,7 @@ namespace Npgsql
                 {
                     ClearQueue(Queue);
                 }
-                                PooledConnectors.Clear();
+                PooledConnectors.Clear();
             }
         }
     }


### PR DESCRIPTION
- Allocating of non-pooling connections was being done
  in NpgsqlConnection, moved that code to NpsqlConnection.
- Since the pool's timer was being started statically,
  opening a non-pooling connection would start the pool's timer
  (bug #1011326).
- The pool's timer is now started on the demand, when a pooled
  connection is first requested. When no more connections remain,
  the timer is stopped.

This is a replacement of #14 (after the migration to github).
