### PR TITLE
Fix bug for array handling when prepared

### DIFF
--- a/src/NpgsqlTypes/ArrayHandling.cs
+++ b/src/NpgsqlTypes/ArrayHandling.cs
@@ -61,16 +61,16 @@ namespace NpgsqlTypes
 
             if (ForExtendedQuery)
             {
-                StringBuilder sb = new StringBuilder("{");
-                //return sb.ToString();
+                StringBuilder sb = new StringBuilder("");
 
-                WriteItem(TypeInfo, NativeData, sb, ForExtendedQuery);
-
-                sb.Append("}");
-                
-                return sb.ToString();
-                
-
+                if (WriteItem(TypeInfo, NativeData, sb, ForExtendedQuery))
+                {
+                    return sb.ToString();
+                }
+                else
+                {
+                    return "{}";
+                }
 
             }
             else

--- a/testsuite/noninteractive/NUnit20/CommandTests.cs
+++ b/testsuite/noninteractive/NUnit20/CommandTests.cs
@@ -3227,14 +3227,36 @@ connection.Open();*/
             using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
 
+                Double[] inVal = new Double[] { 1.2d, 1.3d };
                 NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
-                parameter.Value = new Double[] {1.2d, 1.3d};
+                parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
- 
-                cmd.ExecuteNonQuery();
+
+                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                Assert.AreEqual(inVal.Length, retVal.Length);
+                Assert.AreEqual(inVal[0], retVal[0]);
+                Assert.AreEqual(inVal[1], retVal[1]);
             }
             
-            
+        }
+
+
+        [Test]
+        public void DoubleArrayHandlingZeroItem()
+        {
+
+            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            {
+
+                Double[] inVal = new Double[] { };
+                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                parameter.Value = inVal;
+                cmd.Parameters.Add(parameter);
+
+                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                Assert.AreEqual(inVal.Length, retVal.Length);
+            }
+
         }
         
         [Test]
@@ -3243,17 +3265,39 @@ connection.Open();*/
             
             using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
+                Double[] inVal = new Double[] { 1.2d, 1.3d };
                 NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
-                parameter.Value = new Double[] {1.2d, 1.3d};
+                parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
                 
                 cmd.Prepare();
- 
-                cmd.ExecuteNonQuery();
+
+                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                Assert.AreEqual(inVal.Length, retVal.Length);
+                Assert.AreEqual(inVal[0], retVal[0]);
+                Assert.AreEqual(inVal[1], retVal[1]);
             }
             
             
+        }
+
+        [Test]
+        public void DoubleArrayHandlingZeroItemPrepared()
+        {
+
+            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            {
+                Double[] inVal = new Double[] { };
+                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                parameter.Value = inVal;
+                cmd.Parameters.Add(parameter);
+
+                cmd.Prepare();
+
+                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                Assert.AreEqual(inVal.Length, retVal.Length);
+            }
+
         }
 
         


### PR DESCRIPTION
Consider  the following sample,now the array size of retVal returned by Npgsql is 0 which 2 is expected . 
The patch fix the problem,and modified some cases.

```
        using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
        {

            NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
            parameter.Value = new Double[] {1.2d, 1.3d};
             cmd.Parameters.Add(parameter);

            cmd.Prepare();
            Double[] retVal = (Double[])cmd.ExecuteScalar();
            Assert.AreEqual(2, retVal.Length);//failed,the retVal.Length is 0
        }
```
