### PR TITLE
Work on unit tests for multiple backends

### DIFF
--- a/src/Npgsql/PGUtil.cs
+++ b/src/Npgsql/PGUtil.cs
@@ -763,9 +763,9 @@ namespace Npgsql
     /// </summary>
     public enum ProtocolVersion
     {
-        Unknown,
-        Version2,
-        Version3
+        Unknown  = 0,
+        Version2 = 2,
+        Version3 = 3
     }
 
     public enum ServerVersionCode

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -49,6 +49,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class CommandTests : TestBase
     {
+        public CommandTests(string backendVersion) : base(backendVersion) { }
+
         // Make sure SuppressBinaryBackendEncoding is initialized.
         // Try to make this test run first by prepending '__' for sorting.  This test should run before any other tests
         // that use binary backend suppression.
@@ -3327,7 +3329,7 @@ namespace NpgsqlTests
         [Test]
         public void Bug1010788UpdateRowSource()
         {
-            if (BACKEND_PROTOCOL_VERSION < 3)
+            if (((int)BackendProtocolVersion) < 3)
                 Assert.Ignore("Don't have the right metadata with protocol version 2");
 
             using (var conn = new NpgsqlConnection(ConnectionString))
@@ -3358,8 +3360,9 @@ namespace NpgsqlTests
         [SetCulture("nl-BE")]
         public void InvariantCultureNpgsqlCopySerializer()
         {
-            if (BACKEND_PROTOCOL_VERSION < 3)
-                Assert.Ignore("This test hangs when running with protocol version 2");
+            //if (BACKEND_PROTOCOL_VERSION < 3)
+            //    Assert.Ignore("This test hangs when running with protocol version 2");
+
             // Test for https://github.com/npgsql/Npgsql/pull/92
             // SetCulture is used to set a culture where a comma is used to separate decimal values (0,5) which will cause problems if Npgsql 
             // doesn't convert correctly to use a point. (0.5)
@@ -3478,11 +3481,5 @@ namespace NpgsqlTests
             Assert.AreEqual(typeof(NpgsqlTimeTZ), result.GetType());
             */
         }
-    }
-
-    [TestFixture]
-    public class CommandTestsV2 : CommandTests
-    {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
     }
 }

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -34,6 +34,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class ConnectionTests : TestBase
     {
+        public ConnectionTests(string backendVersion) : base(backendVersion) { }
+
         [Test]
         public void ChangeDatabase()
         {
@@ -439,10 +441,5 @@ namespace NpgsqlTests
             }
         }
 
-    }
-    [TestFixture]
-    public class ConnectionTestsV2 : ConnectionTests
-    {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
     }
 }

--- a/tests/DataAdapterTests.cs
+++ b/tests/DataAdapterTests.cs
@@ -36,6 +36,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class DataAdapterTests : TestBase
     {
+        public DataAdapterTests(string backendVersion) : base(backendVersion) { }
+
         [Test]
         public void InsertWithDataSet()
         {
@@ -419,10 +421,12 @@ namespace NpgsqlTests
             Assert.IsNotNull(common.SelectCommand);
         }
     }
+    /*
     [TestFixture]
     public class DataAdapterTestsV2 : DataAdapterTests
     {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
+        public DataAdapterTestsV2(int backendProtocolVersion) : base(backendProtocolVersion) {}
+
         public override void DoInsertWithCommandBuilderCaseSensitive()
         {
             //Not possible with V2?
@@ -432,4 +436,5 @@ namespace NpgsqlTests
             //Not possible with V2?
         }
     }
+     */
 }

--- a/tests/DataReaderTests.cs
+++ b/tests/DataReaderTests.cs
@@ -1,4 +1,4 @@
-// created on 27/12/2002 at 17:05
+﻿// created on 27/12/2002 at 17:05
 //
 // Author:
 //     Francisco Figueiredo Jr. <fxjrlists@yahoo.com>
@@ -35,6 +35,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class DataReaderTests : TestBase
     {
+        public DataReaderTests(string backendVersion) : base(backendVersion) { }
+
 /*        [Test]
         public void TestNew()
         {
@@ -985,14 +987,15 @@ namespace NpgsqlTests
             }
         }
     }
-
+/*
     [TestFixture]
     public class DataReaderTestsV2 : DataReaderTests
     {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
+        protected override int BackendProtocolVersion { get { return 2; } }
         public override void DoIsIdentityMetadataSupport()
         {
             //Not possible with V2?
         }
     }
+ */
 }

--- a/tests/ExceptionTests.cs
+++ b/tests/ExceptionTests.cs
@@ -35,6 +35,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class ExceptionTests : TestBase
     {
+        public ExceptionTests(string backendVersion) : base(backendVersion) { }
+
         [Test]
         public void ProblemSqlInsideException()
         {

--- a/tests/PrepareTests.cs
+++ b/tests/PrepareTests.cs
@@ -7,11 +7,13 @@ using NUnit.Framework;
 namespace NpgsqlTests
 {
     /// <summary>
-    /// Summary description for PrepareTest.
+    /// Summary description for PrepareTests.
     /// </summary>
     [TestFixture]
-    public class PrepareTest : TestBase
+    public class PrepareTests : TestBase
     {
+        public PrepareTests(string backendVersion) : base(backendVersion) { }
+
         protected override void SetUp()
         {
             base.SetUp();
@@ -127,11 +129,5 @@ namespace NpgsqlTests
             cmd.Prepare(); // Fails
             cmd.ExecuteNonQuery();
         }
-    }
-
-    [TestFixture]
-    public class PrepareTestV2 : PrepareTest
-    {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
     }
 }

--- a/tests/SpeedTests.cs
+++ b/tests/SpeedTests.cs
@@ -15,6 +15,8 @@ namespace NpgsqlTests
     [Explicit]
     public class SpeedTests : TestBase
     {
+        public SpeedTests(string backendVersion) : base(backendVersion) { }
+
         private static readonly TimeSpan TestRunTime = new TimeSpan(0, 0, 10); // 10 seconds
 
         [Test, Description("A normal insert command with one parameter")]

--- a/tests/SystemTransactionsTest.cs
+++ b/tests/SystemTransactionsTest.cs
@@ -11,6 +11,8 @@ namespace NpgsqlTests
     [TestFixture]
     public class SystemTransactionsTest : TestBase
     {
+        public SystemTransactionsTest(string backendVersion) : base(backendVersion) { }
+
         [Test, Description("Single connection enlisting explicitly, committing")]
         public void ExplicitEnlist()
         {
@@ -232,10 +234,5 @@ namespace NpgsqlTests
         }
 
         #endregion
-    }
-
-    public class SystemTransactionsTestV2 : SystemTransactionsTest
-    {
-        protected override int BACKEND_PROTOCOL_VERSION { get { return 2; } }
     }
 }


### PR DESCRIPTION
- Unit tests now use the NUnit parameterized test suite feature
  to run multiple times on different backend versions
- Each parameterized run consults a version-specific env var
  for the conn string (e.g. NPGSQL_TEST_DB_9.1)
- If the version-specific env vars aren't defined, a compiled-in
  default connection string is used instead (simply run against
  localhost:5432). This would be the normal mode for developers.
- As discussed on the devel list, removed testing for protocol 2
