### PR TITLE
Returning DB generated values on insert for EF fixing #159

### DIFF
--- a/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
@@ -136,8 +136,8 @@ namespace Npgsql.SqlGenerators
                     sqlText.AppendFormat(ni, "cast({0} as float4)", _value);
                     break;
                 case PrimitiveTypeKind.Boolean:
-                     sqlText.AppendFormat(ni, "cast({0} as boolean)", ((bool)_value)?"TRUE":"FALSE");
-                     break;
+                    sqlText.AppendFormat(ni, "cast({0} as boolean)", ((bool)_value) ? "TRUE" : "FALSE");
+                    break;
                 case PrimitiveTypeKind.Guid:
                 case PrimitiveTypeKind.String:
                     NpgsqlTypesHelper.TryGetNativeTypeInfo(GetDbType(_primitiveType), out typeInfo);
@@ -265,29 +265,23 @@ namespace Npgsql.SqlGenerators
             Append(")");
         }
 
-        public VisitedExpression ReturningExpression { get; set; }
+        internal void AppendReturning(DbNewInstanceExpression expression)
+        {
+            Append(" RETURNING ");//Don't put () around columns it will probably have unwanted effect
+            bool first = true;
+            foreach (var returingProperty in expression.Arguments)
+            {
+                if (!first)
+                    Append(",");
+                Append("\"" + (returingProperty as DbPropertyExpression).Property.Name + "\"");
+                first = false;
+            }
+        }
 
         internal override void WriteSql(StringBuilder sqlText)
         {
             sqlText.Append("INSERT INTO ");
             base.WriteSql(sqlText);
-            if (ReturningExpression != null)
-            {
-                sqlText.Append(";");
-                ReturningExpression.WriteSql(sqlText);
-            }
-        }
-
-        internal override IEnumerable<PropertyExpression> GetAccessedProperties()
-        {
-            return base.GetAccessedProperties().Concat(ReturningExpression.GetAccessedProperties());
-        }
-
-        internal override IEnumerable<ColumnExpression> GetProjectedColumns()
-        {
-            if (ReturningExpression != null)
-                return ReturningExpression.GetProjectedColumns();
-            return Enumerable.Empty<ColumnExpression>();
         }
     }
 


### PR DESCRIPTION
Based on postgresql documentation RETURING was added in 8.2.

Here is some sample which results in newObject having proper BlogId and also random generated GuidGeneratedByPostgreDatabase by Postgresql backend.

``` csharp
using (var context = new BloggingContext())
{
    var newObject = context.Blogs.Create();
    newObject.Name = "George";
    context.Blogs.Add(newObject);
    context.SaveChanges();
}

public class Blog
{
    //This is also generated by DB because it's a key
    public int BlogId { get; set; }
    public string Name { get; set; }
    [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
    public Guid GuidGeneratedByPostgreDatabase { get; set; }
}
```

Some commends on code...
- _commandTree.Returning is always DbNewInstanceExpression
- RETURING ("col1","col2","col3") results in returing single column where values are joined by comma which is not what EF expects so () may not be there...
- foreach (var returingProperty in expression.Arguments) is always Arguments!=null and Arguments.Count>0
- I think I should create new class ReturingExpression but seems like waste of performance since it's only used here :) If you really want I can change that...
