### PR TITLE
fix deadlock [#1011342]

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -160,6 +160,7 @@ namespace Npgsql
 
         // Counter of notification thread start/stop requests in order to
         internal Int16 _notificationThreadStopCount;
+        internal object _notificationThreadStopSync = new object();
 
         private Exception _notificationException;
 
@@ -1068,13 +1069,15 @@ namespace Npgsql
 
                 // Special case in order to not get problems with thread synchronization.
                 // It will be turned to 0 when synch thread is created.
-                _notificationThreadStopCount = 1;
+                lock (_notificationThreadStopSync)
+                    _notificationThreadStopCount = 1;
             }
         }
 
         internal void AddNotificationThread()
         {
-            _notificationThreadStopCount = 0;
+            lock (_notificationThreadStopSync)
+                _notificationThreadStopCount = 0;
 
             NpgsqlContextHolder contextHolder = new NpgsqlContextHolder(this, CurrentState);
 
@@ -1128,7 +1131,8 @@ namespace Npgsql
                 throw _notificationException;
             }
 
-            _notificationThreadStopCount++;
+            lock (_notificationThreadStopSync)
+                _notificationThreadStopCount++;
 
             if (_notificationThreadStopCount == 1) // If this call was the first to increment.
             {
@@ -1138,7 +1142,8 @@ namespace Npgsql
 
         private void ResumeNotificationThread()
         {
-            _notificationThreadStopCount--;
+            lock (_notificationThreadStopSync)
+                _notificationThreadStopCount--;
 
             if (_notificationThreadStopCount == 0)
             {
@@ -1147,9 +1152,16 @@ namespace Npgsql
             }
         }
 
-        internal Boolean IsNotificationThreadRunning
+        /// <summary>
+        /// Returns whether we are in notification thread and notification thread shoul stop.
+        /// </summary>
+        internal Boolean ShouldNotificationThreadStop
         {
-            get { return _notificationThreadStopCount <= 0; }
+            get
+            {
+                lock (_notificationThreadStopSync)
+                    return _notificationThreadStopCount > 0 && Thread.CurrentThread == _notificationThread;
+            }
         }
 
         internal class NpgsqlContextHolder

--- a/Npgsql/Npgsql/NpgsqlState.BackendResponseV2.cs
+++ b/Npgsql/Npgsql/NpgsqlState.BackendResponseV2.cs
@@ -206,7 +206,7 @@ namespace Npgsql
 
                         case BackEndMessageCode.NotificationResponse:
                             context.FireNotification(new NpgsqlNotificationEventArgs(stream, false));
-                            if (context.IsNotificationThreadRunning)
+                            if (context.ShouldNotificationThreadStop)
                             {
                                 yield break;
                             }

--- a/Npgsql/Npgsql/NpgsqlState.BackendResponseV3.cs
+++ b/Npgsql/Npgsql/NpgsqlState.BackendResponseV3.cs
@@ -274,7 +274,7 @@ namespace Npgsql
                             // Eat the length
                             PGUtil.ReadInt32(stream);
                             context.FireNotification(new NpgsqlNotificationEventArgs(stream, true));
-                            if (context.IsNotificationThreadRunning)
+                            if (context.ShouldNotificationThreadStop)
                             {
                                 yield break;
                             }


### PR DESCRIPTION
This PR fixes a deadlock issue with SyncNotification=true, massive notifications and normal queries. See bug  http://pgfoundry.org/tracker/index.php?func=detail&aid=1011342&group_id=1000140&atid=590, there is a testing source code as well.
The main fix is to replace IsNotificationThreadRunning by ShouldNotificationThreadStop. If ShouldNotificationThreadStop returns True, iteration loop in notification thread breaks and pending query in main thread can proceed. (Before this fix the iteration loop endlessly processed received notifications and hence pending query waited endlessly for Monitor.Enter(_socket)...)
The additional lock statements are necessary, because _notificationThreadStopCount is used in different threads. See http://blogs.developpeur.org/jay/archive/2004/08/05/21876.aspx for this problematic. (I guess, there are more of these issues in the code.)

Udo
