### PR TITLE
Allow unit test db conn string to be overridden

### DIFF
--- a/tests/App.config
+++ b/tests/App.config
@@ -1,10 +1,15 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="ISO-8859-1" ?>
 <configuration>
-  <appSettings>
-    <add key="ConnectionString" value="Server=127.0.0.1;Port=5432;User Id=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Encoding=UNICODE;syncnotification=false;protocol=3"/>
-    <add key="ConnectionStringV2" value="Server=127.0.0.1;Port=5432;User Id=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Encoding=UNICODE;syncnotification=false;protocol=2"/>
-  </appSettings>
-  <connectionStrings>
-    <add name="XmlTestContext" providerName="System.Data.EntityClient" connectionString="metadata=XmlModel\.;provider=Npgsql;provider connection string=&quot;server=127.0.0.1;database=modelXmlTest;user id=npgsql_tests;password=npgsql_tests;enlist=true;&quot;"/>
-  </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+    <appSettings>
+<!--
+  -- Uncomment the following and modify to override the connection string to the test database.
+  -- Note that protocol=3 or 2 is appended programmatically
+  -- If you uncomment this, please do not commit changes upstream, optionally by running:
+  -- git update-index --assume-unchanged App.config
+  -->
+
+<!--
+        <add key="ConnectionStringBase" value="Server=localhost;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;syncnotification=false;" />
+-->
+    </appSettings>
+</configuration>

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -3000,7 +3000,7 @@ namespace NpgsqlTests
     [TestFixture]
     public class CommandTestsV2 : CommandTests
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
     }
 }
 

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -357,6 +357,6 @@ namespace NpgsqlTests
     [TestFixture]
     public class ConnectionTestsV2 : ConnectionTests
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
     }
 }

--- a/tests/DataAdapterTests.cs
+++ b/tests/DataAdapterTests.cs
@@ -423,7 +423,7 @@ namespace NpgsqlTests
     [TestFixture]
     public class DataAdapterTestsV2 : DataAdapterTests
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
         public override void DoInsertWithCommandBuilderCaseSensitive()
         {
             //Not possible with V2?

--- a/tests/DataReaderTests.cs
+++ b/tests/DataReaderTests.cs
@@ -987,7 +987,7 @@ namespace NpgsqlTests
     [TestFixture]
     public class DataReaderTestsV2 : DataReaderTests
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
         public override void DoIsIdentityMetadataSupport()
         {
             //Not possible with V2?

--- a/tests/PrepareTests.cs
+++ b/tests/PrepareTests.cs
@@ -132,6 +132,6 @@ namespace NpgsqlTests
     [TestFixture]
     public class PrepareTestV2 : PrepareTest
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
     }
 }

--- a/tests/SystemTransactionsTest.cs
+++ b/tests/SystemTransactionsTest.cs
@@ -236,6 +236,6 @@ namespace NpgsqlTests
 
     public class SystemTransactionsTestV2 : SystemTransactionsTest
     {
-        protected override string ConnectionString { get { return CONN_STRING_V2; } }
+        protected override string ConnectionString { get { return ConnectionStringV2; } }
     }
 }


### PR DESCRIPTION
The App.config can now optionally define a ConnectionStringBase, which
can contain a custom database connection string that will be used for
unit tests.

Implements request from here: https://github.com/franciscojunior/Npgsql2/pull/44#issuecomment-23533409
