### PR TITLE
Prepare/Execute optimzation

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -80,7 +80,6 @@ namespace Npgsql
         private PrepareStatus prepared = PrepareStatus.NotPrepared;
         private NpgsqlBind bind = null;
         private NpgsqlExecute execute = null;
-        private bool portalDescribeSent = false;
         private NpgsqlRowDescription currentRowDescription = null;
 
         private Int64 lastInsertedOID = 0;

--- a/src/Npgsql/NpgsqlRowDescription.cs
+++ b/src/Npgsql/NpgsqlRowDescription.cs
@@ -125,7 +125,7 @@ namespace Npgsql
             public FormatCode FormatCode
             {
                 get { return _formatCode; }
-                protected set { _formatCode = value; }
+                internal set { _formatCode = value; }
             }
 
             public NpgsqlBackendTypeInfo TypeInfo


### PR DESCRIPTION
Francisco,

Here is a small optimization for prepare/execute.

Turns out, by simply fixing up the row description received from the statement Describe message (following Parse) to reflect support for binary field decoding, the subsequent portal Describe (following Bind) can be eliminated. This simplifies the Bind/Execute step a fair amount.

-Glen
