### PR TITLE
Fix backend protocol version fallback bug

### DIFF
--- a/src/Npgsql/NpgsqlClosedState.cs
+++ b/src/Npgsql/NpgsqlClosedState.cs
@@ -159,7 +159,6 @@ namespace Npgsql
                     throw lastSocketException;
                 }
 
-                //Stream stream = new NetworkStream(socket, true);
                 NpgsqlNetworkStream baseStream = new NpgsqlNetworkStream(socket, true);
                 Stream sslStream = null;
 
@@ -169,9 +168,10 @@ namespace Npgsql
                     baseStream
                         .WriteInt32(8)
                         .WriteInt32(80877103);
-                    // Receive response
 
+                    // Receive response
                     Char response = (Char) baseStream.ReadByte();
+
                     if (response == 'S')
                     {
                         //create empty collection
@@ -203,10 +203,7 @@ namespace Npgsql
                         {
                             SslStream sslStreamPriv;
 
-                            sslStreamPriv = new SslStream(baseStream, true, delegate(object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
-                            {
-                                return context.DefaultValidateRemoteCertificateCallback(cert, chain, errors);
-                            });
+                            sslStreamPriv = new SslStream(baseStream, true, context.DefaultValidateRemoteCertificateCallback);
 
                             sslStreamPriv.AuthenticateAsClient(context.Host, clientCertificates, System.Security.Authentication.SslProtocols.Default, false);
                             sslStream = sslStreamPriv;
@@ -219,7 +216,7 @@ namespace Npgsql
                 }
 
                 context.Socket = socket;
-                context.Basetream = baseStream;
+                context.BaseStream = baseStream;
                 context.Stream = new BufferedStream(sslStream == null ? baseStream : sslStream);
 
                 NpgsqlEventLog.LogMsg(resman, "Log_ConnectedTo", LogLevel.Normal, context.Host, context.Port);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -111,7 +111,7 @@ namespace Npgsql
         // This is a BufferedStream.
         // With SSL, this stream sits on top of the SSL stream, which sits on top of _baseStream.
         // Otherwise, this stream sits directly on top of _baseStream.
-        private Stream _stream;
+        private BufferedStream _stream;
 
         // Mediator which will hold data generated from backend.
         private readonly NpgsqlMediator _mediator;
@@ -540,7 +540,7 @@ namespace Npgsql
         /// <summary>
         /// Default SSL ValidateRemoteCertificateCallback implementation.
         /// </summary>
-        internal bool DefaultValidateRemoteCertificateCallback(X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
+        internal bool DefaultValidateRemoteCertificateCallback(object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors errors)
         {
             if (ValidateRemoteCertificateCallback != null)
             {
@@ -582,7 +582,7 @@ namespace Npgsql
         /// <summary>
         /// The physical connection stream to the backend.
         /// </summary>
-        internal NpgsqlNetworkStream Basetream
+        internal NpgsqlNetworkStream BaseStream
         {
             get { return _baseStream; }
             set { _baseStream = value; }
@@ -591,7 +591,7 @@ namespace Npgsql
         /// <summary>
         /// The top level stream to the backend.
         /// </summary>
-        internal Stream Stream
+        internal BufferedStream Stream
         {
             get { return _stream; }
             set { _stream = value; }


### PR DESCRIPTION
Francisco,

Here is the fix for protocol version fallback.

The problem was that, after failing to startup on version 3, the NetworkStream.Dispose() was being called from .NET, which was closing the Connector even though it had abandoned that stream and started up with a new one.

-Glen
