### PR TITLE
Pool should distribute available connectors in an orderly first come, first served manner.

### DIFF
--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -123,9 +123,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Transactions" />

--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -123,7 +123,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <Reference Include="System.Core">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Transactions" />
@@ -159,6 +161,7 @@
     <Compile Include="NpgsqlTypes\NpgsqlTypeMappings.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTypes.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTypesHelper.cs" />
+    <Compile Include="Npgsql\NpgsqlConnectorRequest.cs" />
     <Compile Include="Npgsql\NpgsqlQuery.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Npgsql\Cache.cs" />

--- a/Npgsql/Npgsql/NpgsqlConnectorRequest.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectorRequest.cs
@@ -1,0 +1,111 @@
+﻿//    Copyright (C) 2002 The Npgsql Development Team
+//    npgsql-general@gborg.postgresql.org
+//    https://github.com/npgsql/Npgsql
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+//
+//    NpgsqlConnectorRequest.cs
+// ------------------------------------------------------------------
+//    Project
+//        Npgsql
+//    Status
+//        0.00.0000 - 03/01/2014 - Sunny Ahuwanya<sunny at ahuwanya.net> - created
+
+using System;
+using System.Threading;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Represents a request for a Connector
+    /// </summary>
+    internal class NpgsqlConnectorRequest
+    {
+        readonly NpgsqlConnection _connection; 
+
+        NpgsqlConnector _connector;
+        int _cancelled = 0; // 0 for false, -1 for true.
+
+        public NpgsqlConnectorRequest(NpgsqlConnection connection)
+        {
+            _connection = connection;
+        }
+
+        /// <summary>
+        /// Gets the connection associated with this request.
+        /// </summary>
+        internal NpgsqlConnection RequestConnection
+        {
+            get { return _connection; }
+        }
+
+        /// <summary>
+        /// Gets or sets a connector for this request.
+        /// </summary>
+        internal NpgsqlConnector Connector
+        {
+            get {
+
+                if (_connector == null)
+                {
+                    //Ensure we are reading the most recent value
+                    _connector = Interlocked.CompareExchange(ref _connector, null, null);
+                }
+
+                return _connector; 
+            }
+            set {
+
+                if (Connector != null)
+                {
+                    throw new InvalidOperationException("Connector can only be set once!");
+                }
+
+                //Set connector
+                Interlocked.CompareExchange(ref _connector, value, null);
+            }
+        }
+
+        /// <summary>
+        /// Indicates that this item has been cancelled. i.e. requestor doesn't care for this request to be serviced anymore
+        /// </summary>
+        internal bool IsCancelled
+        {
+            get
+            {
+                if (_cancelled == 0)
+                {
+                    //Ensure we are reading the most recent value
+                    _cancelled = Interlocked.CompareExchange(ref _cancelled, 0, 0);
+                }
+
+                return _cancelled == -1;
+            }
+            set
+            {
+                if (IsCancelled && value == true)
+                {
+                    throw new InvalidOperationException("IsCancelled can only be set true once!");
+                }
+
+                //Set _cancelled
+                Interlocked.CompareExchange(ref _cancelled, value == true ? -1 : 0, 0);
+            }
+        }
+    }
+}

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -94,7 +94,7 @@ namespace NpgsqlTests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        private const string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;syncnotification=false";
+        private const string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=postgres;Password=postgres;Database=npgsql_tests;syncnotification=false";
 
         /// <summary>
         /// Indicates whether the database schema has already been created in this unit test session.

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -94,7 +94,7 @@ namespace NpgsqlTests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        private const string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=postgres;Password=postgres;Database=npgsql_tests;syncnotification=false";
+        private const string DEFAULT_CONNECTION_STRING = "Server=localhost;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;syncnotification=false";
 
         /// <summary>
         /// Indicates whether the database schema has already been created in this unit test session.


### PR DESCRIPTION
The current connection pool doesn't perform well in a high demand environment because the connectors are not distributed in an orderly fashion.

In the existing logic, when a request for a connector comes in and there is no available connector, it waits for a second and tries again until it gets one or times out.
This is okay when you have a small request rate or when you have a large pool of connectors but in a situation when you have a small pool of connectors and/or a large number of requests, what ends up happening is that there is a lot of contention for connectors. A request might come in and wait for a free connector only to be "cut in line" by another request which just happens to grab the connector while the older request was sleeping. The older request may very well end up not getting a connection and fail.

If you take a web application that performs five database calls in one request, the chances for one database call to fail in such an environment is high. And if one DB call fails. the entire web request fails.
I have a web application that suffered from this issue until I made this change.

A more scalable solution is to distribute the connectors to requests on a first come, first served basis. This will ensure that every request is guaranteed to get their turn or time out in a more even manner.

This pull request addresses two issues:

1. Incoming requests for connectors are queued and processed as the connectors become available.
2. Reduces the sleep time from 1 second to 10 ms. This will not task the CPU any more than it does because the requests are processed one by one.

*UPDATE: (3/8/2014)*: Unit tests issues have been resolved. They all pass now.