### PR TITLE
Policy DLL on NuGet package is not valid.

### DIFF
--- a/src/policyFileBuild.bat
+++ b/src/policyFileBuild.bat
@@ -1,4 +1,4 @@
-@if "%WindowsSdkDir_35%"=="" goto NO_WIN_SDK
+@if "%WindowsSdkDir%"=="" goto NO_WIN_SDK
 
 @setlocal
 
@@ -8,8 +8,13 @@
 @if not exist %net20out% mkdir %net20out%
 @if not exist %net40out% mkdir %net40out%
 
-@"%WindowsSdkDir_35%\al.exe" /nologo /link:policy.2.0.Npgsql.config /out:%net20out%\policy.2.0.Npgsql.dll /keyfile:Npgsql\Npgsql.snk
-@"%WindowsSdkDir_35%\NETFX 4.0 Tools\al.exe" /nologo /link:policy.2.0.Npgsql.config /out:%net40out%\policy.2.0.Npgsql.dll /keyfile:Npgsql\Npgsql.snk
+@set aldir=%WindowsSdkDir_35%
+
+:: If dev env is VS2010, then another path should be used.
+@if "%aldir%"=="" set aldir=%WindowsSDKDir%\Bin
+
+@"%aldir%\al.exe" /nologo /link:policy.2.0.Npgsql.config /out:%net20out%\policy.2.0.Npgsql.dll /keyfile:Npgsql\Npgsql.snk
+@"%aldir%\NETFX 4.0 Tools\al.exe" /nologo /link:policy.2.0.Npgsql.config /out:%net40out%\policy.2.0.Npgsql.dll /keyfile:Npgsql\Npgsql.snk
 @goto :EOF
 
 :NO_WIN_SDK


### PR DESCRIPTION
Hi.

This pull request is not related to previous one. This is related to NuGet packaging.
Excuse me consecutive tiny pull requests.

On NuGet package, there are 2 issues I found:
1) DLLs on clr11 directory are not built for CLR 1.1. They are built for CLR 2.0, so it should not be work. In the first place, is clr11 support necessary? Because NuGet does not support CLR 1.1 environment, they should be released on other format like a zip archive. So I didn't make any patch for this issue.

2) Policy dlls on clr20 directory and clr35 directory are not built for CLR 2 (npgsql.dll their self are built correctly -- only policy.2.0.Npgsql.dlls are not correct). I found that src/policyFileBuild.bat used al.exe and it was depending on path environment variable, but there were two al.exe on .net 4 devenvs, one was for clr2 and another was for clr4. In addition, I also found al.exe for clr 4 was used when we specify al.exe without file path on sdk/visual studio command prompt. I made a patch for this issue which fixes policyFileBuild.bat to use fully file path of al.exe.
