### PR TITLE
Async notification fixes

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1066,13 +1066,13 @@ namespace Npgsql
                 {
                     while (true)
                     {
-#if ! WINDOWS
                         // Mono's implementation of System.Threading.Monitor does not appear to give threads
                         // priority on a first come/first serve basis, as does Microsoft's.  As a result, 
                         // under mono, this loop may execute many times even after another thread has attempted
-                        //  to lock on _socket.  A short Sleep() seems to solve the problem effectively.
+                        // to lock on _socket.  A short Sleep() seems to solve the problem effectively.
+                        // Note that Sleep(0) does not work.
                         Thread.Sleep(1);
-#endif
+
                         lock (connector._socket)
                         {
                             // 20 millisecond timeout


### PR DESCRIPTION
Francisco,

I'm re-submitting the two fixes in PR 46 that are clean and correct.

This will fix the CPU hog problem you were seeing, and eliminates the need for the odd Sleep() call in ProcessServerMessages().

-Glen
