### PR TITLE
Fix bug #152: NpgsqlInterval different constructors different ToString

### DIFF
--- a/Npgsql/NpgsqlTypes/DateDatatypes.cs
+++ b/Npgsql/NpgsqlTypes/DateDatatypes.cs
@@ -157,7 +157,7 @@ namespace NpgsqlTypes
         /// </summary>
         /// <param name="timespan">A time period expressed in a <see cref="TimeSpan"/></param>
         public NpgsqlInterval(TimeSpan timespan)
-            : this(timespan.Ticks)
+            : this(timespan.Days, timespan.Hours, timespan.Minutes, timespan.Seconds, timespan.Milliseconds)
         {
         }
 


### PR DESCRIPTION
Fix for bug #152.

This should make its way into 2.1 RC1.

-Glen
