### PR TITLE
Boolean constants converted to ETRUE instead of TRUE.

### DIFF
--- a/src/Npgsql/SqlGenerators/VisitedExpression.cs
+++ b/src/Npgsql/SqlGenerators/VisitedExpression.cs
@@ -137,6 +137,8 @@ namespace Npgsql.SqlGenerators
                     sqlText.AppendFormat(ni, "cast({0} as float4)", _value);
                     break;
                 case PrimitiveTypeKind.Boolean:
++                    sqlText.AppendFormat(ni, "cast({0} as boolean)", ((bool)_value)?"TRUE":"FALSE");
+                     break;
                 case PrimitiveTypeKind.Guid:
                 case PrimitiveTypeKind.String:
                     NpgsqlTypesHelper.TryGetNativeTypeInfo(GetDbType(_primitiveType), out typeInfo);


### PR DESCRIPTION
Booleans must be converted to TRUE and FALSE instead of ETRUE and EFALSE.
