### PR TITLE
Fix extra_float_digit setup for Postgresql below 9.0

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -648,6 +648,11 @@ namespace Npgsql
             get { return ServerVersion >= new Version(9, 0, 0); }
         }
 
+        internal Boolean SupportsExtraFloatDigits3
+        {
+            get { return ServerVersion >= new Version(9, 0, 0); }
+        }
+
         /// <summary>
         /// Report whether the current connection can support prepare functionality.
         /// </summary>
@@ -853,13 +858,19 @@ namespace Npgsql
 
             /*
              * Set precision digits to maximum value possible. For postgresql before 9 it was 2, after that, it is 3.
-             * This way, we set first to 2 and then to 3. If there is an error because of 3, it will have been set to 2 at least.
              * Check bug report #1010992 for more information.
              */
 
             try
             {
-                NpgsqlCommand commandSingleDoublePrecision = new NpgsqlCommand("SET extra_float_digits=2;SET extra_float_digits=3;", this);
+
+                NpgsqlCommand commandSingleDoublePrecision;
+
+                if (SupportsExtraFloatDigits3)
+                    commandSingleDoublePrecision = new NpgsqlCommand("SET extra_float_digits=3", this);
+                else
+                    commandSingleDoublePrecision = new NpgsqlCommand("SET extra_float_digits=2", this);
+
                 commandSingleDoublePrecision.ExecuteBlind();
 
             }

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -385,6 +385,17 @@ namespace NpgsqlTests
             }
         }
 
+        [Test]
+        public void CheckExtraFloatingDigitsHigherThanTwo()
+        {
+
+            using (NpgsqlCommand c = new NpgsqlCommand("show extra_float_digits", Conn))
+            {
+                string extraDigits = (string) c.ExecuteScalar();
+                Assert.GreaterOrEqual(extraDigits, "2");
+            }
+        }
+
     }
     [TestFixture]
     public class ConnectionTestsV2 : ConnectionTests


### PR DESCRIPTION
Npgsql was sending two commands at the same time to set the extra_float_digits parameter.
The first one with value of 2 and the second one with a value of 3.
The problem is that on postgresql below 9.0, there is no support for value of 3 and then neither
command was being processed letting the parameter with the default value of 0.
Now, Npgsql checks which version it is connected to and sends the correct command accordingly.
