### PR TITLE
Disable logging

### DIFF
--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -288,7 +288,7 @@ namespace NpgsqlTests
 
         static TestBase()
         {
-            NpgsqlEventLog.Level = LogLevel.Debug;
+            NpgsqlEventLog.Level = LogLevel.None;
             NpgsqlEventLog.EchoMessages = true;
         }
 


### PR DESCRIPTION
Test disable logging to check if it is the cause of build server hangs when running tests.
