### PR TITLE
Cosmetic fixes in unit tests

### DIFF
--- a/testsuite/noninteractive/NUnit20/CommandTests.cs
+++ b/testsuite/noninteractive/NUnit20/CommandTests.cs
@@ -40,7 +40,6 @@ using System.Reflection;
 
 namespace NpgsqlTests
 {
-
     public enum EnumTest : short
     {
         Value1 = 0,
@@ -50,14 +49,19 @@ namespace NpgsqlTests
     [TestFixture]
     public class CommandTests : BaseClassTests
     {
-        protected override NpgsqlConnection TheConnection {
-            get { return _conn;}
+        protected override NpgsqlConnection TheConnection
+        {
+            get { return _conn; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _t; }
             set { _t = value; }
         }
-        protected virtual string TheConnectionString {
+
+        protected virtual string TheConnectionString
+        {
             get { return _connString; }
         }
 
@@ -85,7 +89,7 @@ namespace NpgsqlTests
         [Test]
         public void ParametersGetName()
         {
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
 
             // Add parameters.
             command.Parameters.Add(new NpgsqlParameter(":Parameter1", DbType.Boolean));
@@ -93,7 +97,7 @@ namespace NpgsqlTests
             command.Parameters.Add(new NpgsqlParameter(":Parameter3", DbType.DateTime));
             command.Parameters.Add(new NpgsqlParameter("Parameter4", DbType.DateTime));
 
-            IDbDataParameter idbPrmtr = command.Parameters["Parameter1"];
+            var idbPrmtr = command.Parameters["Parameter1"];
             Assert.IsNotNull(idbPrmtr);
             command.Parameters[0].Value = 1;
 
@@ -109,49 +113,42 @@ namespace NpgsqlTests
             Assert.AreEqual(":Parameter3", command.Parameters[2].ParameterName);
             Assert.AreEqual("Parameter4", command.Parameters[3].ParameterName);
         }
-        
+
         [Test]
         public void ParameterNameWithSpace()
         {
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
 
             // Add parameters.
             command.Parameters.Add(new NpgsqlParameter(":Parameter1 ", DbType.Boolean));
-            
+
             Assert.AreEqual(":Parameter1", command.Parameters[0].ParameterName);
-            
         }
 
         [Test]
         public void EmptyQuery()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand(";", TheConnection);
+            var command = new NpgsqlCommand(";", TheConnection);
             command.ExecuteNonQuery();
         }
-        
-        
+
+
         [Test]
         public void NoNameParameterAdd()
         {
-            NpgsqlCommand command = new NpgsqlCommand();
-
+            var command = new NpgsqlCommand();
             command.Parameters.Add(new NpgsqlParameter());
             command.Parameters.Add(new NpgsqlParameter());
-            
-            
             Assert.AreEqual(":Parameter1", command.Parameters[0].ParameterName);
             Assert.AreEqual(":Parameter2", command.Parameters[1].ParameterName);
         }
-        
+
 
         [Test]
         public void FunctionCallFromSelect()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from funcB()", TheConnection);
-
+            var command = new NpgsqlCommand("select * from funcB()", TheConnection);
             NpgsqlDataReader reader = command.ExecuteReader();
-
             Assert.IsNotNull(reader);
             reader.Close();
             //reader.FieldCount
@@ -160,160 +157,104 @@ namespace NpgsqlTests
         [Test]
         public void ExecuteScalar()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select count(*) from tablea", TheConnection);
-
+            var command = new NpgsqlCommand("select count(*) from tablea", TheConnection);
             Object result = command.ExecuteScalar();
-
             Assert.AreEqual(6, result);
             //reader.FieldCount
         }
-        
+
         [Test]
         public void TransactionSetOk()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select count(*) from tablea", TheConnection);
-            
+            var command = new NpgsqlCommand("select count(*) from tablea", TheConnection);
             command.Transaction = _t;
-            
             Object result = command.ExecuteScalar();
-            
             Assert.AreEqual(6, result);
         }
-        
-        
+
+
         [Test]
         public void InsertStringWithBackslashes()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", TheConnection);
-            
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", NpgsqlDbType.Text));
-            
             command.Parameters["p0"].Value = @"\test";
-
             Object result = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, result);
-            
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
-            
 
+            var command2 = new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
             result = command2.ExecuteScalar();
-            
             Assert.AreEqual(@"\test", result);
-            
-            
-            
             //reader.FieldCount
         }
-               
-        
+
+
         [Test]
         public void UseStringParameterWithNoNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", TheConnection);
-            
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", "test"));
-            
-            
             Assert.AreEqual(command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Text);
             Assert.AreEqual(command.Parameters[0].DbType, DbType.String);
-            
             Object result = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, result);
-            
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
-            
 
+            var command2 = new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
             result = command2.ExecuteScalar();
-            
-            
-            
             Assert.AreEqual("test", result);
-            
-            
-            
             //reader.FieldCount
         }
-        
-        
+
+
         [Test]
         public void UseIntegerParameterWithNoNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0)", TheConnection);
-            
+            var command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", 5));
-            
             Assert.AreEqual(command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Integer);
             Assert.AreEqual(command.Parameters[0].DbType, DbType.Int32);
-            
-            
             Object result = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, result);
-            
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
-            
 
+            var command2 = new NpgsqlCommand( "select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
             result = command2.ExecuteScalar();
-            
-            
             Assert.AreEqual(5, result);
-            
-            
-           //reader.FieldCount
+            //reader.FieldCount
         }
-        
-        
+
+
         //[Test]
         public void UseSmallintParameterWithNoNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0)", TheConnection);
-            
-            command.Parameters.Add(new NpgsqlParameter("p0", (Int16)5));
-            
+            var command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0)", TheConnection);
+            command.Parameters.Add(new NpgsqlParameter("p0", (Int16) 5));
             Assert.AreEqual(command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Smallint);
             Assert.AreEqual(command.Parameters[0].DbType, DbType.Int16);
-            
-            
             Object result = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, result);
-            
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
 
+            var command2 = new NpgsqlCommand("select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
             result = command2.ExecuteScalar();
-            
-            
             Assert.AreEqual(5, result);
-            
-            
             //reader.FieldCount
         }
-        
-        
+
+
         [Test]
         public void FunctionCallReturnSingleValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC();", TheConnection);
+            var command = new NpgsqlCommand("funcC();", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(6, result);
             //reader.FieldCount
         }
-        
-        
+
+
         [Test]
-        [ExpectedException(typeof(InvalidOperationException))]
+        [ExpectedException(typeof (InvalidOperationException))]
         public void RollbackWithNoTransaction()
         {
-            
             TheTransaction.Rollback();
             TheTransaction.Rollback();
         }
@@ -322,12 +263,10 @@ namespace NpgsqlTests
         [Test]
         public void FunctionCallReturnSingleValueWithPrepare()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC()", TheConnection);
+            var command = new NpgsqlCommand("funcC()", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Prepare();
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(6, result);
             //reader.FieldCount
         }
@@ -335,30 +274,22 @@ namespace NpgsqlTests
         [Test]
         public void FunctionCallWithParametersReturnSingleValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(:a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(:a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-
             command.Parameters[0].Value = 4;
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
 
         [Test]
         public void FunctionCallWithParametersReturnSingleValueNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(:a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(:a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Integer));
-
             command.Parameters[0].Value = 4;
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
 
@@ -366,20 +297,14 @@ namespace NpgsqlTests
         [Test]
         public void FunctionCallWithParametersPrepareReturnSingleValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(:a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(:a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-
             Assert.AreEqual(1, command.Parameters.Count);
+
             command.Prepare();
-
-
             command.Parameters[0].Value = 4;
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
 
@@ -409,20 +334,14 @@ namespace NpgsqlTests
         [Test]
         public void FunctionCallWithParametersPrepareReturnSingleValueNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(:a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(:a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Integer));
-
             Assert.AreEqual(1, command.Parameters.Count);
+
             command.Prepare();
-
-
             command.Parameters[0].Value = 4;
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
 
@@ -449,24 +368,16 @@ namespace NpgsqlTests
             }
         }
 
-
         [Test]
         public void FunctionCallWithParametersPrepareReturnSingleValueNpgsqlDbType2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(@a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(@a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Integer));
-
             Assert.AreEqual(1, command.Parameters.Count);
             //command.Prepare();
-
-
             command.Parameters[0].Value = 4;
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
 
@@ -496,303 +407,229 @@ namespace NpgsqlTests
         [Test]
         public void FunctionCallReturnResultSet()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcB()", TheConnection);
+            var command = new NpgsqlCommand("funcB()", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
             dr.Close();
         }
-
 
         [Test]
         public void CursorStatement()
         {
             Int32 i = 0;
-
-            
-            NpgsqlCommand command = new NpgsqlCommand("declare te cursor for select * from tablea;", TheConnection);
-
+            var command = new NpgsqlCommand("declare te cursor for select * from tablea;", TheConnection);
             command.ExecuteNonQuery();
-
             command.CommandText = "fetch forward 3 in te;";
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
+            var dr = command.ExecuteReader();
 
             while (dr.Read())
-            {
                 i++;
-            }
-
             Assert.AreEqual(3, i);
 
-
             i = 0;
-
             command.CommandText = "fetch backward 1 in te;";
-
-            NpgsqlDataReader dr2 = command.ExecuteReader();
-
+            var dr2 = command.ExecuteReader();
             while (dr2.Read())
-            {
                 i++;
-            }
-
             Assert.AreEqual(1, i);
 
             command.CommandText = "close te;";
-
             command.ExecuteNonQuery();
         }
 
         [Test]
         public void PreparedStatementNoParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea;", TheConnection);
-
+            var command = new NpgsqlCommand("select * from tablea;", TheConnection);
             command.Prepare();
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
-            
             dr.Close();
         }
-        
-        
+
+
         [Test]
         public void PreparedStatementInsert()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:p0);", TheConnection);
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0);", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", NpgsqlDbType.Text));
             command.Parameters["p0"].Value = "test";
-            
             command.Prepare();
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
         }
-        
+
         [Test]
         public void RTFStatementInsert()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:p0);", TheConnection);
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0);", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", NpgsqlDbType.Text));
             command.Parameters["p0"].Value = @"{\rtf1\ansi\ansicpg1252\uc1 \deff0\deflang1033\deflangfe1033{";
-                       
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
-            
-            
-            String result = (String)new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea);", TheConnection).ExecuteScalar();
-            
+
+            var result = (String)new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea);", TheConnection).ExecuteScalar();
             Assert.AreEqual(@"{\rtf1\ansi\ansicpg1252\uc1 \deff0\deflang1033\deflangfe1033{", result);
         }
-        
-        
-        
+
+
+
         [Test]
         public void PreparedStatementInsertNullValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0);", TheConnection);
+            var command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0);", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", NpgsqlDbType.Integer));
             command.Parameters["p0"].Value = DBNull.Value;
-
             command.Prepare();
 
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
-        }       
+        }
 
         [Test]
         public void PreparedStatementWithParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_int4 = :a and field_int8 = :b;", TheConnection);
-
+            var command = new NpgsqlCommand("select * from tablea where field_int4 = :a and field_int8 = :b;", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
             command.Parameters.Add(new NpgsqlParameter("b", DbType.Int64));
-
             Assert.AreEqual(2, command.Parameters.Count);
-
             Assert.AreEqual(DbType.Int32, command.Parameters[0].DbType);
 
             command.Prepare();
-
             command.Parameters[0].Value = 3;
             command.Parameters[1].Value = 5;
-
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
-            
             dr.Close();
         }
 
         [Test]
         public void PreparedStatementWithParametersNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_int4 = :a and field_int8 = :b;", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_int4 = :a and field_int8 = :b;", TheConnection);
 
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Integer));
             command.Parameters.Add(new NpgsqlParameter("b", NpgsqlDbType.Bigint));
-
             Assert.AreEqual(2, command.Parameters.Count);
-
             Assert.AreEqual(DbType.Int32, command.Parameters[0].DbType);
 
             command.Prepare();
-
             command.Parameters[0].Value = 3;
             command.Parameters[1].Value = 5;
-
-            NpgsqlDataReader dr = command.ExecuteReader();
+            var dr = command.ExecuteReader();
             Assert.IsNotNull(dr);
             dr.Close();
         }
-        
+
         [Test]
         public void FunctionCallWithImplicitParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC", TheConnection);
+            var command = new NpgsqlCommand("funcC", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
-            NpgsqlParameter p = new NpgsqlParameter("@a", NpgsqlDbType.Integer);
+            var p = new NpgsqlParameter("@a", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.InputOutput;
             p.Value = 4;
-            
             command.Parameters.Add(p);
-            
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
-        
-        
+
+
         [Test]
         public void PreparedFunctionCallWithImplicitParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC", TheConnection);
+            var command = new NpgsqlCommand("funcC", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.InputOutput;
             p.Value = 4;
-            
             command.Parameters.Add(p);
-            
             command.Prepare();
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
-        
-        
+
+
         [Test]
         public void FunctionCallWithImplicitParametersWithNoParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC", TheConnection);
+            var command = new NpgsqlCommand("funcC", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(6, result);
             //reader.FieldCount
 
         }
-        
+
         [Test]
         public void FunctionCallOutputParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC()", TheConnection);
+            var command = new NpgsqlCommand("funcC()", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
-            NpgsqlParameter p = new NpgsqlParameter("a", DbType.Int32);
+            var p = new NpgsqlParameter("a", DbType.Int32);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-                        
             command.ExecuteNonQuery();
-            
             Assert.AreEqual(6, command.Parameters["a"].Value);
         }
-        
+
         [Test]
         public void FunctionCallOutputParameter2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC", TheConnection);
+            var command = new NpgsqlCommand("funcC", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
-            NpgsqlParameter p = new NpgsqlParameter("@a", DbType.Int32);
+            var p = new NpgsqlParameter("@a", DbType.Int32);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-                        
             command.ExecuteNonQuery();
-            
             Assert.AreEqual(6, command.Parameters["@a"].Value);
         }
-        
+
         [Test]
         public void OutputParameterWithoutName()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC", TheConnection);
+            var command = new NpgsqlCommand("funcC", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
-            NpgsqlParameter p = command.CreateParameter();
+            var p = command.CreateParameter();
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-                        
             command.ExecuteNonQuery();
-            
             Assert.AreEqual(6, command.Parameters[0].Value);
         }
-        
+
         [Test]
         public void FunctionReturnVoid()
         {
-            NpgsqlCommand command = new NpgsqlCommand("testreturnvoid()", TheConnection);
+            var command = new NpgsqlCommand("testreturnvoid()", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
             command.ExecuteNonQuery();
         }
-        
+
         [Test]
         public void StatementOutputParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("values (4,5), (6,7)", TheConnection);
-                        
-            NpgsqlParameter p = new NpgsqlParameter("a", DbType.Int32);
+            var command = new NpgsqlCommand("values (4,5), (6,7)", TheConnection);
+            var p = new NpgsqlParameter("a", DbType.Int32);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
+
             p = new NpgsqlParameter("b", DbType.Int32);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-            
+
             p = new NpgsqlParameter("c", DbType.Int32);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-                        
+
             command.ExecuteNonQuery();
-            
+
             // Should bear the values of the first tuple.
             Assert.AreEqual(4, command.Parameters["a"].Value);
             Assert.AreEqual(5, command.Parameters["b"].Value);
@@ -811,42 +648,47 @@ namespace NpgsqlTests
             {
                 new NpgsqlCommand("set standard_conforming_strings=off;set escape_string_warning=off", TheConnection).ExecuteNonQuery();
             }
-            catch{}
+            catch
+            {
+            }
             string cmdTxt = "select :par";
-            NpgsqlCommand command = new NpgsqlCommand(cmdTxt, TheConnection);
-            NpgsqlCommand arrCommand = new NpgsqlCommand(cmdTxt, TheConnection);
+            var command = new NpgsqlCommand(cmdTxt, TheConnection);
+            var arrCommand = new NpgsqlCommand(cmdTxt, TheConnection);
             string testStrPar = "This string has a 'literal' backslash \\";
-            string[,] testArrPar = new string[,]{{testStrPar, ""}, {testStrPar, testStrPar}};
+            string[,] testArrPar = new string[,] {{testStrPar, ""}, {testStrPar, testStrPar}};
             command.Parameters.AddWithValue(":par", testStrPar);
-            using(IDataReader rdr = command.ExecuteReader())
+            using (var rdr = command.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(rdr.GetString(0), testStrPar);
             }
             arrCommand.Parameters.AddWithValue(":par", testArrPar);
-            using(IDataReader rdr = arrCommand.ExecuteReader())
+            using (var rdr = arrCommand.ExecuteReader())
             {
                 rdr.Read();
-                Assert.AreEqual(((string[,])rdr.GetValue(0))[0,0], testStrPar);
+                Assert.AreEqual(((string[,]) rdr.GetValue(0))[0, 0], testStrPar);
             }
-            
-            try//the next command will fail on earlier postgres versions, but that is not a bug in itself.
+
+            try //the next command will fail on earlier postgres versions, but that is not a bug in itself.
             {
-                new NpgsqlCommand("set standard_conforming_strings=on;set escape_string_warning=on", TheConnection).ExecuteNonQuery();
+                new NpgsqlCommand("set standard_conforming_strings=on;set escape_string_warning=on", TheConnection)
+                    .ExecuteNonQuery();
             }
-            catch{}
-            using(IDataReader rdr = command.ExecuteReader())
+            catch
+            {
+            }
+            using (var rdr = command.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(rdr.GetString(0), testStrPar);
             }
-            using(IDataReader rdr = arrCommand.ExecuteReader())
+            using (var rdr = arrCommand.ExecuteReader())
             {
                 rdr.Read();
-                Assert.AreEqual(((string[,])rdr.GetValue(0))[0,0], testStrPar);
+                Assert.AreEqual(((string[,]) rdr.GetValue(0))[0, 0], testStrPar);
             }
         }
-        
+
         [Test]
         public void FunctionCallStringEscape()
         {
@@ -858,31 +700,35 @@ namespace NpgsqlTests
             NoticeEventHandler countWarn = delegate(Object c, NpgsqlNoticeEventArgs e) { warnings += 1; };
             TheConnection.Notice += countWarn;
 
-            string testStrPar = "This string has a 'literal' backslash \\";
-            NpgsqlCommand command = new NpgsqlCommand("trim", TheConnection);
+            var testStrPar = "This string has a 'literal' backslash \\";
+            var command = new NpgsqlCommand("trim", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
             command.Parameters.Add(new NpgsqlParameter());
             command.Parameters[0].NpgsqlDbType = NpgsqlDbType.Varchar;
             command.Parameters[0].Value = testStrPar;
 
-            try//the next command will fail on earlier postgres versions, but that is not a bug in itself.
+            try //the next command will fail on earlier postgres versions, but that is not a bug in itself.
             {
                 new NpgsqlCommand("set escape_string_warning=on", TheConnection).ExecuteNonQuery();
                 new NpgsqlCommand("set standard_conforming_strings=off", TheConnection).ExecuteNonQuery();
             }
-            catch{}
-            using(IDataReader rdr = command.ExecuteReader())
+            catch
+            {
+            }
+            using (IDataReader rdr = command.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(testStrPar, rdr.GetString(0));
             }
 
-            try//the next command will fail on earlier postgres versions, but that is not a bug in itself.
+            try //the next command will fail on earlier postgres versions, but that is not a bug in itself.
             {
                 new NpgsqlCommand("set standard_conforming_strings=on", TheConnection).ExecuteNonQuery();
             }
-            catch{}
-            using(IDataReader rdr = command.ExecuteReader())
+            catch
+            {
+            }
+            using (IDataReader rdr = command.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(testStrPar, rdr.GetString(0));
@@ -892,67 +738,57 @@ namespace NpgsqlTests
             Assert.AreEqual(0, warnings);
         }
 
-        
+
         [Test]
         public void ParameterAndOperatorUnclear()
         {
             //Without parenthesis the meaning of [, . and potentially other characters is
             //a syntax error. See comment in NpgsqlCommand.GetClearCommandText() on "usually-redundant parenthesis".
-            NpgsqlCommand command = new NpgsqlCommand("select :arr[2]", TheConnection);
-            command.Parameters.AddWithValue(":arr", new int[]{5,4,3,2,1});
-            using(IDataReader rdr = command.ExecuteReader())
+            var command = new NpgsqlCommand("select :arr[2]", TheConnection);
+            command.Parameters.AddWithValue(":arr", new int[] {5, 4, 3, 2, 1});
+            using (var rdr = command.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(rdr.GetInt32(0), 4);
             }
         }
-        
+
         [Test]
         public void FunctionCallInputOutputParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcC(:a)", TheConnection);
+            var command = new NpgsqlCommand("funcC(:a)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.InputOutput;
             p.Value = 4;
-            
             command.Parameters.Add(p);
-            
-
-            Int64 result = (Int64) command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(1, result);
         }
-        
-        
+
+
         [Test]
         public void StatementMappedOutputParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select 3, 4 as param1, 5 as param2, 6;", TheConnection);
-                        
-            NpgsqlParameter p = new NpgsqlParameter("param2", NpgsqlDbType.Integer);
+            var command = new NpgsqlCommand("select 3, 4 as param1, 5 as param2, 6;", TheConnection);
+
+            var p = new NpgsqlParameter("param2", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
+
             p = new NpgsqlParameter("param1", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
+
             p = new NpgsqlParameter("p", NpgsqlDbType.Integer);
             p.Direction = ParameterDirection.Output;
             p.Value = -1;
-            
             command.Parameters.Add(p);
-            
-            
+
             command.ExecuteNonQuery();
-            
+
             Assert.AreEqual(4, command.Parameters["param1"].Value);
             Assert.AreEqual(5, command.Parameters["param2"].Value);
             //Assert.AreEqual(-1, command.Parameters["p"].Value); //Which is better, not filling this or filling this with an unmapped value?
@@ -964,213 +800,170 @@ namespace NpgsqlTests
         {
             // Notify messages are only sent from server after a transaction is finished.
             // So, finish now the implicit transaction.
-            
             TheTransaction.Rollback();
-            
-            Assert.IsFalse(RecievedNotification);//Test we start correctly.
+            Assert.IsFalse(ReceivedNotification); //Test we start correctly.
 
-            NpgsqlCommand command = new NpgsqlCommand("listen notifytest;", TheConnection);
+            var command = new NpgsqlCommand("listen notifytest;", TheConnection);
             command.ExecuteNonQuery();
 
             TheConnection.Notification += new NotificationEventHandler(NotificationSupportHelper);
 
-
             command = new NpgsqlCommand("notify notifytest;", TheConnection);
             command.ExecuteNonQuery();
 
-            Assert.IsTrue(RecievedNotification);
-            
+            Assert.IsTrue(ReceivedNotification);
+
         }
 
-        public bool RecievedNotification = false;
+        public bool ReceivedNotification = false;
+
         private void NotificationSupportHelper(Object sender, NpgsqlNotificationEventArgs args)
         {
-            RecievedNotification = true;
+            ReceivedNotification = true;
         }
 
-        
-            [Test]
+
+        [Test]
         public void ByteSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Byte));
-
             command.Parameters[0].Value = 2;
-
             Int32 rowsAdded = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, rowsAdded);
-
             command.Parameters.Clear();
         }
-        
-        
-            [Test]
+
+
+        [Test]
         public void ByteaSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1", TheConnection);
-
-
-            Byte[] result = (Byte[]) command.ExecuteScalar();
-            
-
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1", TheConnection);
+            var result = (Byte[]) command.ExecuteScalar();
             Assert.AreEqual(2, result.Length);
         }
 
         [Test]
         public void ByteaLargeSupport()
         {
-            byte[] buff = new byte[100000];
-
+            var buff = new byte[100000];
             new Random().NextBytes(buff);
-
-            NpgsqlCommand command = new NpgsqlCommand("select :val", TheConnection);
-
+            var command = new NpgsqlCommand("select :val", TheConnection);
             command.Parameters.Add("val", NpgsqlDbType.Bytea);
             command.Parameters["val"].Value = buff;
-
-            Byte[] result = (Byte[]) command.ExecuteScalar();
-
+            var result = (Byte[]) command.ExecuteScalar();
             Assert.AreEqual(buff, result);
         }
 
         [Test]
         public void ByteaInsertSupport1()
         {
-            Byte[] toStore = { 0, 1, 255, 254 };
+            Byte[] toStore = {0, 1, 255, 254};
 
-            NpgsqlCommand cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
+            var cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
             cmd.Parameters.Add(new NpgsqlParameter("val", DbType.Binary));
             cmd.Parameters[0].Value = toStore;
             cmd.ExecuteNonQuery();
 
             cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
-
-            Byte[] result = (Byte[])cmd.ExecuteScalar();
-
+            var result = (Byte[]) cmd.ExecuteScalar();
             Assert.AreEqual(toStore, result);
-
         }
 
         [Test]
         public void ByteaInsertSupport2()
         {
-            Byte[] toStore = { 1, 2, 127, 126 };
+            Byte[] toStore = {1, 2, 127, 126};
 
-            NpgsqlCommand cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
+            var cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
             cmd.Parameters.Add(new NpgsqlParameter("val", DbType.Binary));
             cmd.Parameters[0].Value = toStore;
             cmd.ExecuteNonQuery();
 
             cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
-
-            Byte[] result = (Byte[])cmd.ExecuteScalar();
+            var result = (Byte[]) cmd.ExecuteScalar();
 
             Assert.AreEqual(toStore, result);
-
         }
 
         [Test]
         public void ByteaInsertWithPrepareSupport1()
         {
-            Byte[] toStore = { 0 };
+            Byte[] toStore = {0};
 
-            NpgsqlCommand cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
+            var cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
             cmd.Parameters.Add(new NpgsqlParameter("val", DbType.Binary));
             cmd.Parameters[0].Value = toStore;
             cmd.Prepare();
             cmd.ExecuteNonQuery();
 
             cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
-            
+
             cmd.Prepare();
-            Byte[] result = (Byte[])cmd.ExecuteScalar();
-            
-            
+            var result = (Byte[]) cmd.ExecuteScalar();
+
             Assert.AreEqual(toStore, result);
         }
-        
+
         [Test]
         public void ByteaInsertWithPrepareSupport2()
         {
-            Byte[] toStore = { 1 };
+            Byte[] toStore = {1};
 
-            NpgsqlCommand cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
+            var cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
             cmd.Parameters.Add(new NpgsqlParameter("val", DbType.Binary));
             cmd.Parameters[0].Value = toStore;
             cmd.Prepare();
             cmd.ExecuteNonQuery();
 
             cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
-            
+
             cmd.Prepare();
-            Byte[] result = (Byte[])cmd.ExecuteScalar();
-            
-            
+            var result = (Byte[]) cmd.ExecuteScalar();
+
             Assert.AreEqual(toStore, result);
         }
-        
-        
-        
+
         [Test]
         public void ByteaParameterSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
-            
-            Byte[] bytes = new Byte[]{45,44};
-            
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
+            var bytes = new Byte[] {45, 44};
             command.Parameters.Add(":bytesData", NpgsqlTypes.NpgsqlDbType.Bytea);
-                  command.Parameters[":bytesData"].Value = bytes;
-
-
+            command.Parameters[":bytesData"].Value = bytes;
             Object result = command.ExecuteNonQuery();
-            
-
             Assert.AreEqual(-1, result);
         }
-        
+
         [Test]
         public void ByteaParameterWithPrepareSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
-            
-            Byte[] bytes = new Byte[]{45,44};
-            
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
+
+            var bytes = new Byte[] {45, 44};
             command.Parameters.Add(":bytesData", NpgsqlTypes.NpgsqlDbType.Bytea);
-                  command.Parameters[":bytesData"].Value = bytes;
-
-
+            command.Parameters[":bytesData"].Value = bytes;
             command.Prepare();
             Object result = command.ExecuteNonQuery();
-            
-
             Assert.AreEqual(-1, result);
         }
-        
-        
-            [Test]
+
+
+        [Test]
         public void EnumSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Smallint));
-
             command.Parameters[0].Value = EnumTest.Value1;
-            
-
             Int32 rowsAdded = command.ExecuteNonQuery();
-
             Assert.AreEqual(1, rowsAdded);
         }
 
         [Test]
         public void DateTimeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
+            DateTime d = (DateTime) command.ExecuteScalar();
 
             Assert.AreEqual(DateTimeKind.Unspecified, d.Kind);
             Assert.AreEqual("2002-02-02 09:00:23Z", d.ToString("u"));
@@ -1184,38 +977,30 @@ namespace NpgsqlTests
             command.Parameters[0].Value = dt;
 
             command.ExecuteScalar();
-       }
+        }
 
 
         [Test]
         public void DateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual("2002-02-02 09:00:23Z", d.ToString("u"));
 
-            DateTimeFormatInfo culture = new DateTimeFormatInfo();
+            var culture = new DateTimeFormatInfo();
             culture.TimeSeparator = ":";
-            DateTime dt = System.DateTime.Parse("2004-06-04 09:48:00", culture);
-
+            var dt = DateTime.Parse("2004-06-04 09:48:00", culture);
             command.CommandText = "insert into tableb(field_timestamp) values (:a);";
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Timestamp));
             command.Parameters[0].Value = dt;
-
             command.ExecuteScalar();
         }
 
         [Test]
         public void DateSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_date from tablec where field_serial = 1;", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var command = new NpgsqlCommand("select field_date from tablec where field_serial = 1;", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual(DateTimeKind.Unspecified, d.Kind);
             Assert.AreEqual("2002-03-04", d.ToString("yyyy-MM-dd"));
         }
@@ -1223,11 +1008,8 @@ namespace NpgsqlTests
         [Test]
         public void TimeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_time from tablec where field_serial = 2;", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var command = new NpgsqlCommand("select field_time from tablec where field_serial = 2;", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual(DateTimeKind.Unspecified, d.Kind);
             Assert.AreEqual("10:03:45.345", d.ToString("HH:mm:ss.fff"));
         }
@@ -1236,23 +1018,17 @@ namespace NpgsqlTests
         [Ignore]
         public void TimeSupportTimezone()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select '13:03:45.001-05'::timetz", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var command = new NpgsqlCommand("select '13:03:45.001-05'::timetz", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual(DateTimeKind.Local, d.Kind);
             Assert.AreEqual("18:03:45.001", d.ToUniversalTime().ToString("HH:mm:ss.fff"));
         }
-        
+
         [Test]
         public void DateTimeSupportTimezone()
         {
-            NpgsqlCommand command = new NpgsqlCommand("set time zone 5;select field_timestamp_with_timezone from tableg where field_serial = 1;", TheConnection);
-            
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var command = new NpgsqlCommand("set time zone 5;select field_timestamp_with_timezone from tableg where field_serial = 1;", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual(DateTimeKind.Local, d.Kind);
             Assert.AreEqual("2002-02-02 09:00:23Z", d.ToUniversalTime().ToString("u"));
         }
@@ -1262,10 +1038,8 @@ namespace NpgsqlTests
         {
             //Changed the comparison. Did thisassume too much about ToString()?
             NpgsqlCommand command = new NpgsqlCommand("set time zone 5; select field_timestamp_with_timezone from tableg where field_serial = 1;", TheConnection);
-
-            String s = ((DateTime)command.ExecuteScalar()).ToUniversalTime().ToString();
-           
-            Assert.AreEqual(new DateTime(2002,02,02,09,00,23).ToString() , s);
+            var s = ((DateTime) command.ExecuteScalar()).ToUniversalTime().ToString();
+            Assert.AreEqual(new DateTime(2002, 02, 02, 09, 00, 23).ToString(), s);
         }
 
         [Test]
@@ -1273,38 +1047,27 @@ namespace NpgsqlTests
         {
             //2009-11-11 20:15:43.019-03:30
             NpgsqlCommand command = new NpgsqlCommand("set time zone 5;select timestamptz'2009-11-11 20:15:43.019-03:30';", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-
-
+            var d = (DateTime) command.ExecuteScalar();
             Assert.AreEqual(DateTimeKind.Local, d.Kind);
             Assert.AreEqual("2009-11-11 23:45:43Z", d.ToUniversalTime().ToString("u"));
-
         }
-        
+
         [Test]
         public void DateTimeSupportTimezoneEuropeAmsterdam()
         {
             //1929-08-19 00:00:00+01:19:32
             // This test was provided by Christ Akkermans.
-            
-            NpgsqlCommand command = new NpgsqlCommand("SET TIME ZONE 'Europe/Amsterdam';SELECT '1929-08-19 00:00:00'::timestamptz;", TheConnection);
-
-            DateTime d = (DateTime)command.ExecuteScalar();
-            
-           
-
+            var command = new NpgsqlCommand("SET TIME ZONE 'Europe/Amsterdam';SELECT '1929-08-19 00:00:00'::timestamptz;", TheConnection);
+            var d = (DateTime) command.ExecuteScalar();
         }
-
-
 
         [Test]
         public void ProviderDateTimeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
+            var command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
 
             NpgsqlTimeStamp ts;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 ts = reader.GetTimeStamp(0);
@@ -1312,9 +1075,9 @@ namespace NpgsqlTests
 
             Assert.AreEqual("2002-02-02 09:00:23.345", ts.ToString());
 
-            DateTimeFormatInfo culture = new DateTimeFormatInfo();
+            var culture = new DateTimeFormatInfo();
             culture.TimeSeparator = ":";
-            NpgsqlTimeStamp ts1 = NpgsqlTimeStamp.Parse("2004-06-04 09:48:00");
+            var ts1 = NpgsqlTimeStamp.Parse("2004-06-04 09:48:00");
 
             command.CommandText = "insert into tableb(field_timestamp) values (:a);";
             command.Parameters.Add(new NpgsqlParameter("a", DbType.DateTime));
@@ -1327,10 +1090,10 @@ namespace NpgsqlTests
         [Test]
         public void ProviderDateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
+            var command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = 2;", TheConnection);
 
             NpgsqlTimeStamp ts;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 ts = reader.GetTimeStamp(0);
@@ -1338,9 +1101,9 @@ namespace NpgsqlTests
 
             Assert.AreEqual("2002-02-02 09:00:23.345", ts.ToString());
 
-            DateTimeFormatInfo culture = new DateTimeFormatInfo();
+            var culture = new DateTimeFormatInfo();
             culture.TimeSeparator = ":";
-            NpgsqlTimeStamp ts1 = NpgsqlTimeStamp.Parse("2004-06-04 09:48:00");
+            var ts1 = NpgsqlTimeStamp.Parse("2004-06-04 09:48:00");
 
             command.CommandText = "insert into tableb(field_timestamp) values (:a);";
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Timestamp));
@@ -1352,10 +1115,10 @@ namespace NpgsqlTests
         [Test]
         public void ProviderDateSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_date from tablec where field_serial = 1;", TheConnection);
+            var command = new NpgsqlCommand("select field_date from tablec where field_serial = 1;", TheConnection);
 
             NpgsqlDate d;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 d = reader.GetDate(0);
@@ -1367,10 +1130,10 @@ namespace NpgsqlTests
         [Test]
         public void ProviderTimeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_time from tablec where field_serial = 2;", TheConnection);
+            var command = new NpgsqlCommand("select field_time from tablec where field_serial = 2;", TheConnection);
 
             NpgsqlTime t;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 t = reader.GetTime(0);
@@ -1383,10 +1146,10 @@ namespace NpgsqlTests
         [Test]
         public void ProviderTimeSupportTimezone()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select '13:03:45.001-05'::timetz", TheConnection);
+            var command = new NpgsqlCommand("select '13:03:45.001-05'::timetz", TheConnection);
 
             NpgsqlTimeTZ t;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 t = reader.GetTimeTZ(0);
@@ -1398,10 +1161,10 @@ namespace NpgsqlTests
         [Test]
         public void ProviderDateTimeSupportTimezone()
         {
-            NpgsqlCommand command = new NpgsqlCommand("set time zone 5;select field_timestamp_with_timezone from tableg where field_serial = 1;", TheConnection);
+            var command = new NpgsqlCommand("set time zone 5;select field_timestamp_with_timezone from tableg where field_serial = 1;", TheConnection);
 
             NpgsqlTimeStampTZ ts;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 ts = reader.GetTimeStampTZ(0);
@@ -1414,439 +1177,316 @@ namespace NpgsqlTests
         public void ProviderDateTimeSupportTimezone3()
         {
             //2009-11-11 20:15:43.019-03:30
-            NpgsqlCommand command = new NpgsqlCommand("set time zone 5;select timestamptz'2009-11-11 20:15:43.019-03:30';", TheConnection);
+            var command = new NpgsqlCommand("set time zone 5;select timestamptz'2009-11-11 20:15:43.019-03:30';", TheConnection);
 
             NpgsqlTimeStampTZ ts;
-            using (NpgsqlDataReader reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader())
             {
                 reader.Read();
                 ts = reader.GetTimeStampTZ(0);
             }
 
             Assert.AreEqual("2009-11-12 04:45:43.019+05", ts.ToString());
-
         }
 
         [Test]
         public void NumericSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Decimal));
-
             command.Parameters[0].Value = 7.4M;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select * from tableb where field_numeric = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(3);
-
-
-            Assert.AreEqual(7.4000000M, result);
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(3);
+                Assert.AreEqual(7.4000000M, result);
+            }
         }
 
         [Test]
         public void NumericSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Numeric));
-
             command.Parameters[0].Value = 7.4M;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select * from tableb where field_numeric = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(3);
-
-
-            Assert.AreEqual(7.4000000M, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(3);
+                Assert.AreEqual(7.4000000M, result);
+            }
         }
-
 
         [Test]
         public void InsertSingleValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tabled(field_float4) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tabled(field_float4) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", DbType.Single));
-
             command.Parameters[0].Value = 7.4F;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select * from tabled where field_float4 = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Single result = dr.GetFloat(1);
-
-
-            Assert.AreEqual(7.4F, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetFloat(1);
+                Assert.AreEqual(7.4F, result);
+            }
         }
-
 
         [Test]
         public void InsertSingleValueNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tabled(field_float4) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tabled(field_float4) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Real));
-
             command.Parameters[0].Value = 7.4F;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select * from tabled where field_float4 = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Single result = dr.GetFloat(1);
-
-
-            Assert.AreEqual(7.4F, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetFloat(1);
+                Assert.AreEqual(7.4F, result);
+            }
         }
-        
-        
+
+
         [Test]
         public void DoubleValueSupportWithExtendedQuery()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select count(*) from tabled where field_float8 = :a", TheConnection);
+            var command = new NpgsqlCommand("select count(*) from tabled where field_float8 = :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Double));
-
             command.Parameters[0].Value = 0.123456789012345D;
-            
             command.Prepare();
-
-            Object rows = command.ExecuteScalar();
-
-            
+            var rows = command.ExecuteScalar();
             Assert.AreEqual(1, rows);
         }
-  
+
         [Test]
         public void Bug1010992DoubleValueSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :field_float8", TheConnection);
+            var command = new NpgsqlCommand("select :field_float8", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":field_float8", NpgsqlDbType.Double));
-
-            double x = 1d / 7d;
+            double x = 1d/7d;
             //double value = 0.12345678901234561D;
-            
             command.Parameters[0].Value = x;
-            
-            Object valueReturned = command.ExecuteScalar();
-
-            
+            var valueReturned = command.ExecuteScalar();
             Assert.AreEqual(x, valueReturned);
         }
-        
+
         [Test]
         public void InsertDoubleValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tabled(field_float8) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tabled(field_float8) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", DbType.Double));
-
             command.Parameters[0].Value = 7.4D;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
+            var rowsAdded = command.ExecuteNonQuery();
 
             command.CommandText = "select * from tabled where field_float8 = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Double result = dr.GetDouble(2);
-
-
-            Assert.AreEqual(1, rowsAdded);
-            Assert.AreEqual(7.4D, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDouble(2);
+                Assert.AreEqual(1, rowsAdded);
+                Assert.AreEqual(7.4D, result);
+            }
         }
 
 
         [Test]
         public void InsertDoubleValueNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tabled(field_float8) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tabled(field_float8) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Double));
-
             command.Parameters[0].Value = 7.4D;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
+            var rowsAdded = command.ExecuteNonQuery();
 
             command.CommandText = "select * from tabled where field_float8 = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Double result = dr.GetDouble(2);
-
-
-            Assert.AreEqual(1, rowsAdded);
-            Assert.AreEqual(7.4D, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDouble(2);
+                Assert.AreEqual(1, rowsAdded);
+                Assert.AreEqual(7.4D, result);
+            }
         }
 
 
         [Test]
         public void NegativeNumericSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableb where field_serial = 4", TheConnection);
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(3);
-
-            Assert.AreEqual(-4.3000000M, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tableb where field_serial = 4", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(3);
+                Assert.AreEqual(-4.3000000M, result);
+            }
         }
 
 
         [Test]
         public void PrecisionScaleNumericSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableb where field_serial = 4", TheConnection);
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(3);
-
-            Assert.AreEqual(-4.3000000M, result);
-            //Assert.AreEqual(11, result.Precision);
-            //Assert.AreEqual(7, result.Scale);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tableb where field_serial = 4", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(3);
+                Assert.AreEqual(-4.3000000M, result);
+                //Assert.AreEqual(11, result.Precision);
+                //Assert.AreEqual(7, result.Scale);
+            }
         }
 
         [Test]
         public void InsertNullString()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.String));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tablea where field_text is null";
             command.Parameters.Clear();
-
-            Int64 result = (Int64)command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(4, result);
         }
 
         [Test]
         public void InsertNullStringNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Text));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tablea where field_text is null";
             command.Parameters.Clear();
-
-            Int64 result = (Int64)command.ExecuteScalar();
-
+            var result = (Int64) command.ExecuteScalar();
             Assert.AreEqual(4, result);
         }
-
-
 
         [Test]
         public void InsertNullDateTime()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.DateTime));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tableb where field_timestamp is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(4, result);
         }
-
 
         [Test]
         public void InsertNullDateTimeNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Timestamp));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tableb where field_timestamp is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(4, result);
         }
-
-
 
         [Test]
         public void InsertNullInt16()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tableb where field_int2 is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(4, result);
         }
-
 
         [Test]
         public void InsertNullInt16NpgsqlDbType()
         {
             NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (:a)", TheConnection);
-
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Smallint));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tableb where field_int2 is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(4, result);
         }
-
 
         [Test]
         public void InsertNullInt32()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_int4) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_int4) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tablea where field_int4 is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(6, result);
         }
-
 
         [Test]
         public void InsertNullNumeric()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tableb(field_numeric) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Decimal));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tableb where field_numeric is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(3, result);
         }
 
         [Test]
         public void InsertNullBoolean()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_bool) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_bool) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Boolean));
-
             command.Parameters[0].Value = DBNull.Value;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select count(*) from tablea where field_bool is null";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(6, result);
 
         }
@@ -1854,24 +1494,16 @@ namespace NpgsqlTests
         [Test]
         public void InsertBoolean()
         {
-            
-
-
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_bool) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_bool) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Boolean));
-
             command.Parameters[0].Value = false;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select field_bool from tablea where field_serial = (select max(field_serial) from tablea)";
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(false, result);
 
         }
@@ -1879,22 +1511,16 @@ namespace NpgsqlTests
         [Test]
         public void AnsiStringSupport()
         {
-         
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
-
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.AnsiString));
-
             command.Parameters[0].Value = "TesteAnsiString";
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = String.Format("select count(*) from tablea where field_text = '{0}'", command.Parameters[0].Value);
             command.Parameters.Clear();
-
-            Object result = command.ExecuteScalar(); // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
-
+            var result = command.ExecuteScalar();
+                // The missed cast is needed as Server7.2 returns Int32 and Server7.3+ returns Int64
             Assert.AreEqual(1, result);
         }
 
@@ -1902,21 +1528,17 @@ namespace NpgsqlTests
         [Test]
         public void MultipleQueriesFirstResultsetEmpty()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values ('a'); select count(*) from tablea;", TheConnection);
-
-            Object result = command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("insert into tablea(field_text) values ('a'); select count(*) from tablea;", TheConnection);
+            var result = command.ExecuteScalar();
             Assert.AreEqual(7, result);
         }
 
         [Test]
-        [ExpectedException(typeof(NpgsqlException))]
+        [ExpectedException(typeof (NpgsqlException))]
         public void ConnectionStringWithInvalidParameterValue()
         {
-
-            NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString + ";userid=npgsql_tes;pooling=false");
-
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", conn);
+            var conn = new NpgsqlConnection(TheConnectionString + ";userid=npgsql_tes;pooling=false");
+            var command = new NpgsqlCommand("select * from tablea", conn);
 
             try
             {
@@ -1926,31 +1548,21 @@ namespace NpgsqlTests
             finally
             {
                 command.Connection.Close();
-
             }
-            
-            
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof (ArgumentException))]
         public void InvalidConnectionString()
         {
-            
-            NpgsqlConnection conn = new NpgsqlConnection("Server=127.0.0.1;User Id=npgsql_tests;Pooling:false");
-
+            var conn = new NpgsqlConnection("Server=127.0.0.1;User Id=npgsql_tests;Pooling:false");
             conn.Open();
-            
-            
         }
-
 
         [Test]
         public void AmbiguousFunctionParameterType()
         {
             //NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString);
-
-
             NpgsqlCommand command = new NpgsqlCommand("ambiguousParameterType(:a, :b, :c, :d, :e, :f)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
             NpgsqlParameter p = new NpgsqlParameter("a", DbType.Int16);
@@ -1973,13 +1585,11 @@ namespace NpgsqlTests
             command.Parameters.Add(p);
 
             command.ExecuteScalar();
-            
         }
-        
+
         [Test]
         public void AmbiguousFunctionParameterTypePrepared()
         {
-            
             NpgsqlCommand command = new NpgsqlCommand("ambiguousParameterType(:a, :b, :c, :d, :e, :f)", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
             NpgsqlParameter p = new NpgsqlParameter("a", DbType.Int16);
@@ -2000,100 +1610,68 @@ namespace NpgsqlTests
             p = new NpgsqlParameter("f", DbType.String);
             p.Value = "a";
             command.Parameters.Add(p);
-    
-    
+
             command.Prepare();
             command.ExecuteScalar();
-            
         }
 
-
-        
         // The following two methods don't need checks because what is being tested is the 
         // execution of parameter replacing which happens on ExecuteNonQuery method. So, if these
         // methods don't throw exception, they are ok.
         [Test]
         public void TestParameterReplace()
         {
-            String sql = @"select * from tablea where
-                            field_serial = :a
-                         ";
-
-
-            NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-
+            const string sql = @"select * from tablea where field_serial = :a";
+            var command = new NpgsqlCommand(sql, TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-
             command.Parameters[0].Value = 2;
-
             command.ExecuteNonQuery();
         }
-        
+
         [Test]
         public void TestParameterReplace2()
         {
-            String sql = @"select * from tablea where
-                         field_serial = :a+1
-                         ";
-
-
-            NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-
+            const string sql = @"select * from tablea where field_serial = :a+1";
+            var command = new NpgsqlCommand(sql, TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-
             command.Parameters[0].Value = 1;
-
             command.ExecuteNonQuery();
         }
-        
+
         [Test]
         public void TestParameterNameInParameterValue()
         {
-            String sql = "insert into tablea(field_text, field_int4) values ( :a, :b );" ;
+            const string sql = "insert into tablea(field_text, field_int4) values ( :a, :b );";
+            const string aValue = "test :b";
 
-            String aValue = "test :b";
-
-            NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-
+            var command = new NpgsqlCommand(sql, TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Text));
-
             command.Parameters[":a"].Value = aValue;
-            
             command.Parameters.Add(new NpgsqlParameter(":b", NpgsqlDbType.Integer));
-
             command.Parameters[":b"].Value = 1;
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(rowsAdded, 1);
-            
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_text, field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
-            
-            NpgsqlDataReader dr = command2.ExecuteReader();
-            
-            dr.Read();
-            
-            String a = dr.GetString(0);;
-            Int32 b = dr.GetInt32(1);
-            
-            dr.Close();
-            
-            
-            
-            Assert.AreEqual(aValue, a);
-            Assert.AreEqual(1, b);
+
+            var command2 = new NpgsqlCommand("select field_text, field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", TheConnection);
+            using (var dr = command2.ExecuteReader())
+            {
+                dr.Read();
+                var a = dr.GetString(0);
+                var b = dr.GetInt32(1);
+                Assert.AreEqual(aValue, a);
+                Assert.AreEqual(1, b);
+            }
         }
 
         [Test]
         public void TestBoolParameter1()
         {
             // will throw exception if bool parameter can't be used as boolean expression
-            NpgsqlCommand command = new NpgsqlCommand("select case when (foo is null) then false else foo end as bar from (select :a as foo) as x", TheConnection);
-            NpgsqlParameter p0 = new NpgsqlParameter(":a", true);
+            var command = new NpgsqlCommand("select case when (foo is null) then false else foo end as bar from (select :a as foo) as x", TheConnection);
+            var p0 = new NpgsqlParameter(":a", true);
             // with setting pramater type
             p0.DbType = DbType.Boolean;
             command.Parameters.Add(p0);
-
             command.ExecuteScalar();
         }
 
@@ -2101,33 +1679,27 @@ namespace NpgsqlTests
         public void TestBoolParameter2()
         {
             // will throw exception if bool parameter can't be used as boolean expression
-            NpgsqlCommand command = new NpgsqlCommand("select case when (foo is null) then false else foo end as bar from (select :a as foo) as x", TheConnection);
-            NpgsqlParameter p0 = new NpgsqlParameter(":a", true);
+            var command = new NpgsqlCommand("select case when (foo is null) then false else foo end as bar from (select :a as foo) as x", TheConnection);
+            var p0 = new NpgsqlParameter(":a", true);
             // not setting parameter type
             command.Parameters.Add(p0);
-
             command.ExecuteScalar();
         }
 
         [Test]
         public void TestPointSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_point from tablee where field_serial = 1", TheConnection);
-
-            NpgsqlPoint p = (NpgsqlPoint) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_point from tablee where field_serial = 1", TheConnection);
+            var p = (NpgsqlPoint) command.ExecuteScalar();
             Assert.AreEqual(4, p.X);
             Assert.AreEqual(3, p.Y);
         }
 
-
         [Test]
         public void TestBoxSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_box from tablee where field_serial = 2", TheConnection);
-
-            NpgsqlBox box = (NpgsqlBox) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_box from tablee where field_serial = 2", TheConnection);
+            var box = (NpgsqlBox) command.ExecuteScalar();
             Assert.AreEqual(5, box.UpperRight.X);
             Assert.AreEqual(4, box.UpperRight.Y);
             Assert.AreEqual(4, box.LowerLeft.X);
@@ -2137,10 +1709,8 @@ namespace NpgsqlTests
         [Test]
         public void TestLSegSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_lseg from tablee where field_serial = 3", TheConnection);
-
-            NpgsqlLSeg lseg = (NpgsqlLSeg) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_lseg from tablee where field_serial = 3", TheConnection);
+            var lseg = (NpgsqlLSeg) command.ExecuteScalar();
             Assert.AreEqual(4, lseg.Start.X);
             Assert.AreEqual(3, lseg.Start.Y);
             Assert.AreEqual(5, lseg.End.X);
@@ -2150,10 +1720,8 @@ namespace NpgsqlTests
         [Test]
         public void TestClosedPathSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_path from tablee where field_serial = 4", TheConnection);
-
-            NpgsqlPath path = (NpgsqlPath) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_path from tablee where field_serial = 4", TheConnection);
+            var path = (NpgsqlPath) command.ExecuteScalar();
             Assert.AreEqual(false, path.Open);
             Assert.AreEqual(2, path.Count);
             Assert.AreEqual(4, path[0].X);
@@ -2165,10 +1733,8 @@ namespace NpgsqlTests
         [Test]
         public void TestOpenPathSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_path from tablee where field_serial = 5", TheConnection);
-
-            NpgsqlPath path = (NpgsqlPath) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_path from tablee where field_serial = 5", TheConnection);
+            var path = (NpgsqlPath) command.ExecuteScalar();
             Assert.AreEqual(true, path.Open);
             Assert.AreEqual(2, path.Count);
             Assert.AreEqual(4, path[0].X);
@@ -2177,15 +1743,11 @@ namespace NpgsqlTests
             Assert.AreEqual(4, path[1].Y);
         }
 
-
-
         [Test]
         public void TestPolygonSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_polygon from tablee where field_serial = 6", TheConnection);
-
-            NpgsqlPolygon polygon = (NpgsqlPolygon) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_polygon from tablee where field_serial = 6", TheConnection);
+            var polygon = (NpgsqlPolygon) command.ExecuteScalar();
             Assert.AreEqual(2, polygon.Count);
             Assert.AreEqual(4, polygon[0].X);
             Assert.AreEqual(3, polygon[0].Y);
@@ -2193,163 +1755,123 @@ namespace NpgsqlTests
             Assert.AreEqual(4, polygon[1].Y);
         }
 
-
         [Test]
         public void TestCircleSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_circle from tablee where field_serial = 7", TheConnection);
-
-            NpgsqlCircle circle = (NpgsqlCircle) command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select field_circle from tablee where field_serial = 7", TheConnection);
+            var circle = (NpgsqlCircle) command.ExecuteScalar();
             Assert.AreEqual(4, circle.Center.X);
             Assert.AreEqual(3, circle.Center.Y);
             Assert.AreEqual(5, circle.Radius);
         }
-        
+
         [Test]
         public void SetParameterValueNull()
         {
-            NpgsqlCommand cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
-                  NpgsqlParameter param = cmd.CreateParameter();
-                  param.ParameterName="val";
+            var cmd = new NpgsqlCommand("insert into tablef(field_bytea) values (:val)", TheConnection);
+            var param = cmd.CreateParameter();
+            param.ParameterName = "val";
             param.NpgsqlDbType = NpgsqlDbType.Bytea;
-                  param.Value = DBNull.Value;
-            
-                  cmd.Parameters.Add(param);
-            
-                  cmd.ExecuteNonQuery();
+            param.Value = DBNull.Value;
+            cmd.Parameters.Add(param);
+            cmd.ExecuteNonQuery();
 
-                  cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
-            
-                  Object result = cmd.ExecuteScalar();
-            
-            
+            cmd = new NpgsqlCommand("select field_bytea from tablef where field_serial = (select max(field_serial) from tablef)", TheConnection);
+            var result = cmd.ExecuteScalar();
             Assert.AreEqual(DBNull.Value, result);
         }
-        
-        
+
+
         [Test]
         public void TestCharParameterLength()
         {
-            String sql = "insert into tableh(field_char5) values ( :a );" ;
-    
-            String aValue = "atest";
-    
-            NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-    
+            const string sql = "insert into tableh(field_char5) values ( :a );";
+            const string aValue = "atest";
+            var command = new NpgsqlCommand(sql, TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Char));
-    
             command.Parameters[":a"].Value = aValue;
             command.Parameters[":a"].Size = 5;
-            
-            Int32 rowsAdded = command.ExecuteNonQuery();
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(rowsAdded, 1);
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_char5 from tableh where field_serial = (select max(field_serial) from tableh)", TheConnection);
-            
-            NpgsqlDataReader dr = command2.ExecuteReader();
-            
-            dr.Read();
-            
-            String a = dr.GetString(0);;
-                        
-            dr.Close();
-            
-            
-            Assert.AreEqual(aValue, a);
+
+            var command2 = new NpgsqlCommand("select field_char5 from tableh where field_serial = (select max(field_serial) from tableh)", TheConnection);
+            using (var dr = command2.ExecuteReader())
+            {
+                dr.Read();
+                String a = dr.GetString(0);
+                Assert.AreEqual(aValue, a);
+            }
         }
-        
+
         [Test]
         public void ParameterHandlingOnQueryWithParameterPrefix()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select to_char(field_time, 'HH24:MI') from tablec where field_serial = :a;", TheConnection);
-            
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
+            var command = new NpgsqlCommand("select to_char(field_time, 'HH24:MI') from tablec where field_serial = :a;", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Integer);
             p.Value = 2;
-            
             command.Parameters.Add(p);
-
-            String d = (String)command.ExecuteScalar();
-
-
+            var d = (String) command.ExecuteScalar();
             Assert.AreEqual("10:03", d);
         }
-        
+
         [Test]
         public void MultipleRefCursorSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("testmultcurfunc", TheConnection);
+            var command = new NpgsqlCommand("testmultcurfunc", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-            
-            dr.Read();
-            
-            Int32 one = dr.GetInt32(0);
-            
-            dr.NextResult();
-            
-            dr.Read();
-            
-            Int32 two = dr.GetInt32(0);
-            
-            dr.Close();
-            
-            
-            Assert.AreEqual(1, one);
-            Assert.AreEqual(2, two);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var one = dr.GetInt32(0);
+                dr.NextResult();
+                dr.Read();
+                var two = dr.GetInt32(0);
+                Assert.AreEqual(1, one);
+                Assert.AreEqual(2, two);
+            }
         }
-        
+
         [Test]
         public void ProcedureNameWithSchemaSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("public.testreturnrecord", TheConnection);
+            var command = new NpgsqlCommand("public.testreturnrecord", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Integer));
             command.Parameters[0].Direction = ParameterDirection.Output;
-
             command.Parameters.Add(new NpgsqlParameter(":b", NpgsqlDbType.Integer));
             command.Parameters[1].Direction = ParameterDirection.Output;
-
             command.ExecuteNonQuery();
-            
+
             Assert.AreEqual(4, command.Parameters[0].Value);
             Assert.AreEqual(5, command.Parameters[1].Value);
         }
-        
+
         [Test]
         public void ReturnRecordSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("testreturnrecord", TheConnection);
+            var command = new NpgsqlCommand("testreturnrecord", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Integer));
             command.Parameters[0].Direction = ParameterDirection.Output;
-
             command.Parameters.Add(new NpgsqlParameter(":b", NpgsqlDbType.Integer));
             command.Parameters[1].Direction = ParameterDirection.Output;
-
             command.ExecuteNonQuery();
-            
+
             Assert.AreEqual(4, command.Parameters[0].Value);
             Assert.AreEqual(5, command.Parameters[1].Value);
         }
-        
+
         [Test]
         public void ReturnSetofRecord()
         {
-            NpgsqlCommand command = new NpgsqlCommand("testreturnsetofrecord", TheConnection);
+            var command = new NpgsqlCommand("testreturnsetofrecord", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Integer));
             command.Parameters[0].Direction = ParameterDirection.Output;
-
             command.Parameters.Add(new NpgsqlParameter(":b", NpgsqlDbType.Integer));
             command.Parameters[1].Direction = ParameterDirection.Output;
-
             command.ExecuteNonQuery();
-            
+
             Assert.AreEqual(8, command.Parameters[0].Value);
             Assert.AreEqual(9, command.Parameters[1].Value);
         }
@@ -2357,19 +1879,16 @@ namespace NpgsqlTests
         [Test]
         public void ReturnRecordSupportWithResultset()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand("testreturnrecordresultset", TheConnection);
+
+            var command = new NpgsqlCommand("testreturnrecordresultset", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
             command.Parameters.Add(new NpgsqlParameter(":a", NpgsqlDbType.Integer));
             command.Parameters[0].Value = 1;
-
             command.Parameters.Add(new NpgsqlParameter(":b", NpgsqlDbType.Integer));
             command.Parameters[1].Value = 4;
 
-
             NpgsqlDataReader dr = null;
-            
+
             try
             {
                 dr = command.ExecuteReader();
@@ -2379,132 +1898,93 @@ namespace NpgsqlTests
                 if (dr != null)
                     dr.Close();
             }
-            
         }
 
-        
-        
         [Test]
         public void ParameterTypeBoolean()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
-            
+            var p = new NpgsqlParameter();
             p.ParameterName = "test";
-            
             p.Value = true;
-            
             Assert.AreEqual(NpgsqlDbType.Boolean, p.NpgsqlDbType);
         }
 
-        
         [Test]
         public void ParameterTypeTimestamp()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
-            
+            var p = new NpgsqlParameter();
             p.ParameterName = "test";
-            
             p.Value = DateTime.Now;
-            
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType);
         }
-        
-        
+
         [Test]
         public void ParameterTypeText()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
-            
+            var p = new NpgsqlParameter();
             p.ParameterName = "test";
-            
             p.Value = "teste";
-            
             Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType);
         }
 
         [Test]
         public void ReadUncommitedTransactionSupport()
         {
-            String sql = "select 1 as test";
-            
-            using(NpgsqlConnection c = new NpgsqlConnection(TheConnectionString))
+            const string sql = "select 1 as test";
+            using (var c = new NpgsqlConnection(TheConnectionString))
             {
-            
                 c.Open();
-                
-                NpgsqlTransaction t = c.BeginTransaction(IsolationLevel.ReadUncommitted);
+                var t = c.BeginTransaction(IsolationLevel.ReadUncommitted);
                 Assert.IsNotNull(t);
-                
-                NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-                    
+
+                var command = new NpgsqlCommand(sql, TheConnection);
                 command.ExecuteReader().Close();
             }
-            
         }
-        
+
         [Test]
         public void RepeatableReadTransactionSupport()
         {
-            String sql = "select 1 as test";
-            
-            using (NpgsqlConnection c = new NpgsqlConnection(TheConnectionString))
+            const string sql = "select 1 as test";
+            using (var c = new NpgsqlConnection(TheConnectionString))
             {
-            
                 c.Open();
-                
-                NpgsqlTransaction t = c.BeginTransaction(IsolationLevel.RepeatableRead);
+                var t = c.BeginTransaction(IsolationLevel.RepeatableRead);
                 Assert.IsNotNull(t);
-                
-                NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-                    
+
+                var command = new NpgsqlCommand(sql, TheConnection);
                 command.ExecuteReader().Close();
-                
                 c.Close();
             }
-            
         }
-        
+
         [Test]
         public void SetTransactionToSerializable()
         {
-            String sql = "show transaction_isolation;";
-            
-            using (NpgsqlConnection c = new NpgsqlConnection(TheConnectionString))
+            const string sql = "show transaction_isolation;";
+            using (var c = new NpgsqlConnection(TheConnectionString))
             {
-                
-            
                 c.Open();
-                
-                NpgsqlTransaction t = c.BeginTransaction(IsolationLevel.Serializable);
+                var t = c.BeginTransaction(IsolationLevel.Serializable);
                 Assert.IsNotNull(t);
-                
-                NpgsqlCommand command = new NpgsqlCommand(sql, c);
-                
-                String isolation = (String)command.ExecuteScalar();
-                
+                var command = new NpgsqlCommand(sql, c);
+                var isolation = (String) command.ExecuteScalar();
                 c.Close();
-                    
                 Assert.AreEqual("serializable", isolation);
             }
         }
-        
-        
+
         [Test]
         public void TestParameterNameWithDot()
         {
-            String sql = "insert into tableh(field_char5) values ( :a.parameter );" ;
-    
-            String aValue = "atest";
-    
-            NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-    
+            const string sql = "insert into tableh(field_char5) values ( :a.parameter );";
+            const string aValue = "atest";
+            var command = new NpgsqlCommand(sql, TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":a.parameter", NpgsqlDbType.Char));
-    
             command.Parameters[":a.parameter"].Value = aValue;
             command.Parameters[":a.parameter"].Size = 5;
-            
-            
-            Int32 rowsAdded = -1;
+
+            var rowsAdded = -1;
             try
             {
                 rowsAdded = command.ExecuteNonQuery();
@@ -2515,700 +1995,496 @@ namespace NpgsqlTests
             }
 
             Assert.AreEqual(rowsAdded, 1);
-            
-            NpgsqlCommand command2 = new NpgsqlCommand("select field_char5 from tableh where field_serial = (select max(field_serial) from tableh)", TheConnection);
-            
-            String a = (String)command2.ExecuteScalar();
-            
+
+            var command2 = new NpgsqlCommand("select field_char5 from tableh where field_serial = (select max(field_serial) from tableh)", TheConnection);
+            var a = (String) command2.ExecuteScalar();
             Assert.AreEqual(aValue, a);
         }
-
 
         [Test]
         public void LastInsertedOidSupport()
         {
-
-            NpgsqlCommand insertCommand = new NpgsqlCommand("insert into tablea(field_text) values ('a');", TheConnection);
+            var insertCommand = new NpgsqlCommand("insert into tablea(field_text) values ('a');", TheConnection);
             // Insert this dummy row, just to enable us to see what was the last oid in order we can assert it later.
             insertCommand.ExecuteNonQuery();
 
-            NpgsqlCommand selectCommand = new NpgsqlCommand("select max(oid) from tablea;", TheConnection);     
-
-
-            Int64 previousOid = (Int64) selectCommand.ExecuteScalar();
+            var selectCommand = new NpgsqlCommand("select max(oid) from tablea;", TheConnection);
+            var previousOid = (Int64) selectCommand.ExecuteScalar();
 
             insertCommand.ExecuteNonQuery();
 
             Assert.AreEqual(previousOid + 1, insertCommand.LastInsertedOID);
-
-            
         }
-        
+
         /*[Test]
         public void SetServerVersionToNull()
         {
-
             ServerVersion o = TheConnection.ServerVersion;
-            
             if(o == null)
               return;
         }*/
-        
+
         [Test]
         public void VerifyFunctionNameWithDeriveParameters()
         {
             try
             {
-                NpgsqlCommand invalidCommandName = new NpgsqlCommand("invalidfunctionname", TheConnection);
-                
+                var invalidCommandName = new NpgsqlCommand("invalidfunctionname", TheConnection);
                 NpgsqlCommandBuilder.DeriveParameters(invalidCommandName);
             }
             catch (InvalidOperationException e)
             {
-                ResourceManager resman = new ResourceManager(typeof(NpgsqlCommandBuilder));
-                string expected = string.Format(resman.GetString("Exception_InvalidFunctionName"), "invalidfunctionname");
+                var resman = new ResourceManager(typeof (NpgsqlCommandBuilder));
+                var expected = string.Format(resman.GetString("Exception_InvalidFunctionName"), "invalidfunctionname");
                 Assert.AreEqual(expected, e.Message);
             }
         }
-        
-        
+
         [Test]
         public void DoubleSingleQuotesValueSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
+            var command = new NpgsqlCommand("insert into tablea(field_text) values (:a)", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", NpgsqlDbType.Text));
-
             command.Parameters[0].Value = "''";
-
-            Int32 rowsAdded = command.ExecuteNonQuery();
-
+            var rowsAdded = command.ExecuteNonQuery();
             Assert.AreEqual(1, rowsAdded);
 
             command.CommandText = "select * from tablea where field_text = :a";
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            
-            Assert.IsTrue(dr.Read());
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                Assert.IsTrue(dr.Read());
+            }
         }
-        
+
         [Test]
         public void ReturnInfinityDateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values ('infinity'::timestamp);", TheConnection);
-            
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values ('infinity'::timestamp);", TheConnection);
             command.ExecuteNonQuery();
-            
-            
+
             command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = (select max(field_serial) from tableb);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(DateTime.MaxValue, result);
         }
 
         [Test]
         public void ReturnMinusInfinityDateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values ('-infinity'::timestamp);", TheConnection);
-            
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values ('-infinity'::timestamp);", TheConnection);
             command.ExecuteNonQuery();
-            
-            
+
             command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = (select max(field_serial) from tableb);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(DateTime.MinValue, result);
         }
 
         [Test]
         public void InsertInfinityDateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Timestamp);
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Timestamp);
             p.Value = DateTime.MaxValue;
-            
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = (select max(field_serial) from tableb);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(DateTime.MaxValue, result);
         }
 
         [Test]
         public void InsertMinusInfinityDateTimeSupportNpgsqlDbType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Timestamp);
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Timestamp);
             p.Value = DateTime.MinValue;
-            
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = (select max(field_serial) from tableb);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(DateTime.MinValue, result);
         }
-        
+
         [Test]
         public void InsertMinusInfinityDateTimeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", DateTime.MinValue);
-
+            var command = new NpgsqlCommand("insert into tableb(field_timestamp) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", DateTime.MinValue);
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_timestamp from tableb where field_serial = (select max(field_serial) from tableb);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(DateTime.MinValue, result);
         }
 
         [Test]
         public void MinusInfinityDateTimeSupport()
         {
-            NpgsqlCommand command = TheConnection.CreateCommand();
-                       
+            var command = TheConnection.CreateCommand();
             command.Parameters.Add(new NpgsqlParameter("p0", DateTime.MinValue));
-
             command.CommandText = "select 1 where current_date=:p0";
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(null, result);
         }
-        
-        
+
         [Test]
         public void PlusInfinityDateTimeSupport()
         {
-            NpgsqlCommand command = TheConnection.CreateCommand();
-                       
+            var command = TheConnection.CreateCommand();
             command.Parameters.Add(new NpgsqlParameter("p0", DateTime.MaxValue));
-
             command.CommandText = "select 1 where current_date=:p0";
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(null, result);
         }
-
 
         [Test]
         public void InetTypeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablej(field_inet) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
-
+            var command = new NpgsqlCommand("insert into tablej(field_inet) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
             p.Value = new NpgsqlInet("127.0.0.1");
-            
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_inet from tablej where field_serial = (select max(field_serial) from tablej);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
-            Assert.AreEqual((IPAddress)new NpgsqlInet("127.0.0.1"), (IPAddress)result);
+            var result = command.ExecuteScalar();
+            Assert.AreEqual((IPAddress) new NpgsqlInet("127.0.0.1"), (IPAddress) result);
         }
 
         [Test]
         public void IPAddressTypeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablej(field_inet) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
-
+            var command = new NpgsqlCommand("insert into tablej(field_inet) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
             p.Value = IPAddress.Parse("127.0.0.1");
-            
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_inet from tablej where field_serial = (select max(field_serial) from tablej);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(IPAddress.Parse("127.0.0.1"), result);
         }
 
         [Test]
         public void BitTypeSupportWithPrepare()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
-
+            var command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
             p.Value = true;
-            
             command.Parameters.Add(p);
-
             command.Prepare();
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_bit from tablek where field_serial = (select max(field_serial) from tablek);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(true, result);
         }
 
         [Test]
         public void BitTypeSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
-
+            var command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
             p.Value = true;
-            
             command.Parameters.Add(p);
-
-
             command.ExecuteNonQuery();
-            
-            command = new NpgsqlCommand("select field_bit from tablek where field_serial = (select max(field_serial) from tablek);", TheConnection);
 
-            Object result = command.ExecuteScalar();
-            
+            command = new NpgsqlCommand("select field_bit from tablek where field_serial = (select max(field_serial) from tablek);", TheConnection);
+            var result = command.ExecuteScalar();
             Assert.AreEqual(true, result);
         }
 
         [Test]
         public void BitTypeSupport2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
-
+            var command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
             p.Value = 3;
-            
             command.Parameters.Add(p);
-
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_bit from tablek where field_serial = (select max(field_serial) from tablek);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(true, result);
         }
-
 
         [Test]
         public void BitTypeSupport3()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
-
+            var command = new NpgsqlCommand("insert into tablek(field_bit) values (:a);", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Bit);
             p.Value = 6;
-            
             command.Parameters.Add(p);
-
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_bit from tablek where field_serial = (select max(field_serial) from tablek);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(false, result);
         }
 
         //[Test]
         public void FunctionReceiveCharParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("d/;", TheConnection);
-            
-
-            NpgsqlParameter p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
-
+            var command = new NpgsqlCommand("d/;", TheConnection);
+            var p = new NpgsqlParameter("a", NpgsqlDbType.Inet);
             p.Value = IPAddress.Parse("127.0.0.1");
-            
             command.Parameters.Add(p);
-
             command.ExecuteNonQuery();
-            
+
             command = new NpgsqlCommand("select field_inet from tablej where field_serial = (select max(field_serial) from tablej);", TheConnection);
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(new NpgsqlInet("127.0.0.1"), result);
         }
 
         [Test]
         public void FunctionCaseSensitiveName()
         {
-            NpgsqlCommand command = new NpgsqlCommand("\"FunctionCaseSensitive\"", TheConnection);
+            var command = new NpgsqlCommand("\"FunctionCaseSensitive\"", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Integer));
             command.Parameters.Add(new NpgsqlParameter("p2", NpgsqlDbType.Text));
-
-            Object result = command.ExecuteScalar();
-
+            var result = command.ExecuteScalar();
             Assert.AreEqual(0, result);
-            
         }
 
         [Test]
         public void FunctionCaseSensitiveNameWithSchema()
         {
-            NpgsqlCommand command = new NpgsqlCommand("\"public\".\"FunctionCaseSensitive\"", TheConnection);
+            var command = new NpgsqlCommand("\"public\".\"FunctionCaseSensitive\"", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
             command.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Integer));
             command.Parameters.Add(new NpgsqlParameter("p2", NpgsqlDbType.Text));
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(0, result);
-            
         }
 
         [Test]
         public void FunctionCaseSensitiveNameDeriveParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("\"FunctionCaseSensitive\"", TheConnection);
-
-            
-
+            var command = new NpgsqlCommand("\"FunctionCaseSensitive\"", TheConnection);
             NpgsqlCommandBuilder.DeriveParameters(command);
-            
-            
             Assert.AreEqual(NpgsqlDbType.Integer, command.Parameters[0].NpgsqlDbType);
             Assert.AreEqual(NpgsqlDbType.Text, command.Parameters[1].NpgsqlDbType);
-            
         }
-        
+
         [Test]
         public void FunctionCaseSensitiveNameDeriveParametersWithSchema()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand("\"public\".\"FunctionCaseSensitive\"", TheConnection);
-            
+            var command = new NpgsqlCommand("\"public\".\"FunctionCaseSensitive\"", TheConnection);
             NpgsqlCommandBuilder.DeriveParameters(command);
-            
-            
             Assert.AreEqual(NpgsqlDbType.Integer, command.Parameters[0].NpgsqlDbType);
             Assert.AreEqual(NpgsqlDbType.Text, command.Parameters[1].NpgsqlDbType);
-
-            
-            
         }
-        
+
         [Test]
         public void CaseSensitiveParameterNames()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :p1", TheConnection);
-            
+            var command = new NpgsqlCommand("select :p1", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("P1", NpgsqlDbType.Integer)).Value = 5;
-
-            
-            Object result = command.ExecuteScalar();
-            
+            var result = command.ExecuteScalar();
             Assert.AreEqual(5, result);
-            
         }
-
 
         [Test]
         public void FunctionTestTimestamptzParameterSupport()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand("testtimestamptzparameter", TheConnection);
+            var command = new NpgsqlCommand("testtimestamptzparameter", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
             command.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.TimestampTZ));
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            Int32 count = 0;
-            
-            while (dr.Read())
-                count++;
-
-            Assert.IsTrue(count > 1);
-            
-            
-            
-            
-            
-            
+            using (var dr = command.ExecuteReader())
+            {
+                var count = 0;
+                while (dr.Read())
+                    count++;
+                Assert.IsTrue(count > 1);
+            }
         }
-        
+
         [Test]
         public void GreaterThanInQueryStringWithPrepare()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select count(*) from tablea where field_serial >:param1", TheConnection);
-            
+            var command = new NpgsqlCommand("select count(*) from tablea where field_serial >:param1", TheConnection);
             command.Parameters.AddWithValue(":param1", 1);
-            
-
             command.Prepare();
             command.ExecuteScalar();
-            
-            
         }
-        
+
         [Test]
         public void CharParameterValueSupport()
         {
             const String query = @"create temp table test ( tc char(1) );
-            insert into test values(' ');
-            select * from test where tc=:charparam";
-
-            NpgsqlCommand command = new NpgsqlCommand(query, TheConnection);
-
-            IDbDataParameter sqlParam = command.CreateParameter();
+                                   insert into test values(' ');
+                                   select * from test where tc=:charparam";
+            var command = new NpgsqlCommand(query, TheConnection);
+            var sqlParam = command.CreateParameter();
             sqlParam.ParameterName = "charparam";
-            
+
             // Exception Can't cast System.Char into any valid DbType.
             sqlParam.Value = ' ';
             command.Parameters.Add(sqlParam);
+            var res = (String) command.ExecuteScalar();
 
-            String res = (String)command.ExecuteScalar();
-            
-            Assert.AreEqual(" ", res);                    
-            
-            
+            Assert.AreEqual(" ", res);
         }
+
         [Test]
         public void ConnectionStringCommandTimeout()
         {
-           /* NpgsqlConnection connection = new NpgsqlConnection("Server=localhost; Database=test; User=postgres; Password=12345;
-CommandTimeout=180");
-NpgsqlCommand command = new NpgsqlCommand("\"Foo\"", connection);
-connection.Open();*/
-
-	
-			
-	        using (NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString + ";CommandTimeout=180;pooling=false"))
+            /* NpgsqlConnection connection = new NpgsqlConnection("Server=localhost; Database=test; User=postgres; Password=12345;
+ CommandTimeout=180");
+ NpgsqlCommand command = new NpgsqlCommand("\"Foo\"", connection);
+ connection.Open();*/
+            using (var conn = new NpgsqlConnection(TheConnectionString + ";CommandTimeout=180;pooling=false"))
             {
-                
-                
-		NpgsqlCommand command = new NpgsqlCommand("\"Foo\"", conn);
+                var command = new NpgsqlCommand("\"Foo\"", conn);
                 conn.Open();
-                
                 Assert.AreEqual(180, command.CommandTimeout);
             }
-            
-            
         }
-        
-         [Test]
+
+        [Test]
         public void ParameterExplicitType()
         {
-            
             object param = 1;
-            
-            using(NpgsqlCommand cmd = new NpgsqlCommand("select a, max(b) from (select :param as a, 1 as b) x group by a", TheConnection))
+
+            using (NpgsqlCommand cmd = new NpgsqlCommand("select a, max(b) from (select :param as a, 1 as b) x group by a", TheConnection))
             {
                 cmd.Parameters.AddWithValue("param", param);
                 cmd.Parameters[0].DbType = DbType.Int32;
-                
-                using(IDataReader rdr = cmd.ExecuteReader(CommandBehavior.SingleRow))
+
+                using (var rdr = cmd.ExecuteReader(CommandBehavior.SingleRow))
                 {
                     rdr.Read();
                 }
 
                 param = "text";
                 cmd.Parameters[0].DbType = DbType.String;
-                using(IDataReader rdr = cmd.ExecuteReader(CommandBehavior.SingleRow))
+                using (var rdr = cmd.ExecuteReader(CommandBehavior.SingleRow))
                 {
                     rdr.Read();
                 }
-            
             }
         }
-        
+
 
         [Test]
         public void ParameterExplicitType2()
         {
-
-            const string query = @"create temp table test ( tc date );  select * from test where tc=:param";
-        
-            NpgsqlCommand command = new NpgsqlCommand(query, TheConnection);
-
-           IDbDataParameter sqlParam = command.CreateParameter();
-           sqlParam.ParameterName = "param";
-           sqlParam.Value = "2008-1-1";
-           //sqlParam.DbType = DbType.Object;
-           command.Parameters.Add(sqlParam);
-           
-          
-           command.ExecuteScalar();
+            var command = new NpgsqlCommand(@"create temp table test ( tc date );  select * from test where tc=:param", TheConnection);
+            var sqlParam = command.CreateParameter();
+            sqlParam.ParameterName = "param";
+            sqlParam.Value = "2008-1-1";
+            //sqlParam.DbType = DbType.Object;
+            command.Parameters.Add(sqlParam);
+            command.ExecuteScalar();
         }
-        
+
         [Test]
         public void ParameterExplicitType2DbTypeObject()
         {
-
-            const string query = @"create temp table test ( tc date );  select * from test where tc=:param";
-        
-            NpgsqlCommand command = new NpgsqlCommand(query, TheConnection);
-
-           IDbDataParameter sqlParam = command.CreateParameter();
-           sqlParam.ParameterName = "param";
-           sqlParam.Value = "2008-1-1";
-           sqlParam.DbType = DbType.Object;
-           command.Parameters.Add(sqlParam);
-           
-           
-           command.ExecuteScalar();
+            var command = new NpgsqlCommand(@"create temp table test ( tc date );  select * from test where tc=:param", TheConnection);
+            var sqlParam = command.CreateParameter();
+            sqlParam.ParameterName = "param";
+            sqlParam.Value = "2008-1-1";
+            sqlParam.DbType = DbType.Object;
+            command.Parameters.Add(sqlParam);
+            command.ExecuteScalar();
         }
-        
+
         [Test]
         public void ParameterExplicitType2DbTypeObjectWithPrepare()
         {
-
             new NpgsqlCommand("create temp table test ( tc date )", TheConnection).ExecuteNonQuery();
-        
-            const string query = @"select * from test where tc=:param";
-        
-            NpgsqlCommand command = new NpgsqlCommand(query, TheConnection);
+            var command = new NpgsqlCommand(@"select * from test where tc=:param", TheConnection);
 
-            IDbDataParameter sqlParam = command.CreateParameter();
+            var sqlParam = command.CreateParameter();
             sqlParam.ParameterName = "param";
             sqlParam.Value = "2008-1-1";
             sqlParam.DbType = DbType.Object;
             command.Parameters.Add(sqlParam);
-           
             command.Prepare();
-           
             command.ExecuteScalar();
         }
-        
+
         [Test]
         public void ParameterExplicitType2DbTypeObjectWithPrepare2()
         {
-
             new NpgsqlCommand("create temp table test ( tc date )", TheConnection).ExecuteNonQuery();
-            
-            const string query = @"select * from test where tc=:param or tc=:param2";
-        
-            NpgsqlCommand command = new NpgsqlCommand(query, TheConnection);
+            var command = new NpgsqlCommand(@"select * from test where tc=:param or tc=:param2", TheConnection);
 
-            IDbDataParameter sqlParam = command.CreateParameter();
+            var sqlParam = command.CreateParameter();
             sqlParam.ParameterName = "param";
             sqlParam.Value = "2008-1-1";
             sqlParam.DbType = DbType.Object;
             command.Parameters.Add(sqlParam);
-            
+
             sqlParam = command.CreateParameter();
             sqlParam.ParameterName = "param2";
             sqlParam.Value = DateTime.Now;
             sqlParam.DbType = DbType.Date;
             command.Parameters.Add(sqlParam);
-            
+
             command.Prepare();
-            
             command.ExecuteScalar();
         }
 
         [Test]
         public void Int32WithoutQuotesPolygon()
         {
-
-            NpgsqlCommand a = new NpgsqlCommand("select 'polygon ((:a :b))' ", TheConnection);
+            var a = new NpgsqlCommand("select 'polygon ((:a :b))' ", TheConnection);
             a.Parameters.Add(new NpgsqlParameter("a", 1));
             a.Parameters.Add(new NpgsqlParameter("b", 1));
-            
             a.ExecuteScalar();
-                      
-                 
         }
-        
+
         [Test]
         public void Int32WithoutQuotesPolygon2()
         {
-
-            NpgsqlCommand a = new NpgsqlCommand("select 'polygon ((:a :b))' ", TheConnection);
+            var a = new NpgsqlCommand("select 'polygon ((:a :b))' ", TheConnection);
             a.Parameters.Add(new NpgsqlParameter("a", 1)).DbType = DbType.Int32;
             a.Parameters.Add(new NpgsqlParameter("b", 1)).DbType = DbType.Int32;
-            
             a.ExecuteScalar();
-                      
-                 
         }
-        
+
         [Test]
         public void TestUUIDDataType()
         {
-
-            string createTable =
-            @"DROP TABLE if exists public.person;
-            CREATE TABLE public.person ( 
-            person_id serial PRIMARY KEY NOT NULL,
-            person_uuid uuid NOT NULL
-            ) WITH(OIDS=FALSE);";
-            NpgsqlCommand command = new NpgsqlCommand(createTable, TheConnection);
+            const string createTable =
+                @"DROP TABLE if exists public.person;
+                  CREATE TABLE public.person ( 
+                    person_id serial PRIMARY KEY NOT NULL,
+                    person_uuid uuid NOT NULL
+                  ) WITH(OIDS=FALSE);";
+            var command = new NpgsqlCommand(createTable, TheConnection);
             command.ExecuteNonQuery();
 
-            string insertSql = "INSERT INTO person (person_uuid) VALUES (:param1);";
             NpgsqlParameter uuidDbParam = new NpgsqlParameter(":param1", NpgsqlDbType.Uuid);
             uuidDbParam.Value = Guid.NewGuid();
 
-            command = new NpgsqlCommand(insertSql, TheConnection);
+            command = new NpgsqlCommand(@"INSERT INTO person (person_uuid) VALUES (:param1);", TheConnection);
             command.Parameters.Add(uuidDbParam);
             command.ExecuteNonQuery();
 
             command = new NpgsqlCommand("SELECT person_uuid::uuid FROM person LIMIT 1", TheConnection);
-
-
-            object result = command.ExecuteScalar();
-            Assert.AreEqual(typeof(Guid), result.GetType());
+            var result = command.ExecuteScalar();
+            Assert.AreEqual(typeof (Guid), result.GetType());
         }
-        
+
         [Test]
         public void TestBug1006158OutputParameters()
         {
-
-            string createFunction =
-            @"CREATE OR REPLACE FUNCTION more_params(OUT a integer, OUT b boolean) AS
+            const string createFunction =
+                @"CREATE OR REPLACE FUNCTION more_params(OUT a integer, OUT b boolean) AS
             $BODY$DECLARE
                 BEGIN
                     a := 3;
                     b := true;
                 END;$BODY$
               LANGUAGE 'plpgsql' VOLATILE;";
-              
-            NpgsqlCommand command = new NpgsqlCommand(createFunction, TheConnection);
+
+            var command = new NpgsqlCommand(createFunction, TheConnection);
             command.ExecuteNonQuery();
 
             command = new NpgsqlCommand("more_params", TheConnection);
@@ -3219,115 +2495,96 @@ connection.Open();*/
             command.Parameters.Add(new NpgsqlParameter("b", DbType.Boolean));
             command.Parameters[1].Direction = ParameterDirection.Output;
 
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
 
             Assert.AreEqual(3, command.Parameters[0].Value);
             Assert.AreEqual(true, command.Parameters[1].Value);
         }
-        
-        
+
+
         [Test]
         public void TestSavePoint()
         {
-            
             if (TheConnection.PostgreSqlVersion < new Version("8.0.0"))
                 return;
-                
+
             const String theSavePoint = "theSavePoint";
-            
+
             TheTransaction.Save(theSavePoint);
-            
+
             new NpgsqlCommand("insert into tablea (field_text) values ('savepointtest')", TheConnection).ExecuteNonQuery();
-            
-            object result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection).ExecuteScalar();
-            
+
+            var result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection).ExecuteScalar();
             Assert.AreEqual(1, result);
-            
+
             TheTransaction.Rollback(theSavePoint);
-            
+
             result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection).ExecuteScalar();
-            
             Assert.AreEqual(0, result);
-            
         }
-        
+
         [Test]
-        [ExpectedException(typeof(InvalidOperationException))]
+        [ExpectedException(typeof (InvalidOperationException))]
         public void TestSavePointWithSemicolon()
         {
             if (TheConnection.PostgreSqlVersion < new Version("8.0.0"))
-                // Fake exception just to make test pass;
-                throw new InvalidOperationException();
-            
+                Assert.Ignore("Not supported on Postgres version {0} (< 8.0.0)", TheConnection.PostgreSqlVersion);
+
             const String theSavePoint = "theSavePoint;";
-            
+
             TheTransaction.Save(theSavePoint);
-            
+
             new NpgsqlCommand("insert into tablea (field_text) values ('savepointtest')", TheConnection).ExecuteNonQuery();
-            
-            object result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection).ExecuteScalar();
-            
+
+            var result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection) .ExecuteScalar();
             Assert.AreEqual(1, result);
-            
+
             TheTransaction.Rollback(theSavePoint);
-            
+
             result = new NpgsqlCommand("select count(*) from tablea where field_text = 'savepointtest'", TheConnection).ExecuteScalar();
-            
             Assert.AreEqual(0, result);
-            
         }
-        
+
         [Test]
         public void TestPreparedStatementParameterCastIsNotAdded()
         {
             // Test by Waldemar Bergstreiser            
 
             new NpgsqlCommand("create table testpreparedstatementparametercast ( C1 int );", TheConnection).ExecuteNonQuery();
-            IDbCommand cmd = new NpgsqlCommand("select C1 from testpreparedstatementparametercast where :p0 is null or  C1 = :p0 ", TheConnection);
-            
-            IDbDataParameter paramP0 = cmd.CreateParameter();
+            var cmd = new NpgsqlCommand("select C1 from testpreparedstatementparametercast where :p0 is null or  C1 = :p0 ", TheConnection);
+
+            var paramP0 = cmd.CreateParameter();
             paramP0.ParameterName = "p0";
             paramP0.DbType = DbType.Int32;
-        cmd.Parameters.Add(paramP0);
-            cmd.Prepare();    // This cause a runtime exception // Tested with PostgreSQL 8.3 //
-             
-           
-            
+            cmd.Parameters.Add(paramP0);
+            cmd.Prepare(); // This cause a runtime exception // Tested with PostgreSQL 8.3 //
         }
-        
+
         [Test]
-        [ExpectedException(typeof(NpgsqlException))]
+        [ExpectedException(typeof (NpgsqlException))]
         public void TestErrorInPreparedStatementCausesReleaseConnectionToThrowException()
         {
             // This is caused by having an error with the prepared statement and later, Npgsql is trying to release the plan as it was successful created.             
-
-            IDbCommand cmd = new NpgsqlCommand("sele", TheConnection);
-            
-                cmd.Prepare();    
-             
-            
-        
+            var cmd = new NpgsqlCommand("sele", TheConnection);
+            cmd.Prepare();
         }
-        
+
         [Test]
         public void TestBug1010488ArrayParameterWithNullValue()
         {
             // Test by Christ Akkermans       
-            
             new NpgsqlCommand(@"CREATE OR REPLACE FUNCTION NullTest (input INT4[]) RETURNS VOID                             
             AS $$
             DECLARE
             BEGIN
             END
             $$ LANGUAGE plpgsql;", TheConnection).ExecuteNonQuery();
-            
-            using (NpgsqlCommand cmd = new NpgsqlCommand("NullTest", TheConnection))
-            {
 
-                NpgsqlParameter parameter = new NpgsqlParameter("", NpgsqlDbType.Integer | NpgsqlDbType.Array);
-                parameter.Value = new object[] { 5, 5, DBNull.Value };
+            using (var cmd = new NpgsqlCommand("NullTest", TheConnection))
+            {
+                var parameter = new NpgsqlParameter("", NpgsqlDbType.Integer | NpgsqlDbType.Array);
+                parameter.Value = new object[] {5, 5, DBNull.Value};
                 cmd.Parameters.Add(parameter);
- 
                 cmd.CommandType = System.Data.CommandType.StoredProcedure;
                 cmd.ExecuteNonQuery();
             }
@@ -3343,13 +2600,11 @@ connection.Open();*/
             END
             $$ LANGUAGE plpgsql;", TheConnection).ExecuteNonQuery();
 
-            using (NpgsqlCommand cmd = new NpgsqlCommand("NullTest", TheConnection))
+            using (var cmd = new NpgsqlCommand("NullTest", TheConnection))
             {
-
                 NpgsqlParameter parameter = new NpgsqlParameter("", NpgsqlDbType.Integer | NpgsqlDbType.Array);
-                parameter.Value = new object[] { 5, 5, null };
+                parameter.Value = new object[] {5, 5, null};
                 cmd.Parameters.Add(parameter);
-
                 cmd.CommandType = System.Data.CommandType.StoredProcedure;
                 cmd.ExecuteNonQuery();
             }
@@ -3358,306 +2613,241 @@ connection.Open();*/
         [Test]
         public void VarCharArrayHandling()
         {
-            
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Varchar | NpgsqlDbType.Array);
-                parameter.Value = new object[] { "test", "test"};
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Varchar | NpgsqlDbType.Array);
+                parameter.Value = new object[] {"test", "test"};
                 cmd.Parameters.Add(parameter);
- 
                 cmd.ExecuteNonQuery();
             }
-            
-            
         }
-        
+
         [Test]
         public void DoubleArrayHandling()
         {
-            
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                Double[] inVal = new Double[] { 1.2d, 1.3d };
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                var inVal = new[] {1.2d, 1.3d};
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
                 parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
 
-                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                var retVal = (Double[]) cmd.ExecuteScalar();
                 Assert.AreEqual(inVal.Length, retVal.Length);
                 Assert.AreEqual(inVal[0], retVal[0]);
                 Assert.AreEqual(inVal[1], retVal[1]);
             }
-            
         }
-
 
         [Test]
         public void DoubleArrayHandlingZeroItem()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                Double[] inVal = new Double[] { };
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                var inVal = new Double[] {};
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
                 parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
-
-                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                var retVal = (Double[]) cmd.ExecuteScalar();
                 Assert.AreEqual(inVal.Length, retVal.Length);
             }
-
         }
-        
+
         [Test]
         public void DoubleArrayHandlingPrepared()
         {
-            
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-                Double[] inVal = new Double[] { 1.2d, 1.3d };
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                var inVal = new[] {1.2d, 1.3d};
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
                 parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
-                
                 cmd.Prepare();
 
-                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                var retVal = (Double[]) cmd.ExecuteScalar();
                 Assert.AreEqual(inVal.Length, retVal.Length);
                 Assert.AreEqual(inVal[0], retVal[0]);
                 Assert.AreEqual(inVal[1], retVal[1]);
             }
-            
-            
         }
 
         [Test]
         public void DoubleArrayHandlingZeroItemPrepared()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-                Double[] inVal = new Double[] { };
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
+                var inVal = new Double[] {};
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double | NpgsqlDbType.Array);
                 parameter.Value = inVal;
                 cmd.Parameters.Add(parameter);
-
                 cmd.Prepare();
 
-                Double[] retVal = (Double[])cmd.ExecuteScalar();
+                var retVal = (Double[]) cmd.ExecuteScalar();
                 Assert.AreEqual(inVal.Length, retVal.Length);
             }
-
         }
 
-        
         [Test]
         public void Bug1010521NpgsqlIntervalShouldBeQuoted()
         {
-            
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Interval);
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Interval);
                 parameter.Value = new NpgsqlInterval(DateTime.Now.TimeOfDay);
                 cmd.Parameters.Add(parameter);
- 
                 cmd.ExecuteNonQuery();
             }
-            
-            
         }
 
         [Test]
         public void Bug1010543Int32MinValueThrowException()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Integer);
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Integer);
                 parameter.Value = Int32.MinValue;
                 cmd.Parameters.Add(parameter);
-
                 cmd.ExecuteNonQuery();
             }
-
-
         }
 
         [Test]
         public void Bug1010543Int16MinValueThrowException()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", DbType.Int16);
+                var parameter = new NpgsqlParameter("p1", DbType.Int16);
                 parameter.Value = Int16.MinValue;
                 cmd.Parameters.Add(parameter);
-
                 cmd.ExecuteNonQuery();
             }
-
-
-
         }
+
         [Test]
         public void Bug1010543Int16MinValueThrowExceptionPrepared()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", DbType.Int16);
+                var parameter = new NpgsqlParameter("p1", DbType.Int16);
                 parameter.Value = Int16.MinValue;
                 cmd.Parameters.Add(parameter);
-
                 cmd.Prepare();
                 cmd.ExecuteNonQuery();
             }
-
-
-
         }
 
         [Test]
         public void HandleInt16MinValueParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
             command.Parameters[0].Value = Int16.MinValue;
-
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int16.MinValue, result);
         }
 
         [Test]
         public void HandleInt32MinValueParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
             command.Parameters[0].Value = Int32.MinValue;
-
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int32.MinValue, result);
         }
 
         [Test]
         public void HandleInt64MinValueParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int64));
             command.Parameters[0].Value = Int64.MinValue;
-            
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int64.MinValue, result);
         }
 
         [Test]
         public void HandleInt16MinValueParameterPrepared()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
             command.Parameters[0].Value = Int16.MinValue;
             command.Prepare();
-
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int16.MinValue, result);
         }
 
         [Test]
         public void HandleInt32MinValueParameterPrepared()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
             command.Parameters[0].Value = Int32.MinValue;
             command.Prepare();
-
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int32.MinValue, result);
         }
 
         [Test]
         public void HandleInt64MinValueParameterPrepared()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :a", TheConnection);
+            var command = new NpgsqlCommand("select :a", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int64));
             command.Parameters[0].Value = Int64.MinValue;
             command.Prepare();
-
-            Object result = command.ExecuteScalar();
+            var result = command.ExecuteScalar();
             Assert.AreEqual(Int64.MinValue, result);
         }
-
 
         [Test]
         public void Bug1010557BackslashGetDoubled()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Text);
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Text);
                 parameter.Value = "test\\str";
                 cmd.Parameters.Add(parameter);
-
-                object result = cmd.ExecuteScalar();
-                Assert.AreEqual("test\\str", result); 
+                var result = cmd.ExecuteScalar();
+                Assert.AreEqual("test\\str", result);
             }
-
-
         }
 
         [Test]
         public void NumberConversionWithCulture()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p1", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p1", TheConnection))
             {
-
                 Thread.CurrentThread.CurrentCulture = new CultureInfo("es-ES");
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double);
+                var parameter = new NpgsqlParameter("p1", NpgsqlDbType.Double);
                 parameter.Value = 5.5;
                 cmd.Parameters.Add(parameter);
-
-                object result = cmd.ExecuteScalar();
-
+                var result = cmd.ExecuteScalar();
                 Thread.CurrentThread.CurrentCulture = new CultureInfo("");
                 Assert.AreEqual(5.5, result);
-
             }
-
-
         }
-        
+
         [Test]
         public void TestNullParameterValueInStatement()
         {
             // Test by Andrus Moor
-            IDbCommand cmd = TheConnection.CreateCommand();
+            var cmd = TheConnection.CreateCommand();
             int? i = null;
             cmd.Parameters.Add(new NpgsqlParameter("p0", i));
             cmd.CommandText = "select :p0 is null or :p0=0 ";
-            
             cmd.ExecuteScalar();
         }
-        
+
         [Test]
         public void PreparedStatementWithParametersWithSize()
         {
-
-            using (NpgsqlCommand cmd = new NpgsqlCommand("select :p0, :p1;", TheConnection))
+            using (var cmd = new NpgsqlCommand("select :p0, :p1;", TheConnection))
             {
-
-                NpgsqlParameter parameter = new NpgsqlParameter("p0", NpgsqlDbType.Varchar);
+                var parameter = new NpgsqlParameter("p0", NpgsqlDbType.Varchar);
                 parameter.Value = "test";
                 parameter.Size = 10;
                 cmd.Parameters.Add(parameter);
-                
+
                 parameter = new NpgsqlParameter("p1", NpgsqlDbType.Varchar);
                 parameter.Value = "test";
                 parameter.Size = 10;
@@ -3666,134 +2856,86 @@ connection.Open();*/
                 cmd.Prepare();
                 cmd.ExecuteNonQuery();
             }
-
-
-
         }
 
         [Test]
         public void CommandTimeoutReset()
         {
-
-            NpgsqlCommand cmd = new NpgsqlCommand();
-
+            var cmd = new NpgsqlCommand();
             cmd.CommandTimeout = Int32.MaxValue;
-
             cmd.Connection = TheConnection;
-
             Assert.AreEqual(Int32.MaxValue, cmd.CommandTimeout);
-
-
-
         }
-        
+
         [Test]
         public void SelectInfinityValueDateDataType()
         {
-            IDbCommand cmd = TheConnection.CreateCommand();
+            var cmd = TheConnection.CreateCommand();
             cmd.CommandText = "create temp table test (dt date); insert into test values ('-infinity'::date);select * from test";
-            var dr = cmd.ExecuteReader();
-            dr.Read();
-           // InvalidCastException was unhandled
-          // at Npgsql.ForwardsOnlyDataReader.GetValue(Int32 Index)
-          //  at Npgsql.NpgsqlDataReader.GetDateTime(Int32 i) ..
-
-            dr.GetDateTime(0);
-
-            dr.Close();
-
+            using (var dr = cmd.ExecuteReader())
+            {
+                dr.Read();
+                // InvalidCastException was unhandled
+                // at Npgsql.ForwardsOnlyDataReader.GetValue(Int32 Index)
+                //  at Npgsql.NpgsqlDataReader.GetDateTime(Int32 i) ..
+                dr.GetDateTime(0);
+            }
         }
-
-
 
         [Test]
-
         public void DeriveParametersWithParameterNameFromFunction()
-
         {
-
-            NpgsqlCommand command = new NpgsqlCommand("testoutparameter2", TheConnection);
-
+            var command = new NpgsqlCommand("testoutparameter2", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-
-
             NpgsqlCommandBuilder.DeriveParameters(command);
-
-
-
             Assert.AreEqual(":x", command.Parameters[0].ParameterName);
-
             Assert.AreEqual(":y", command.Parameters[1].ParameterName);
-
-            
-
-
-
         }
-        
+
         [Test]
         public void NegativeMoneySupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select '-10.5'::money", TheConnection);
-
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(0);
-
-            dr.Close();
-
-            Assert.AreEqual(-10.5, result);
-            
-            
+            var command = new NpgsqlCommand("select '-10.5'::money", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(0);
+                Assert.AreEqual(-10.5, result);
+            }
         }
 
         [Test]
         public void Bug1011085()
         {
             // Money format is not set in accordance with the system locale format
-
-            NpgsqlCommand command = new NpgsqlCommand("select :moneyvalue", TheConnection);
-            Decimal expectedValue = 8.99m;
-
-            command.Parameters.Add ("moneyvalue", NpgsqlDbType.Money).Value = expectedValue;
-
-            Decimal result = (Decimal) command.ExecuteScalar ();
+            var command = new NpgsqlCommand("select :moneyvalue", TheConnection);
+            var expectedValue = 8.99m;
+            command.Parameters.Add("moneyvalue", NpgsqlDbType.Money).Value = expectedValue;
+            var result = (Decimal) command.ExecuteScalar();
             Assert.AreEqual(expectedValue, result);
 
             expectedValue = 100m;
-            command.Parameters [0].Value = expectedValue;
-            result = (Decimal) command.ExecuteScalar ();
+            command.Parameters[0].Value = expectedValue;
+            result = (Decimal) command.ExecuteScalar();
             Assert.AreEqual(expectedValue, result);
 
             expectedValue = 72.25m;
-            command.Parameters [0].Value = expectedValue;
-            result = (Decimal) command.ExecuteScalar ();
+            command.Parameters[0].Value = expectedValue;
+            result = (Decimal) command.ExecuteScalar();
             Assert.AreEqual(expectedValue, result);
-
-
-
         }
-       
+
         [Test]
         public void Bug1010714AndPatch1010715()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
-            
-            Byte[] bytes = new Byte[]{45,44};
-            
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_bytea = :bytesData", TheConnection);
+            var bytes = new Byte[] {45, 44};
             command.Parameters.AddWithValue(":bytesData", bytes);
-            
             Assert.AreEqual(DbType.Binary, command.Parameters[0].DbType);
-            
-            Object result = command.ExecuteNonQuery();
-            
-
+            var result = command.ExecuteNonQuery();
             Assert.AreEqual(-1, result);
         }
-        
+
         [Test]
         public void TestNpgsqlSpecificTypesCLRTypesNpgsqlInet()
         {
@@ -3801,49 +2943,32 @@ connection.Open();*/
             // for a discussion where an NpgsqlInet type isn't shown in a datagrid
             // This test tries to check if the type returned is an IPAddress when using
             // the GetValue() of NpgsqlDataReader and NpgsqlInet when using GetProviderValue();
-            
-            NpgsqlCommand command = new NpgsqlCommand("select '192.168.10.10'::inet;", TheConnection);
-            
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
 
-            Object result = dr.GetValue(0);
-            
-            dr.Close();
-            
-
-            Assert.AreEqual(typeof(IPAddress), result.GetType());
-            
-            
+            var command = new NpgsqlCommand("select '192.168.10.10'::inet;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetValue(0);
+                Assert.AreEqual(typeof (IPAddress), result.GetType());
+            }
         }
 
         [Test]
         public void Bug1011100NpgsqlParameterandDBNullValue()
         {
-
-            using (Npgsql.NpgsqlCommand cmd = new Npgsql.NpgsqlCommand(
-            "select :BLOB"))
+            using (var cmd = new NpgsqlCommand("select :BLOB"))
             {
                 cmd.Connection = TheConnection;
 
-                Npgsql.NpgsqlParameter paramBLOB = new Npgsql.NpgsqlParameter();
+                var paramBLOB = new NpgsqlParameter();
                 paramBLOB.ParameterName = "BLOB";
                 cmd.Parameters.Add(paramBLOB);
-
                 cmd.Parameters[0].Value = DBNull.Value;
-                
-                
                 Assert.AreEqual(DbType.String, cmd.Parameters[0].DbType);
 
-
-
-                cmd.Parameters[0].Value = new byte[] { 1, 2, 3 };
-
-
+                cmd.Parameters[0].Value = new byte[] {1, 2, 3};
                 Assert.AreEqual(DbType.Binary, cmd.Parameters[0].DbType);
             }
-
         }
 
         [Test]
@@ -3853,25 +2978,18 @@ connection.Open();*/
             // for a discussion where an NpgsqlInet type isn't shown in a datagrid
             // This test tries to check if the type returned is an IPAddress when using
             // the GetValue() of NpgsqlDataReader and NpgsqlInet when using GetProviderValue();
-            
-            NpgsqlCommand command = new NpgsqlCommand("select '2010-01-17 15:45'::timestamp;", TheConnection);
-            
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-            dr.Read();
 
-            Object result = dr.GetValue(0);
-            Object result2 = dr.GetProviderSpecificValue(0);
-            
-            dr.Close();
-            
-
-            Assert.AreEqual(typeof(DateTime), result.GetType());
-            Assert.AreEqual(typeof(NpgsqlTimeStamp), result2.GetType());
-            
-            
+            var command = new NpgsqlCommand("select '2010-01-17 15:45'::timestamp;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetValue(0);
+                var result2 = dr.GetProviderSpecificValue(0);
+                Assert.AreEqual(typeof (DateTime), result.GetType());
+                Assert.AreEqual(typeof (NpgsqlTimeStamp), result2.GetType());
+            }
         }
-        
+
         [Test]
         public void TimeoutFirstParameters()
         {
@@ -3879,7 +2997,7 @@ connection.Open();*/
             //regardless of this setting, Npgsql will always use the E string prefix when possible,
             //therefore, this test is not fully functional on version 2.
  
-            NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString);
+            var conn = new NpgsqlConnection(TheConnectionString);
             conn.Open();
             try//the next command will fail on earlier postgres versions, but that is not a bug in itself.
             {
@@ -3887,23 +3005,30 @@ connection.Open();*/
             }
             catch{}
 
-            NpgsqlCommand command = new NpgsqlCommand("SELECT :dummy, pg_sleep(1.5)", conn);
-            command.Parameters.Add(new NpgsqlParameter("dummy", NpgsqlDbType.Text));
-            command.Parameters[0].Value = "foo";
-            command.CommandTimeout = 1;
-            try
-            {
-                command.ExecuteNonQuery();
-                Assert.Fail("1.5s command survived a 1s timeout");
-            }
-            catch (NpgsqlException)
-            {
-                // We cannot currently identify that the exception was a timeout
-                // in a locale-independent fashion, so just assume so.
-            }
-            finally
-            {
-                conn.Close();
+            using (conn = new NpgsqlConnection(TheConnectionString)) {
+                conn.Open();
+                try //the next command will fail on earlier postgres versions, but that is not a bug in itself.
+                {
+                    new NpgsqlCommand("set standard_conforming_strings=off", conn).ExecuteNonQuery();
+                }
+                catch
+                {
+                }
+
+                var command = new NpgsqlCommand("SELECT :dummy, pg_sleep(1.5)", conn);
+                command.Parameters.Add(new NpgsqlParameter("dummy", NpgsqlDbType.Text));
+                command.Parameters[0].Value = "foo";
+                command.CommandTimeout = 1;
+                try
+                {
+                    command.ExecuteNonQuery();
+                    Assert.Fail("1.5s command survived a 1s timeout");
+                }
+                catch (NpgsqlException)
+                {
+                    // We cannot currently identify that the exception was a timeout
+                    // in a locale-independent fashion, so just assume so.
+                }
             }
         }
 
@@ -3913,212 +3038,148 @@ connection.Open();*/
             // Function calls entail internal queries; verify that they do not
             // sabotage the requested timeout.
 
-            NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString);
-            conn.Open();
+            using (var conn = new NpgsqlConnection(TheConnectionString)) {
+                conn.Open();
 
-            NpgsqlCommand command = new NpgsqlCommand("pg_sleep", conn);
-            command.CommandType = CommandType.StoredProcedure;
-            command.Parameters.Add(new NpgsqlParameter());
-            command.Parameters[0].NpgsqlDbType = NpgsqlDbType.Double;
-            command.Parameters[0].Value = 1.5;
-            command.CommandTimeout = 1;
-            try
-            {
-                command.ExecuteNonQuery();
-                Assert.Fail("1.5s function call survived a 1s timeout");
+                var command = new NpgsqlCommand("pg_sleep", conn);
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.Add(new NpgsqlParameter());
+                command.Parameters[0].NpgsqlDbType = NpgsqlDbType.Double;
+                command.Parameters[0].Value = 1.5;
+                command.CommandTimeout = 1;
+                try
+                {
+                    command.ExecuteNonQuery();
+                    Assert.Fail("1.5s function call survived a 1s timeout");
+                }
+                catch (NpgsqlException)
+                {
+                    // We cannot currently identify that the exception was a timeout
+                    // in a locale-independent fashion, so just assume so.
+                }
             }
-            catch (NpgsqlException)
-            {
-                // We cannot currently identify that the exception was a timeout
-                // in a locale-independent fashion, so just assume so.
-            }
-            finally
-            {
-                conn.Close();
-            }
-        }    
-        
+        }
+
         [Test]
         public void Bug1010788UpdateRowSource()
         {
-
-            using(NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString))
+            using (var conn = new NpgsqlConnection(TheConnectionString))
             {
                 conn.Open();
-    
-                NpgsqlCommand command = new NpgsqlCommand("select * from tableB", conn);
-    
+                var command = new NpgsqlCommand("select * from tableB", conn);
                 Assert.AreEqual(UpdateRowSource.Both, command.UpdatedRowSource);
-    
-                NpgsqlCommandBuilder cmdBuilder = new NpgsqlCommandBuilder();
-    
-                NpgsqlDataAdapter da = new NpgsqlDataAdapter(command);
-    
-                cmdBuilder.DataAdapter = da;
-    
-                Assert.IsNotNull(da.SelectCommand);
-    
-                Assert.IsNotNull(cmdBuilder.DataAdapter);
-                
-                
-                NpgsqlCommand updateCommand = cmdBuilder.GetUpdateCommand();
-    
-                Assert.AreEqual(UpdateRowSource.None, updateCommand.UpdatedRowSource);
-    
-            }
 
-            
+                var cmdBuilder = new NpgsqlCommandBuilder();
+                var da = new NpgsqlDataAdapter(command);
+                cmdBuilder.DataAdapter = da;
+                Assert.IsNotNull(da.SelectCommand);
+                Assert.IsNotNull(cmdBuilder.DataAdapter);
+
+                NpgsqlCommand updateCommand = cmdBuilder.GetUpdateCommand();
+                Assert.AreEqual(UpdateRowSource.None, updateCommand.UpdatedRowSource);
+            }
         }
 
         [Test]
         public void VerifyFunctionWithNoParametersWithDeriveParameters()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcb", TheConnection);
+            var command = new NpgsqlCommand("funcb", TheConnection);
             NpgsqlCommandBuilder.DeriveParameters(command);
         }
 
         [Test]
         public void DataTypeTests()
         {
-
             // Test all types according to this table:
             // http://www.postgresql.org/docs/9.1/static/datatype.html
 
             // bigint
-
-            NpgsqlCommand cmd = new NpgsqlCommand("select 1::bigint", TheConnection);
-
-            Object result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Int64), result.GetType());
-
-            
+            var cmd = new NpgsqlCommand("select 1::bigint", TheConnection);
+            var result = cmd.ExecuteScalar();
+            Assert.AreEqual(typeof (Int64), result.GetType());
 
             // bit
-
             cmd.CommandText = "select '1'::bit(1)";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Boolean), result.GetType());
-
+            Assert.AreEqual(typeof (Boolean), result.GetType());
 
             // bit(2)
-
             cmd.CommandText = "select '11'::bit(2)";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(BitString), result.GetType());
-
+            Assert.AreEqual(typeof (BitString), result.GetType());
 
             // boolean
-
             cmd.CommandText = "select 1::boolean";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Boolean), result.GetType());
+            Assert.AreEqual(typeof (Boolean), result.GetType());
 
             // box
-
             cmd.CommandText = "select '((7,4),(8,3))'::box";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(NpgsqlBox), result.GetType());
+            Assert.AreEqual(typeof (NpgsqlBox), result.GetType());
 
             // bytea 
-
             cmd.CommandText = @"SELECT E'\\xDEADBEEF'::bytea;";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Byte[]), result.GetType());
-
+            Assert.AreEqual(typeof (Byte[]), result.GetType());
 
             // varchar(2)
-
             cmd.CommandText = "select 'aa'::varchar(2);";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(String), result.GetType());
+            Assert.AreEqual(typeof (String), result.GetType());
 
             // char(2)
-
             cmd.CommandText = "select 'aa'::char(2);";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(String), result.GetType());
+            Assert.AreEqual(typeof (String), result.GetType());
 
             // cidr
-
             cmd.CommandText = "select '192.168/24'::cidr";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(String), result.GetType());
-
-
+            Assert.AreEqual(typeof (String), result.GetType());
 
             // int4
-
             cmd.CommandText = "select 1::int4";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Int32), result.GetType());
+            Assert.AreEqual(typeof (Int32), result.GetType());
 
             // int8
-
             cmd.CommandText = "select 1::int8";
-
             result = cmd.ExecuteScalar();
-
-            Assert.AreEqual(typeof(Int64), result.GetType());
+            Assert.AreEqual(typeof (Int64), result.GetType());
 
 
             /*
             // time
-
             cmd.CommandText = "select current_time::time";
-
             result = cmd.ExecuteScalar();
-
             Assert.AreEqual(typeof(NpgsqlTime), result.GetType());
 
             // timetz
-
             cmd.CommandText = "select current_time::timetz";
-
             result = cmd.ExecuteScalar();
-
             Assert.AreEqual(typeof(NpgsqlTimeTZ), result.GetType());
             */
-            
-
-
-
-
         }
-
-
     }
-    
+
 
     [TestFixture]
     public class CommandTestsV2 : CommandTests
     {
-        protected override NpgsqlConnection TheConnection {
+        protected override NpgsqlConnection TheConnection
+        {
             get { return _connV2; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _tV2; }
             set { _tV2 = value; }
         }
-        protected override string TheConnectionString {
+
+        protected override string TheConnectionString
+        {
             get { return _connV2String; }
         }
     }

--- a/testsuite/noninteractive/NUnit20/ConnectionTests.cs
+++ b/testsuite/noninteractive/NUnit20/ConnectionTests.cs
@@ -35,71 +35,63 @@ namespace NpgsqlTests
     [TestFixture]
     public class ConnectionTests : BaseClassTests
     {
-        protected override NpgsqlConnection TheConnection {
+        protected override NpgsqlConnection TheConnection
+        {
             get { return _conn; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _t; }
             set { _t = value; }
         }
-        protected virtual string TheConnectionString {
+        protected virtual string TheConnectionString
+        {
             get { return _connString; }
         }
+
         [Test]
         public void ChangeDatabase()
         {
             TheConnection.ChangeDatabase("template1");
-
-            NpgsqlCommand command = new NpgsqlCommand("select current_database()", TheConnection);
-
-            String result = (String)command.ExecuteScalar();
-
+            var command = new NpgsqlCommand("select current_database()", TheConnection);
+            var result = (String)command.ExecuteScalar();
             Assert.AreEqual("template1", result);
         }
 
-		[Test]
-		public void ChangeDatabaseTestConnectionCache()
-		{
-			NpgsqlConnection conn1 = new NpgsqlConnection(TheConnectionString);
-			NpgsqlConnection conn2 = new NpgsqlConnection(TheConnectionString);
+        [Test]
+        public void ChangeDatabaseTestConnectionCache()
+        {
+            using (var conn1 = new NpgsqlConnection(TheConnectionString))
+            using (var conn2 = new NpgsqlConnection(TheConnectionString))
+            {
+                //	connection 1 change database
+                conn1.Open();
+                conn1.ChangeDatabase("template1");
+                var command = new NpgsqlCommand("select current_database()", conn1);
+                var db1 = (String)command.ExecuteScalar();
+                Assert.AreEqual("template1", db1);
 
-			NpgsqlCommand command;
-
-			//	connection 1 change database
-			conn1.Open();
-			conn1.ChangeDatabase("template1");
-			command = new NpgsqlCommand("select current_database()", conn1);
-			string db1 = (String)command.ExecuteScalar();
-
-			Assert.AreEqual("template1", db1);
-
-			//	connection 2 's database should not changed, so should different from conn1
-			conn2.Open();
-			command = new NpgsqlCommand("select current_database()", conn2);
-			string db2 = (String)command.ExecuteScalar();
-
-			Assert.AreNotEqual(db1, db2);
-
-			conn1.Close();
-			conn2.Close();
-		}
+                //	connection 2 's database should not changed, so should different from conn1
+                conn2.Open();
+                command = new NpgsqlCommand("select current_database()", conn2);
+                var db2 = (String)command.ExecuteScalar();
+                Assert.AreNotEqual(db1, db2);
+            }
+        }
 
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void NestedTransaction()
         {
-            NpgsqlTransaction t;
-                
-            t = TheConnection.BeginTransaction();
-            if(t == null)
-              return;
+            var t = TheConnection.BeginTransaction();
+            if (t == null)
+                return;
         }
 
         [Test]
         public void SequencialTransaction()
         {
             TheTransaction.Rollback();
-
             TheTransaction = TheConnection.BeginTransaction();
         }
 
@@ -108,146 +100,113 @@ namespace NpgsqlTests
         {
             try
             {
-                NpgsqlConnection conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j");
-
+                var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j");
                 conn.Open();
             }
-
             catch (NpgsqlException e)
             {
-				Type type_NpgsqlState = typeof(NpgsqlConnection).Assembly.GetType("Npgsql.NpgsqlState");
-				ResourceManager resman = new ResourceManager(type_NpgsqlState);
-				string expected = string.Format(resman.GetString("Exception_FailedConnection"), "127.0.0.1");
-				Assert.AreEqual(expected, e.Message);
+                var type_NpgsqlState = typeof(NpgsqlConnection).Assembly.GetType("Npgsql.NpgsqlState");
+                var resman = new ResourceManager(type_NpgsqlState);
+                var expected = string.Format(resman.GetString("Exception_FailedConnection"), "127.0.0.1");
+                Assert.AreEqual(expected, e.Message);
             }
         }
-		
-		[Test]
+
+        [Test]
         [ExpectedException(typeof(NpgsqlException))]
         public void ConnectionStringWithEqualSignValue()
         {
-            
-            NpgsqlConnection conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j==");
-            
+            var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j==");
             conn.Open();
-            
         }
-        
+
         [Test]
         [ExpectedException(typeof(NpgsqlException))]
         public void ConnectionStringWithSemicolonSignValue()
         {
-            
-            NpgsqlConnection conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password='j;'");
-            
+            var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password='j;'");
             conn.Open();
-            
         }
-        
+
         [Test]
         public void SearchPathSupport()
         {
-            
-            NpgsqlConnection conn = new NpgsqlConnection(TheConnectionString + ";searchpath=public");
-            try 
+            using (var conn = new NpgsqlConnection(TheConnectionString + ";searchpath=public"))
             {
                 conn.Open();
-            
-                NpgsqlCommand c = new NpgsqlCommand("show search_path", conn);
-                
-                String searchpath = (String) c.ExecuteScalar();
+                var c = new NpgsqlCommand("show search_path", conn);
+                var searchpath = (String)c.ExecuteScalar();
                 //Note, public is no longer implicitly added to paths, so this is no longer "public, public".
-                Assert.AreEqual("public", searchpath );
-                
+                Assert.AreEqual("public", searchpath);
             }
-            
-            finally 
-            {
-                conn.Close();
-                
-            }
-            
-            
-            
         }
-        
+
         [Test]
         public void ConnectorNotInitializedException1000581()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
             command.CommandText = @"SELECT 123";
 
-            for(int i = 0; i < 2; i++)
+            for (var i = 0; i < 2; i++)
             {
-                NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString);
-                
-                try 
+                using (var connection = new NpgsqlConnection(TheConnectionString))
                 {
                     connection.Open();
                     command.Connection = connection;
                     command.Transaction = connection.BeginTransaction();
                     command.ExecuteScalar();
                     command.Transaction.Commit();
-                  
-                    
-                } 
-                finally 
-                {
-                     connection.Close();
-                    
                 }
-               
-
             }
-            
-            
         }
 
         [Test]
         public void UseAllConnectionsInPool()
         {
-
             // As this method uses a lot of connections, clear all connections from all pools before starting. 
             // This is needed in order to not reach the max connections allowed and start to raise errors.
 
-            NpgsqlConnection.ClearAllPools ();
-
-            List<NpgsqlConnection> openedConnections = new List<NpgsqlConnection>();
-            // repeat test to exersize pool
-            for (int i = 0; i < 10; ++i)
+            NpgsqlConnection.ClearAllPools();
+            try
             {
-                try
+                var openedConnections = new List<NpgsqlConnection>();
+                // repeat test to exersize pool
+                for (var i = 0; i < 10; ++i)
                 {
-                    // 18 since base class opens two and the default pool size is 20
-                    for (int j = 0; j < 18; ++j)
+                    try
                     {
-                        NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString);
-                        connection.Open();
-                        openedConnections.Add(connection);
+                        // 18 since base class opens two and the default pool size is 20
+                        for (var j = 0; j < 18; ++j)
+                        {
+                            var connection = new NpgsqlConnection(TheConnectionString);
+                            connection.Open();
+                            openedConnections.Add(connection);
+                        }
+                    }
+                    finally
+                    {
+                        openedConnections.ForEach(delegate(NpgsqlConnection con) { con.Dispose(); });
+                        openedConnections.Clear();
                     }
                 }
-                finally
-                {
-                    openedConnections.ForEach(delegate(NpgsqlConnection con) { con.Dispose(); });
-                    openedConnections.Clear();
-                }
             }
-
-            NpgsqlConnection.ClearAllPools ();
+            finally
+            {
+                NpgsqlConnection.ClearAllPools();
+            }
         }
 
         [Test]
         [ExpectedException(typeof(Exception))]
         public void ExceedConnectionsInPool()
         {
-            List<NpgsqlConnection> openedConnections = new List<NpgsqlConnection>();
+            var openedConnections = new List<NpgsqlConnection>();
             try
             {
                 // exceed default pool size of 20
-                for (int i = 0; i < 21; ++i)
+                for (var i = 0; i < 21; ++i)
                 {
-                    NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString);
+                    var connection = new NpgsqlConnection(TheConnectionString);
                     connection.Open();
                     openedConnections.Add(connection);
                 }
@@ -255,7 +214,7 @@ namespace NpgsqlTests
             finally
             {
                 openedConnections.ForEach(delegate(NpgsqlConnection con) { con.Dispose(); });
-                NpgsqlConnection.ClearAllPools ();
+                NpgsqlConnection.ClearAllPools();
             }
         }
 
@@ -263,15 +222,15 @@ namespace NpgsqlTests
         [Ignore]
         public void NpgsqlErrorRepro1()
         {
-            using (NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString))
+            using (var connection = new NpgsqlConnection(TheConnectionString))
             {
                 connection.Open();
-                using (NpgsqlTransaction transaction = connection.BeginTransaction())
+                using (var transaction = connection.BeginTransaction())
                 {
-                    LargeObjectManager largeObjectMgr = new LargeObjectManager(connection);
+                    var largeObjectMgr = new LargeObjectManager(connection);
                     try
                     {
-                        LargeObject largeObject = largeObjectMgr.Open(-1, LargeObjectManager.READWRITE);
+                        var largeObject = largeObjectMgr.Open(-1, LargeObjectManager.READWRITE);
                         transaction.Commit();
                     }
                     catch
@@ -280,48 +239,39 @@ namespace NpgsqlTests
                     }
                 } // *1* sometimes it throws "System.NotSupportedException: This stream does not support seek operations"
 
-                using (NpgsqlCommand command = connection.CreateCommand())
+                using (var command = connection.CreateCommand())
                 {
                     command.CommandText = "SELECT * FROM pg_database";
-                    using (NpgsqlDataReader reader = command.ExecuteReader())
+                    using (var reader = command.ExecuteReader())
                     {
                         Assert.IsTrue(reader.Read()); // *2* this fails if the initial connection is used
                     }
                 }
             } // *3* sometimes it throws "System.NotSupportedException: This stream does not support seek operations"
         }
-  
+
         [Test]
         public void Bug1011001()
         {
             //[#1011001] Bug in NpgsqlConnectionStringBuilder affects on cache and connection pool
-            
-            string connString = "Server=server;Port=5432;User Id=user;Password=passwor;Database=database;";
-    
-            NpgsqlConnectionStringBuilder csb1 = new NpgsqlConnectionStringBuilder(connString);
 
-            string cs1 = csb1.ToString();
-        
-            NpgsqlConnectionStringBuilder csb2 = new NpgsqlConnectionStringBuilder(cs1);
-        
-            string cs2 = csb2.ToString();
-            
+            var csb1 = new NpgsqlConnectionStringBuilder(@"Server=server;Port=5432;User Id=user;Password=passwor;Database=database;");
+            var cs1 = csb1.ToString();
+            var csb2 = new NpgsqlConnectionStringBuilder(cs1);
+            var cs2 = csb2.ToString();
             Assert.IsTrue(cs1 == cs2);
-            
-                                
-      
         }
-        
+
         [Test]
         public void NpgsqlErrorRepro2()
         {
-            NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString);
+            var connection = new NpgsqlConnection(TheConnectionString);
             connection.Open();
-            NpgsqlTransaction transaction = connection.BeginTransaction();
-            LargeObjectManager largeObjectMgr = new LargeObjectManager(connection);
+            var transaction = connection.BeginTransaction();
+            var largeObjectMgr = new LargeObjectManager(connection);
             try
             {
-                LargeObject largeObject = largeObjectMgr.Open(-1, LargeObjectManager.READWRITE);
+                var largeObject = largeObjectMgr.Open(-1, LargeObjectManager.READWRITE);
                 transaction.Commit();
             }
             catch
@@ -348,10 +298,10 @@ namespace NpgsqlTests
             using (connection = new NpgsqlConnection(TheConnectionString))
             {
                 connection.Open();
-                using (NpgsqlCommand command = connection.CreateCommand())
+                using (var command = connection.CreateCommand())
                 {
                     command.CommandText = "SELECT * FROM pg_database";
-                    using (NpgsqlDataReader reader = command.ExecuteReader())
+                    using (var reader = command.ExecuteReader())
                     {
                         Assert.IsTrue(reader.Read());
                         // *1* this fails if the connection for the pool happens to be the bad one from above
@@ -360,29 +310,24 @@ namespace NpgsqlTests
                 }
             }
         }
-        
+
         [Test]
         public void GetSchemaForeignKeys()
         {
-            
-            DataTable dt = TheConnection.GetSchema("ForeignKeys");
-            
+            var dt = TheConnection.GetSchema("ForeignKeys");
             Assert.IsNotNull(dt);
-            
-            
         }
 
         [Test]
         public void ChangeState()
         {
-
-            using (NpgsqlConnection c = new NpgsqlConnection (TheConnectionString)) 
+            using (var c = new NpgsqlConnection(TheConnectionString))
             {
-                bool stateChangeCalledForOpen = false;
-                bool stateChangeCalledForClose = false;
+                var stateChangeCalledForOpen = false;
+                var stateChangeCalledForClose = false;
 
-
-                c.StateChange += new StateChangeEventHandler( delegate(object sender, StateChangeEventArgs e) {
+                c.StateChange += new StateChangeEventHandler(delegate(object sender, StateChangeEventArgs e)
+                {
                     if (e.OriginalState == ConnectionState.Closed && e.CurrentState == ConnectionState.Open)
                         stateChangeCalledForOpen = true;
 
@@ -390,55 +335,53 @@ namespace NpgsqlTests
                         stateChangeCalledForClose = true;
                 });
 
-                c.Open ();
-                c.Close ();
+                c.Open();
+                c.Close();
 
-                Assert.IsTrue (stateChangeCalledForOpen);
-                Assert.IsTrue (stateChangeCalledForClose);
-
+                Assert.IsTrue(stateChangeCalledForOpen);
+                Assert.IsTrue(stateChangeCalledForClose);
             }
-
-
-
-
         }
 
         [Test]
-		public void GetSchemaParameterMarkerFormats()
-		{
-			DataTable dt = TheConnection.GetSchema("DataSourceInformation");
-			String parameterMarkerFormat = dt.Rows[0]["ParameterMarkerFormat"] as string;
+        public void GetSchemaParameterMarkerFormats()
+        {
+            var dt = TheConnection.GetSchema("DataSourceInformation");
+            var parameterMarkerFormat = (string)dt.Rows[0]["ParameterMarkerFormat"];
 
-			using (NpgsqlConnection connection = new NpgsqlConnection(TheConnectionString))
-			{
-				connection.Open();
-				using (NpgsqlCommand command = connection.CreateCommand())
-				{
-					const String parameterName = "p_field_int4";
-					command.CommandText = "SELECT * FROM tablea WHERE field_int4=" + String.Format(parameterMarkerFormat, parameterName);
-					command.Parameters.Add(new NpgsqlParameter(parameterName,4));
-					using (NpgsqlDataReader reader = command.ExecuteReader())
-					{
-						Assert.IsTrue(reader.Read());
-						// This is OK, when no exceptions are occurred.
-					}
-				}
-			}
-		}
+            using (var connection = new NpgsqlConnection(TheConnectionString))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    const String parameterName = "p_field_int4";
+                    command.CommandText = "SELECT * FROM tablea WHERE field_int4=" + String.Format(parameterMarkerFormat, parameterName);
+                    command.Parameters.Add(new NpgsqlParameter(parameterName, 4));
+                    using (var reader = command.ExecuteReader())
+                    {
+                        Assert.IsTrue(reader.Read());
+                        // This is OK, when no exceptions are occurred.
+                    }
+                }
+            }
+        }
 
 
     }
     [TestFixture]
     public class ConnectionTestsV2 : ConnectionTests
     {
-        protected override NpgsqlConnection TheConnection {
+        protected override NpgsqlConnection TheConnection
+        {
             get { return _connV2; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _tV2; }
             set { _tV2 = value; }
         }
-        protected override string TheConnectionString {
+        protected override string TheConnectionString
+        {
             get { return _connV2String; }
         }
     }

--- a/testsuite/noninteractive/NUnit20/DataAdapterTests.cs
+++ b/testsuite/noninteractive/NUnit20/DataAdapterTests.cs
@@ -47,16 +47,13 @@ namespace NpgsqlTests
         [Test]
         public void InsertWithDataSet()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb", TheConnection);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select * from tableb", TheConnection);
 
             da.InsertCommand = new NpgsqlCommand("insert into tableb(field_int2, field_timestamp, field_numeric) values (:a, :b, :c)", TheConnection);
 
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
-
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("b", DbType.DateTime));
-
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("c", DbType.Decimal));
 
             da.InsertCommand.Parameters[0].Direction = ParameterDirection.Input;
@@ -67,34 +64,23 @@ namespace NpgsqlTests
             da.InsertCommand.Parameters[1].SourceColumn = "field_timestamp";
             da.InsertCommand.Parameters[2].SourceColumn = "field_numeric";
 
-
             da.Fill(ds);
 
-
-            DataTable dt = ds.Tables[0];
-
-            DataRow dr = dt.NewRow();
+            var dt = ds.Tables[0];
+            var dr = dt.NewRow();
             dr["field_int2"] = 4;
             dr["field_timestamp"] = new DateTime(2003, 01, 30, 14, 0, 0);
             dr["field_numeric"] = 7.3M;
-            
-
             dt.Rows.Add(dr);
 
-
-            DataSet ds2 = ds.GetChanges();
-            
-
+            var ds2 = ds.GetChanges();
             da.Update(ds2);
-            
             
             ds.Merge(ds2);
             ds.AcceptChanges();
 
-
-            NpgsqlDataReader dr2 = new NpgsqlCommand("select * from tableb where field_serial > 4", TheConnection).ExecuteReader();
+            var dr2 = new NpgsqlCommand("select * from tableb where field_serial > 4", TheConnection).ExecuteReader();
             dr2.Read();
-
 
             Assert.AreEqual(4, dr2[1]);
             Assert.AreEqual(7.3000000M, dr2[3]);
@@ -104,16 +90,13 @@ namespace NpgsqlTests
         [Test]
         public void DataAdapterUpdateReturnValue()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb", TheConnection);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select * from tableb", TheConnection);
 
             da.InsertCommand = new NpgsqlCommand("insert into tableb(field_int2, field_timestamp, field_numeric) values (:a, :b, :c)", TheConnection);
 
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
-
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("b", DbType.DateTime));
-
             da.InsertCommand.Parameters.Add(new NpgsqlParameter("c", DbType.Decimal));
 
             da.InsertCommand.Parameters[0].Direction = ParameterDirection.Input;
@@ -124,49 +107,36 @@ namespace NpgsqlTests
             da.InsertCommand.Parameters[1].SourceColumn = "field_timestamp";
             da.InsertCommand.Parameters[2].SourceColumn = "field_numeric";
 
-
             da.Fill(ds);
 
 
-            DataTable dt = ds.Tables[0];
-
-            DataRow dr = dt.NewRow();
+            var dt = ds.Tables[0];
+            var dr = dt.NewRow();
             dr["field_int2"] = 4;
             dr["field_timestamp"] = new DateTime(2003, 01, 30, 14, 0, 0);
             dr["field_numeric"] = 7.3M;
-            
-
             dt.Rows.Add(dr);
             
             dr = dt.NewRow();
             dr["field_int2"] = 4;
             dr["field_timestamp"] = new DateTime(2003, 01, 30, 14, 0, 0);
             dr["field_numeric"] = 7.3M;
-            
             dt.Rows.Add(dr);
 
-
-            DataSet ds2 = ds.GetChanges();
-            
-
-            int daupdate = da.Update(ds2);
+            var ds2 = ds.GetChanges();
+            var daupdate = da.Update(ds2);
             
             Assert.AreEqual(2, daupdate);
-            
-            
-
-         
         }
         
         [Test]
         [Ignore]
         public void DataAdapterUpdateReturnValue2()
         {
-            
-            NpgsqlCommand cmd = TheConnection.CreateCommand();
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tabled", TheConnection);
-            NpgsqlCommandBuilder cb = new NpgsqlCommandBuilder(da);
-            DataSet ds = new DataSet();
+            var cmd = TheConnection.CreateCommand();
+            var da = new NpgsqlDataAdapter("select * from tabled", TheConnection);
+            var cb = new NpgsqlCommandBuilder(da);
+            var ds = new DataSet();
             da.Fill(ds);
 
             //## Insert a new row with id = 1
@@ -180,7 +150,7 @@ namespace NpgsqlTests
             //## change value to newvalue
             ds.Tables[0].Rows[0][1] = 0.7;
             //## update should fail, and make a DBConcurrencyException
-            int count = da.Update(ds);
+            var count = da.Update(ds);
             //## count is 1, even if the isn't updated in the database
             Assert.AreEqual(0, count);
         }
@@ -188,10 +158,8 @@ namespace NpgsqlTests
         [Test]
         public void FillWithEmptyResultset()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb where field_serial = -1", TheConnection);
-
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select * from tableb where field_serial = -1", TheConnection);
 
             da.Fill(ds);
 
@@ -207,17 +175,16 @@ namespace NpgsqlTests
         [Ignore]
         public void FillAddWithKey()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select field_serial, field_int2, field_timestamp, field_numeric from tableb", TheConnection);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select field_serial, field_int2, field_timestamp, field_numeric from tableb", TheConnection);
 
             da.MissingSchemaAction = MissingSchemaAction.AddWithKey;
             da.Fill(ds);
 
-            DataColumn field_serial = ds.Tables[0].Columns[0];
-            DataColumn field_int2 = ds.Tables[0].Columns[1];
-            DataColumn field_timestamp = ds.Tables[0].Columns[2];
-            DataColumn field_numeric = ds.Tables[0].Columns[3];
+            var field_serial = ds.Tables[0].Columns[0];
+            var field_int2 = ds.Tables[0].Columns[1];
+            var field_timestamp = ds.Tables[0].Columns[2];
+            var field_numeric = ds.Tables[0].Columns[3];
 
             Assert.IsFalse(field_serial.AllowDBNull);
             Assert.IsTrue(field_serial.AutoIncrement);
@@ -255,17 +222,16 @@ namespace NpgsqlTests
         [Test]
         public void FillAddColumns()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select field_serial, field_int2, field_timestamp, field_numeric from tableb", TheConnection);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select field_serial, field_int2, field_timestamp, field_numeric from tableb", TheConnection);
 
             da.MissingSchemaAction = MissingSchemaAction.Add;
             da.Fill(ds);
 
-            DataColumn field_serial = ds.Tables[0].Columns[0];
-            DataColumn field_int2 = ds.Tables[0].Columns[1];
-            DataColumn field_timestamp = ds.Tables[0].Columns[2];
-            DataColumn field_numeric = ds.Tables[0].Columns[3];
+            var field_serial = ds.Tables[0].Columns[0];
+            var field_int2 = ds.Tables[0].Columns[1];
+            var field_timestamp = ds.Tables[0].Columns[2];
+            var field_numeric = ds.Tables[0].Columns[3];
 
             Assert.AreEqual("field_serial", field_serial.ColumnName);
             Assert.AreEqual(typeof(int), field_serial.DataType);
@@ -287,22 +253,18 @@ namespace NpgsqlTests
         [Test]
         public void UpdateLettingNullFieldValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (2)", TheConnection);
+            var command = new NpgsqlCommand("insert into tableb(field_int2) values (2)", TheConnection);
             command.ExecuteNonQuery();
-            
 
-            DataSet ds = new DataSet();
+            var ds = new DataSet();
 
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection);
+            var da = new NpgsqlDataAdapter("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection);
             da.InsertCommand = new NpgsqlCommand(";", TheConnection);
-      			da.UpdateCommand = new NpgsqlCommand("update tableb set field_int2 = :a, field_timestamp = :b, field_numeric = :c where field_serial = :d", TheConnection);
+            da.UpdateCommand = new NpgsqlCommand("update tableb set field_int2 = :a, field_timestamp = :b, field_numeric = :c where field_serial = :d", TheConnection);
 
             da.UpdateCommand.Parameters.Add(new NpgsqlParameter("a", DbType.Int16));
-
             da.UpdateCommand.Parameters.Add(new NpgsqlParameter("b", DbType.DateTime));
-
             da.UpdateCommand.Parameters.Add(new NpgsqlParameter("c", DbType.Decimal));
-            
             da.UpdateCommand.Parameters.Add(new NpgsqlParameter("d", NpgsqlDbType.Bigint));
 
             da.UpdateCommand.Parameters[0].Direction = ParameterDirection.Input;
@@ -317,36 +279,29 @@ namespace NpgsqlTests
 
             da.Fill(ds);
             
-            DataTable dt = ds.Tables[0];
+            var dt = ds.Tables[0];
             Assert.IsNotNull(dt);
 
-            DataRow dr = ds.Tables[0].Rows[ds.Tables[0].Rows.Count - 1];
-            
+            var dr = ds.Tables[0].Rows[ds.Tables[0].Rows.Count - 1];
             dr["field_int2"] = 4;
             
-            DataSet ds2 = ds.GetChanges();
-
+            var ds2 = ds.GetChanges();
             da.Update(ds2);
-
             ds.Merge(ds2);
             ds.AcceptChanges();
 
-
-            NpgsqlDataReader dr2 = new NpgsqlCommand("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection).ExecuteReader();
-            dr2.Read();
-            
-            Assert.AreEqual(4, dr2["field_int2"]);
-            
-            dr2.Close();
+            using (var dr2 = new NpgsqlCommand("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection).ExecuteReader())
+            {
+                dr2.Read();
+                Assert.AreEqual(4, dr2["field_int2"]);
+            }
         }
 
         [Test]
         public void FillWithDuplicateColumnName()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select field_serial, field_serial from tableb", TheConnection);
-
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select field_serial, field_serial from tableb", TheConnection);
             da.Fill(ds);
         }
         
@@ -356,42 +311,36 @@ namespace NpgsqlTests
         {
             DoUpdateWithDataSet();
         }
+
         public virtual void DoUpdateWithDataSet()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tableb(field_int2) values (2)", TheConnection);
+            var command = new NpgsqlCommand("insert into tableb(field_int2) values (2)", TheConnection);
             command.ExecuteNonQuery();
-            
 
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection);
-            
-            NpgsqlCommandBuilder cb = new NpgsqlCommandBuilder(da);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection);
+            var cb = new NpgsqlCommandBuilder(da);
             Assert.IsNotNull(cb);
             
             da.Fill(ds);
             
-            DataTable dt = ds.Tables[0];
+            var dt = ds.Tables[0];
             Assert.IsNotNull(dt);
 
-            DataRow dr = ds.Tables[0].Rows[ds.Tables[0].Rows.Count - 1];
+            var dr = ds.Tables[0].Rows[ds.Tables[0].Rows.Count - 1];
             
             dr["field_int2"] = 4;
             
-            DataSet ds2 = ds.GetChanges();
-
+            var ds2 = ds.GetChanges();
             da.Update(ds2);
-
             ds.Merge(ds2);
             ds.AcceptChanges();
 
-
-            NpgsqlDataReader dr2 = new NpgsqlCommand("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection).ExecuteReader();
-            dr2.Read();
-            
-            Assert.AreEqual(4, dr2["field_int2"]);
-            
-            dr2.Close();
+            using (var dr2 = new NpgsqlCommand("select * from tableb where field_serial = (select max(field_serial) from tableb)", TheConnection).ExecuteReader())
+            {
+                dr2.Read();
+                Assert.AreEqual(4, dr2["field_int2"]);
+            }   
         }
         
         [Test]
@@ -402,51 +351,42 @@ namespace NpgsqlTests
         }
         public virtual void DoInsertWithCommandBuilderCaseSensitive()
         {
-            DataSet ds = new DataSet();
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tablei", TheConnection);
-            NpgsqlCommandBuilder builder = new NpgsqlCommandBuilder(da);
+            var ds = new DataSet();
+            var da = new NpgsqlDataAdapter("select * from tablei", TheConnection);
+            var builder = new NpgsqlCommandBuilder(da);
             Assert.IsNotNull(builder);
 
             da.Fill(ds);
 
-
-            DataTable dt = ds.Tables[0];
-
-            DataRow dr = dt.NewRow();
+            var dt = ds.Tables[0];
+            var dr = dt.NewRow();
             dr["Field_Case_Sensitive"] = 4;
-            
             dt.Rows.Add(dr);
 
-
-            DataSet ds2 = ds.GetChanges();
-
+            var ds2 = ds.GetChanges();
             da.Update(ds2);
-
             ds.Merge(ds2);
             ds.AcceptChanges();
 
-
-            NpgsqlDataReader dr2 = new NpgsqlCommand("select * from tablei", TheConnection).ExecuteReader();
-            dr2.Read();
-
-
-            Assert.AreEqual(4, dr2[1]);
-            dr2.Close();
+            using (var dr2 = new NpgsqlCommand("select * from tablei", TheConnection).ExecuteReader())
+            {
+                dr2.Read();
+                Assert.AreEqual(4, dr2[1]);
+            }
         }
 
         [Test]
         public void IntervalAsTimeSpan()
         {
-            DataTable dt = new DataTable();
-            DataColumn c = dt.Columns.Add("dauer", typeof(TimeSpan));
+            var dt = new DataTable();
+            var c = dt.Columns.Add("dauer", typeof(TimeSpan));
             // DataColumn c = dt.Columns.Add("dauer", typeof(NpgsqlInterval));
             c.AllowDBNull = true;
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
             command.CommandType = CommandType.Text;
             command.CommandText = "SELECT CAST('1 hour' AS interval) AS dauer";
             command.Connection = TheConnection;
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter();
+            var da = new NpgsqlDataAdapter();
             da.SelectCommand = command;
             da.Fill(dt);
             foreach (DataRow dr in dt.Rows)
@@ -458,15 +398,15 @@ namespace NpgsqlTests
         [Test]
         public void IntervalAsTimeSpan2()
         {
-            DataTable dt = new DataTable();
+            var dt = new DataTable();
             //DataColumn c = dt.Columns.Add("dauer", typeof(TimeSpan));
             // DataColumn c = dt.Columns.Add("dauer", typeof(NpgsqlInterval));
             //c.AllowDBNull = true;
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
             command.CommandType = CommandType.Text;
             command.CommandText = "SELECT CAST('1 hour' AS interval) AS dauer";
             command.Connection = TheConnection;
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter();
+            var da = new NpgsqlDataAdapter();
             da.SelectCommand = command;
             da.Fill(dt);
             foreach (DataRow dr in dt.Rows)
@@ -478,12 +418,11 @@ namespace NpgsqlTests
         [Test]
         public void DbDataAdapterCommandAccess()
         {
-
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
             command.CommandType = CommandType.Text;
             command.CommandText = "SELECT CAST('1 hour' AS interval) AS dauer";
             command.Connection = TheConnection;
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter();
+            var da = new NpgsqlDataAdapter();
             da.SelectCommand = command;
             System.Data.Common.DbDataAdapter common = da;
             Assert.IsNotNull(common.SelectCommand);

--- a/testsuite/noninteractive/NUnit20/DataReaderTests.cs
+++ b/testsuite/noninteractive/NUnit20/DataReaderTests.cs
@@ -61,140 +61,111 @@ namespace NpgsqlTests
         [Test]
         public void RecordsAffecte()
         {
-            NpgsqlCommand command = new NpgsqlCommand("insert into tablea(field_int4) values (7); insert into tablea(field_int4) values (8)", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            try
-            {
+            var command = new NpgsqlCommand("insert into tablea(field_int4) values (7); insert into tablea(field_int4) values (8)", TheConnection);
+            using (var dr = command.ExecuteReader()) {
                 Assert.AreEqual(2, dr.RecordsAffected);
-            }
-            finally
-            {
-                dr.Close();
             }
         }
 
         [Test]
         public void GetBoolean()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 4;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-            Boolean result = dr.GetBoolean(4);
-            Assert.AreEqual(true, result);
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 4;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetBoolean(4);
+                Assert.AreEqual(true, result);
+            }
         }
-
 
         [Test]
         public void GetChars()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-            Char[] result = new Char[6];
-
-
-            dr.GetChars(1, 0, result, 0, 6);
-
-            Assert.AreEqual("Random", new String(result));
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = new Char[6];
+                dr.GetChars(1, 0, result, 0, 6);
+                Assert.AreEqual("Random", new String(result));
+            }
         }
+
         [Test]
         public void GetCharsSequential()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SequentialAccess);
-
-            dr.Read();
-            Char[] result = new Char[6];
-
-
-            dr.GetChars(1, 0, result, 0, 6);
-
-            Assert.AreEqual("Random", new String(result));
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader(CommandBehavior.SequentialAccess))
+            {
+                dr.Read();
+                var result = new Char[6];
+                dr.GetChars(1, 0, result, 0, 6);
+                Assert.AreEqual("Random", new String(result));
+            }
         }
-           
            
         [Test]
         public void GetBytes1()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1;", TheConnection);
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = new Byte[2];
 
-            NpgsqlDataReader dr = command.ExecuteReader();
+                var a = dr.GetBytes(0, 0, result, 0, 2);
+                var b = dr.GetBytes(0, result.Length, result, 0, 2);
 
-            dr.Read();
-            Byte[] result = new Byte[2];
-
-
-            Int64 a = dr.GetBytes(0, 0, result, 0, 2);
-            Int64 b = dr.GetBytes(0, result.Length, result, 0, 2);
-
-            Assert.AreEqual('S', (Char)result[0]);
-            Assert.AreEqual('.', (Char)result[1]);
-            Assert.AreEqual(2, a);
-            Assert.AreEqual(0, b);
-            
-            dr.Close();
+                Assert.AreEqual('S', (Char) result[0]);
+                Assert.AreEqual('.', (Char) result[1]);
+                Assert.AreEqual(2, a);
+                Assert.AreEqual(0, b);
+            }
         }
 
         [Test]
         public void GetBytes2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select '\\001\\002\\003'::bytea;", TheConnection);
+            var command = new NpgsqlCommand("select '\\001\\002\\003'::bytea;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = new Byte[3];
 
-            NpgsqlDataReader dr = command.ExecuteReader();
+                var a = dr.GetBytes(0, 0, result, 0, 0);
+                var b = dr.GetBytes(0, 0, result, 0, 1);
+                var c = dr.GetBytes(0, 0, result, 0, 2);
+                var d = dr.GetBytes(0, 0, result, 0, 3);
 
-            dr.Read();
-            Byte[] result = new Byte[3];
-
-
-            Int64 a = dr.GetBytes(0, 0, result, 0, 0);
-            Int64 b = dr.GetBytes(0, 0, result, 0, 1);
-            Int64 c = dr.GetBytes(0, 0, result, 0, 2);
-            Int64 d = dr.GetBytes(0, 0, result, 0, 3);
-
-            Assert.AreEqual(1, result[0]);
-            Assert.AreEqual(2, result[1]);
-            Assert.AreEqual(3, result[2]);
-            Assert.AreEqual(0, a);
-            Assert.AreEqual(1, b);
-            Assert.AreEqual(2, c);
-            Assert.AreEqual(3, d);
-            
-            dr.Close();
+                Assert.AreEqual(1, result[0]);
+                Assert.AreEqual(2, result[1]);
+                Assert.AreEqual(3, result[2]);
+                Assert.AreEqual(0, a);
+                Assert.AreEqual(1, b);
+                Assert.AreEqual(2, c);
+                Assert.AreEqual(3, d);
+            }
         }
 
         [Test]
         [Ignore]
         public void GetBytesSequential()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1;", TheConnection);
+            var command = new NpgsqlCommand("select field_bytea from tablef where field_serial = 1;", TheConnection);
 
-            using (NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SequentialAccess))
+            using (var dr = command.ExecuteReader(CommandBehavior.SequentialAccess))
             {
-
                 dr.Read();
-                Byte[] result = new Byte[2];
+                var result = new Byte[2];
 
-
-                Int64 a = dr.GetBytes(0, 0, result, 0, 2);
-                Int64 b = dr.GetBytes(0, result.Length, result, 0, 2);
+                var a = dr.GetBytes(0, 0, result, 0, 2);
+                var b = dr.GetBytes(0, result.Length, result, 0, 2);
 
                 Assert.AreEqual('S', (Char)result[0]);
                 Assert.AreEqual('.', (Char)result[1]);
                 Assert.AreEqual(2, a);
                 Assert.AreEqual(0, b);
-
             }
         }
         
@@ -203,101 +174,77 @@ namespace NpgsqlTests
         [Test]
         public void GetInt32()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 2;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-
-            Int32 result = dr.GetInt32(2);
-
-            //ConsoleWriter cw = new ConsoleWriter(Console.Out);
-
-            //cw.WriteLine(result.GetType().Name);
-            Assert.AreEqual(4, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 2;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetInt32(2);
+                //ConsoleWriter cw = new ConsoleWriter(Console.Out);
+                //cw.WriteLine(result.GetType().Name);
+                Assert.AreEqual(4, result);
+            }
         }
-
 
         [Test]
         public void GetInt16()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableb where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            Int16 result = dr.GetInt16(1);
-
-            Assert.AreEqual(2, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tableb where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetInt16(1);
+                Assert.AreEqual(2, result);
+            }
         }
 
 
         [Test]
         public void GetDecimal()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableb where field_serial = 3;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            Decimal result = dr.GetDecimal(3);
-
-
-            Assert.AreEqual(4.2300000M, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tableb where field_serial = 3;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetDecimal(3);
+                Assert.AreEqual(4.2300000M, result);
+            }
         }
 
 
         [Test]
         public void GetDouble()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tabled where field_serial = 2;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            //Double result = Double.Parse(dr.GetInt32(2).ToString());
-            Double result = dr.GetDouble(2);
-
-            Assert.AreEqual(.123456789012345D, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tabled where field_serial = 2;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                //Double result = Double.Parse(dr.GetInt32(2).ToString());
+                var result = dr.GetDouble(2);
+                Assert.AreEqual(.123456789012345D, result);
+            }
         }
 
 
         [Test]
         public void GetFloat()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tabled where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            //Single result = Single.Parse(dr.GetInt32(2).ToString());
-            Single result = dr.GetFloat(1);
-
-            Assert.AreEqual(.123456F, result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tabled where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                //Single result = Single.Parse(dr.GetInt32(2).ToString());
+                var result = dr.GetFloat(1);
+                Assert.AreEqual(.123456F, result);
+            }
         }
 
         [Test]
         public void GetMoney()
         {
-            NpgsqlCommand cmd = new NpgsqlCommand("select :param", TheConnection);
-            decimal monAmount = 1234.5m;
+            var cmd = new NpgsqlCommand("select :param", TheConnection);
+            const decimal monAmount = 1234.5m;
             cmd.Parameters.Add("param", NpgsqlDbType.Money).Value = monAmount;
-            using(IDataReader rdr = cmd.ExecuteReader())
+            using (var rdr = cmd.ExecuteReader())
             {
                 rdr.Read();
                 Assert.AreEqual(monAmount, rdr[0]);
@@ -307,27 +254,22 @@ namespace NpgsqlTests
         [Test]
         public void GetString()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            String result = dr.GetString(1);
-
-            Assert.AreEqual("Random text", result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetString(1);
+                Assert.AreEqual("Random text", result);
+            }
         }
-
 
         [Test]
         public void GetStringWithParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
 
-            String test = "Random text";
-            NpgsqlParameter param = new NpgsqlParameter();
+            const string test = "Random text";
+            var param = new NpgsqlParameter();
             param.ParameterName = "value";
             param.DbType = DbType.String;
             //param.NpgsqlDbType = NpgsqlDbType.Text;
@@ -335,24 +277,21 @@ namespace NpgsqlTests
             param.Value = test;
             command.Parameters.Add(param);
 
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            String result = dr.GetString(1);
-
-            Assert.AreEqual(test, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetString(1);
+                Assert.AreEqual(test, result);
+            }
         }
 
         [Test]
         public void GetStringWithQuoteWithParameter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
 
-            String test = "Text with ' single quote";
-            NpgsqlParameter param = new NpgsqlParameter();
+            const string test = "Text with ' single quote";
+            var param = new NpgsqlParameter();
             param.ParameterName = "value";
             param.DbType = DbType.String;
             //param.NpgsqlDbType = NpgsqlDbType.Text;
@@ -360,42 +299,35 @@ namespace NpgsqlTests
             param.Value = test;
             command.Parameters.Add(param);
 
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            String result = dr.GetString(1);
-
-            Assert.AreEqual(test, result);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = dr.GetString(1);
+                Assert.AreEqual(test, result);
+            }
         }
 
 
         [Test]
         public void GetValueByName()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            String result = (String) dr["field_text"];
-
-            Assert.AreEqual("Random text", result);
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where field_serial = 1;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                var result = (String) dr["field_text"];
+                Assert.AreEqual("Random text", result);
+            }
         }
 
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void GetValueFromEmptyResultset()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_text = :value;", TheConnection);
 
-            String test = "Text single quote";
-            NpgsqlParameter param = new NpgsqlParameter();
+            const string test = "Text single quote";
+            var param = new NpgsqlParameter();
             param.ParameterName = "value";
             param.DbType = DbType.String;
             //param.NpgsqlDbType = NpgsqlDbType.Text;
@@ -403,21 +335,20 @@ namespace NpgsqlTests
             param.Value = test;
             command.Parameters.Add(param);
 
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-
-            // This line should throw the invalid operation exception as the datareader will
-            // have an empty resultset.
-            Console.WriteLine(dr.IsDBNull(1));
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                // This line should throw the invalid operation exception as the datareader will
+                // have an empty resultset.
+                Console.WriteLine(dr.IsDBNull(1));
+            }
         }
 
         [Test]
         public void GetInt32ArrayFieldType()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select cast(null as integer[])", TheConnection);
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            var command = new NpgsqlCommand("select cast(null as integer[])", TheConnection);
+            using (var dr = command.ExecuteReader())
             {
                 Assert.AreEqual(typeof(int[]), dr.GetFieldType(0));
             }
@@ -426,13 +357,13 @@ namespace NpgsqlTests
         [Test]
         public void TestMultiDimensionalArray()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select :i", TheConnection);
+            var command = new NpgsqlCommand("select :i", TheConnection);
             command.Parameters.AddWithValue(":i", (new decimal[,]{{0,1,2},{3,4,5}}));
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
                 Assert.AreEqual(2, (dr[0] as Array).Rank);
-                decimal[,] da = dr[0] as decimal[,];
+                var da = (decimal[,])dr[0];
                 Assert.AreEqual(da.GetUpperBound(0), 1);
                 Assert.AreEqual(da.GetUpperBound(1), 2);
                 decimal cmp = 0m;
@@ -444,9 +375,9 @@ namespace NpgsqlTests
         [Test]
         public void TestArrayOfBytea1()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select get_byte(:i[1], 2)", TheConnection);
+            var command = new NpgsqlCommand("select get_byte(:i[1], 2)", TheConnection);
             command.Parameters.AddWithValue(":i", new byte[][]{new byte[]{0,1,2}, new byte[]{3,4,5}});
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
                 Assert.AreEqual(dr[0], 2);
@@ -456,9 +387,9 @@ namespace NpgsqlTests
         [Test]
         public void TestArrayOfBytea2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select get_byte(:i[1], 2)", TheConnection);
+            var command = new NpgsqlCommand("select get_byte(:i[1], 2)", TheConnection);
             command.Parameters.AddWithValue(":i", new byte[][]{new byte[]{1,2,3}, new byte[]{4,5,6}});
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
                 Assert.AreEqual(dr[0], 3);
@@ -468,22 +399,23 @@ namespace NpgsqlTests
         [Test]
         public void TestOverlappedParameterNames()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = :test_name or field_serial = :test_name_long", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_serial = :test_name or field_serial = :test_name_long", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("test_name", DbType.Int32, 4, "a"));
             command.Parameters.Add(new NpgsqlParameter("test_name_long", DbType.Int32, 4, "aa"));
 
             command.Parameters[0].Value = 2;
             command.Parameters[1].Value = 3;
 
-            NpgsqlDataReader dr = command.ExecuteReader();
-            Assert.IsNotNull(dr);
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                Assert.IsNotNull(dr);
+            }
         }
         
         [Test]
         public void TestOverlappedParameterNamesWithPrepare()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = :test_name or field_serial = :test_name_long", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_serial = :test_name or field_serial = :test_name_long", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("test_name", DbType.Int32, 4, "abc_de"));
             command.Parameters.Add(new NpgsqlParameter("test_name_long", DbType.Int32, 4, "abc_defg"));
 
@@ -491,68 +423,58 @@ namespace NpgsqlTests
             command.Parameters[1].Value = 3;
 
             command.Prepare();
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-            Assert.IsNotNull(dr);
-            dr.Close();
+
+            using (var dr = command.ExecuteReader())
+            {
+                Assert.IsNotNull(dr);
+            }
         }
 
         [Test]
         [ExpectedException(typeof(NpgsqlException))]
         public void TestNonExistentParameterName()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = :a or field_serial = :aa", TheConnection);
+            var command = new NpgsqlCommand("select * from tablea where field_serial = :a or field_serial = :aa", TheConnection);
             command.Parameters.Add(new NpgsqlParameter(":b", DbType.Int32, 4, "b"));
             command.Parameters.Add(new NpgsqlParameter(":aa", DbType.Int32, 4, "aa"));
 
             command.Parameters[0].Value = 2;
             command.Parameters[1].Value = 3;
 
-            NpgsqlDataReader dr = command.ExecuteReader();
-            Assert.IsNotNull(dr);
+            using (var dr = command.ExecuteReader())
+            {
+                Assert.IsNotNull(dr);
+            }
         }
 
         [Test]
         public void UseDataAdapter()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter();
-
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            var da = new NpgsqlDataAdapter();
             da.SelectCommand = command;
-
-            DataSet ds = new DataSet();
-
+            var ds = new DataSet();
             da.Fill(ds);
-
             //ds.WriteXml("TestUseDataAdapter.xml");
         }
 
         [Test]
         public void UseDataAdapterNpgsqlConnectionConstructor()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
             command.Connection = TheConnection;
-
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter(command);
-
-            DataSet ds = new DataSet();
-
+            var da = new NpgsqlDataAdapter(command);
+            var ds = new DataSet();
             da.Fill(ds);
-
             //ds.WriteXml("TestUseDataAdapterNpgsqlConnectionConstructor.xml");
         }
 
         [Test]
         public void UseDataAdapterStringNpgsqlConnectionConstructor()
         {
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tablea", TheConnection);
-
-            DataSet ds = new DataSet();
-
+            var da = new NpgsqlDataAdapter("select * from tablea", TheConnection);
+            var ds = new DataSet();
             da.Fill(ds);
-
             //ds.WriteXml("TestUseDataAdapterStringNpgsqlConnectionConstructor.xml");
         }
 
@@ -560,39 +482,28 @@ namespace NpgsqlTests
         [Test]
         public void UseDataAdapterStringStringConstructor()
         {
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tablea", TheConnectionString);
-
-            DataSet ds = new DataSet();
-
+            var da = new NpgsqlDataAdapter("select * from tablea", TheConnectionString);
+            var ds = new DataSet();
             da.Fill(ds);
-
             ds.WriteXml("TestUseDataAdapterStringStringConstructor.xml");
         }
 
         [Test]
         public void UseDataAdapterStringStringConstructor2()
         {
-            NpgsqlDataAdapter da = new NpgsqlDataAdapter("select * from tableb", TheConnectionString);
-
-            DataSet ds = new DataSet();
-
+            var da = new NpgsqlDataAdapter("select * from tableb", TheConnectionString);
+            var ds = new DataSet();
             da.Fill(ds);
-
             ds.WriteXml("TestUseDataAdapterStringStringConstructor2.xml");
         }
 
         [Test]
         public void DataGridWebControlSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-            
+            var command = new NpgsqlCommand("select * from tablea;", TheConnection);
+            var dr = command.ExecuteReader();
             //Console.WriteLine(dr.FieldCount);
-            
-
-            DataGrid dg = new DataGrid();
-
+            var dg = new DataGrid();
             dg.DataSource = dr;
             dg.DataBind();
         }
@@ -602,12 +513,9 @@ namespace NpgsqlTests
         [ExpectedException(typeof(InvalidOperationException))]
         public void ReadPastDataReaderEnd()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
+            var command = new NpgsqlCommand("select * from tablea;", TheConnection);
+            var dr = command.ExecuteReader();
             while (dr.Read()) {}
-
             Object o = dr[0];
             Assert.IsNotNull(o);
         }
@@ -615,86 +523,71 @@ namespace NpgsqlTests
         [Test]
         public void IsDBNull()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_text from tablea;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-            Assert.AreEqual(false, dr.IsDBNull(0));
-            dr.Read();
-            Assert.AreEqual(true, dr.IsDBNull(0));
-            
-            dr.Close();
+            var command = new NpgsqlCommand("select field_text from tablea;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                Assert.AreEqual(false, dr.IsDBNull(0));
+                dr.Read();
+                Assert.AreEqual(true, dr.IsDBNull(0));
+            }
         }
 
         [Test]
         public void IsDBNullFromScalar()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select max(field_serial) from tablea;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-            Assert.AreEqual(false, dr.IsDBNull(0));
-            dr.Close();
+            var command = new NpgsqlCommand("select max(field_serial) from tablea;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                Assert.AreEqual(false, dr.IsDBNull(0));
+            }
         }
-
-
 
         [Test]
         public void TypesNames()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where 1 = 2;", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-            dr.Read();
-
-            Assert.AreEqual("int4", dr.GetDataTypeName(0));
-            Assert.AreEqual("text", dr.GetDataTypeName(1));
-            Assert.AreEqual("int4", dr.GetDataTypeName(2));
-            Assert.AreEqual("int8", dr.GetDataTypeName(3));
-            Assert.AreEqual("bool", dr.GetDataTypeName(4));
-
-            dr.Close();
+            var command = new NpgsqlCommand("select * from tablea where 1 = 2;", TheConnection);
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                Assert.AreEqual("int4", dr.GetDataTypeName(0));
+                Assert.AreEqual("text", dr.GetDataTypeName(1));
+                Assert.AreEqual("int4", dr.GetDataTypeName(2));
+                Assert.AreEqual("int8", dr.GetDataTypeName(3));
+                Assert.AreEqual("bool", dr.GetDataTypeName(4));
+            }
 
             command.CommandText = "select * from tableb where 1 = 2";
-
-            dr = command.ExecuteReader();
-
-            dr.Read();
-
-            Assert.AreEqual("int4", dr.GetDataTypeName(0));
-            Assert.AreEqual("int2", dr.GetDataTypeName(1));
-            Assert.AreEqual("timestamp", dr.GetDataTypeName(2));
-            Assert.AreEqual("numeric", dr.GetDataTypeName(3));
+            using (var dr = command.ExecuteReader())
+            {
+                dr.Read();
+                Assert.AreEqual("int4", dr.GetDataTypeName(0));
+                Assert.AreEqual("int2", dr.GetDataTypeName(1));
+                Assert.AreEqual("timestamp", dr.GetDataTypeName(2));
+                Assert.AreEqual("numeric", dr.GetDataTypeName(3));
+            }
         }
         
         [Test]
         public void SingleRowCommandBehaviorSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SingleRow);
-
-            
-            Int32 i = 0;
-            
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            var dr = command.ExecuteReader(CommandBehavior.SingleRow);
+            var i = 0;
             while (dr.Read())
                 i++;
-            
             Assert.AreEqual(1, i);
         }
 
         [Test]
         public void SingleRowForwardOnlyCommandBehaviorSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-            Int32 i = 0;
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            var i = 0;
 
-            using (NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SingleRow | CommandBehavior.SequentialAccess))
+            using (var dr = command.ExecuteReader(CommandBehavior.SingleRow | CommandBehavior.SequentialAccess))
             {
-
                 while (dr.Read())
                 {
                     if (!dr.IsDBNull(0))
@@ -712,18 +605,17 @@ namespace NpgsqlTests
         [Test]
         public void SingleRowCommandBehaviorSupportFunctioncall()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcb", TheConnection);
+            var command = new NpgsqlCommand("funcb", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
 
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SingleRow);
+            using (var dr = command.ExecuteReader(CommandBehavior.SingleRow))
+            {
 
-            
-            Int32 i = 0;
-            
-            while (dr.Read())
-                i++;
-            
-            Assert.AreEqual(1, i);
+                var i = 0;
+                while (dr.Read())
+                    i++;
+                Assert.AreEqual(1, i);
+            }
         }
         
         [Test]
@@ -732,47 +624,40 @@ namespace NpgsqlTests
             //FIXME: Find a way of supporting single row with prepare.
             // Problem is that prepare plan must already have the limit 1 single row support.
             
-            NpgsqlCommand command = new NpgsqlCommand("funcb()", TheConnection);
+            var command = new NpgsqlCommand("funcb()", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-            
             command.Prepare();
 
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SingleRow);
-
-            
-            Int32 i = 0;
-            
-            while (dr.Read())
-                i++;
-            
-            Assert.AreEqual(1, i);
+            using (var dr = command.ExecuteReader(CommandBehavior.SingleRow))
+            {
+                var i = 0;
+                while (dr.Read())
+                    i++;
+                Assert.AreEqual(1, i);
+            }
         }
         
         [Test]
         public void PrimaryKeyFieldsMetadataSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from metadatatest1", TheConnection);
-            
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.KeyInfo);
-
-            
-            DataTable metadata = dr.GetSchemaTable();
-            
-            Boolean keyfound = false;
-            
-            foreach(DataRow r in metadata.Rows)
+            var command = new NpgsqlCommand("select * from metadatatest1", TheConnection);
+            using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
             {
-                if ((Boolean)r["IsKey"] )
+                var metadata = dr.GetSchemaTable();
+                var keyfound = false;
+
+                foreach (DataRow r in metadata.Rows)
                 {
-                    Assert.AreEqual("field_pk", r["ColumnName"]);
-                    keyfound = true;
+                    if ((Boolean) r["IsKey"])
+                    {
+                        Assert.AreEqual("field_pk", r["ColumnName"]);
+                        keyfound = true;
+                    }
+
                 }
-                    
+                if (!keyfound)
+                    Assert.Fail("No primary key found!");
             }
-            if (!keyfound)
-                Assert.Fail("No primary key found!");
-            
-            dr.Close();
         }
         
         [Test]
@@ -780,117 +665,97 @@ namespace NpgsqlTests
         {
             DoIsIdentityMetadataSupport();
         }
+
         public virtual void DoIsIdentityMetadataSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from metadatatest1", TheConnection);
-            
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.KeyInfo);
+            var command = new NpgsqlCommand("select * from metadatatest1", TheConnection);
 
-            
-            DataTable metadata = dr.GetSchemaTable();
-            
-            Boolean identityfound = false;
-            
-            foreach(DataRow r in metadata.Rows)
+            using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
             {
-                if ((Boolean)r["IsAutoIncrement"] )
+                var metadata = dr.GetSchemaTable();
+                var identityfound = false;
+
+                foreach (DataRow r in metadata.Rows)
                 {
-                    Assert.AreEqual("field_serial", r["ColumnName"]);
-                    identityfound = true;
+                    if ((Boolean) r["IsAutoIncrement"])
+                    {
+                        Assert.AreEqual("field_serial", r["ColumnName"]);
+                        identityfound = true;
+                    }
+
                 }
-                    
+                if (!identityfound)
+                    Assert.Fail("No identity column found!");
             }
-            if (!identityfound)
-                Assert.Fail("No identity column found!");
-            
-            dr.Close();
         }
         
         [Test]
         public void HasRowsWithoutResultset()
         {
-            NpgsqlCommand command = new NpgsqlCommand("delete from tablea where field_serial = 2000000", TheConnection);
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-
-                        
+            var command = new NpgsqlCommand("delete from tablea where field_serial = 2000000", TheConnection);
+            var dr = command.ExecuteReader();
             Assert.IsFalse(dr.HasRows);
         }
    
         [Test]
         public void ParameterAppearMoreThanOneTime()
         {
-            
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea where field_serial = :parameter and field_int4 = :parameter", TheConnection);
-            
+            var command = new NpgsqlCommand("select * from tablea where field_serial = :parameter and field_int4 = :parameter", TheConnection);
             command.Parameters.Add("parameter", NpgsqlDbType.Integer);
             command.Parameters["parameter"].Value = 1;
-            
-            NpgsqlDataReader dr = command.ExecuteReader();
-                        
-            Assert.IsFalse(dr.HasRows);
-            
-            dr.Close();
+            using (var dr = command.ExecuteReader())
+            {
+                Assert.IsFalse(dr.HasRows);
+            }
         }
         
         [Test]
         public void SchemaOnlySingleRowCommandBehaviorSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SchemaOnly | CommandBehavior.SingleRow);
-
-            
-            Int32 i = 0;
-            
-            while (dr.Read())
-                i++;
-            
-            Assert.AreEqual(0, i);
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            using (var dr = command.ExecuteReader(CommandBehavior.SchemaOnly | CommandBehavior.SingleRow))
+            {
+                var i = 0;
+                while (dr.Read())
+                    i++;
+                Assert.AreEqual(0, i);
+            }
         }
         
         [Test]
         public void SchemaOnlyCommandBehaviorSupport()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SchemaOnly);
-
-            
-            Int32 i = 0;
-            
-            while (dr.Read())
-                i++;
-            
-            Assert.AreEqual(0, i);
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            using (var dr = command.ExecuteReader(CommandBehavior.SchemaOnly))
+            {
+                var i = 0;
+                while (dr.Read())
+                    i++;
+                Assert.AreEqual(0, i);
+            }
         }
-        
         
         [Test]
         public void SchemaOnlyCommandBehaviorSupportFunctioncall()
         {
-            NpgsqlCommand command = new NpgsqlCommand("funcb", TheConnection);
+            var command = new NpgsqlCommand("funcb", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
-
-            NpgsqlDataReader dr = command.ExecuteReader(CommandBehavior.SchemaOnly);
-
-            
-            Int32 i = 0;
-            
-            while (dr.Read())
-                i++;
-            
-            Assert.AreEqual(0, i);
+            using (var dr = command.ExecuteReader(CommandBehavior.SchemaOnly))
+            {
+                var i = 0;
+                while (dr.Read())
+                    i++;
+                Assert.AreEqual(0, i);
+            }
         }
         
         [Test]
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void FieldNameDoesntExistOnGetOrdinal()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            
+            var command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
 
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 int idx =  dr.GetOrdinal("field_int");
             }
@@ -899,11 +764,11 @@ namespace NpgsqlTests
         [Test]
         public void FieldNameDoesntExistBackwardsCompat()
         {
-            using(NpgsqlConnection backCompatCon = new NpgsqlConnection(TheConnectionString + ";Compatible=2.0.2"))
-                using(NpgsqlCommand command = new NpgsqlCommand("select field_serial from tablea", backCompatCon))
+            using (var backCompatCon = new NpgsqlConnection(TheConnectionString + ";Compatible=2.0.2"))
+                using (var command = new NpgsqlCommand("select field_serial from tablea", backCompatCon))
                 {
                     backCompatCon.Open();
-                    using(IDataReader rdr = command.ExecuteReader())
+                    using (var rdr = command.ExecuteReader())
                         Assert.AreEqual(rdr.GetOrdinal("field_int"), -1);
                 }
         }
@@ -912,13 +777,11 @@ namespace NpgsqlTests
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void FieldNameDoesntExist()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            
+            var command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
 
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-                
                 Object a = dr["field_int"];
                 Assert.IsNotNull(a);
             }
@@ -927,12 +790,11 @@ namespace NpgsqlTests
         [Test]
         public void FieldNameKanaWidthWideRequestForNarrowFieldName()
         {//Should ignore Kana width and hence find the first of these two fields
-            NpgsqlCommand command = new NpgsqlCommand("select 123 as ｦｧｨｩｪｫｬ, 124 as ヲァィゥェォャ", TheConnection);
+            var command = new NpgsqlCommand("select 123 as ｦｧｨｩｪｫｬ, 124 as ヲァィゥェォャ", TheConnection);
 
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-                
                 Assert.AreEqual(dr["ｦｧｨｩｪｫｬ"], 123);
                 Assert.AreEqual(dr["ヲァィゥェォャ"], 123);// Wide version.
             }
@@ -941,12 +803,11 @@ namespace NpgsqlTests
         [Test]
         public void FieldNameKanaWidthNarrowRequestForWideFieldName()
         {//Should ignore Kana width and hence find the first of these two fields
-            NpgsqlCommand command = new NpgsqlCommand("select 123 as ヲァィゥェォャ, 124 as ｦｧｨｩｪｫｬ", TheConnection);
+            var command = new NpgsqlCommand("select 123 as ヲァィゥェォャ, 124 as ｦｧｨｩｪｫｬ", TheConnection);
 
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-                
                 Assert.AreEqual(dr["ヲァィゥェォャ"], 123);
                 Assert.AreEqual(dr["ｦｧｨｩｪｫｬ"], 123);// Narrow version.
             }
@@ -956,66 +817,73 @@ namespace NpgsqlTests
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void FieldIndexDoesntExist()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            
+            var command = new NpgsqlCommand("select field_serial from tablea", TheConnection);
 
-            using(NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-                
                 Object a = dr[5];
                 Assert.IsNotNull(a);
             }
         }
+
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void ExecuteReaderBeforeClosingReader()
         {
             if (TheConnection.PreloadReader)//this behavior won't happen in this case so we fake it for the sake of the test.
                 throw new InvalidOperationException();
-            NpgsqlCommand cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            using(NpgsqlDataReader dr1 = cmd1.ExecuteReader())
+
+            var cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
+            using (var dr1 = cmd1.ExecuteReader())
+            using (var cmd2 = new NpgsqlCommand("select * from tablea", TheConnection))
+            using (var dr2 = cmd2.ExecuteReader())
             {
-                NpgsqlCommand cmd2 = new NpgsqlCommand("select * from tablea", TheConnection);
-                NpgsqlDataReader dr2 = cmd2.ExecuteReader();
             }
         }
+
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void ExecuteScalarBeforeClosingReader()
         {
             if (TheConnection.PreloadReader)//this behavior won't happen in this case so we fake it for the sake of the test.
                 throw new InvalidOperationException();
-            NpgsqlCommand cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            using(NpgsqlDataReader dr1 = cmd1.ExecuteReader())
+
+            var cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
+
+            using (var dr1 = cmd1.ExecuteReader())
+            using (var cmd2 = new NpgsqlCommand("select * from tablea", TheConnection))
             {
-                NpgsqlCommand cmd2 = new NpgsqlCommand("select * from tablea", TheConnection);
                 cmd2.ExecuteScalar();
             }
         }
+
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void ExecuteNonQueryBeforeClosingReader()
         {
             if (TheConnection.PreloadReader)//this behavior won't happen in this case so we fake it for the sake of the test.
                 throw new InvalidOperationException();
-            NpgsqlCommand cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            using(NpgsqlDataReader dr1 = cmd1.ExecuteReader())
+
+            var cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
+            using (var dr1 = cmd1.ExecuteReader())
+            using (var cmd2 = new NpgsqlCommand("select * from tablea", TheConnection))
             {
-                NpgsqlCommand cmd2 = new NpgsqlCommand("select * from tablea", TheConnection);
                 cmd2.ExecuteNonQuery();
             }
         }
+
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void PrepareBeforeClosingReader()
         {
             if (TheConnection.PreloadReader)//this behavior won't happen in this case so we fake it for the sake of the test.
                 throw new InvalidOperationException();
-            NpgsqlCommand cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
-            using(NpgsqlDataReader dr1 = cmd1.ExecuteReader())
+
+            var cmd1 = new NpgsqlCommand("select field_serial from tablea", TheConnection);
+            using (var dr1 = cmd1.ExecuteReader())
+            using (var cmd2 = new NpgsqlCommand("select * from tablea", TheConnection))
             {
-                NpgsqlCommand cmd2 = new NpgsqlCommand("select * from tablea", TheConnection);
                 cmd2.Prepare();
             }
         }
@@ -1023,43 +891,37 @@ namespace NpgsqlTests
         [Test]
         public void LoadDataTable()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableh", TheConnection);
-            NpgsqlDataReader dr = command.ExecuteReader();
-            DataTable dt = new DataTable();
+            var command = new NpgsqlCommand("select * from tableh", TheConnection);
+            var dr = command.ExecuteReader();
+            var dt = new DataTable();
             dt.Load(dr);
             dr.Close();
 
             Assert.AreEqual(5, dt.Columns[1].MaxLength);
             Assert.AreEqual(5, dt.Columns[2].MaxLength);
         }
+
         [Test]
         public void CleansupOkWithDisposeCalls()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tablea", TheConnection);
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            var command = new NpgsqlCommand("select * from tablea", TheConnection);
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-                
                 dr.Close();
-                using (NpgsqlCommand upd = TheConnection.CreateCommand())
+
+                using (var upd = TheConnection.CreateCommand())
                 {
                     upd.CommandText = "select * from tablea";
                     upd.Prepare();
                 }
-                
-           
             }
-            
-            
-            
-            
         }
-        
         
         [Test]
         public void TestOutParameter2()
         {
-            NpgsqlCommand command = new NpgsqlCommand("testoutparameter2", TheConnection);
+            var command = new NpgsqlCommand("testoutparameter2", TheConnection);
             command.CommandType = CommandType.StoredProcedure;
             
             command.Parameters.Add(new NpgsqlParameter("@x", NpgsqlDbType.Integer)).Value = 1;
@@ -1070,46 +932,32 @@ namespace NpgsqlTests
             command.Parameters["@sum"].Direction = ParameterDirection.Output;
             command.Parameters["@product"].Direction = ParameterDirection.Output;
             
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
                 
                 Assert.AreEqual(3, command.Parameters["@sum"].Value);
                 Assert.AreEqual(2, command.Parameters["@product"].Value);
-                
-                
-           
             }
-            
         }
 
         [Test]
         public void GetValueWithNullFields()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select * from tableb", TheConnection);
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            var command = new NpgsqlCommand("select * from tableb", TheConnection);
+            using (var dr = command.ExecuteReader())
             {
                 dr.Read();
-
-                Boolean result = dr.IsDBNull(2);
-
+                var result = dr.IsDBNull(2);
                 Assert.IsTrue(result);
-
-
-
             }
-
-
-
-
         }
-
         
         [Test]
         public void HasRowsGetValue()
         {
-            NpgsqlCommand command = new NpgsqlCommand("select 1", TheConnection);
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            var command = new NpgsqlCommand("select 1", TheConnection);
+            using (var dr = command.ExecuteReader())
             {
                 Assert.IsTrue(dr.HasRows);
                 Assert.IsTrue(dr.Read());
@@ -1117,25 +965,23 @@ namespace NpgsqlTests
             }
         }
         
-        
         [Test]
         public void IntervalAsTimeSpan()
         {
-            NpgsqlCommand command = new NpgsqlCommand();
+            var command = new NpgsqlCommand();
             command.CommandType = CommandType.Text;
             command.CommandText = "SELECT CAST('1 hour' AS interval) AS dauer";
             command.Connection = TheConnection;
             
-            using (NpgsqlDataReader dr = command.ExecuteReader())
+            using (var dr = command.ExecuteReader())
             {
                 Assert.IsTrue(dr.HasRows);
                 Assert.IsTrue(dr.Read());
-                TimeSpan ts = dr.GetTimeSpan(0);
+                var ts = dr.GetTimeSpan(0);
             }
         }
-
-        
     }
+
     [TestFixture]
     public class DataReaderTestsV2 : DataReaderTests
     {

--- a/testsuite/noninteractive/NUnit20/ExceptionTests.cs
+++ b/testsuite/noninteractive/NUnit20/ExceptionTests.cs
@@ -1,4 +1,4 @@
-﻿// project created on 30/11/2002 at 22:00
+// project created on 30/11/2002 at 22:00
 //
 // Author:
 //  David Rowley <dgrowley@gmail.com>
@@ -32,29 +32,32 @@ using NUnit.Framework;
 
 namespace NpgsqlTests
 {
-
     [TestFixture]
     public class ExceptionTests : BaseClassTests
     {
-        protected override NpgsqlConnection TheConnection {
-            get { return _conn;}
+        protected override NpgsqlConnection TheConnection
+        {
+            get { return _conn; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _t; }
             set { _t = value; }
         }
-        protected virtual string TheConnectionString {
+
+        protected virtual string TheConnectionString
+        {
             get { return _connString; }
         }
 
         [Test]
         public void ProblemSqlInsideException()
         {
-            String sql = "selec 1 as test";
+            const string sql = "selec 1 as test";
             try
             {
-                NpgsqlCommand command = new NpgsqlCommand(sql, TheConnection);
-
+                var command = new NpgsqlCommand(sql, TheConnection);
                 command.ExecuteReader();
             }
             catch (NpgsqlException ex)
@@ -66,9 +69,9 @@ namespace NpgsqlTests
         [Test]
         public void ExceptionFieldsArePopulated()
         {
-            String dropTable = "DROP TABLE IF EXISTS public.uniqueviolation";
-            String createTable = "CREATE TABLE public.uniqueviolation (id INT NOT NULL, CONSTRAINT uniqueviolation_pkey PRIMARY KEY (id))";
-            String insertStatement = "INSERT INTO public.uniqueviolation (id) VALUES(1)";
+            const string dropTable = @"DROP TABLE IF EXISTS public.uniqueviolation";
+            const string createTable = @"CREATE TABLE public.uniqueviolation (id INT NOT NULL, CONSTRAINT uniqueviolation_pkey PRIMARY KEY (id))";
+            const string insertStatement = @"INSERT INTO public.uniqueviolation (id) VALUES(1)";
 
             // Since the 5 error fields were added as of PostgreSQL 9.3, we'll skip testing for versions previous to that.
             if (TheConnection.PostgreSqlVersion < new Version("9.3"))
@@ -78,7 +81,7 @@ namespace NpgsqlTests
             // cases than this as the same code is executed in all error situations.
             try
             {
-                NpgsqlCommand command = new NpgsqlCommand(dropTable, TheConnection);
+                var command = new NpgsqlCommand(dropTable, TheConnection);
                 command.ExecuteNonQuery();
 
                 command = new NpgsqlCommand(createTable, TheConnection);
@@ -104,9 +107,9 @@ namespace NpgsqlTests
         [Test]
         public void ColumnNameExceptionFieldIsPopulated()
         {
-            String dropTable = "DROP TABLE IF EXISTS public.notnullviolation";
-            String createTable = "CREATE TABLE public.notnullviolation (id INT NOT NULL)";
-            String insertStatement = "INSERT INTO public.notnullviolation (id) VALUES(NULL)";
+            const string dropTable = @"DROP TABLE IF EXISTS public.notnullviolation";
+            const string createTable = @"CREATE TABLE public.notnullviolation (id INT NOT NULL)";
+            const string insertStatement = @"INSERT INTO public.notnullviolation (id) VALUES(NULL)";
 
             // Since the 5 error fields were added as of PostgreSQL 9.3, we'll skip testing for versions previous to that.
             if (TheConnection.PostgreSqlVersion < new Version("9.3"))
@@ -114,7 +117,7 @@ namespace NpgsqlTests
 
             try
             {
-                NpgsqlCommand command = new NpgsqlCommand(dropTable, TheConnection);
+                var command = new NpgsqlCommand(dropTable, TheConnection);
                 command.ExecuteNonQuery();
 
                 command = new NpgsqlCommand(createTable, TheConnection);
@@ -140,9 +143,9 @@ namespace NpgsqlTests
             // datatypename field is populated is when using domain types. So here we'll
             // create a domain that simply does not allow NULLs then try and cast NULL
             // to it.
-            String dropDomain = "DROP DOMAIN IF EXISTS public.intnotnull";
-            String createDomain = "CREATE DOMAIN public.intnotnull AS INT NOT NULL";
-            String castStatement = "SELECT CAST(NULL AS public.intnotnull)";
+            const string dropDomain = @"DROP DOMAIN IF EXISTS public.intnotnull";
+            const string createDomain = @"CREATE DOMAIN public.intnotnull AS INT NOT NULL";
+            const string castStatement = @"SELECT CAST(NULL AS public.intnotnull)";
 
             // Since the 5 error fields were added as of PostgreSQL 9.3, we'll skip testing for versions previous to that.
             if (TheConnection.PostgreSqlVersion < new Version("9.3"))
@@ -150,7 +153,7 @@ namespace NpgsqlTests
 
             try
             {
-                NpgsqlCommand command = new NpgsqlCommand(dropDomain, TheConnection);
+                var command = new NpgsqlCommand(dropDomain, TheConnection);
                 command.ExecuteNonQuery();
 
                 command = new NpgsqlCommand(createDomain, TheConnection);
@@ -167,6 +170,5 @@ namespace NpgsqlTests
                 Assert.AreEqual("intnotnull", ex.DataTypeName);
             }
         }
-
     }
 }

--- a/testsuite/noninteractive/NUnit20/NpgsqlParameterTests.cs
+++ b/testsuite/noninteractive/NUnit20/NpgsqlParameterTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // NpgsqlParameterTest.cs - NUnit Test Cases for testing the
 //                          NpgsqlParameter class
 // Author:
@@ -49,12 +49,12 @@ namespace NpgsqlTests
         [Test]
         public void Constructor1()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
+            var p = new NpgsqlParameter();
             Assert.AreEqual(DbType.String, p.DbType, "DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "Direction");
             Assert.IsFalse(p.IsNullable, "IsNullable");
 #if NET_2_0
-			//Assert.AreEqual (0, p.LocaleId, "LocaleId");
+            //Assert.AreEqual (0, p.LocaleId, "LocaleId");
 #endif
             Assert.AreEqual(string.Empty, p.ParameterName, "ParameterName");
             Assert.AreEqual(0, p.Precision, "Precision");
@@ -62,7 +62,7 @@ namespace NpgsqlTests
             Assert.AreEqual(0, p.Size, "Size");
             Assert.AreEqual(string.Empty, p.SourceColumn, "SourceColumn");
 #if NET_2_0
-			Assert.IsFalse (p.SourceColumnNullMapping, "SourceColumnNullMapping");
+            Assert.IsFalse(p.SourceColumnNullMapping, "SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "SourceVersion");
             Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "NpgsqlDbType");
@@ -80,14 +80,14 @@ namespace NpgsqlTests
         [Test]
         public void Constructor2_Value_DateTime()
         {
-            DateTime value = new DateTime(2004, 8, 24);
+            var value = new DateTime(2004, 8, 24);
 
-            NpgsqlParameter p = new NpgsqlParameter("address", value);
+            var p = new NpgsqlParameter("address", value);
             Assert.AreEqual(DbType.DateTime, p.DbType, "B:DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "B:Direction");
             Assert.IsFalse(p.IsNullable, "B:IsNullable");
 #if NET_2_0
-			//Assert.AreEqual (0, p.LocaleId, "B:LocaleId");
+            //Assert.AreEqual (0, p.LocaleId, "B:LocaleId");
 #endif
             Assert.AreEqual("address", p.ParameterName, "B:ParameterName");
             Assert.AreEqual(0, p.Precision, "B:Precision");
@@ -95,13 +95,13 @@ namespace NpgsqlTests
             //Assert.AreEqual (0, p.Size, "B:Size");
             Assert.AreEqual(string.Empty, p.SourceColumn, "B:SourceColumn");
 #if NET_2_0
-			Assert.IsFalse (p.SourceColumnNullMapping, "B:SourceColumnNullMapping");
+            Assert.IsFalse(p.SourceColumnNullMapping, "B:SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "B:SourceVersion");
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "B:NpgsqlDbType");
 #if NET_2_0
-			// FIXME
-			//Assert.AreEqual (new SqlDateTime (value), p.NpgsqlValue, "B:NpgsqlValue");
+            // FIXME
+            //Assert.AreEqual (new SqlDateTime (value), p.NpgsqlValue, "B:NpgsqlValue");
 #endif
             Assert.AreEqual(value, p.Value, "B:Value");
 #if NET_2_0
@@ -114,12 +114,12 @@ namespace NpgsqlTests
         [Test]
         public void Constructor2_Value_DBNull()
         {
-            NpgsqlParameter p = new NpgsqlParameter("address", DBNull.Value);
+            var p = new NpgsqlParameter("address", DBNull.Value);
             Assert.AreEqual(DbType.String, p.DbType, "B:DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "B:Direction");
             Assert.IsFalse(p.IsNullable, "B:IsNullable");
 #if NET_2_0
-			//Assert.AreEqual (0, p.LocaleId, "B:LocaleId");
+            //Assert.AreEqual (0, p.LocaleId, "B:LocaleId");
 #endif
             Assert.AreEqual("address", p.ParameterName, "B:ParameterName");
             Assert.AreEqual(0, p.Precision, "B:Precision");
@@ -127,13 +127,13 @@ namespace NpgsqlTests
             Assert.AreEqual(0, p.Size, "B:Size");
             Assert.AreEqual(string.Empty, p.SourceColumn, "B:SourceColumn");
 #if NET_2_0
-			Assert.IsFalse (p.SourceColumnNullMapping, "B:SourceColumnNullMapping");
+            Assert.IsFalse(p.SourceColumnNullMapping, "B:SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "B:SourceVersion");
             Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "B:NpgsqlDbType");
 #if NET_2_0
-			// FIXME
-			//Assert.AreEqual (SqlString.Null, p.NpgsqlValue, "B:NpgsqlValue");
+            // FIXME
+            //Assert.AreEqual (SqlString.Null, p.NpgsqlValue, "B:NpgsqlValue");
 #endif
             Assert.AreEqual(DBNull.Value, p.Value, "B:Value");
 #if NET_2_0
@@ -146,12 +146,12 @@ namespace NpgsqlTests
         [Test]
         public void Constructor2_Value_Null()
         {
-            NpgsqlParameter p = new NpgsqlParameter("address", (Object)null);
+            var p = new NpgsqlParameter("address", (Object) null);
             Assert.AreEqual(DbType.String, p.DbType, "A:DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "A:Direction");
             Assert.IsFalse(p.IsNullable, "A:IsNullable");
 #if NET_2_0
-			//Assert.AreEqual (0, p.LocaleId, "A:LocaleId");
+            //Assert.AreEqual (0, p.LocaleId, "A:LocaleId");
 #endif
             Assert.AreEqual("address", p.ParameterName, "A:ParameterName");
             Assert.AreEqual(0, p.Precision, "A:Precision");
@@ -159,12 +159,12 @@ namespace NpgsqlTests
             Assert.AreEqual(0, p.Size, "A:Size");
             Assert.AreEqual(string.Empty, p.SourceColumn, "A:SourceColumn");
 #if NET_2_0
-			Assert.IsFalse (p.SourceColumnNullMapping, "A:SourceColumnNullMapping");
+            Assert.IsFalse(p.SourceColumnNullMapping, "A:SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "A:SourceVersion");
             Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "A:NpgsqlDbType");
 #if NET_2_0
-			Assert.IsNull (p.NpgsqlValue, "A:NpgsqlValue");
+            Assert.IsNull(p.NpgsqlValue, "A:NpgsqlValue");
 #endif
             Assert.IsNull(p.Value, "A:Value");
 #if NET_2_0
@@ -175,30 +175,31 @@ namespace NpgsqlTests
         }
 
 #if NET_2_0
-		[Test] //.ctor (String, NpgsqlDbType, Int32, String, ParameterDirection, bool, byte, byte, DataRowVersion, object)
-		public void Constructor7 ()
-		{
-			NpgsqlParameter p1 = new NpgsqlParameter ("p1Name", NpgsqlDbType.Varchar, 20,
-							    "srcCol", ParameterDirection.InputOutput, false, 0, 0,
-							    DataRowVersion.Original, "foo");
-			Assert.AreEqual (DbType.String, p1.DbType, "DbType");
-			Assert.AreEqual (ParameterDirection.InputOutput, p1.Direction, "Direction");
-			Assert.AreEqual (false, p1.IsNullable, "IsNullable");
-			//Assert.AreEqual (999, p1.LocaleId, "#");
-			Assert.AreEqual ("p1Name", p1.ParameterName, "ParameterName");
-			Assert.AreEqual (0, p1.Precision, "Precision");
-			Assert.AreEqual (0, p1.Scale, "Scale");
-			Assert.AreEqual (20, p1.Size, "Size");
-			Assert.AreEqual ("srcCol", p1.SourceColumn, "SourceColumn");
-			Assert.AreEqual (false, p1.SourceColumnNullMapping, "SourceColumnNullMapping");
-			Assert.AreEqual (DataRowVersion.Original, p1.SourceVersion, "SourceVersion");
+        [Test]
+        //.ctor (String, NpgsqlDbType, Int32, String, ParameterDirection, bool, byte, byte, DataRowVersion, object)
+        public void Constructor7()
+        {
+            var p1 = new NpgsqlParameter("p1Name", NpgsqlDbType.Varchar, 20,
+                                         "srcCol", ParameterDirection.InputOutput, false, 0, 0,
+                                         DataRowVersion.Original, "foo");
+            Assert.AreEqual(DbType.String, p1.DbType, "DbType");
+            Assert.AreEqual(ParameterDirection.InputOutput, p1.Direction, "Direction");
+            Assert.AreEqual(false, p1.IsNullable, "IsNullable");
+            //Assert.AreEqual (999, p1.LocaleId, "#");
+            Assert.AreEqual("p1Name", p1.ParameterName, "ParameterName");
+            Assert.AreEqual(0, p1.Precision, "Precision");
+            Assert.AreEqual(0, p1.Scale, "Scale");
+            Assert.AreEqual(20, p1.Size, "Size");
+            Assert.AreEqual("srcCol", p1.SourceColumn, "SourceColumn");
+            Assert.AreEqual(false, p1.SourceColumnNullMapping, "SourceColumnNullMapping");
+            Assert.AreEqual(DataRowVersion.Original, p1.SourceVersion, "SourceVersion");
             Assert.AreEqual(NpgsqlDbType.Varchar, p1.NpgsqlDbType, "NpgsqlDbType");
-			//Assert.AreEqual (3210, p1.NpgsqlValue, "#");
-			Assert.AreEqual ("foo", p1.Value, "Value");
+            //Assert.AreEqual (3210, p1.NpgsqlValue, "#");
+            Assert.AreEqual("foo", p1.Value, "Value");
             //Assert.AreEqual ("database", p1.XmlSchemaCollectionDatabase, "XmlSchemaCollectionDatabase");
             //Assert.AreEqual ("name", p1.XmlSchemaCollectionName, "XmlSchemaCollectionName");
             //Assert.AreEqual ("schema", p1.XmlSchemaCollectionOwningSchema, "XmlSchemaCollectionOwningSchema");
-		}
+        }
 
         //[Test]
         //public void CompareInfo ()
@@ -215,7 +216,7 @@ namespace NpgsqlTests
         {
             Byte value = 0x0a;
 
-            NpgsqlParameter param = new NpgsqlParameter();
+            var param = new NpgsqlParameter();
             param.Value = value;
             // no support for byte
             Assert.AreEqual(NpgsqlDbType.Smallint, param.NpgsqlDbType, "#1");
@@ -225,9 +226,9 @@ namespace NpgsqlTests
         [Test]
         public void InferType_ByteArray()
         {
-            Byte[] value = new Byte[] { 0x0a, 0x0d };
+            var value = new Byte[] {0x0a, 0x0d};
 
-            NpgsqlParameter param = new NpgsqlParameter();
+            var param = new NpgsqlParameter();
             param.Value = value;
             Assert.AreEqual(NpgsqlDbType.Bytea, param.NpgsqlDbType, "#1");
             Assert.AreEqual(DbType.Binary, param.DbType, "#2");
@@ -451,7 +452,7 @@ namespace NpgsqlTests
         public void InferType_Enum()
         {
             NpgsqlParameter param;
-            
+
 #if NeedsPorting
             param = new NpgsqlParameter();
             param.Value = ByteEnum.A;
@@ -468,9 +469,8 @@ namespace NpgsqlTests
         [Test]
         public void InferType_Guid()
         {
-            Guid value = Guid.NewGuid();
-
-            NpgsqlParameter param = new NpgsqlParameter();
+            var value = Guid.NewGuid();
+            var param = new NpgsqlParameter();
             param.Value = value;
             Assert.AreEqual(NpgsqlDbType.Uuid, param.NpgsqlDbType, "#1");
             Assert.AreEqual(DbType.Guid, param.DbType, "#2");
@@ -494,7 +494,7 @@ namespace NpgsqlTests
             Assert.AreEqual(NpgsqlDbType.Smallint, param.NpgsqlDbType, "#B1");
             Assert.AreEqual(DbType.Int16, param.DbType, "#B2");
 
-            value = (Int16)0;
+            value = (Int16) 0;
             param = new NpgsqlParameter();
             param.Value = value;
             Assert.AreEqual(NpgsqlDbType.Smallint, param.NpgsqlDbType, "#C1");
@@ -554,45 +554,52 @@ namespace NpgsqlTests
         [Test]
         [Ignore]
 #if NET_2_0
-		[Category ("NotWorking")]
+        [Category("NotWorking")]
 #endif
         public void InferType_Invalid()
         {
-            object[] notsupported = new object[] {
-				UInt16.MaxValue,
-				UInt32.MaxValue,
-				UInt64.MaxValue,
-				SByte.MaxValue,
-				new NpgsqlParameter ()
-			};
+            var notsupported = new object[]
+                                        {
+                                            UInt16.MaxValue,
+                                            UInt32.MaxValue,
+                                            UInt64.MaxValue,
+                                            SByte.MaxValue,
+                                            new NpgsqlParameter()
+                                        };
 
-            NpgsqlParameter param = new NpgsqlParameter();
+            var param = new NpgsqlParameter();
 
-            for (int i = 0; i < notsupported.Length; i++)
+            for (var i = 0; i < notsupported.Length; i++)
             {
 #if NET_2_0
-				param.Value = notsupported [i];
-				try {
-					NpgsqlDbType type = param.NpgsqlDbType;
-					Assert.Fail ("#A1:" + i + " (" + type + ")");
-				} catch (ArgumentException ex) {
-					// The parameter data type of ... is invalid
-					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#A2");
-					Assert.IsNull (ex.InnerException, "#A3");
-					Assert.IsNotNull (ex.Message, "#A4");
-					Assert.IsNull (ex.ParamName, "#A5");
-				}
+                param.Value = notsupported[i];
+                try
+                {
+                    var type = param.NpgsqlDbType;
+                    Assert.Fail("#A1:" + i + " (" + type + ")");
+                }
+                catch (ArgumentException ex)
+                {
+                    // The parameter data type of ... is invalid
+                    Assert.AreEqual(typeof (ArgumentException), ex.GetType(), "#A2");
+                    Assert.IsNull(ex.InnerException, "#A3");
+                    Assert.IsNotNull(ex.Message, "#A4");
+                    Assert.IsNull(ex.ParamName, "#A5");
+                }
 
-				try {
-					DbType type = param.DbType;
-					Assert.Fail ("#B1:" + i + " (" + type + ")");
-				} catch (ArgumentException ex) {
-					// The parameter data type of ... is invalid
-					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#B2");
-					Assert.IsNull (ex.InnerException, "#B3");
-					Assert.IsNotNull (ex.Message, "#B4");
-					Assert.IsNull (ex.ParamName, "#B5");
-				}
+                try
+                {
+                    var type = param.DbType;
+                    Assert.Fail("#B1:" + i + " (" + type + ")");
+                }
+                catch (ArgumentException ex)
+                {
+                    // The parameter data type of ... is invalid
+                    Assert.AreEqual(typeof (ArgumentException), ex.GetType(), "#B2");
+                    Assert.IsNull(ex.InnerException, "#B3");
+                    Assert.IsNotNull(ex.Message, "#B4");
+                    Assert.IsNull(ex.ParamName, "#B5");
+                }
 #else
                 try
                 {
@@ -632,9 +639,8 @@ namespace NpgsqlTests
         [Test]
         public void InferType_Single()
         {
-            Single value = Single.MaxValue;
-
-            NpgsqlParameter param = new NpgsqlParameter();
+            var value = Single.MaxValue;
+            var param = new NpgsqlParameter();
             param.Value = value;
             Assert.AreEqual(NpgsqlDbType.Real, param.NpgsqlDbType, "#1");
             Assert.AreEqual(DbType.Single, param.DbType, "#2");
@@ -643,9 +649,8 @@ namespace NpgsqlTests
         [Test]
         public void InferType_String()
         {
-            String value = "some text";
-
-            NpgsqlParameter param = new NpgsqlParameter();
+            const string value = "some text";
+            var param = new NpgsqlParameter();
             param.Value = value;
             Assert.AreEqual(NpgsqlDbType.Text, param.NpgsqlDbType, "#1");
             Assert.AreEqual(DbType.String, param.DbType, "#2");
@@ -654,17 +659,16 @@ namespace NpgsqlTests
         [Test]
         [Ignore]
 #if NET_2_0
-		[Category ("NotWorking")]
+        [Category("NotWorking")]
 #endif
         public void InferType_TimeSpan()
         {
-            TimeSpan value = new TimeSpan(4, 6, 23);
-
-            NpgsqlParameter param = new NpgsqlParameter();
+            var value = new TimeSpan(4, 6, 23);
+            var param = new NpgsqlParameter();
 #if NET_2_0
-			param.Value = value;
-			Assert.AreEqual (NpgsqlDbType.Interval, param.NpgsqlDbType, "#1");
-			Assert.AreEqual (DbType.Time, param.DbType, "#2");
+            param.Value = value;
+            Assert.AreEqual(NpgsqlDbType.Interval, param.NpgsqlDbType, "#1");
+            Assert.AreEqual(DbType.Time, param.DbType, "#2");
 #else
             try
             {
@@ -702,7 +706,7 @@ namespace NpgsqlTests
         [Test] // bug #320196
         public void ParameterNullTest()
         {
-            NpgsqlParameter param = new NpgsqlParameter("param", NpgsqlDbType.Numeric);
+            var param = new NpgsqlParameter("param", NpgsqlDbType.Numeric);
             Assert.AreEqual(0, param.Scale, "#A1");
             param.Value = DBNull.Value;
             Assert.AreEqual(0, param.Scale, "#A2");
@@ -733,19 +737,19 @@ namespace NpgsqlTests
             Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#C2");
             p.Value = DBNull.Value;
 #if NET_2_0
-			Assert.AreEqual (DbType.String, p.DbType, "#D1");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#D2");
+            Assert.AreEqual(DbType.String, p.DbType, "#D1");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#D2");
 #else
             Assert.AreEqual(DbType.Int32, p.DbType, "#D1");
             Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#D2");
 #endif
-            p.Value = new byte[] { 0x0a };
+            p.Value = new byte[] {0x0a};
             Assert.AreEqual(DbType.Binary, p.DbType, "#E1");
             Assert.AreEqual(NpgsqlDbType.Bytea, p.NpgsqlDbType, "#E2");
             p.Value = null;
 #if NET_2_0
-			Assert.AreEqual (DbType.String, p.DbType, "#F1");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#F2");
+            Assert.AreEqual(DbType.String, p.DbType, "#F1");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#F2");
 #else
             Assert.AreEqual(DbType.Binary, p.DbType, "#F1");
             Assert.AreEqual(NpgsqlDbType.VarBinary, p.NpgsqlDbType, "#F2");
@@ -755,8 +759,8 @@ namespace NpgsqlTests
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#G2");
             p.Value = null;
 #if NET_2_0
-			Assert.AreEqual (DbType.String, p.DbType, "#H1");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#H2");
+            Assert.AreEqual(DbType.String, p.DbType, "#H1");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#H2");
 #else
             Assert.AreEqual(DbType.DateTime, p.DbType, "#H1");
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#H2");
@@ -810,7 +814,7 @@ namespace NpgsqlTests
         [Ignore]
         public void ParameterName()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
+            var p = new NpgsqlParameter();
             p.ParameterName = "name";
             Assert.AreEqual("name", p.ParameterName, "#A:ParameterName");
             Assert.AreEqual(string.Empty, p.SourceColumn, "#A:SourceColumn");
@@ -833,68 +837,68 @@ namespace NpgsqlTests
         }
 
 #if NET_2_0
-		[Test]
-		public void ResetDbType ()
-		{
-			NpgsqlParameter p;
+        [Test]
+        public void ResetDbType()
+        {
+            NpgsqlParameter p;
 
-			//Parameter with an assigned value but no DbType specified
-			p = new NpgsqlParameter ("foo", 42);
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.Int32, p.DbType, "#A:DbType");
-			Assert.AreEqual (NpgsqlDbType.Integer, p.NpgsqlDbType, "#A:NpgsqlDbType");
-			Assert.AreEqual (42, p.Value, "#A:Value");
+            //Parameter with an assigned value but no DbType specified
+            p = new NpgsqlParameter("foo", 42);
+            p.ResetDbType();
+            Assert.AreEqual(DbType.Int32, p.DbType, "#A:DbType");
+            Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#A:NpgsqlDbType");
+            Assert.AreEqual(42, p.Value, "#A:Value");
 
-			p.DbType = DbType.DateTime; //assigning a DbType
-			Assert.AreEqual (DbType.DateTime, p.DbType, "#B:DbType1");
-			Assert.AreEqual (NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#B:SqlDbType1");
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.Int32, p.DbType, "#B:DbType2");
-			Assert.AreEqual (NpgsqlDbType.Integer, p.NpgsqlDbType, "#B:SqlDbtype2");
+            p.DbType = DbType.DateTime; //assigning a DbType
+            Assert.AreEqual(DbType.DateTime, p.DbType, "#B:DbType1");
+            Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#B:SqlDbType1");
+            p.ResetDbType();
+            Assert.AreEqual(DbType.Int32, p.DbType, "#B:DbType2");
+            Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#B:SqlDbtype2");
 
-			//Parameter with an assigned NpgsqlDbType but no specified value
-			p = new NpgsqlParameter ("foo", NpgsqlDbType.Integer);
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.String, p.DbType, "#C:DbType");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#C:NpgsqlDbType");
+            //Parameter with an assigned NpgsqlDbType but no specified value
+            p = new NpgsqlParameter("foo", NpgsqlDbType.Integer);
+            p.ResetDbType();
+            Assert.AreEqual(DbType.String, p.DbType, "#C:DbType");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#C:NpgsqlDbType");
 
-			p.DbType = DbType.DateTime; //assigning a NpgsqlDbType
-			Assert.AreEqual (DbType.DateTime, p.DbType, "#D:DbType1");
-			Assert.AreEqual (NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#D:SqlDbType1");
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.String, p.DbType, "#D:DbType2");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#D:SqlDbType2");
+            p.DbType = DbType.DateTime; //assigning a NpgsqlDbType
+            Assert.AreEqual(DbType.DateTime, p.DbType, "#D:DbType1");
+            Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#D:SqlDbType1");
+            p.ResetDbType();
+            Assert.AreEqual(DbType.String, p.DbType, "#D:DbType2");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#D:SqlDbType2");
 
-			p = new NpgsqlParameter ();
-			p.Value = DateTime.MaxValue;
-			Assert.AreEqual (DbType.DateTime, p.DbType, "#E:DbType1");
-			Assert.AreEqual (NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#E:SqlDbType1");
-			p.Value = null;
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.String, p.DbType, "#E:DbType2");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#E:SqlDbType2");
-
-			p = new NpgsqlParameter ("foo", NpgsqlDbType.Varchar);
-			p.Value = DateTime.MaxValue;
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.DateTime, p.DbType, "#F:DbType");
-			Assert.AreEqual (NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#F:NpgsqlDbType");
-			Assert.AreEqual (DateTime.MaxValue, p.Value, "#F:Value");
+            p = new NpgsqlParameter();
+            p.Value = DateTime.MaxValue;
+            Assert.AreEqual(DbType.DateTime, p.DbType, "#E:DbType1");
+            Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#E:SqlDbType1");
+            p.Value = null;
+            p.ResetDbType();
+            Assert.AreEqual(DbType.String, p.DbType, "#E:DbType2");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#E:SqlDbType2");
 
             p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
-			p.Value = DBNull.Value;
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.String, p.DbType, "#G:DbType");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
-			Assert.AreEqual (DBNull.Value, p.Value, "#G:Value");
+            p.Value = DateTime.MaxValue;
+            p.ResetDbType();
+            Assert.AreEqual(DbType.DateTime, p.DbType, "#F:DbType");
+            Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#F:NpgsqlDbType");
+            Assert.AreEqual(DateTime.MaxValue, p.Value, "#F:Value");
 
             p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
-			p.Value = null;
-			p.ResetDbType ();
-			Assert.AreEqual (DbType.String, p.DbType, "#G:DbType");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
-			Assert.IsNull (p.Value, "#G:Value");
-		}
+            p.Value = DBNull.Value;
+            p.ResetDbType();
+            Assert.AreEqual(DbType.String, p.DbType, "#G:DbType");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
+            Assert.AreEqual(DBNull.Value, p.Value, "#G:Value");
+
+            p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
+            p.Value = null;
+            p.ResetDbType();
+            Assert.AreEqual(DbType.String, p.DbType, "#G:DbType");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
+            Assert.IsNull(p.Value, "#G:Value");
+        }
 
 #if NeedsPorting
 		[Test]
@@ -943,7 +947,7 @@ namespace NpgsqlTests
         [Ignore]
         public void SourceColumn()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
+            var p = new NpgsqlParameter();
             p.SourceColumn = "name";
             Assert.AreEqual(string.Empty, p.ParameterName, "#A:ParameterName");
             Assert.AreEqual("name", p.SourceColumn, "#A:SourceColumn");
@@ -966,22 +970,22 @@ namespace NpgsqlTests
         }
 
 #if NET_2_0
-		[Test]
-		public void SourceColumnNullMapping ()
-		{
-			NpgsqlParameter p = new NpgsqlParameter ();
-			Assert.IsFalse (p.SourceColumnNullMapping, "#1");
-			p.SourceColumnNullMapping = true;
-			Assert.IsTrue (p.SourceColumnNullMapping, "#2");
-			p.SourceColumnNullMapping = false;
-			Assert.IsFalse (p.SourceColumnNullMapping, "#3");
-		}
+        [Test]
+        public void SourceColumnNullMapping()
+        {
+            var p = new NpgsqlParameter();
+            Assert.IsFalse(p.SourceColumnNullMapping, "#1");
+            p.SourceColumnNullMapping = true;
+            Assert.IsTrue(p.SourceColumnNullMapping, "#2");
+            p.SourceColumnNullMapping = false;
+            Assert.IsFalse(p.SourceColumnNullMapping, "#3");
+        }
 #endif
 
         [Test]
         public void NpgsqlDbTypeTest()
         {
-            NpgsqlParameter p = new NpgsqlParameter("zipcode", 3510);
+            var p = new NpgsqlParameter("zipcode", 3510);
             p.NpgsqlDbType = NpgsqlDbType.Timestamp;
             Assert.AreEqual(DbType.DateTime, p.DbType, "#A:DbType");
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#A:NpgsqlDbType");
@@ -995,7 +999,7 @@ namespace NpgsqlTests
         [Test]
         public void Bug1011100NpgsqlDbTypeTest()
         {
-            NpgsqlParameter p = new NpgsqlParameter();
+            var p = new NpgsqlParameter();
             p.Value = DBNull.Value;
             Assert.AreEqual(DbType.String, p.DbType, "#A:DbType");
             Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#A:NpgsqlDbType");
@@ -1021,25 +1025,25 @@ namespace NpgsqlTests
         [Ignore]
         public void NpgsqlDbTypeTest_Value_Invalid()
         {
-            NpgsqlParameter p = new NpgsqlParameter("zipcode", 3510);
+            var p = new NpgsqlParameter("zipcode", 3510);
             try
             {
-                p.NpgsqlDbType = (NpgsqlDbType)666;
+                p.NpgsqlDbType = (NpgsqlDbType) 666;
                 Assert.Fail("#1");
             }
             catch (ArgumentOutOfRangeException ex)
             {
 #if NET_2_0
-				// The NpgsqlDbType enumeration value, 666, is
-				// invalid
-				Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#2");
-				Assert.IsNull (ex.InnerException, "#3");
-				Assert.IsNotNull (ex.Message, "#4");
-				Assert.IsTrue (ex.Message.IndexOf ("666") != -1, "#5:" + ex.Message);
-				Assert.AreEqual ("NpgsqlDbType", ex.ParamName, "#6");
+                // The NpgsqlDbType enumeration value, 666, is
+                // invalid
+                Assert.AreEqual(typeof (ArgumentOutOfRangeException), ex.GetType(), "#2");
+                Assert.IsNull(ex.InnerException, "#3");
+                Assert.IsNotNull(ex.Message, "#4");
+                Assert.IsTrue(ex.Message.IndexOf("666") != -1, "#5:" + ex.Message);
+                Assert.AreEqual("NpgsqlDbType", ex.ParamName, "#6");
 #else
-                // Specified argument was out of the range of
-                // valid values
+    // Specified argument was out of the range of
+    // valid values
                 Assert.AreEqual(typeof(ArgumentOutOfRangeException), ex.GetType(), "#2");
                 Assert.IsNull(ex.InnerException, "#3");
                 Assert.IsNotNull(ex.Message, "#4");
@@ -1049,13 +1053,13 @@ namespace NpgsqlTests
         }
 
 #if NET_2_0
-		[Test]
-		public void NpgsqlValue ()
-		{
-			NpgsqlParameter parameter = new NpgsqlParameter ();
-			Assert.IsNull (parameter.NpgsqlValue, "#A1");
+        [Test]
+        public void NpgsqlValue()
+        {
+            var parameter = new NpgsqlParameter();
+            Assert.IsNull(parameter.NpgsqlValue, "#A1");
 
-			object value;
+            object value;
 
 #if NeedsPorting
 			value = "Char";
@@ -1083,13 +1087,13 @@ namespace NpgsqlTests
 			Assert.AreEqual (value, parameter.Value, "Boolean:Value");
 #endif
 
-			value = new DateTime (2008, 6, 4);
-			parameter.NpgsqlValue = value;
-			Assert.AreEqual (NpgsqlDbType.Timestamp, parameter.NpgsqlDbType, "DateTime:NpgsqlDbType");
-			Assert.IsNotNull (parameter.NpgsqlValue, "DateTime:SqlValue1");
-			Assert.AreEqual (typeof (NpgsqlTimeStamp), parameter.NpgsqlValue.GetType (), "DateTime:SqlValue2");
-            Assert.AreEqual(value, (DateTime)((NpgsqlTimeStamp)parameter.NpgsqlValue), "DateTime:SqlValue3");
-			Assert.AreEqual (value, parameter.Value, "DateTime:Value");
+            value = new DateTime(2008, 6, 4);
+            parameter.NpgsqlValue = value;
+            Assert.AreEqual(NpgsqlDbType.Timestamp, parameter.NpgsqlDbType, "DateTime:NpgsqlDbType");
+            Assert.IsNotNull(parameter.NpgsqlValue, "DateTime:SqlValue1");
+            Assert.AreEqual(typeof (NpgsqlTimeStamp), parameter.NpgsqlValue.GetType(), "DateTime:SqlValue2");
+            Assert.AreEqual(value, (DateTime) ((NpgsqlTimeStamp) parameter.NpgsqlValue), "DateTime:SqlValue3");
+            Assert.AreEqual(value, parameter.Value, "DateTime:Value");
 
 #if NeedsPorting
 			value = Guid.NewGuid ();
@@ -1340,11 +1344,11 @@ namespace NpgsqlTests
             NpgsqlTimeStamp value = DateTime.Now;
 
 #if NET_2_0
-			parameter = new NpgsqlParameter ();
-			parameter.NpgsqlValue = value;
-			Assert.AreEqual (NpgsqlDbType.Timestamp, parameter.NpgsqlDbType, "#A:NpgsqlDbType");
-			Assert.AreEqual (value, parameter.NpgsqlValue, "#A:NpgsqlValue");
-			Assert.AreEqual (value, parameter.Value, "#A:Value");
+            parameter = new NpgsqlParameter();
+            parameter.NpgsqlValue = value;
+            Assert.AreEqual(NpgsqlDbType.Timestamp, parameter.NpgsqlDbType, "#A:NpgsqlDbType");
+            Assert.AreEqual(value, parameter.NpgsqlValue, "#A:NpgsqlValue");
+            Assert.AreEqual(value, parameter.Value, "#A:Value");
 
 #if NeedsPorting
 			parameter = new NpgsqlParameter ();
@@ -1359,11 +1363,11 @@ namespace NpgsqlTests
             parameter.Value = value;
             Assert.AreEqual(NpgsqlDbType.Timestamp, parameter.NpgsqlDbType, "#C:NpgsqlDbType");
 #if NET_2_0
-			Assert.AreEqual (value, parameter.NpgsqlValue, "#C:NpgsqlValue");
+            Assert.AreEqual(value, parameter.NpgsqlValue, "#C:NpgsqlValue");
 #endif
             Assert.AreEqual(value, parameter.Value, "#C:Value");
         }
-        
+
 #if NeedsPorting
         [Test]
         public void SqlTypes_SqlDecimal()
@@ -1664,7 +1668,7 @@ namespace NpgsqlTests
         {
             NpgsqlParameter p;
 
-            p = new NpgsqlParameter("name", (Object)null);
+            p = new NpgsqlParameter("name", (Object) null);
             p.Value = 42;
             Assert.AreEqual(DbType.Int32, p.DbType, "#A:DbType");
             Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#A:NpgsqlDbType");
@@ -1672,8 +1676,8 @@ namespace NpgsqlTests
 
             p.Value = DBNull.Value;
 #if NET_2_0
-			Assert.AreEqual (DbType.String, p.DbType, "#B:DbType");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#B:NpgsqlDbType");
+            Assert.AreEqual(DbType.String, p.DbType, "#B:DbType");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#B:NpgsqlDbType");
 #else
             Assert.AreEqual(DbType.Int32, p.DbType, "#B:DbType");
             Assert.AreEqual(NpgsqlDbType.Integer, p.NpgsqlDbType, "#B:NpgsqlDbType");
@@ -1687,8 +1691,8 @@ namespace NpgsqlTests
 
             p.Value = null;
 #if NET_2_0
-			Assert.AreEqual (DbType.String, p.DbType, "#D:DbType");
-			Assert.AreEqual (NpgsqlDbType.Text, p.NpgsqlDbType, "#D:NpgsqlDbType");
+            Assert.AreEqual(DbType.String, p.DbType, "#D:DbType");
+            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#D:NpgsqlDbType");
 #else
             Assert.AreEqual(DbType.DateTime, p.DbType, "#D:DbType");
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#D:NpgsqlDbType");

--- a/testsuite/noninteractive/NUnit20/PrepareTests.cs
+++ b/testsuite/noninteractive/NUnit20/PrepareTests.cs
@@ -12,62 +12,57 @@ namespace NpgsqlTests
     [TestFixture]
     public class PrepareTest : BaseClassTests
     {
-        protected override NpgsqlConnection TheConnection {
+        protected override NpgsqlConnection TheConnection
+        {
             get { return _conn; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _t; }
             set { _t = value; }
         }
+
         protected override void SetUp()
         {
             base.SetUp();
-            string sql = @"	CREATE TABLE public.preparetest
-                         (
-                         testid serial NOT NULL,
-                         varchar_notnull varchar(100) NOT NULL,
-                         varchar_null varchar(100),
-                         integer_notnull int4 NOT NULL,
-                         integer_null int4,
-                         bigint_notnull int8 NOT NULL,
-                         bigint_null int8
-                         ) WITHOUT OIDS;";
-            NpgsqlCommand cmd = new NpgsqlCommand(sql, TheConnection);
+            const string sql = @"	CREATE TABLE public.preparetest
+                               (
+                               testid serial NOT NULL,
+                               varchar_notnull varchar(100) NOT NULL,
+                               varchar_null varchar(100),
+                               integer_notnull int4 NOT NULL,
+                               integer_null int4,
+                               bigint_notnull int8 NOT NULL,
+                               bigint_null int8
+                               ) WITHOUT OIDS;";
+            var cmd = new NpgsqlCommand(sql, TheConnection);
             cmd.ExecuteNonQuery();
             CommitTransaction = true;
         }
 
-
-        
         protected override void TearDown()
         {
-            
-            string sql = @"	DROP TABLE public.preparetest;";
-            NpgsqlCommand cmd = new NpgsqlCommand(sql, TheConnection);
-
+            const string sql = @"	DROP TABLE public.preparetest;";
+            var cmd = new NpgsqlCommand(sql, TheConnection);
             cmd.ExecuteNonQuery();
             CommitTransaction = true;
             base.TearDown();
         }
-        
 
         [Test]
         public void TestInt8Null()
         {
-            NpgsqlCommand cmd = GetCommand();
-
-
+            var cmd = GetCommand();
             // Default params work OK
             cmd.ExecuteNonQuery();
 
             cmd.Parameters[5].Value = System.DBNull.Value;
             //cmd.Parameters[5].Value = null;
-
             // This too
             cmd.ExecuteNonQuery();
 
             cmd.Prepare();
-
             // This will fail
             cmd.ExecuteNonQuery();
         }
@@ -75,19 +70,15 @@ namespace NpgsqlTests
         [Test]
         public void TestInt4Null()
         {
-            NpgsqlCommand cmd = GetCommand();
-
-
+            var cmd = GetCommand();
             // Default params work OK
             cmd.ExecuteNonQuery();
 
             cmd.Parameters[3].Value = System.DBNull.Value;
-
             // This too
             cmd.ExecuteNonQuery();
 
             cmd.Prepare();
-
             // This will fail
             cmd.ExecuteNonQuery();
         }
@@ -95,45 +86,41 @@ namespace NpgsqlTests
         [Test]
         public void TestVarcharNull()
         {
-            NpgsqlCommand cmd = GetCommand();
-
-
+            var cmd = GetCommand();
             // Default params work OK
             cmd.ExecuteNonQuery();
 
             cmd.Parameters[1].Value = System.DBNull.Value;
-
             // This too
             cmd.ExecuteNonQuery();
 
             cmd.Prepare();
-
             // This inserts a string with the value 'NULL'
             cmd.ExecuteNonQuery();
         }
 
         private NpgsqlCommand GetCommand()
         {
-            string sql = @"	INSERT INTO preparetest(varchar_notnull, varchar_null, integer_notnull, integer_null, bigint_notnull, bigint_null)
-                         VALUES(:param1, :param2, :param3, :param4, :param5, :param6)";
-            NpgsqlCommand cmd = new NpgsqlCommand(sql, TheConnection);
+            const string sql = @"	INSERT INTO preparetest(varchar_notnull, varchar_null, integer_notnull, integer_null, bigint_notnull, bigint_null)
+                                    VALUES(:param1, :param2, :param3, :param4, :param5, :param6)";
+            var cmd = new NpgsqlCommand(sql, TheConnection);
 
-            NpgsqlParameter p1 = new NpgsqlParameter("param1", DbType.String, 100);
+            var p1 = new NpgsqlParameter("param1", DbType.String, 100);
             p1.Value = "One";
             cmd.Parameters.Add(p1);
-            NpgsqlParameter p2 = new NpgsqlParameter("param2", DbType.String, 100);
+            var p2 = new NpgsqlParameter("param2", DbType.String, 100);
             p2.Value = "Two";
             cmd.Parameters.Add(p2);
-            NpgsqlParameter p3 = new NpgsqlParameter("param3", DbType.Int32);
+            var p3 = new NpgsqlParameter("param3", DbType.Int32);
             p3.Value = 3;
             cmd.Parameters.Add(p3);
-            NpgsqlParameter p4 = new NpgsqlParameter("param4", DbType.Int32);
+            var p4 = new NpgsqlParameter("param4", DbType.Int32);
             p4.Value = 4;
             cmd.Parameters.Add(p4);
-            NpgsqlParameter p5 = new NpgsqlParameter("param5", DbType.Int64);
+            var p5 = new NpgsqlParameter("param5", DbType.Int64);
             p5.Value = 5;
             cmd.Parameters.Add(p5);
-            NpgsqlParameter p6 = new NpgsqlParameter("param6", DbType.Int64);
+            var p6 = new NpgsqlParameter("param6", DbType.Int64);
             p6.Value = 6;
             cmd.Parameters.Add(p6);
 
@@ -143,27 +130,28 @@ namespace NpgsqlTests
         [Test]
         public void TestSubquery()
         {
-            string sql = "SELECT testid FROM preparetest WHERE :p1 IN (SELECT varchar_notnull FROM preparetest)";
-            NpgsqlCommand cmd = new NpgsqlCommand(sql, TheConnection);
-            NpgsqlParameter p1 = new NpgsqlParameter(":p1", DbType.String);
+            const string sql = @"SELECT testid FROM preparetest WHERE :p1 IN (SELECT varchar_notnull FROM preparetest)";
+            var cmd = new NpgsqlCommand(sql, TheConnection);
+            var p1 = new NpgsqlParameter(":p1", DbType.String);
             p1.Value = "blahblah";
             cmd.Parameters.Add(p1);
-
-
             cmd.ExecuteNonQuery(); // Succeeds
 
             cmd.Prepare(); // Fails
-
             cmd.ExecuteNonQuery();
         }
     }
+
     [TestFixture]
     public class PrepareTestV2 : PrepareTest
     {
-        protected override NpgsqlConnection TheConnection {
+        protected override NpgsqlConnection TheConnection
+        {
             get { return _connV2; }
         }
-        protected override NpgsqlTransaction TheTransaction {
+
+        protected override NpgsqlTransaction TheTransaction
+        {
             get { return _tV2; }
         }
     }

--- a/testsuite/noninteractive/NUnit20/SystemTransactionsTest.cs
+++ b/testsuite/noninteractive/NUnit20/SystemTransactionsTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Transactions;
 using Npgsql;
@@ -14,29 +14,28 @@ namespace NpgsqlTests
         {
             get { return _conn; }
         }
+
         protected override NpgsqlTransaction TheTransaction
         {
             get { return _t; }
             set { _t = value; }
         }
+
         protected virtual string TheConnectionString
         {
             get { return _connString; }
         }
 
-
         //[Test, Description("TransactionScope with a single connection, enlisting explicitly")]
         [Test]
         public void SimpleTransactionScopeWithExplicitEnlist()
         {
-
-
             try
             {
-                string connectionString = TheConnectionString;
-                using (var connection = new NpgsqlConnection(connectionString)) 
+                var connectionString = TheConnectionString;
+                using (var connection = new NpgsqlConnection(connectionString))
                 {
-                    using (var scope = new TransactionScope()) 
+                    using (var scope = new TransactionScope())
                     {
                         connection.Open();
                         connection.EnlistTransaction(Transaction.Current);
@@ -56,32 +55,31 @@ namespace NpgsqlTests
                 // This transaction should commit.
                 CommitTransaction = true;
             }
-            catch (System.NotImplementedException) {}
+            catch (System.NotImplementedException)
+            {
+            }
             // Mono version below 3.0 doesn't implement transaction methods. So just ignore. 
-
-            
-
         }
 
         //[Test, Description("TransactionScope with a single connection, enlisting implicitly")]
         [Test]
-        public void SimpleTransactionScopeWithImplicitEnlist ()
+        public void SimpleTransactionScopeWithImplicitEnlist()
         {
-            try 
+            try
             {
-                string connectionString = TheConnectionString + ";enlist=true";
-                using (var scope = new TransactionScope()) 
+                var connectionString = TheConnectionString + ";enlist=true";
+                using (var scope = new TransactionScope())
                 {
-                    using (var connection = new NpgsqlConnection(connectionString)) 
+                    using (var connection = new NpgsqlConnection(connectionString))
                     {
-                        connection.Open ();
-                        var command = new NpgsqlCommand ("insert into tablea(field_text) values (:p0)", connection);
-                        command.Parameters.Add (new NpgsqlParameter("p0", "test"));
-                        Assert.AreEqual (1, command.ExecuteNonQuery ());
+                        connection.Open();
+                        var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", connection);
+                        command.Parameters.Add(new NpgsqlParameter("p0", "test"));
+                        Assert.AreEqual(1, command.ExecuteNonQuery());
                     }
-                    scope.Complete ();
+                    scope.Complete();
                 }
-                AssertNoTransactions ();
+                AssertNoTransactions();
 
 
                 // Clean up data left in the last transaction.
@@ -91,11 +89,11 @@ namespace NpgsqlTests
 
                 // This transaction should commit.
                 CommitTransaction = true;
-            } 
-            catch (System.NotImplementedException) {}
+            }
+            catch (System.NotImplementedException)
+            {
+            }
             // Mono version below 3.0 doesn't implement transaction methods. So just ignore. 
-            
-            
         }
 
         [Test]
@@ -103,139 +101,116 @@ namespace NpgsqlTests
         {
             int field_serial1;
             int field_serial2;
-            try 
+            try
             {
-                string connectionString = TheConnectionString + ";enlist=true";
-                using (TransactionScope scope = new TransactionScope()) 
+                var connectionString = TheConnectionString + ";enlist=true";
+                using (var scope = new TransactionScope())
                 {
                     //UseStringParameterWithNoNpgsqlDbType
-                    using (NpgsqlConnection connection = new NpgsqlConnection(connectionString)) 
+                    using (var connection = new NpgsqlConnection(connectionString))
                     {
-                        connection.Open ();
-                        NpgsqlCommand command = new NpgsqlCommand ("insert into tablea(field_text) values (:p0)", connection);
-                
-                        command.Parameters.Add (new NpgsqlParameter("p0", "test"));
-                
-                
-                        Assert.AreEqual (command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Text);
-                        Assert.AreEqual (command.Parameters[0].DbType, DbType.String);
-                
-                        Object result = command.ExecuteNonQuery ();
-                
-                        Assert.AreEqual (1, result);
-                
-                
-                        field_serial1 = (int)new NpgsqlCommand ("select max(field_serial) from tablea", connection).ExecuteScalar ();
-                        NpgsqlCommand command2 = new NpgsqlCommand ("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", connection);
-                
-                
-                        result = command2.ExecuteScalar ();
-                
-                
-                
-                        Assert.AreEqual ("test", result);
+                        connection.Open();
+                        var command = new NpgsqlCommand("insert into tablea(field_text) values (:p0)", connection);
+                        command.Parameters.Add(new NpgsqlParameter("p0", "test"));
+                        Assert.AreEqual(command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Text);
+                        Assert.AreEqual(command.Parameters[0].DbType, DbType.String);
+                        object result = command.ExecuteNonQuery();
+                        Assert.AreEqual(1, result);
+
+                        field_serial1 = (int) new NpgsqlCommand("select max(field_serial) from tablea", connection).ExecuteScalar();
+                        var command2 = new NpgsqlCommand("select field_text from tablea where field_serial = (select max(field_serial) from tablea)", connection);
+                        result = command2.ExecuteScalar();
+                        Assert.AreEqual("test", result);
                     }
                     //UseIntegerParameterWithNoNpgsqlDbType
-                    using (NpgsqlConnection connection = new NpgsqlConnection(connectionString)) 
+                    using (var connection = new NpgsqlConnection(connectionString))
                     {
-                        connection.Open ();
-                        NpgsqlCommand command = new NpgsqlCommand ("insert into tablea(field_int4) values (:p0)", connection);
-                
-                        command.Parameters.Add (new NpgsqlParameter("p0", 5));
-                
-                        Assert.AreEqual (command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Integer);
-                        Assert.AreEqual (command.Parameters[0].DbType, DbType.Int32);
-                
-                
-                        Object result = command.ExecuteNonQuery ();
-                
-                        Assert.AreEqual (1, result);
-                
-                
-                        field_serial2 = (int)new NpgsqlCommand ("select max(field_serial) from tablea", connection).ExecuteScalar ();
-                        NpgsqlCommand command2 = new NpgsqlCommand ("select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", connection);
-                
-                
-                        result = command2.ExecuteScalar ();
-                
-                
-                        Assert.AreEqual (5, result);
-                
+                        connection.Open();
+                        var command = new NpgsqlCommand("insert into tablea(field_int4) values (:p0)", connection);
+                        command.Parameters.Add(new NpgsqlParameter("p0", 5));
+                        Assert.AreEqual(command.Parameters[0].NpgsqlDbType, NpgsqlDbType.Integer);
+                        Assert.AreEqual(command.Parameters[0].DbType, DbType.Int32);
+                        Object result = command.ExecuteNonQuery();
+                        Assert.AreEqual(1, result);
+
+                        field_serial2 = (int) new NpgsqlCommand("select max(field_serial) from tablea", connection).ExecuteScalar();
+                        var command2 = new NpgsqlCommand( "select field_int4 from tablea where field_serial = (select max(field_serial) from tablea)", connection);
+                        result = command2.ExecuteScalar();
+                        Assert.AreEqual(5, result);
+
                         // using new connection here... make sure we can't see previous results even though
                         // it is the same distributed transaction
-                        NpgsqlCommand command3 = new NpgsqlCommand ("select field_text from tablea where field_serial = :p0", connection);
-                        command3.Parameters.Add (new NpgsqlParameter("p0", field_serial1));
-                
-                        result = command3.ExecuteScalar ();
-                
-                
+                        var command3 = new NpgsqlCommand("select field_text from tablea where field_serial = :p0", connection);
+                        command3.Parameters.Add(new NpgsqlParameter("p0", field_serial1));
+                        result = command3.ExecuteScalar();
+
                         // won't see value of "test" since that's
                         // another connection
-                        Assert.AreEqual (null, result);
+                        Assert.AreEqual(null, result);
                     }
                     // not commiting here.
                 }
                 // This is an attempt to wait for the distributed transaction to rollback
                 // not guaranteed to work, but should be good enough for testing purposes.
-                System.Threading.Thread.Sleep (500);
-                AssertNoTransactions ();
+                System.Threading.Thread.Sleep(500);
+                AssertNoTransactions();
                 // ensure they no longer exist since we rolled back
-                AssertRowNotExist ("field_text", field_serial1);
-                AssertRowNotExist ("field_int4", field_serial2);
-            } 
-            catch (NotImplementedException) 
+                AssertRowNotExist("field_text", field_serial1);
+                AssertRowNotExist("field_int4", field_serial2);
+            }
+            catch (NotImplementedException)
             {
-                
+
             }
         }
 
         [Test]
         public void FunctionTestTimestamptzParameterSupport()
         {
-            try 
+            try
             {
-                string connectionString = TheConnectionString + ";enlist=true";
-                using (TransactionScope scope = new TransactionScope()) 
+                var connectionString = TheConnectionString + ";enlist=true";
+                using (var scope = new TransactionScope())
                 {
-                    using (NpgsqlConnection connection = new NpgsqlConnection(connectionString)) 
+                    using (var connection = new NpgsqlConnection(connectionString))
                     {
-                        connection.Open ();
-                        NpgsqlCommand command = new NpgsqlCommand ("testtimestamptzparameter", connection);
+                        connection.Open();
+                        var command = new NpgsqlCommand("testtimestamptzparameter", connection);
                         command.CommandType = CommandType.StoredProcedure;
-                
-                        command.Parameters.Add (new NpgsqlParameter("p1", NpgsqlDbType.TimestampTZ));
-                
+
+                        command.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.TimestampTZ));
+
                         //NpgsqlDataReader dr = command.ExecuteReader();
-                
+
                         //Int32 count = 0;
-                
+
                         //while (dr.Read())
                         //count++;
-                        NpgsqlDataAdapter da = new NpgsqlDataAdapter (command);
-                        DataTable dt = new DataTable ();
-                        da.Fill (dt);
-                
-                        Assert.IsTrue (dt.Rows.Count > 1);
+                        var da = new NpgsqlDataAdapter(command);
+                        var dt = new DataTable();
+                        da.Fill(dt);
+
+                        Assert.IsTrue(dt.Rows.Count > 1);
                     }
                 }
-            } 
-            catch (NotImplementedException) 
+            }
+            catch (NotImplementedException)
             {
-                
+
             }
         }
 
         private void AssertNoTransactions()
         {
             // ensure no transactions remain
-            NpgsqlCommand command = new NpgsqlCommand("select count(*) from pg_prepared_xacts where database = :database", TheConnection);
+            var command = new NpgsqlCommand("select count(*) from pg_prepared_xacts where database = :database", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("database", TheConnection.Database));
             Assert.AreEqual(0, command.ExecuteScalar());
         }
 
         private void AssertRowNotExist(string columnName, int field_serial)
         {
-            NpgsqlCommand command = new NpgsqlCommand("select " + columnName + " from tablea where field_serial = :p0", TheConnection);
+            var command = new NpgsqlCommand("select " + columnName + " from tablea where field_serial = :p0", TheConnection);
             command.Parameters.Add(new NpgsqlParameter("p0", field_serial));
             object result = command.ExecuteScalar();
             Assert.AreEqual(null, result);
@@ -251,26 +226,26 @@ namespace NpgsqlTests
         [Test]
         public void ReuseConnection()
         {
-            try 
+            try
             {
-                string connectionString = TheConnectionString + ";enlist=true";
-                using (TransactionScope scope = new TransactionScope()) 
+                var connectionString = TheConnectionString + ";enlist=true";
+                using (var scope = new TransactionScope())
                 {
-                    using (NpgsqlConnection connection = new NpgsqlConnection(connectionString)) 
+                    using (var connection = new NpgsqlConnection(connectionString))
                     {
-                        connection.Open ();
-                        connection.Close ();
-                        connection.Open ();
-                        connection.Close ();
+                        connection.Open();
+                        connection.Close();
+                        connection.Open();
+                        connection.Close();
                     }
                 }
-            } 
-            catch (NotImplementedException) 
+            }
+            catch (NotImplementedException)
             {
-                
+
             }
         }
-	}
+    }
 
     public class SystemTransactionsTestV2 : SystemTransactionsTest
     {
@@ -278,11 +253,13 @@ namespace NpgsqlTests
         {
             get { return _connV2; }
         }
+
         protected override NpgsqlTransaction TheTransaction
         {
             get { return _tV2; }
             set { _tV2 = value; }
         }
+
         protected override string TheConnectionString
         {
             get { return _connV2String; }

--- a/testsuite/noninteractive/NUnit20/TypesTests.cs
+++ b/testsuite/noninteractive/NUnit20/TypesTests.cs
@@ -1,4 +1,4 @@
-﻿// Npgsql.NpgsqlCommand.cs
+// Npgsql.NpgsqlCommand.cs
 //
 // Author:
 //  Josh Cooley <jbnpgsql@tuxinthebox.net>
@@ -36,8 +36,8 @@ namespace NpgsqlTests
     /// Tests NpgsqlTypes.* independent of a database
     /// </summary>
     [TestFixture]
-	public class TypesTests
-	{
+    public class TypesTests
+    {
         [Test]
         public void NpgsqlIntervalParse()
         {
@@ -94,42 +94,42 @@ namespace NpgsqlTests
 
             input = "1 year";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 12).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*12).Ticks, test.TotalTicks, input);
 
             input = "2 years";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 24).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*24).Ticks, test.TotalTicks, input);
 
             input = "1 year -1 mon";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 11).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*11).Ticks, test.TotalTicks, input);
 
             input = "1 year -2 mons";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 10).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*10).Ticks, test.TotalTicks, input);
 
             input = "1 year -1 day";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 12 - 1).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*12 - 1).Ticks, test.TotalTicks, input);
 
             input = "1 year -2 days";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 12 - 2).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*12 - 2).Ticks, test.TotalTicks, input);
 
             input = "1 year -1 mon -1 day";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 11 - 1).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*11 - 1).Ticks, test.TotalTicks, input);
 
             input = "1 year -2 mons -2 days";
             test = NpgsqlInterval.Parse(input);
-            Assert.AreEqual(TimeSpan.FromDays(30 * 10 - 2).Ticks, test.TotalTicks, input);
+            Assert.AreEqual(TimeSpan.FromDays(30*10 - 2).Ticks, test.TotalTicks, input);
 
             input = "1 day 2:3:4.005";
             test = NpgsqlInterval.Parse(input);
             Assert.AreEqual(new TimeSpan(1, 2, 3, 4, 5).Ticks, test.TotalTicks, input);
 
             var oldCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Globalization.CultureInfo testCulture = new System.Globalization.CultureInfo("fr-FR");
+            var testCulture = new System.Globalization.CultureInfo("fr-FR");
             Assert.AreEqual(",", testCulture.NumberFormat.NumberDecimalSeparator, "decimal seperator");
             try
             {
@@ -231,7 +231,8 @@ namespace NpgsqlTests
 
             Assert.AreEqual("00:02:03.456789", new NpgsqlInterval(1234567891).ToString());
 
-            Assert.AreEqual("1 day 02:03:04.005", new NpgsqlInterval(new TimeSpan(1, 2, 3, 4, 5)).JustifyInterval().ToString());
+            Assert.AreEqual("1 day 02:03:04.005",
+                            new NpgsqlInterval(new TimeSpan(1, 2, 3, 4, 5)).JustifyInterval().ToString());
 
             Assert.AreEqual("3 mons 2 days 00:02:03.456789", new NpgsqlInterval(3, 2, 1234567890).ToString());
 
@@ -244,7 +245,7 @@ namespace NpgsqlTests
             Assert.AreEqual("14 mons 3 days 04:05:06.007", new NpgsqlInterval(1, 2, 3, 4, 5, 6, 7).ToString());
 
             var oldCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Globalization.CultureInfo testCulture = new System.Globalization.CultureInfo("fr-FR");
+            var testCulture = new System.Globalization.CultureInfo("fr-FR");
             Assert.AreEqual(",", testCulture.NumberFormat.NumberDecimalSeparator, "decimal seperator");
             try
             {
@@ -336,7 +337,7 @@ namespace NpgsqlTests
             Assert.AreEqual("00:02:03.456789", new NpgsqlTime(1234567891).ToString());
 
             var oldCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Globalization.CultureInfo testCulture = new System.Globalization.CultureInfo("fr-FR");
+            var testCulture = new System.Globalization.CultureInfo("fr-FR");
             Assert.AreEqual(",", testCulture.NumberFormat.NumberDecimalSeparator, "decimal seperator");
             try
             {
@@ -403,7 +404,7 @@ namespace NpgsqlTests
             Assert.AreEqual("0001-05-07 BC", new NpgsqlDate(-1, 5, 7).ToString());
 
             var oldCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Globalization.CultureInfo testCulture = new System.Globalization.CultureInfo("fr-FR");
+            var testCulture = new System.Globalization.CultureInfo("fr-FR");
             Assert.AreEqual(",", testCulture.NumberFormat.NumberDecimalSeparator, "decimal seperator");
             try
             {
@@ -486,11 +487,11 @@ namespace NpgsqlTests
             Assert.AreEqual(1, date.Month);
             Assert.AreEqual(1, date.Year);
 
-            NpgsqlInterval diff = new NpgsqlDate(1, 1, 1) - new NpgsqlDate(-1, 12, 31);
+            var diff = new NpgsqlDate(1, 1, 1) - new NpgsqlDate(-1, 12, 31);
             Assert.AreEqual(new NpgsqlInterval(0, 1, 0), diff);
 
             // Test of the addMonths method (positive values added)
-            NpgsqlDate dateForTestMonths = new NpgsqlDate(2008, 1, 1);
+            var dateForTestMonths = new NpgsqlDate(2008, 1, 1);
             Assert.AreEqual(dateForTestMonths.AddMonths(0), dateForTestMonths);
             Assert.AreEqual(dateForTestMonths.AddMonths(4), new NpgsqlDate(2008, 5, 1));
             Assert.AreEqual(dateForTestMonths.AddMonths(11), new NpgsqlDate(2008, 12, 1));
@@ -577,7 +578,7 @@ namespace NpgsqlTests
         [Test]
         public void NpgsqlTimeTzConvert()
         {
-            NpgsqlTimeTZ timetz = new NpgsqlTimeTZ(13, 3, 45.001, new NpgsqlTimeZone(-5, 0));
+            var timetz = new NpgsqlTimeTZ(13, 3, 45.001, new NpgsqlTimeZone(-5, 0));
 
             Assert.AreEqual(13, timetz.Hours);
             Assert.AreEqual(3, timetz.Minutes);
@@ -592,10 +593,10 @@ namespace NpgsqlTests
             Assert.AreEqual(45, timetz.UTCTime.Seconds);
             Assert.AreEqual(1, timetz.UTCTime.Milliseconds);
 
-            TimeSpan utcOffset = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now);
+            var utcOffset = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now);
             // add utc time as timespan to get local time as a timespan
-            TimeSpan localTime = utcOffset + new TimeSpan(0, 18, 3, 45, 1);
-            DateTime localDateTime = (DateTime)timetz;
+            var localTime = utcOffset + new TimeSpan(0, 18, 3, 45, 1);
+            var localDateTime = (DateTime) timetz;
 
             Assert.AreEqual(localTime.Hours, localDateTime.Hour);
             Assert.AreEqual(localTime.Minutes, localDateTime.Minute);
@@ -609,85 +610,64 @@ namespace NpgsqlTests
             Assert.AreEqual(1, timetz.LocalTime.Milliseconds);
 
         }
-        
+
         [Test]
         public void NpgsqlMacAddress()
         {
-            System.Net.NetworkInformation.PhysicalAddress local = System.Net.NetworkInformation.PhysicalAddress.Parse("012345ABCDEF");
-            NpgsqlMacAddress mac = new NpgsqlMacAddress(local);
-
-            NpgsqlMacAddress mac2 = new NpgsqlMacAddress("01:23-45-aB,cD.eF");
+            System.Net.NetworkInformation.PhysicalAddress local =
+                System.Net.NetworkInformation.PhysicalAddress.Parse("012345ABCDEF");
+            var mac = new NpgsqlMacAddress(local);
+            var mac2 = new NpgsqlMacAddress("01:23-45-aB,cD.eF");
 
             Assert.AreEqual(mac, mac2);
             Assert.AreEqual(mac.ToString(), mac2.ToString());
         }
-        
+
         [Test]
         public void Bug1011018()
         {
-            
-            NpgsqlParameter p = new NpgsqlParameter();
+            var p = new NpgsqlParameter();
             p.NpgsqlDbType = NpgsqlDbType.Time;
             p.Value = DateTime.Now;
-            
             Object o = p.Value;
-            
-            
-            
         }
+
         [Test]
         public void Bug1011321WrongBitStringvalue()
         {
-
-            BitString b = new BitString (true, 32);
-
-            Assert.AreEqual ("11111111111111111111111111111111", b.ToString ());
-
-
+            var b = new BitString(true, 32);
+            Assert.AreEqual("11111111111111111111111111111111", b.ToString());
         }
 
         [Test]
         public void Bug1011321WrongBitStringvalue2()
         {
-            BitString b = new BitString (true, 6);
-            
-            Assert.AreEqual ("111111", b.ToString ());
-            
-            
+            var b = new BitString(true, 6);
+            Assert.AreEqual("111111", b.ToString());
         }
+
         [Test]
         public void Bug1011321WrongBitStringvalue3()
         {
-            BitString b = new BitString (true, 32);
-            
-            BitString b2 = new BitString("11111111111111111111111111111111");
-            
+            var b = new BitString(true, 32);
+            var b2 = new BitString("11111111111111111111111111111111");
             Assert.IsTrue(b == b2);
-            
-            
         }
-        
+
         [Test]
         public void BitStringSupport()
         {
-            String bitMask = "1101101101101101101101101011011011010110110110";
-            BitString b = new BitString(bitMask);
-            
-            Assert.AreEqual (bitMask, b.ToString ());
-            
-            
+            const string bitMask = "1101101101101101101101101011011011010110110110";
+            var b = new BitString(bitMask);
+            Assert.AreEqual(bitMask, b.ToString());
         }
-        
+
         [Test]
         public void BitStringSupport2()
         {
-            String bitMask = "110110110110110110110110101101101";
-            BitString b = new BitString(bitMask);
-            
-            Assert.AreEqual (bitMask, b.ToString ());
-            
-            
+            const string bitMask = "110110110110110110110110101101101";
+            var b = new BitString(bitMask);
+            Assert.AreEqual(bitMask, b.ToString());
         }
-        
-	}
+    }
 }


### PR DESCRIPTION
- Converted tabs to spaces as per new .editorconfig
- Removed empty lines
- Introduced implicit var typing
- Introduced using() in many instances

No substantial change made to any test, same list of failing/passing tests
