### PR TITLE
Corrected EntityFunctions.DiffMinutes support.

### DIFF
--- a/src/Npgsql/SqlGenerators/SqlBaseGenerator.cs
+++ b/src/Npgsql/SqlGenerators/SqlBaseGenerator.cs
@@ -1269,17 +1269,17 @@ namespace Npgsql.SqlGenerators
                 // DATE_PART('year', end) - DATE_PART('year', start)
                 case "Years":
                     {
-                        dateDiff = new LiteralExpression("DATE_PART(\'year\',");
+                        dateDiff = new LiteralExpression("(DATE_PART(\'year\',");
                         dateDiff.Append(end);
                         dateDiff.Append(") - DATE_PART(\'year\',");
                         dateDiff.Append(start);
-                        dateDiff.Append(")");
+                        dateDiff.Append("))::INT");
                     }
                     break;
                 //years_diff * 12 + (DATE_PART('month', end) - DATE_PART('month', start))
                 case "Months":
                     {
-                        dateDiff = new LiteralExpression("DATE_PART(\'year\',");
+                        dateDiff = new LiteralExpression("(DATE_PART(\'year\',");
                         dateDiff.Append(end);
                         dateDiff.Append(")*12 - DATE_PART(\'year\',");
                         dateDiff.Append(start);
@@ -1287,7 +1287,7 @@ namespace Npgsql.SqlGenerators
                         dateDiff.Append(args[1].Accept(this));
                         dateDiff.Append(") - DATE_PART(\'month\',");
                         dateDiff.Append(start);
-                        dateDiff.Append(")");
+                        dateDiff.Append("))::INT");
                     }
                     break;
                  //DATE_PART('day', end - start)
@@ -1297,7 +1297,7 @@ namespace Npgsql.SqlGenerators
                         dateDiff.Append(end);
                         dateDiff.Append("-");
                         dateDiff.Append(start);
-                        dateDiff.Append(")");
+                        dateDiff.Append(")::INT");
                     }
                     break;
                  //FLOOR(EXTRACT(EPOCH FROM end - start) operationAndFactor)::INT

--- a/src/Npgsql/SqlGenerators/SqlBaseGenerator.cs
+++ b/src/Npgsql/SqlGenerators/SqlBaseGenerator.cs
@@ -1077,6 +1077,7 @@ namespace Npgsql.SqlGenerators
                     case "AddNanoseconds":
                     case "AddSeconds":
                     case "AddYears":
+                        return DateAdd(function.Name, args);
                     case "DiffDays":                                          
                     case "DiffHours":
                     case "DiffMicroseconds":
@@ -1086,7 +1087,7 @@ namespace Npgsql.SqlGenerators
                     case "DiffNanoseconds":
                     case "DiffSeconds":
                     case "DiffYears":   
-                        return DateAdd(function.Name, args);
+                        return DateDiff(function.Name, args);
                     //    return 
                     case "Day":
                     case "Hour":
@@ -1223,11 +1224,6 @@ namespace Npgsql.SqlGenerators
                 operation = "+";
                 part = functionName.Substring(3);
             }
-            else if (functionName.Contains("Diff"))
-            {
-                operation = "-";
-                part = functionName.Substring(4);
-            }
             else throw new NotSupportedException();
 
             if (part == "Nanoseconds")
@@ -1246,6 +1242,82 @@ namespace Npgsql.SqlGenerators
                                    : String.Format(" * INTERVAL '1 {0}'", part));
 
             return dateAddDiff;
+        }        /// <summary>
+        /// PostgreSQL has no direct functions to implements DateTime canonical functions
+        /// http://msdn.microsoft.com/en-us/library/bb738626.aspx
+        /// http://msdn.microsoft.com/en-us/library/bb738626.aspx
+        /// but we can use workaround:
+        /// http://www.sqlines.com/postgresql/how-to/datediff
+        /// </summary>
+        /// <param name="functionName"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private VisitedExpression DateDiff(string functionName, IList<DbExpression> args)
+        {
+            System.Diagnostics.Debug.Assert(args.Count == 2);
+            string part = functionName.Substring(4);
+            if (!functionName.Contains("Diff"))
+                 throw new NotSupportedException();
+            int divisor=1;
+            VisitedExpression dateDiff = null;
+            switch(part)
+            {
+                // DATE_PART('year', end) - DATE_PART('year', start)
+                case "Years":
+                    {
+                        dateDiff = new LiteralExpression("DATE_PART(\'year\',");
+                        dateDiff.Append(args[0].Accept(this));
+                        dateDiff.Append(") - DATE_PART(\'year\',");
+                        dateDiff.Append(args[1].Accept(this));
+                        dateDiff.Append(")");
+                    }
+                    break;
+                //years_diff * 12 + (DATE_PART('month', end) - DATE_PART('month', start))
+                case "Months":
+                    {
+                        dateDiff = new LiteralExpression("DATE_PART(\'year\',");
+                        dateDiff.Append(args[0].Accept(this));
+                        dateDiff.Append(")*12 - DATE_PART(\'year\',");
+                        dateDiff.Append(args[1].Accept(this));
+                        dateDiff.Append(")*12+DATE_PART(\'month\',");
+                        dateDiff.Append(args[0].Accept(this));
+                        dateDiff.Append(") - DATE_PART(\'month\',");
+                        dateDiff.Append(args[1].Accept(this));
+                        dateDiff.Append(")");
+                    }
+                    break;
+                 //DATE_PART('day', end - start)
+                 case "Days":
+                    {
+                        dateDiff = new LiteralExpression("DATE_PART('day',");
+                        dateDiff.Append(args[0].Accept(this));
+                        dateDiff.Append("-");
+                        dateDiff.Append(args[1].Accept(this));
+                        dateDiff.Append(")");
+                    }
+                    break;
+                 //FLOOR(EXTRACT(EPOCH FROM end - start)/$divisor)::INT
+                 case "Hours":
+                    divisor = 60*60;
+                    break;
+                 case "Minutes":
+                    divisor = 60;
+                    break;
+                 case "Seconds":
+                    divisor = 1;
+                    break;
+                default:
+                    throw new NotSupportedException(); 
+            }
+            if(dateDiff == null)
+            {
+                dateDiff = new LiteralExpression("FLOOR(EXTRACT(EPOCH FROM ");
+                dateDiff.Append(args[0].Accept(this));
+                dateDiff.Append("-");
+                dateDiff.Append(args[1].Accept(this));
+                dateDiff.Append(string.Format(")/{0})::INT", divisor));
+            }
+            return dateDiff;
         }
 
         private VisitedExpression BitwiseOperator(IList<DbExpression> args, string oper)


### PR DESCRIPTION
Hello Francisco! What do you think about applying my patch for EntityFunctions.DiffXXXXX?

The implementation of sql generating for EntityFunctions.DiffXXXXX was wrong.

In my case using of EntityFunctions.DiffMinutes with EF 4.3 generate script code
("time"-((E'2013-01-01 00:00:00.000000')) * INTERVAL '1 Minutes')
that causes postgres error
ERROR:  invalid syntax for type double precision: "2013-01-01 00:00:00.000000"
LINE 1: select ("time"-((E'2013-01-01 00:00:00.000000')) * INTERVAL ...

