### PR TITLE
Fix EF call to ConvertToBackend() (which now returns byte[], not string)

### DIFF
--- a/src/Npgsql/SqlGenerators/VisitedExpression.cs
+++ b/src/Npgsql/SqlGenerators/VisitedExpression.cs
@@ -147,7 +147,7 @@ namespace Npgsql.SqlGenerators
                     // Check https://github.com/franciscojunior/Npgsql2/pull/10 for more info.
                     // NativeToBackendTypeConverterOptions.Default should provide the correct
                     // formatting rules for any backend >= 8.0.
-                    sqlText.Append(typeInfo.ConvertToBackend(_value, false));
+                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false)));
                     break;
                 case PrimitiveTypeKind.Time:
                     sqlText.AppendFormat(ni, "TIME '{0:T}'", _value);


### PR DESCRIPTION
Francisco,

Here's the fix for the ConvertToBackend() bug that turned up in PR #67.

-Glen
