### PR TITLE
GetResultSchema When current description is null

### DIFF
--- a/Npgsql/Npgsql/NpgsqlDataReader.cs
+++ b/Npgsql/Npgsql/NpgsqlDataReader.cs
@@ -496,8 +496,7 @@ namespace Npgsql
         private DataTable GetResultsetSchema()
         {
             DataTable result = null;
-
-            if (CurrentDescription.NumFields > 0)
+            if (CurrentDescription != null && CurrentDescription.NumFields > 0)
             {
                 result = new DataTable("SchemaTable");
 


### PR DESCRIPTION
When using npgsql together with nhibernate, sometimes we get a null exception when nhibernate tries to get the schema table. An added null check here would ensure that GetSchemaTable returns null (instead of throwing an exception).
