### PR TITLE
Include License.rtf to NpgsqlDdexProvider (VS2012)

### DIFF
--- a/NpgsqlDdexProvider/NpgsqlDdexProvider2012.csproj
+++ b/NpgsqlDdexProvider/NpgsqlDdexProvider2012.csproj
@@ -131,6 +131,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="License.rtf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <EmbeddedResource Include="Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
The built VSIX installer cannot be worked due to lack of License.rtf.

This PR fixes it so that you can build NpgsqlDdexProvider and run it on VS2012.
