### PR TITLE
More consistent key/value parsing in NpgsqlConnectionStringBuilder

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -578,23 +578,36 @@ namespace Npgsql
             if (value == null)
             {
                 Remove(keyword);
+                return;
+            }
+
+            string strValue = value as string;
+            if (strValue != null)
+            {
+                // .NET's DbConnectionStringBuilder trims whitespace and discards empty values,
+                // so we do the same
+                strValue = strValue.Trim();
+                if (strValue.Length == 0)
+                {
+                    Remove(keyword);
+                    return;
+                }
+                value = strValue;
+            }
+
+            Keywords key = GetKey(keyword);
+            SetValue(key, value);
+            if (key == Keywords.Protocol)
+            {
+                base[GetKeyName(key)] = ToString(this.Protocol);
+            }
+            else if (key == Keywords.Compatible)
+            {
+                base[GetKeyName(key)] = ((Version) this.Compatible).ToString();
             }
             else
             {
-                Keywords key = GetKey(keyword);
-                SetValue(key, value);
-                if (key == Keywords.Protocol)
-                {
-                    base[GetKeyName(key)] = ToString(this.Protocol);
-                }
-                else if (key == Keywords.Compatible)
-                {
-                    base[GetKeyName(key)] = ((Version) this.Compatible).ToString();
-                }
-                else
-                {
-                    base[GetKeyName(key)] = value;
-                }
+                base[GetKeyName(key)] = value;
             }
         }
 


### PR DESCRIPTION
.NET's DbConnectionStringBuilder, which NpgsqlConnectionStringBuilder extends, trims strings values and discards pairs with empty ones. However, NCSB's setter behaved differently, adding empty strings, leading to inconsistent behavior (bug #1011001).

Modified NCSB's behavior to be consistent with DCSB - trim and discard empty.

This is a replacement of #15 (after the migration to github)
