### PR TITLE
Fix string value to match its own description.

### DIFF
--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -633,7 +633,7 @@ namespace NpgsqlTests
             string cmdTxt = "select :par";
             var command = new NpgsqlCommand(cmdTxt, Conn);
             var arrCommand = new NpgsqlCommand(cmdTxt, Conn);
-            string testStrPar = "This string has a single quote: '', a double quote: \", and a backslash: \\";
+            string testStrPar = "This string has a single quote: ', a double quote: \", and a backslash: \\";
             string[,] testArrPar = new string[,] {{testStrPar, ""}, {testStrPar, testStrPar}};
             command.Parameters.AddWithValue(":par", testStrPar);
             using (var rdr = command.ExecuteReader())


### PR DESCRIPTION
The string value was saying it contained one single quote when in fact it contained two.
It was using postgresql syntax of using 2 single quotes to represent 1 single quote.
