### PR TITLE
Fixes for issue #231

### DIFF
--- a/Npgsql/Npgsql/NpgsqlParameterCollection.cs
+++ b/Npgsql/Npgsql/NpgsqlParameterCollection.cs
@@ -347,7 +347,7 @@ namespace Npgsql
         public override void RemoveAt(string parameterName)
         {
             NpgsqlEventLog.LogMethodEnter(LogLevel.Debug, CLASSNAME, "RemoveAt", parameterName);
-			RemoveAt(this.IndexOf(parameterName));
+            RemoveAt(this.IndexOf(parameterName));
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace Npgsql
             {
                 throw new IndexOutOfRangeException();
             }
-			Remove(this.InternalList[index]);
+            Remove(this.InternalList[index]);
         }
 
         /// <summary>
@@ -525,7 +525,7 @@ namespace Npgsql
             {
                 throw new InvalidOperationException("No parameter with the specified name exists in the collection");
             }
-			RemoveAt(index);
+            RemoveAt(index);
         }
 
 
@@ -537,7 +537,7 @@ namespace Npgsql
         {
             NpgsqlEventLog.LogMethodEnter(LogLevel.Debug, CLASSNAME, "Remove", oValue);
             CheckType(oValue);
-			Remove(oValue as NpgsqlParameter);
+            Remove(oValue as NpgsqlParameter);
         }
 
 
@@ -588,11 +588,11 @@ namespace Npgsql
         public override void Clear()
         {
             NpgsqlEventLog.LogMethodEnter(LogLevel.Debug, CLASSNAME, "Clear");
-			foreach(NpgsqlParameter toRemove in this.InternalList)
-			{
-				// clean up the parameter so it can be added to another command if required.
-				toRemove.Collection = null;
-			}
+            foreach(NpgsqlParameter toRemove in this.InternalList)
+            {
+                // clean up the parameter so it can be added to another command if required.
+                toRemove.Collection = null;
+            }
             this.InternalList.Clear();
             this.InvalidateHashLookups();
         }
@@ -837,14 +837,14 @@ namespace Npgsql
         /// <returns>True if the parameter was found and removed, otherwise false.</returns>
         public bool Remove(NpgsqlParameter item)
         {
-			if(item == null)
-			{
-				return false;
-			}
-			if(item.Collection != this)
-			{
-				throw new InvalidOperationException("The item does not belong to this collection");
-			}
+            if(item == null)
+            {
+                return false;
+            }
+            if(item.Collection != this)
+            {
+                throw new InvalidOperationException("The item does not belong to this collection");
+            }
             if(InternalList.Remove(item))
             {
                 item.Collection = null;

--- a/tests/NpgsqlParameterTests.cs
+++ b/tests/NpgsqlParameterTests.cs
@@ -46,24 +46,24 @@ namespace NpgsqlTests
     [TestFixture]
     public class NpgsqlParameterTest
     {
-		/// <summary>
-		/// Test which validates that Clear() indeed cleans up the parameters in a command so they can be added to other commands safely.
-		/// </summary>
-		[Test]
-		public void NpgsqlParameterCollectionClearTest()
-		{
-			var p = new NpgsqlParameter();
-			var c1 = new NpgsqlCommand();
-			var c2 = new NpgsqlCommand();
-			c1.Parameters.Add(p);
-			Assert.AreEqual(1, c1.Parameters.Count);
-			Assert.AreEqual(0, c2.Parameters.Count);
-			c1.Parameters.Clear();
-			Assert.AreEqual(0, c1.Parameters.Count);
-			c2.Parameters.Add(p);
-			Assert.AreEqual(0, c1.Parameters.Count);
-			Assert.AreEqual(1, c2.Parameters.Count);
-		}
+        /// <summary>
+        /// Test which validates that Clear() indeed cleans up the parameters in a command so they can be added to other commands safely.
+        /// </summary>
+        [Test]
+        public void NpgsqlParameterCollectionClearTest()
+        {
+            var p = new NpgsqlParameter();
+            var c1 = new NpgsqlCommand();
+            var c2 = new NpgsqlCommand();
+            c1.Parameters.Add(p);
+            Assert.AreEqual(1, c1.Parameters.Count);
+            Assert.AreEqual(0, c2.Parameters.Count);
+            c1.Parameters.Clear();
+            Assert.AreEqual(0, c1.Parameters.Count);
+            c2.Parameters.Add(p);
+            Assert.AreEqual(0, c1.Parameters.Count);
+            Assert.AreEqual(1, c2.Parameters.Count);
+        }
 
 
         [Test]


### PR DESCRIPTION
See: https://github.com/npgsql/Npgsql/issues/231

Fixed the issue by implementing proper clean up in the Clear() method.
Cleaned up the Remove methods in NpgsqlParameterCollection as they
re-implemented the same code 6 times (Remove and RemoveAt+overloads).
Now all end up in 1 Remove method which performs the remove and the
parameter cleanup. Easier to maintain ;)
Added a test to verify my fix. Please verify the Remove changes as I
can't run the rest of the tests.
