### PR TITLE
Replace Mono SslClientStream with .NET SslStream to fix SSL-related errors

### DIFF
--- a/src/Npgsql/NpgsqlConnectorPool.cs
+++ b/src/Npgsql/NpgsqlConnectorPool.cs
@@ -383,6 +383,7 @@ namespace Npgsql
                 Connector.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
                 Connector.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
                 Connector.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
+                Connector.ValidateRemoteCertificateCallback += Connection.ValidateRemoteCertificateCallbackDelegate;
 
                 try
                 {
@@ -416,6 +417,7 @@ namespace Npgsql
                             Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
                             Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
                             Spare.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
+                            Spare.ValidateRemoteCertificateCallback += Connection.ValidateRemoteCertificateCallbackDelegate;
 
                             Spare.Open();
 
@@ -423,6 +425,7 @@ namespace Npgsql
                             Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
                             Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
                             Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+                            Spare.ValidateRemoteCertificateCallback -= Connection.ValidateRemoteCertificateCallbackDelegate;
 
                             Queue.Available.Enqueue(Spare);
                         }
@@ -473,6 +476,7 @@ namespace Npgsql
             Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
             Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
             Connector.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+            Connector.ValidateRemoteCertificateCallback -= Connection.ValidateRemoteCertificateCallbackDelegate;
 
             bool inQueue = false;
 


### PR DESCRIPTION
This change fixes an issue when connecting to a PostgreSQL database
configured to accept connections only with a valid client certificate.
With Mono's SslClientStream, an encryption error would occur when trying
to connect. WIth .NET's SslStream, the connection can be successfully
opened. The Mono-based callbacks have been marked "Obsolete". The newer
ValidateRemoteCertificateCallback is used automatically if it is
provided.
