### PR TITLE
NpgsqlError

### DIFF
--- a/src/Npgsql/NpgsqlError.cs
+++ b/src/Npgsql/NpgsqlError.cs
@@ -352,7 +352,11 @@ namespace Npgsql
                                     _constraintName = PGUtil.ReadString(stream);
                                     ;
                                     break;
-								
+                                default:
+                                    // Unknown error field; consume and discard.
+                                    PGUtil.ReadString(stream);
+                                    ;
+                                    break;
 							}
 						}
 					}


### PR DESCRIPTION
Fix bug that would cause NpgsqlError to stop reading error fields prematurally if it encountered a field type it doesn't understand.
