### PR TITLE
Fix SSL connection setup problem reported in #176

### DIFF
--- a/Npgsql/Npgsql/NpgsqlClosedState.cs
+++ b/Npgsql/Npgsql/NpgsqlClosedState.cs
@@ -180,7 +180,8 @@ namespace Npgsql
                         //trigger the callback to fetch some certificates
                         context.DefaultProvideClientCertificatesCallback(clientCertificates);
 
-                        if (context.UseMonoSsl)
+                        //if (context.UseMonoSsl)
+                        if (!NpgsqlConnector.UseSslStream)
                         {
                             SslClientStream sslStreamPriv;
 

--- a/Npgsql/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/Npgsql/NpgsqlConnection.cs
@@ -325,6 +325,13 @@ namespace Npgsql
             get { return settings.SSL; }
         }
 
+
+        public Boolean UseSslStream
+        {
+            get { return NpgsqlConnector.UseSslStream; }
+            set { NpgsqlConnector.UseSslStream = value; }
+        }
+
         /// <summary>
         /// Gets the time to wait while trying to establish a connection
         /// before terminating the attempt and generating an error.
@@ -1025,7 +1032,7 @@ namespace Npgsql
             }
             else
             {
-                return false;
+                return true;
             }
         }
 

--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -255,6 +255,8 @@ namespace Npgsql
             get { return settings.SslMode; }
         }
 
+        internal static Boolean UseSslStream = false;
+
         internal Boolean UseMonoSsl
         {
             get { return ValidateRemoteCertificateCallback == null; }


### PR DESCRIPTION
After this patch: https://github.com/npgsql/Npgsql/commit/101585999206218e7c09b7b25e57a6d2d0b789da Npgsql was only using the SSLStream option.
The patch was supposed to allow the user to choose between Mono.Security ssl and SSLStream based on setting a validate remote certificate callback.
Unfortunately it didn't work because the callback is set by default which makes the code to always use SSLStream and by default, it doesn't validate any certificate.
With this fix another check was created where the user says through NpgsqlConnection if she wants or not to use the SSLStream.

After merging this patch, the user won't need to add any callback, unless she really wants to validate a remote certificate.
Now Npgsql continues to use Mono.Security ssl implementation by default unless user changes it using `NpgsqlConnection.UseSslStream = true` 
Fix #176
