### PR TITLE
Make Npgsql use SSLStream for ssl connections instead of using Mono.Secu...

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -255,7 +255,7 @@ namespace Npgsql
             get { return settings.SslMode; }
         }
 
-        internal static Boolean UseSslStream = false;
+        internal static Boolean UseSslStream = true;
 
         internal Boolean UseMonoSsl
         {


### PR DESCRIPTION
...rity.

Mono.Security assembly is used by Npgsql to provide ssl support.
SSLStream class found in .Net class library also provides support for ssl.
Before this patch, Npgsql used Mono.Security by default.
With this change, it will use SSLStream class found in .Net class library.
