### PR TITLE
Bug fix: ConnectionString: "AlwaysPrepare=true" not always honored

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.cs
@@ -320,6 +320,11 @@ namespace Npgsql
                 if (this.connection != null)
                 {
                     m_Connector = this.connection.Connector;
+
+                    if (m_Connector != null && m_Connector.AlwaysPrepare)
+                    {
+                        prepared = PrepareStatus.NeedsPrepare;
+                    }
                 }
 
                 SetCommandTimeout();


### PR DESCRIPTION
Hi guys.

Per issue #141, the AlwaysPrepare directive was being ignored in cases where NpgsqlCommand.Connection is assigned after construction.  This fixes it.

-Glen
