### PR TITLE
Commented out semicolon NOT ignored

### DIFF
--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -119,6 +119,13 @@ namespace NpgsqlTests
         }
 
         [Test]
+        public void CommentedOutSemicolon()
+        {
+            var command = new NpgsqlCommand("-- 1\n-- 2; abc\n-- 3;", Conn);
+            command.ExecuteNonQuery();
+        }
+
+        [Test]
         public void NoNameParameterAdd()
         {
             var command = new NpgsqlCommand();


### PR DESCRIPTION
If there is a semicolon within a single line comment "--", Npgsql
assumes that it marks the end of a statement and starts the next
statement (chunk) immediately after it, ignoring that this is still
commented out.
This commit ignores semicolons within single line comments.

I have created a test demonstrating the issue:
This will throw an exception although the command is valid (though meaningless in this case)

``` csharp
[Test]
public void CommentedOutSemicolon()
{
  var command = new NpgsqlCommand("-- 1\n-- 2; abc\n-- 3;", Conn);
  command.ExecuteNonQuery();
}
```
