### PR TITLE
Fix bug #152: NpgsqlInterval different constructors different ToString

### DIFF
--- a/Npgsql/NpgsqlTypes/DateDatatypes.cs
+++ b/Npgsql/NpgsqlTypes/DateDatatypes.cs
@@ -149,10 +149,8 @@ namespace NpgsqlTypes
         /// </summary>
         /// <param name="ticks">A time period expressed in 100ns units.</param>
         public NpgsqlInterval(long ticks)
+            : this(new TimeSpan(ticks))
         {
-            _months = 0;
-            _days = 0;
-            _ticks = ticks;
         }
 
         /// <summary>
@@ -160,7 +158,7 @@ namespace NpgsqlTypes
         /// </summary>
         /// <param name="timespan">A time period expressed in a <see cref="TimeSpan"/></param>
         public NpgsqlInterval(TimeSpan timespan)
-            : this(timespan.Ticks)
+            : this(0, timespan.Days, timespan.Ticks - (TicksPerDay * timespan.Days))
         {
         }
 

--- a/tests/TypesTests.cs
+++ b/tests/TypesTests.cs
@@ -244,6 +244,12 @@ namespace NpgsqlTests
 
             Assert.AreEqual("14 mons 3 days 04:05:06.007", new NpgsqlInterval(1, 2, 3, 4, 5, 6, 7).ToString());
 
+            Assert.AreEqual(new NpgsqlInterval(0, 2, 3, 4, 5).ToString(), new NpgsqlInterval(new TimeSpan(0, 2, 3, 4, 5)).ToString());
+            
+            Assert.AreEqual(new NpgsqlInterval(1, 2, 3, 4, 5).ToString(), new NpgsqlInterval(new TimeSpan(1, 2, 3, 4, 5)).ToString());
+            const long moreThanAMonthInTicks = TimeSpan.TicksPerDay*40;
+            Assert.AreEqual(new NpgsqlInterval(moreThanAMonthInTicks).ToString(), new NpgsqlInterval(new TimeSpan(moreThanAMonthInTicks)).ToString());
+            
             var oldCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
             var testCulture = new System.Globalization.CultureInfo("fr-FR");
             Assert.AreEqual(",", testCulture.NumberFormat.NumberDecimalSeparator, "decimal seperator");


### PR DESCRIPTION
Take the days from the Timespan, then the remaining ticks.
NpgsqlInterval(long) now calls NpgsqlInterval(TimeSpan) to make TimeSpan do the division work.
Largely inspired by commit fd99912a019a3e987edfba8511431c82ec3cd9a5 from glenebob
