### PR TITLE
Fix #177. Add proper quoting to xml datatype.

### DIFF
--- a/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
@@ -439,7 +439,9 @@ namespace NpgsqlTypes
             nativeTypeMapping.AddType("uuid", NpgsqlDbType.Uuid, DbType.Guid, true);
             nativeTypeMapping.AddTypeAlias("uuid", typeof (Guid));
 
-            nativeTypeMapping.AddType("xml", NpgsqlDbType.Xml, DbType.Xml, true);
+            nativeTypeMapping.AddType("xml", NpgsqlDbType.Xml, DbType.Xml, false,
+                                            BasicNativeToBackendTypeConverter.StringToTextText,
+                                            BasicNativeToBackendTypeConverter.StringToTextBinary);
 
             nativeTypeMapping.AddType("interval", NpgsqlDbType.Interval, DbType.Object, true,
                                             ExtendedNativeToBackendTypeConverter.ToInterval);

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -1732,6 +1732,38 @@ namespace NpgsqlTests
         }
 
         [Test]
+        public void TestXmlParameter()
+        {
+            TestXmlParameter_Internal(false);
+        }
+
+        [Test]
+        public void TestXmlParameterPrepared()
+        {
+            TestXmlParameter_Internal(true);
+        }
+
+        
+        private void TestXmlParameter_Internal(bool prepare)
+        {
+            using (var command = new NpgsqlCommand("select @PrecisionXML", Conn))
+            {
+                var sXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <strings type=\"array\"> <string> this is a test with ' single quote </string></strings>";
+                var parameter = command.CreateParameter();
+                parameter.DbType = DbType.Xml;  // To make it work we need to use DbType.String; and then CAST it in the sSQL: cast(@PrecisionXML as xml)
+                parameter.ParameterName = "@PrecisionXML";
+                parameter.Value = sXML;
+                command.Parameters.Add(parameter);
+
+                if (prepare)
+                    command.Prepare();
+                command.ExecuteScalar();
+            }
+
+        }
+
+
+        [Test]
         public void SetParameterValueNull()
         {
             var cmd = new NpgsqlCommand("insert into data(field_bytea) values (:val)", Conn);


### PR DESCRIPTION
Fix #177.
This patches handles xml datatype the same way as text regarding quoting thus the text converters are used.
