### PR TITLE
Fixed wrong comma putting in AddFunctionColumnListSupport of NpgsqlCommand.Rewrite

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
@@ -177,11 +177,16 @@ namespace Npgsql
             for (int i = 0 ; i < Parameters.Count ; i++)
             {
                 var p = Parameters[i];
+                bool isFirstOutputOrInputOutput = true;
 
                 switch(p.Direction)
                 {
                     case ParameterDirection.Output: case ParameterDirection.InputOutput:
-                        if (i > 0)
+                        if (isFirstOutputOrInputOutput)
+                        {
+                            isFirstOutputOrInputOutput = false;
+                        }
+                        else
                         {
                             st.WriteString(", ");
                         }


### PR DESCRIPTION
Checking on i > 0 will only work if the first parameter in the parameter list has Output or InputOutput direction. It will create leading comma in other cases.
