### PR TITLE
Add test demonstrating bug in datetime array encoding.

### DIFF
--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -2718,6 +2718,10 @@ namespace NpgsqlTests
             }
         }
 
+        // Type coersion in the native to backend converters does not work so
+        // well for arrays.  The rules for type coersion of array elements
+        // does not work the same as for non-arrays.  This test demonstrates
+        // the problem.
         private void DateTimeArrayHandlingInternal(bool prepare)
         {
             using (var cmd = new NpgsqlCommand("select :p1", Conn))
@@ -2740,12 +2744,14 @@ namespace NpgsqlTests
         }
 
         [Test]
+        [Ignore]
         public void DateTimeArrayHandling()
         {
             DateTimeArrayHandlingInternal(false);
         }
 
         [Test]
+        [Ignore]
         public void DateTimeArrayHandlingPrepared()
         {
             DateTimeArrayHandlingInternal(true);


### PR DESCRIPTION
Francisco,

I found a bug. I'm just submitting a new test at the moment.

-Glen
