### PR TITLE
Boolean binary backend encoding fix

### DIFF
--- a/src/Npgsql/ASCIIBytes.cs
+++ b/src/Npgsql/ASCIIBytes.cs
@@ -89,9 +89,11 @@ namespace Npgsql
     internal class ASCIIByteArrays
     {
         internal static readonly byte[] Empty           = new byte[0];
+        internal static readonly byte[] Byte_0          = new byte[] { 0 };
+        internal static readonly byte[] Byte_1          = new byte[] { 1 };
         internal static readonly byte[] NULL            = BackendEncoding.UTF8Encoding.GetBytes("NULL");
-        internal static readonly byte[] Byte_0          = BackendEncoding.UTF8Encoding.GetBytes("0");
-        internal static readonly byte[] Byte_1          = BackendEncoding.UTF8Encoding.GetBytes("1");
+        internal static readonly byte[] AsciiDigit_0    = BackendEncoding.UTF8Encoding.GetBytes("0");
+        internal static readonly byte[] AsciiDigit_1    = BackendEncoding.UTF8Encoding.GetBytes("1");
         internal static readonly byte[] TRUE            = BackendEncoding.UTF8Encoding.GetBytes("TRUE");
         internal static readonly byte[] FALSE           = BackendEncoding.UTF8Encoding.GetBytes("FALSE");
         internal static readonly byte[] INFINITY        = BackendEncoding.UTF8Encoding.GetBytes("INFINITY");

--- a/src/NpgsqlTypes/NpgsqlTypeConvNativeToBackend.cs
+++ b/src/NpgsqlTypes/NpgsqlTypeConvNativeToBackend.cs
@@ -372,7 +372,7 @@ namespace NpgsqlTypes
         internal static byte[] ToBit(NpgsqlNativeTypeInfo TypeInfo, Object NativeData, Boolean forExtendedQuery, NativeToBackendTypeConverterOptions options, bool arrayElement)
         {
             if (NativeData is bool)
-                return ((bool)NativeData) ? ASCIIByteArrays.Byte_1 : ASCIIByteArrays.Byte_0;
+                return ((bool)NativeData) ? ASCIIByteArrays.AsciiDigit_1 : ASCIIByteArrays.AsciiDigit_0;
             // It may seem more sensible to just convert an integer to a BitString here and pass it on.
             // However behaviour varies in terms of how this is interpretted if being passed to a bitstring
             // value smaller than the int.

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -1553,8 +1553,7 @@ namespace NpgsqlTests
             command.ExecuteScalar();
         }
 
-        [Test]
-        public void TestBoolParameterPrepared()
+        private void TestBoolParameter_Internal(bool prepare)
         {
             // Add test for prepared queries with bool parameter.
             // This test was created based on a report from Andrus Moor in the help forum:
@@ -1562,13 +1561,45 @@ namespace NpgsqlTests
 
             var command = new NpgsqlCommand("select :boolValue", Conn);
 
-            command.Parameters.Add(":boolValue", NpgsqlDbType.Boolean).Value = false;
-            command.Prepare();
+            command.Parameters.Add(":boolValue", NpgsqlDbType.Boolean);
+
+            if (prepare)
+            {
+                command.Prepare();
+            }
+
+            command.Parameters["boolvalue"].Value = false;
 
             Assert.IsFalse((bool)command.ExecuteScalar());
+
+            command.Parameters["boolvalue"].Value = true;
+
+            Assert.IsTrue((bool)command.ExecuteScalar());
         }
 
         [Test]
+        public void TestBoolParameter()
+        {
+            TestBoolParameter_Internal(false);
+        }
+
+        [Test]
+        public void TestBoolParameterPrepared()
+        {
+            TestBoolParameter_Internal(true);
+        }
+
+        [Test]
+        public void TestBoolParameterPrepared_SuppressBinary()
+        {
+            using (SuppressBackendBinary())
+            {
+                TestBoolParameter_Internal(true);
+            }
+        }
+
+        [Test]
+        [Ignore]
         public void TestBoolParameterPrepared2()
         {
             // will throw exception if bool parameter can't be used as boolean expression


### PR DESCRIPTION
Francisco,

Here is the fix for bug:
http://pgfoundry.org/forum/forum.php?thread_id=15672&forum_id=519&group_id=1000140

Sending binary boolean parameters works properly now.  For reference, the encoder was sending the ascii digits '0' or '1', rather than the byte values 0 or 1.  PG naturally interprets any non-zero byte value as TRUE.

I [Ignore]'d test TestBoolParameterPrepared2().  This problem is not related to the boolean bug, it is related to all parameter types, and it's way out of scope for this branch.  NpgsqlParameter simply does not do automatic type coercion, which it will need to do in order for Prepare() to have the type information it needs to succeed in the situation tested.  You may recall our conversation touching on this a few weeks ago  I have a branch that fixes this problem, but it is not ready yet, and it is not trivial.  I think we have to let this problem slide awhile longer (it's been there a long time already), as I cannot guarantee I'll be ready to commit anything soon enough to be part of the next beta.  Developers will need to continue to set parameter types explicitly in order to use Prepare() successfully.

-Glen
