### PR TITLE
NpgsqlConnectionStringBuilder: Fix KeyNotFoundException for Keywords.ApplicationName

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -163,6 +163,7 @@ namespace Npgsql
             valueDescriptions.Add(Keywords.Compatible, new ValueDescription(THIS_VERSION));
             valueDescriptions.Add(Keywords.ApplicationName, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.AlwaysPrepare, new ValueDescription(typeof(bool)));
+            valueDescriptions.Add(Keywords.ApplicationName, new ValueDescription(typeof(string)));
         }
 
         public NpgsqlConnectionStringBuilder()


### PR DESCRIPTION
Creating an instance of `NpgsqlConnectionStringBuilder` would lead to a `KeyNotFoundException` in `NpgsqlConnectionStringBuilder.SetValue(string, Keyword, object)` due to a missing value description entry.

Example case to reproduce the error condition:

```
var connectionStr = new NpgsqlConnectionStringBuilder {
            Host = _host,
            UserName = _username,
            Password = _password,
            ApplicationName = "foobar"  // << offending code
};
```
