### PR TITLE
Initial connection pool request tracking

### DIFF
--- a/Npgsql/Npgsql/NpgsqlEventLog.cs
+++ b/Npgsql/Npgsql/NpgsqlEventLog.cs
@@ -127,7 +127,7 @@ namespace Npgsql
         /// </remarks>
         /// <param name="message">The message to write to the event log</param>
         /// <param name="msglevel">The minimum <see cref="Npgsql.LogLevel">LogLevel</see> for which this message should be logged.</param>
-        private static void LogMsg(String message, LogLevel msglevel)
+        internal static void LogMsg(String message, LogLevel msglevel)
         {
             if (msglevel > Level)
             {


### PR DESCRIPTION
This is an initial work to add connection pool request tracking.
This would be used to help diagnose where the connections from the pool
have been allocated when Npgsql starts to report that a new connection
cannot be returned.
See #237 for more info.