### PR TITLE
Add nuget packages content folders to ignore, as suggested by Shay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 [Bb]uild/
 [Oo]bj/
 [Oo]bj/
+packages/*/


### PR DESCRIPTION
(@roji), https://github.com/npgsql/Npgsql/pull/213#issuecomment-46753768 so they aren't added by mistake.

All dependent packages are handled by nuget restore.
