### PR TITLE
Add tests support for App.config settings to define the connection

### DIFF
--- a/tests/App.config
+++ b/tests/App.config
@@ -3,6 +3,7 @@
   <appSettings>
     <add key="ConnectionString" value="Server=127.0.0.1;Port=5432;User Id=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Encoding=UNICODE;syncnotification=false;protocol=3"/>
     <add key="ConnectionStringV2" value="Server=127.0.0.1;Port=5432;User Id=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Encoding=UNICODE;syncnotification=false;protocol=2"/>
+    <add key="ConnectionStringBase" value="Server=127.0.0.1;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;syncnotification=false;"/>
   </appSettings>
   <connectionStrings>
     <add name="XmlTestContext" providerName="System.Data.EntityClient" connectionString="metadata=XmlModel\.;provider=Npgsql;provider connection string=&quot;server=127.0.0.1;database=modelXmlTest;user id=npgsql_tests;password=npgsql_tests;enlist=true;&quot;"/>

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -47,7 +47,7 @@ namespace NpgsqlTests
         /// </summary>
         protected virtual string ConnectionString { get { return CONN_STRING_BASE + ";protocol=" + BACKEND_PROTOCOL_VERSION; } }
 
-        private const string CONN_STRING_BASE = "Server=localhost;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;syncnotification=false";
+        private readonly string CONN_STRING_BASE = ConfigurationManager.AppSettings["ConnectionStringBase"];
 
         protected virtual int BACKEND_PROTOCOL_VERSION { get { return 3; } }
 


### PR DESCRIPTION
string

Today the connection string settings are hardcoded inside the
TestBase.cs file. Added support to enable set this connection string
through the App.config file.
