### PR TITLE
[EFMigrations] Always creating setting type text instead of varchar(MaxLength)

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlMigrationSqlGenerator.cs
+++ b/Npgsql.EntityFramework/NpgsqlMigrationSqlGenerator.cs
@@ -629,17 +629,7 @@ namespace Npgsql
                         sql.Append("int8");
                     break;
                 case PrimitiveTypeKind.String:
-                    //Seems like bug in EF 6.0.2 to set MaxLength to 1 instead of 0 if not specified
-                    //http://entityframework.codeplex.com/workitem/1784 TODO: Investigate and put back to
-                    //if (column.MaxLength != null && column.MaxLength > 0)
-                    if (column.MaxLength != null && column.MaxLength > 1)
-                    {
-                        sql.Append("varchar(");
-                        sql.Append(column.MaxLength);
-                        sql.Append(")");
-                    }
-                    else
-                        sql.Append("text");
+                    sql.Append("text");
                     break;
                 case PrimitiveTypeKind.Time:
                     if (column.Precision != null)

--- a/tests/EntityFrameworkMigrationTests.cs
+++ b/tests/EntityFrameworkMigrationTests.cs
@@ -369,7 +369,7 @@ namespace NpgsqlTests
                 Assert.AreEqual("CREATE SCHEMA IF NOT EXISTS someSchema", statments.ElementAt(0).Sql);
             else
                 Assert.AreEqual("CREATE SCHEMA someSchema", statments.ElementAt(0).Sql);
-            Assert.AreEqual("CREATE TABLE \"someSchema\".\"someTable\"(\"SomeString\" varchar(233) NOT NULL DEFAULT '',\"AnotherString\" text,\"SomeBytes\" bytea,\"SomeLong\" serial8,\"SomeDateTime\" timestamp)", statments.ElementAt(1).Sql);
+            Assert.AreEqual("CREATE TABLE \"someSchema\".\"someTable\"(\"SomeString\" text NOT NULL DEFAULT '',\"AnotherString\" text,\"SomeBytes\" bytea,\"SomeLong\" serial8,\"SomeDateTime\" timestamp)", statments.ElementAt(1).Sql);
         }
 
         [Test]


### PR DESCRIPTION
I noticed 9.4 is arriving so wanted to check if there is something new with default GUID problem... Same as before...
But while searching on Google I found someone with problem:  http://stackoverflow.com/questions/23741521/postgresql-autogeneration-of-uuid-doesnt-work-with-entityframework
So I pulled latest code and wanted to reproduce I ran in different problem...
Same as here: https://groups.google.com/forum/#!topic/npgsql-help/6Szvoq95Of0 I had problem with 1073741823... in EF 6.0.1 if no [MaxLength(#)] was set it was null, then in EF 6.0.2 they changed this to be 1... And now in EF6.1 they are probably looking at https://github.com/npgsql/Npgsql/blob/master/Npgsql.EntityFramework/NpgsqlProviderManifest.Manifest.xml#L22 which has 1073741823 

So while looking at what real maximum string length in Pgsql is I ran into this article: http://blog.jonanin.com/2013/11/20/postgresql-char-varchar/

Since EntityFramework is already doing validation of MaxLength value there is no need for setting this things in Postgresql so always setting to TEXT makes sense...
