### PR TITLE
NpgsqlError fix and improvement

### DIFF
--- a/src/Npgsql/NpgsqlError.cs
+++ b/src/Npgsql/NpgsqlError.cs
@@ -55,6 +55,117 @@ namespace Npgsql
     [Serializable]
     public sealed class NpgsqlError
     {
+        /// <summary>
+        /// Error and notice message field codes
+        /// </summary>
+        private enum ErrorFieldTypeCodes : byte
+        {
+            /// <summary>
+            /// Severity: the field contents are ERROR, FATAL, or PANIC (in an error message),
+            /// or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message), or a localized
+            /// translation of one of these. Always present.
+            /// </summary>
+            Severity = (byte)'S',
+
+            /// <summary>
+            /// Code: the SQLSTATE code for the error (see Appendix A). Not localizable. Always present.
+            /// </summary>
+            Code = (byte)'C',
+
+            /// <summary>
+            /// Message: the primary human-readable error message. This should be accurate
+            /// but terse (typically one line). Always present.
+            /// </summary>
+            Message = (byte)'M',
+
+            /// <summary>
+            /// Detail: an optional secondary error message carrying more detail about the problem.
+            /// Might run to multiple lines.
+            /// </summary>
+            Detail = (byte)'D',
+
+            /// <summary>
+            /// Hint: an optional suggestion what to do about the problem. This is intended to differ
+            /// from Detail in that it offers advice (potentially inappropriate) rather than hard facts.
+            /// Might run to multiple lines.
+            /// </summary>
+            Hint = (byte)'H',
+
+            /// <summary>
+            /// Position: the field value is a decimal ASCII integer, indicating an error cursor
+            /// position as an index into the original query string. The first character has index 1,
+            /// and positions are measured in characters not bytes.
+            /// </summary>
+            Position = (byte)'P',
+
+            /// <summary>
+            /// Internal position: this is defined the same as the P field, but it is used when the
+            /// cursor position refers to an internally generated command rather than the one submitted
+            /// by the client.
+            /// The q field will always appear when this field appears.
+            /// </summary>
+            InternalPosition = (byte)'p',
+
+            /// <summary>
+            /// Internal query: the text of a failed internally-generated command.
+            /// This could be, for example, a SQL query issued by a PL/pgSQL function.
+            /// </summary>
+            InternalQuery = (byte)'q',
+
+            /// <summary>
+            /// Where: an indication of the context in which the error occurred.
+            /// Presently this includes a call stack traceback of active procedural language functions
+            /// and internally-generated queries. The trace is one entry per line, most recent first.
+            /// </summary>
+            Where = (byte)'W',
+
+            /// <summary>
+            /// Schema name: if the error was associated with a specific database object,
+            /// the name of the schema containing that object, if any.
+            /// </summary>
+            SchemaName =  (byte)'s',
+
+            /// <summary>
+            /// Table name: if the error was associated with a specific table, the name of the table.
+            /// (Refer to the schema name field for the name of the table's schema.)
+            /// </summary>
+            TableName = (byte)'t',
+
+            /// <summary>
+            /// Column name: if the error was associated with a specific table column, the name of the column.
+            /// (Refer to the schema and table name fields to identify the table.)
+            /// </summary>
+            ColumnName = (byte)'c',
+
+            /// <summary>
+            /// Data type name: if the error was associated with a specific data type, the name of the data type.
+            /// (Refer to the schema name field for the name of the data type's schema.)
+            /// </summary>
+            DataTypeName = (byte)'d',
+
+            /// <summary>
+            /// Constraint name: if the error was associated with a specific constraint, the name of the constraint.
+            /// Refer to fields listed above for the associated table or domain.
+            /// (For this purpose, indexes are treated as constraints, even if they weren't created with constraint syntax.)
+            /// </summary>
+            ConstraintName = (byte)'n',
+
+            /// <summary>
+            /// File: the file name of the source-code location where the error was reported.
+            /// </summary>
+            File = (byte)'F',
+
+            /// <summary>
+            /// Line: the line number of the source-code location where the error was reported.
+            /// </summary>
+            Line = (byte)'L',
+
+            /// <summary>
+            /// Routine: the name of the source-code routine reporting the error.
+            /// </summary>
+            Routine = (byte)'R'
+        }
+
         private readonly ProtocolVersion protocol_version;
         private readonly String _severity = String.Empty;
         private readonly String _code = String.Empty;
@@ -280,75 +391,83 @@ namespace Npgsql
                     }
                     else
                     {
-                        for (char field = (char) stream.ReadByte(); field != 0; field = (char) stream.ReadByte())
+                        bool done = false;
+                        int fieldCode;
+
+                        while (! done && (fieldCode = stream.ReadByte()) != -1)
                         {
-                            switch (field)
+                            switch ((byte)fieldCode)
                             {
-                                case 'S':
+                                case 0 :
+                                    // Null terminator; error message fully consumed.
+                                    done = true;
+                                    ;
+                                    break;
+                                case (byte)ErrorFieldTypeCodes.Severity :
                                     _severity = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'C':
+                                case (byte)ErrorFieldTypeCodes.Code :
                                     _code = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'M':
+                                case (byte)ErrorFieldTypeCodes.Message :
                                     _message = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'D':
+                                case (byte)ErrorFieldTypeCodes.Detail :
                                     _detail = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'H':
+                                case (byte)ErrorFieldTypeCodes.Hint :
                                     _hint = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'P':
+                                case (byte)ErrorFieldTypeCodes.Position :
                                     _position = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'p':
+                                case (byte)ErrorFieldTypeCodes.InternalPosition :
                                     _internalPosition = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'q':
+                                case (byte)ErrorFieldTypeCodes.InternalQuery :
                                     _internalQuery = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'W':
+                                case (byte)ErrorFieldTypeCodes.Where :
                                     _where = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'F':
+                                case (byte)ErrorFieldTypeCodes.File :
                                     _file = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'L':
+                                case (byte)ErrorFieldTypeCodes.Line :
                                     _line = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'R':
+                                case (byte)ErrorFieldTypeCodes.Routine :
                                     _routine = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 's':
+                                case (byte)ErrorFieldTypeCodes.SchemaName :
                                     _schemaName = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 't':
+                                case (byte)ErrorFieldTypeCodes.TableName :
                                     _tableName = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'c':
+                                case (byte)ErrorFieldTypeCodes.ColumnName :
                                     _columnName = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'd':
+                                case (byte)ErrorFieldTypeCodes.DataTypeName :
                                     _datatypeName = PGUtil.ReadString(stream);
                                     ;
                                     break;
-                                case 'n':
+                                case (byte)ErrorFieldTypeCodes.ConstraintName :
                                     _constraintName = PGUtil.ReadString(stream);
                                     ;
                                     break;
@@ -361,7 +480,9 @@ namespace Npgsql
                             }
                         }
                     }
+
                     break;
+
             }
         }
 


### PR DESCRIPTION
Francisco,

Here is the fix for the NpgsqlError bug that would cause it to quit reading error fields prematurely upon hitting a code it doesn't recognize.

This bug was discovered when running 2.0.12 against a 9.3 backend.  The first commit (bug fix) can be applied easily against older versions.

I've also added some design improvement.

-Glen
