### PR TITLE
Prepare/Execute optimzation

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -82,7 +82,6 @@ namespace Npgsql
         private PrepareStatus prepared = PrepareStatus.NotPrepared;
         private NpgsqlBind bind = null;
         private NpgsqlExecute execute = null;
-        private bool portalDescribeSent = false;
         private NpgsqlRowDescription currentRowDescription = null;
 
         private Int64 lastInsertedOID = 0;
@@ -708,25 +707,11 @@ namespace Npgsql
                 }
                 else
                 {
-                    bool sendPortalDescribe = ! portalDescribeSent;
-
                     // Update the Bind object with current parameter data as needed.
                     BindParameters();
 
-                    // Write the Bind message to the wire.
+                    // Write the Bind, Execute, and Sync messages to the wire.
                     m_Connector.Bind(bind);
-
-                    if (sendPortalDescribe)
-                    {
-                        NpgsqlDescribe portalDescribe = new NpgsqlDescribePortal(bind.PortalName);
-
-                        // Write a Describe message to the wire.
-                        m_Connector.Describe(portalDescribe);
-
-                        portalDescribeSent = true;
-                    }
-
-                    // Finally, write the Execute and Sync messages to the wire.
                     m_Connector.Execute(execute);
                     m_Connector.Sync();
 
@@ -742,13 +727,6 @@ namespace Npgsql
                         true,
                         currentRowDescription
                     );
-
-                    if (sendPortalDescribe)
-                    {
-                        // We sent a Describe message. If the query produces a result set,
-                        // PG sent a row description, and the reader has now found it,
-                        currentRowDescription = reader.CurrentDescription;
-                    }
                 }
 
                 return reader;
@@ -823,7 +801,6 @@ namespace Npgsql
             {
                 bind = null;
                 execute = null;
-                portalDescribeSent = false;
                 currentRowDescription = null;
                 prepared = PrepareStatus.NeedsPrepare;
             }
@@ -914,7 +891,11 @@ namespace Npgsql
                         if (returnRowDescData.TypeInfo != null)
                         {
                             // Binary format?
-                            resultFormatCodes[i] = returnRowDescData.TypeInfo.SupportsBinaryBackendData ? (Int16)FormatCode.Binary : (Int16)FormatCode.Text;
+                            // PG always defaults to text encoding.  We can fix up the row description
+                            // here based on support for binary encoding.  Once this is done,
+                            // there is no need to request another row description after Bind.
+                            returnRowDescData.FormatCode = returnRowDescData.TypeInfo.SupportsBinaryBackendData ? FormatCode.Binary : FormatCode.Text;
+                            resultFormatCodes[i] = (Int16)returnRowDescData.FormatCode;
                         }
                         else
                         {
@@ -928,10 +909,14 @@ namespace Npgsql
                     resultFormatCodes = new Int16[] { 0 };
                 }
 
+                // Save the row description for use with all future Executes.
+                currentRowDescription = returnRowDesc;
+
                 // The Bind and Execute message objects live through multiple Executes.
                 // Only Bind changes at all between Executes, which is done in BindParameters().
                 bind = new NpgsqlBind(portalName, planName, new Int16[Parameters.Count], null, resultFormatCodes);
                 execute = new NpgsqlExecute(portalName, 0);
+
                 prepared = PrepareStatus.V3Prepared;
             }
         }

--- a/src/Npgsql/NpgsqlRowDescription.cs
+++ b/src/Npgsql/NpgsqlRowDescription.cs
@@ -125,7 +125,7 @@ namespace Npgsql
             public FormatCode FormatCode
             {
                 get { return _formatCode; }
-                protected set { _formatCode = value; }
+                set { _formatCode = value; }
             }
 
             public NpgsqlBackendTypeInfo TypeInfo


### PR DESCRIPTION
Francisco,

Here is a small optimization for prepare/execute.

Turns out, by simply fixing up the row description received from the statement Describe message (following Parse) to reflect support for binary field decoding, the subsequent portal Describe (following Bind) can be eliminated.  This simplifies the Bind/Execute step a fair amount.

-Glen
