### PR TITLE
Expose API for advisory locks

### DIFF
--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -160,6 +160,7 @@
     <Compile Include="NpgsqlTypes\NpgsqlTypeMappings.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTypes.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTypesHelper.cs" />
+    <Compile Include="Npgsql\NpgsqlAdvisoryLocks.cs" />
     <Compile Include="Npgsql\NpgsqlQuery.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Npgsql\Cache.cs" />

--- a/Npgsql/Npgsql/NpgsqlAdvisoryLocks.cs
+++ b/Npgsql/Npgsql/NpgsqlAdvisoryLocks.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Npgsql.Npgsql
+{
+    /// <summary>
+    /// Represents an exclusive advisory lock managed in the Postgresql backend. Can be used for
+    /// cooperative application synchronization.
+    /// See <a href="http://www.postgresql.org/docs/9.3/static/explicit-locking.html">the Postgresql documentation</a>
+    /// </summary>
+    public class NpgsqlExclusiveAdvisoryLock
+    {
+        readonly NpgsqlConnection _conn;
+        readonly long? _key;
+        readonly int _key1;
+        readonly int _key2;
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the single key <paramref name="key"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key">a single 64-bit key identifying this lock</param>
+        public NpgsqlExclusiveAdvisoryLock(NpgsqlConnection conn, long key)
+        {
+            _conn = conn;
+            _key = key;
+        }
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the dual keys <paramref name="key1"/>
+        /// and <paramref name="key2"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key1">a 32-bit key identifying this lock along with <paramref name="key2"/></param>
+        /// <param name="key2">a 32-bit key identifying this lock along with <paramref name="key1"/></param>
+        public NpgsqlExclusiveAdvisoryLock(NpgsqlConnection conn, int key1, int key2)
+        {
+            _conn = conn;
+            _key1 = key1;
+            _key2 = key2;
+        }
+
+        /// <summary>
+        /// Attempts to acquire the lock.
+        /// If another session already holds a lock on the same resource identifier, this method will
+        /// block until the resource becomes available. Multiple lock requests stack, so that if the
+        /// same resource is locked three times it must then be unlocked three times to be released
+        /// for other sessions' use.
+        /// </summary>
+        /// <returns>a handle that, when disposed, frees the lock</returns>
+        public IDisposable Acquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_advisory_lock(" + key + ")", _conn))
+                cmd.ExecuteNonQuery();
+            return new NpgsqlAdvisoryLockHandle(_conn, "SELECT pg_advisory_unlock(" + key + ")");
+        }
+
+        /// <summary>
+        /// Similar to <see cref="Acquire"/>, except the method will not block for the lock to become
+        /// available. It will either obtain the lock immediately and return true, or return false if
+        /// the lock cannot be acquired immediately.
+        /// </summary>
+        /// <param name="handle">if the method returned true, will contain a handle that, when disposed,
+        /// frees the lock. Otherwise null.</param>
+        /// <returns>whether the lock was acquired</returns>
+        public bool TryAcquire(out IDisposable handle)
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(" + key + ")", _conn))
+            {
+                var result = (bool)cmd.ExecuteScalar();
+                handle = result ? new NpgsqlAdvisoryLockHandle(_conn, "SELECT pg_advisory_unlock(" + key + ")") : null;
+                return result;
+            }
+        }
+    }
+
+    public class NpgsqlSharedAdvisoryLock
+    {
+        readonly NpgsqlConnection _conn;
+        readonly long? _key;
+        readonly int _key1;
+        readonly int _key2;
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the single key <paramref name="key"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key">a single 64-bit key identifying this lock</param>
+        public NpgsqlSharedAdvisoryLock(NpgsqlConnection conn, long key)
+        {
+            _conn = conn;
+            _key = key;
+        }
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the dual keys <paramref name="key1"/>
+        /// and <paramref name="key2"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key1">a 32-bit key identifying this lock along with <paramref name="key2"/></param>
+        /// <param name="key2">a 32-bit key identifying this lock along with <paramref name="key1"/></param>
+        public NpgsqlSharedAdvisoryLock(NpgsqlConnection conn, int key1, int key2)
+        {
+            _conn = conn;
+            _key1 = key1;
+            _key2 = key2;
+        }
+
+        /// <summary>
+        /// Attempts to acquire the lock.
+        /// If another session already holds a lock on the same resource identifier, this method will
+        /// block until the resource becomes available. Multiple lock requests stack, so that if the
+        /// same resource is locked three times it must then be unlocked three times to be released
+        /// for other sessions' use.
+        /// </summary>
+        /// <returns>a handle that, when disposed, frees the lock</returns>
+        public IDisposable Acquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_advisory_lock_shared(" + key + ")", _conn))
+                cmd.ExecuteNonQuery();
+            return new NpgsqlAdvisoryLockHandle(_conn, "SELECT pg_advisory_unlock_shared(" + key + ")");
+        }
+
+        /// <summary>
+        /// Similar to <see cref="Acquire"/>, except the method will not block for the lock to become
+        /// available. It will either obtain the lock immediately and return true, or return false if
+        /// the lock cannot be acquired immediately.
+        /// </summary>
+        /// <param name="handle">if the method returned true, will contain a handle that, when disposed,
+        /// frees the lock. Otherwise null.</param>
+        /// <returns>whether the lock was acquired</returns>
+        public bool TryAcquire(out IDisposable handle)
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock_shared(" + key + ")", _conn))
+            {
+                var result = (bool)cmd.ExecuteScalar();
+                handle = result ? new NpgsqlAdvisoryLockHandle(_conn, "SELECT pg_advisory_unlock_shared(" + key + ")") : null;
+                return result;
+            }
+        }
+    }
+
+    public class NpgsqlExclusiveTransactionAdvisoryLock
+    {
+        readonly NpgsqlConnection _conn;
+        readonly long? _key;
+        readonly int _key1;
+        readonly int _key2;
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the single key <paramref name="key"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key">a single 64-bit key identifying this lock</param>
+        public NpgsqlExclusiveTransactionAdvisoryLock(NpgsqlConnection conn, long key)
+            : this(conn)
+        {
+            _key = key;
+        }
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the dual keys <paramref name="key1"/>
+        /// and <paramref name="key2"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key1">a 32-bit key identifying this lock along with <paramref name="key2"/></param>
+        /// <param name="key2">a 32-bit key identifying this lock along with <paramref name="key1"/></param>
+        public NpgsqlExclusiveTransactionAdvisoryLock(NpgsqlConnection conn, int key1, int key2)
+            : this(conn)
+        {
+            _key1 = key1;
+            _key2 = key2;
+        }
+
+        NpgsqlExclusiveTransactionAdvisoryLock(NpgsqlConnection conn)
+        {
+            if (conn.PostgreSqlVersion < new Version(9, 1, 0))
+                throw new NotSupportedException("Transaction advisory locks aren't supported prior to Postgresql 9.1");
+            _conn = conn;            
+        }
+
+        /// <summary>
+        /// Attempts to acquire the lock.
+        /// If another session already holds a lock on the same resource identifier, this method will
+        /// block until the resource becomes available. Multiple lock requests stack, so that if the
+        /// same resource is locked three times it must then be unlocked three times to be released
+        /// for other sessions' use.
+        /// </summary>
+        /// <returns>a handle that, when disposed, frees the lock</returns>
+        public void Acquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_advisory_xact_lock(" + key + ")", _conn))
+                cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Similar to <see cref="Acquire"/>, except the method will not block for the lock to become
+        /// available. It will either obtain the lock immediately and return true, or return false if
+        /// the lock cannot be acquired immediately.
+        /// </summary>
+        /// <param name="handle">if the method returned true, will contain a handle that, when disposed,
+        /// frees the lock. Otherwise null.</param>
+        /// <returns>whether the lock was acquired</returns>
+        public bool TryAcquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_try_advisory_xact_lock(" + key + ")", _conn))
+                return (bool)cmd.ExecuteScalar();
+        }
+    }
+
+    public class NpgsqlSharedTransactionAdvisoryLock
+    {
+        readonly NpgsqlConnection _conn;
+        readonly long? _key;
+        readonly int _key1;
+        readonly int _key2;
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the single key <paramref name="key"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key">a single 64-bit key identifying this lock</param>
+        public NpgsqlSharedTransactionAdvisoryLock(NpgsqlConnection conn, long key)
+            : this(conn)
+        {
+            _key = key;
+        }
+
+        /// <summary>
+        /// Create the lock on <paramref name="conn"/> with the dual keys <paramref name="key1"/>
+        /// and <paramref name="key2"/>.
+        /// </summary>
+        /// <param name="conn">the connection on which to manage the lock</param>
+        /// <param name="key1">a 32-bit key identifying this lock along with <paramref name="key2"/></param>
+        /// <param name="key2">a 32-bit key identifying this lock along with <paramref name="key1"/></param>
+        public NpgsqlSharedTransactionAdvisoryLock(NpgsqlConnection conn, int key1, int key2)
+            : this(conn)
+        {
+            _key1 = key1;
+            _key2 = key2;
+        }
+
+        NpgsqlSharedTransactionAdvisoryLock(NpgsqlConnection conn)
+        {
+            if (conn.PostgreSqlVersion < new Version(9, 1, 0))
+                throw new NotSupportedException("Transaction advisory locks aren't supported prior to Postgresql 9.1");
+            _conn = conn;            
+        }
+
+        /// <summary>
+        /// Attempts to acquire the lock.
+        /// If another session already holds a lock on the same resource identifier, this method will
+        /// block until the resource becomes available. Multiple lock requests stack, so that if the
+        /// same resource is locked three times it must then be unlocked three times to be released
+        /// for other sessions' use.
+        /// </summary>
+        /// <returns>a handle that, when disposed, frees the lock</returns>
+        public void Acquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_advisory_xact_lock_shared(" + key + ")", _conn))
+                cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Similar to <see cref="Acquire"/>, except the method will not block for the lock to become
+        /// available. It will either obtain the lock immediately and return true, or return false if
+        /// the lock cannot be acquired immediately.
+        /// </summary>
+        /// <param name="handle">if the method returned true, will contain a handle that, when disposed,
+        /// frees the lock. Otherwise null.</param>
+        /// <returns>whether the lock was acquired</returns>
+        public bool TryAcquire()
+        {
+            var key = _key.HasValue ? _key.ToString() : _key1 + "," + _key2;
+            using (var cmd = new NpgsqlCommand("SELECT pg_try_advisory_xact_lock_shared(" + key + ")", _conn))
+                return (bool)cmd.ExecuteScalar();
+        }
+    }
+
+    class NpgsqlAdvisoryLockHandle : IDisposable
+    {
+        readonly NpgsqlConnection _conn;
+        readonly string _unlockCmdText;
+
+        internal NpgsqlAdvisoryLockHandle(NpgsqlConnection conn, string unlockCmdText)
+        {
+            _conn = conn;
+            _unlockCmdText = unlockCmdText;
+        }
+
+        public void Dispose()
+        {
+            // Note that the Postgresql unlock function returns false if the unlock failed, and
+            // issues a warning - but never an error.
+            using (var cmd = new NpgsqlCommand(_unlockCmdText, _conn))
+                cmd.ExecuteNonQuery();
+        }
+
+        // TODO: Implement destructor
+    }
+}

--- a/Npgsql/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/Npgsql/NpgsqlConnection.cs
@@ -1250,6 +1250,15 @@ namespace Npgsql
             Promotable.Enlist(transaction);
         }
 
+        /// <summary>
+        /// Instructs the backend to release any advisory locks held by this connection.
+        /// </summary>
+        public void ReleaseAllAdvisoryLocks()
+        {
+            using (var cmd = new NpgsqlCommand("SELECT pg_advisory_unlock_all()", this))
+                cmd.ExecuteNonQuery();            
+        }
+
 #if NET35
         /// <summary>
         /// DB provider factory.

--- a/tests/AdvisoryLockTests.cs
+++ b/tests/AdvisoryLockTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Npgsql;
+using Npgsql.Npgsql;
+using NUnit.Framework;
+
+namespace NpgsqlTests
+{
+    public class AdvisoryLockTests : TestBase
+    {
+        public AdvisoryLockTests(string backendVersion) : base(backendVersion) {}
+
+        [Test, Description("Basic scenario for an exclusive advisory lock")]
+        public void Exclusive()
+        {
+            long count;
+            var lock1 = new NpgsqlExclusiveAdvisoryLock(Conn, 8);
+            using (lock1.Acquire())
+            {
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND objid=8 AND mode='ExclusiveLock'");
+                Assert.That(count, Is.EqualTo(1));
+
+                using (var conn2 = new NpgsqlConnection(Conn.ConnectionString))
+                {
+                    conn2.Open();
+                    var lock2 = new NpgsqlExclusiveAdvisoryLock(conn2, 8);
+                    IDisposable handle;
+                    var result = lock2.TryAcquire(out handle);
+                    Assert.That(result, Is.False);
+                    Assert.That(handle, Is.Null);
+                }
+            }
+            count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND classid IS NULL AND objid=8 AND mode='ExclusiveLock'");
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        [Test, Description("Basic scenario for an exclusive advisory lock, using two int keys instead of one long")]
+        public void ExclusiveWithIntKeys()
+        {
+            long count;
+            var lock1 = new NpgsqlExclusiveAdvisoryLock(Conn, 10, 11);
+            using (lock1.Acquire())
+            {
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND classid=10 AND objid=11 AND mode='ExclusiveLock'");
+                Assert.That(count, Is.EqualTo(1));
+            }
+            count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND classid=10 AND objid=11 AND mode='ExclusiveLock'");
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        [Test, Description("Basic scenario for a shared advisory lock")]
+        public void Shared()
+        {
+            long count;
+            var lock1 = new NpgsqlSharedAdvisoryLock(Conn, 8);
+            using (lock1.Acquire())
+            {
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND objid=8 AND mode='ShareLock'");
+                Assert.That(count, Is.EqualTo(1));
+
+                using (var conn2 = new NpgsqlConnection(Conn.ConnectionString))
+                {
+                    conn2.Open();
+                    var lock2 = new NpgsqlSharedAdvisoryLock(conn2, 8);
+                    IDisposable handle;
+                    var result = lock2.TryAcquire(out handle);
+                    Assert.That(result, Is.True);
+                    Assert.That(handle, Is.Not.Null);
+                    handle.Dispose();
+                }
+            }
+            count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND classid IS NULL AND objid=8 AND mode='ShareLock'");
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        [Test, Description("Basic scenario for an exclusive transaction advisory lock")]
+        public void ExclusiveTransaction()
+        {
+            if (Conn.PostgreSqlVersion < new Version(9, 1, 0))
+                Assert.Ignore("Transaction advisory locks aren't supported prior to Postgresql 9.1");
+
+            using (var conn2 = new NpgsqlConnection(Conn.ConnectionString))
+            {
+                long count;
+                var tx = Conn.BeginTransaction();
+
+                var lock1 = new NpgsqlExclusiveTransactionAdvisoryLock(Conn, 8);
+                lock1.Acquire();
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND objid=8 AND mode='ExclusiveLock'");
+                Assert.That(count, Is.EqualTo(1));
+
+                conn2.Open();
+                var lock2 = new NpgsqlExclusiveAdvisoryLock(conn2, 8);
+                IDisposable handle;
+                var result = lock2.TryAcquire(out handle);
+                Assert.That(result, Is.False);
+                Assert.That(handle, Is.Null);
+
+                tx.Commit();
+
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND objid=8 AND mode='ExclusiveLock'");
+                Assert.That(count, Is.EqualTo(0));
+
+                result = lock2.TryAcquire(out handle);
+                Assert.That(result, Is.True);
+                Assert.That(handle, Is.Not.Null);
+                handle.Dispose();
+            }
+        }
+
+        [Test, Description("Tests the connection's ReleaseAllAdvisoryLocks functionality")]
+        public void ReleaseAll()
+        {
+            long count;
+            var lock1 = new NpgsqlExclusiveAdvisoryLock(Conn, 8);
+            using (lock1.Acquire())
+            {
+                Conn.ReleaseAllAdvisoryLocks();
+                count = (long)ExecuteScalar(@"SELECT COUNT(*) FROM pg_locks WHERE locktype='advisory' AND classid=10 AND objid=11 AND mode='ExclusiveLock'");
+                Assert.That(count, Is.EqualTo(0));
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ExecuteNonQuery("SELECT pg_advisory_unlock_all()");
+        }
+    }
+}

--- a/tests/NpgsqlTests.csproj
+++ b/tests/NpgsqlTests.csproj
@@ -168,6 +168,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdvisoryLockTests.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="EntityFrameworkBasicTests.cs" />
     <Compile Include="EntityFrameworkMigrationTests.cs" />


### PR DESCRIPTION
Postgresql has a mechanism for backend-managed advisory locks: http://www.postgresql.org/docs/9.3/static/explicit-locking.html

Exposed this via a clean API in Npgsql. This is part of #301.

As this is a feature and not a bugfix, should definitely not be included in 2.2.