### PR TITLE
Rollback support for timetz in EF.

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlProviderManifest.Manifest.xml
+++ b/Npgsql.EntityFramework/NpgsqlProviderManifest.Manifest.xml
@@ -73,11 +73,6 @@
         <Precision Minimum="0" Maximum="6" DefaultValue="6" Constant="false"/>
       </FacetDescriptions>
     </Type>
-    <Type Name="timetz" PrimitiveTypeKind="Time">
-      <FacetDescriptions>
-        <Precision Minimum="0" Maximum="6" DefaultValue="6" Constant="false"/>
-      </FacetDescriptions>
-    </Type>
     <Type Name="timestamptz" PrimitiveTypeKind="DateTimeOffset">
       <FacetDescriptions>
         <Precision Minimum="0" Maximum="10" DefaultValue="7" Constant="false"/>

--- a/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
+++ b/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
@@ -127,7 +127,6 @@ namespace Npgsql
                         return TypeUsage.CreateDateTimeOffsetTypeUsage(primitiveType, null);
                     }
                 case "time":
-                case "timetz":
                 case "interval":
                     if (storeType.Facets.TryGetValue(PrecisionFacet, false, out facet) &&
                         !facet.IsUnbounded && facet.Value != null)

--- a/Npgsql.EntityFramework/NpgsqlSchema.ssdl
+++ b/Npgsql.EntityFramework/NpgsqlSchema.ssdl
@@ -33,7 +33,7 @@
           else null
         end as precision,
         case
-          when t.typname in ('time', 'timetz', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
+          when t.typname in ('time', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
           when t.typname = 'interval' and a.atttypmod &amp; 65535 != 65535 then a.atttypmod &amp; 65535
           else null
         end as datetime_precision,
@@ -154,7 +154,7 @@
           else null
         end as precision,
         case
-          when t.typname in ('time', 'timetz', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
+          when t.typname in ('time', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
           when t.typname = 'interval' and a.atttypmod &amp; 65535 != 65535 then a.atttypmod &amp; 65535
           else null
         end as datetime_precision,

--- a/Npgsql.EntityFramework/NpgsqlSchemaV3.ssdl
+++ b/Npgsql.EntityFramework/NpgsqlSchemaV3.ssdl
@@ -33,7 +33,7 @@
           else null
         end as precision,
         case
-          when t.typname in ('time', 'timetz', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
+          when t.typname in ('time', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
           when t.typname = 'interval' and a.atttypmod &amp; 65535 != 65535 then a.atttypmod &amp; 65535
           else null
         end as datetime_precision,
@@ -154,7 +154,7 @@
           else null
         end as precision,
         case
-          when t.typname in ('time', 'timetz', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
+          when t.typname in ('time', 'timestamp', 'timestamptz') and a.atttypmod != -1 then a.atttypmod
           when t.typname = 'interval' and a.atttypmod &amp; 65535 != 65535 then a.atttypmod &amp; 65535
           else null
         end as datetime_precision,


### PR DESCRIPTION
Rollback support for timetz in EF. It didn't work, since the TimeSpan class can't handle time zones, and update and save fails (can't cast interval to timetz).
