### PR TITLE
Fix entity framework xml ids after change of RootNamespace

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
+++ b/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
@@ -16,7 +16,7 @@ namespace Npgsql
     internal class NpgsqlProviderManifest : DbXmlEnabledProviderManifest
     {
         public NpgsqlProviderManifest(string serverVersion)
-            : base(CreateXmlReaderForResource("NpgsqlProviderManifest.Manifest.xml"))
+            : base(CreateXmlReaderForResource("Npgsql.NpgsqlProviderManifest.Manifest.xml"))
         {
         }
 
@@ -26,11 +26,11 @@ namespace Npgsql
 
             if (informationType == StoreSchemaDefinition)
             {
-                xmlReader = CreateXmlReaderForResource("NpgsqlSchema.ssdl");
+                xmlReader = CreateXmlReaderForResource("Npgsql.NpgsqlSchema.ssdl");
             }
             else if (informationType == StoreSchemaMapping)
             {
-                xmlReader = CreateXmlReaderForResource("NpgsqlSchema.msl");
+                xmlReader = CreateXmlReaderForResource("Npgsql.NpgsqlSchema.msl");
             }
 
             if (xmlReader == null)


### PR DESCRIPTION
(https://github.com/npgsql/Npgsql/commit/6e32569)

After adding the root namespace, Npgsql Entity Framework xml files
weren't being found anymore. This patch fixes the name of those ids used
to find the files inside Npgsql assembly.

Thanks jjchiw for the patch:
https://github.com/jjchiw/Npgsql/commit/409a820e9f3265f9002de5bb37314e37a416a59c

Only applied the part about NpgsqlProviderManifest.cs file.
