### PR TITLE
Command timeout

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.cs
@@ -176,6 +176,7 @@ namespace Npgsql
 
                 if (m_Connector != null && m_Connector.AlwaysPrepare)
                 {
+                    CommandTimeout = m_Connector.CommandTimeout;
                     prepared = PrepareStatus.NeedsPrepare;
                 }
             }
@@ -189,13 +190,14 @@ namespace Npgsql
         /// <summary>
         /// Used to execute internal commands.
         /// </summary>
-        internal NpgsqlCommand(String cmdText, NpgsqlConnector connector)
+        internal NpgsqlCommand(String cmdText, NpgsqlConnector connector, int CommandTimeout = 20)
         {
             NpgsqlEventLog.LogMethodEnter(LogLevel.Debug, CLASSNAME, CLASSNAME);
 
             planName = String.Empty;
             commandText = cmdText;
             this.m_Connector = connector;
+            this.CommandTimeout = CommandTimeout;
             commandType = CommandType.Text;
 
             // Removed this setting. It was causing too much problem.


### PR DESCRIPTION
Francisco,

This PR utilizes PG's statement_timeout parameter to implement statement timeout. There are some trade offs here that should be mentioned and reviewed:

Pro: We should almost never have to do the work required to tell PG to cancel a request in progress (due to timeout).

Pro: The error from PG on timeout is more relevant ("...due to statement timeout") than what a timeout currently results in ("...due to user request").

Con: Whenever commandTimeout differs from the last value sent to the backend, it has to be sent again, representing an overhead that could be substantial depending on how Npgsql us used.

Con (barely): If PG fails to send a timeout error in a timely fashion (a "timeout error timeout", so to speak), the frontend's timeout logic will cause an additional 5 seconds to elapse before the cancel-request method is used, in violation of the user's timeout value.

Glen
