### PR TITLE
Fixing ParameterMarkerFormat value of the schema collection

### DIFF
--- a/src/Npgsql/NpgsqlMetaData.xml
+++ b/src/Npgsql/NpgsqlMetaData.xml
@@ -57,7 +57,7 @@
     <IdentifierPattern>(^\[\p{Lo}\p{Lu}\p{Ll}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Nd}@$#_]*$)|(^\[[^\]\0]|\]\]+\]$)|(^\"[^\"\0]|\"\"+\"$)</IdentifierPattern>
     <IdentifierCase>1</IdentifierCase>
     <OrderByColumnsInSelect>false</OrderByColumnsInSelect>
-    <ParameterMarkerFormat>{0}</ParameterMarkerFormat>
+    <ParameterMarkerFormat>:{0}</ParameterMarkerFormat>
     <ParameterMarkerPattern>@[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)</ParameterMarkerPattern>
     <ParameterNameMaxLength>128</ParameterNameMaxLength>
     <ParameterNamePattern>^[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)</ParameterNamePattern>

--- a/testsuite/noninteractive/NUnit20/ConnectionTests.cs
+++ b/testsuite/noninteractive/NUnit20/ConnectionTests.cs
@@ -373,6 +373,29 @@ namespace NpgsqlTests
             
         }
 
+		[Test]
+		public void GetSchemaParameterMarkerFormats()
+		{
+			DataTable dt = TheConnection.GetSchema("DataSourceInformation");
+			String parameterMarkerFormat = dt.Rows[0]["ParameterMarkerFormat"] as string;
+
+			using (NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString))
+			{
+				connection.Open();
+				using (NpgsqlCommand command = connection.CreateCommand())
+				{
+					const String parameterName = "p_field_int4";
+					command.CommandText = "SELECT * FROM tablea WHERE field_int4=" + String.Format(parameterMarkerFormat, parameterName);
+					command.Parameters.Add(new NpgsqlParameter(parameterName,4));
+					using (NpgsqlDataReader reader = command.ExecuteReader())
+					{
+						Assert.IsTrue(reader.Read());
+						// This is OK, when no exceptions are occurred.
+					}
+				}
+			}
+		}
+
     }
     [TestFixture]
     public class ConnectionTestsV2 : ConnectionTests


### PR DESCRIPTION
Hi.

I made a tiny patch to fix common schema collection related issue.

A value of "ParameterMarkerFormat" column of "DataSourceInfo" schema collection which is returned from NpgsqlConnection.GetSchema() is not valid. It must be usable as a format parameter for String.Format method to make a parameter placeholder on a SQL. So, its value should be ":{0}" rather than "{0}".

This pull request contains a metadata XML file fix and an unit test method for this issue.
