### PR TITLE
EF: Fix INSERT INTO with no specified column values, by using DEFAULT VALUES.

### DIFF
--- a/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
@@ -195,6 +195,9 @@ namespace Npgsql.SqlGenerators
 
         public void AppendColumns(IEnumerable<VisitedExpression> columns)
         {
+            if (!columns.Any())
+                return;
+
             Append("(");
             bool first = true;
             foreach (VisitedExpression expression in columns)
@@ -209,16 +212,23 @@ namespace Npgsql.SqlGenerators
 
         public void AppendValues(IEnumerable<VisitedExpression> columns)
         {
-            Append(" VALUES (");
-            bool first = true;
-            foreach (VisitedExpression expression in columns)
+            if (columns.Any())
             {
-                if (!first)
-                    Append(",");
-                Append(expression);
-                first = false;
+                Append(" VALUES (");
+                bool first = true;
+                foreach (VisitedExpression expression in columns)
+                {
+                    if (!first)
+                        Append(",");
+                    Append(expression);
+                    first = false;
+                }
+                Append(")");
             }
-            Append(")");
+            else
+            {
+                Append(" DEFAULT VALUES");
+            }
         }
 
         internal void AppendReturning(DbNewInstanceExpression expression)

--- a/tests/EntityFrameworkBasicTests.cs
+++ b/tests/EntityFrameworkBasicTests.cs
@@ -79,6 +79,11 @@ namespace NpgsqlTests
             public virtual Blog Blog { get; set; }
         }
 
+        public class NoColumnsEntity
+        {
+            public int Id { get; set; }
+        }
+
         public class BloggingContext : DbContext
         {
             public BloggingContext(string connection)
@@ -88,6 +93,7 @@ namespace NpgsqlTests
 
             public DbSet<Blog> Blogs { get; set; }
             public DbSet<Post> Posts { get; set; }
+            public DbSet<NoColumnsEntity> NoColumnsEntities { get; set; }
         }
 
         [Test]
@@ -108,6 +114,7 @@ namespace NpgsqlTests
                         Title = "Some post Title " + i
                     });
                 context.Blogs.Add(blog);
+                context.NoColumnsEntities.Add(new NoColumnsEntity());
                 context.SaveChanges();
             }
 
@@ -120,6 +127,7 @@ namespace NpgsqlTests
                 {
                     StringAssert.StartsWith("Some post Title ", post.Title);
                 }
+                Assert.AreEqual(1, context.NoColumnsEntities.Count());
             }
         }
 


### PR DESCRIPTION
Fixes #233.

Instead of running

```
INSERT INTO "dbo"."Test"() VALUES () RETURNING "Id"
```

which results in parse error, run this instead:

```
INSERT INTO "dbo"."Test" DEFAULT VALUES RETURNING "Id"
```

which corresponds to the syntax at http://www.postgresql.org/docs/9.3/static/sql-insert.html.
