### PR TITLE
Removed old compatibility versions

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -270,6 +270,8 @@ namespace Npgsql
                 throw new ArgumentOutOfRangeException(
                     key, String.Format(L10N.IntegerKeyValMax, key, MaxPoolSize));
             }
+            if (Compatible != null)
+                throw new NotSupportedException("No compatibility modes supported in this Npgsql version");
         }
 
         #region Parsing Functions

--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -753,7 +753,7 @@ namespace Npgsql
                             break;
                         case BackEndMessageCode.RowDescription:
                             _log.Trace("Received RowDescription");
-                            yield return new NpgsqlRowDescription(Stream, OidToNameMapping, CompatVersion);
+                            yield return new NpgsqlRowDescription(Stream, OidToNameMapping);
                             break;
 
                         case BackEndMessageCode.ParameterDescription:

--- a/Npgsql/Npgsql/NpgsqlDataReader.cs
+++ b/Npgsql/Npgsql/NpgsqlDataReader.cs
@@ -894,11 +894,8 @@ namespace Npgsql
         {
             get
             {
-                if (_connector.CompatVersion <= Npgsql205)
-                    return CurrentDescription == null ? -1 : CurrentDescription.NumFields;
-                else
-                    // We read msdn documentation and bug report #1010649 that the common return value is 0.
-                    return CurrentDescription == null ? 0 : CurrentDescription.NumFields;
+                // We read msdn documentation and bug report #1010649 that the common return value is 0.
+                return CurrentDescription == null ? 0 : CurrentDescription.NumFields;
             }
         }
 

--- a/Npgsql/Npgsql/NpgsqlRowDescription.cs
+++ b/Npgsql/Npgsql/NpgsqlRowDescription.cs
@@ -151,23 +151,12 @@ namespace Npgsql
         private readonly Dictionary<string, int> caseInsensitiveNameIndexTable;
         private readonly Version _compatVersion;
 
-        private readonly static Version KANA_FIX_VERSION = new Version(2, 0, 2, 1);
-        private readonly static Version GET_ORDINAL_THROW_EXCEPTION = KANA_FIX_VERSION;
-
-        public NpgsqlRowDescription(Stream stream, NpgsqlBackendTypeMapping type_mapping, Version compatVersion)
+        public NpgsqlRowDescription(Stream stream, NpgsqlBackendTypeMapping type_mapping)
         {
             int num = ReadNumFields(stream);
             fields_data = new FieldData[num];
-            if((_compatVersion = compatVersion) < KANA_FIX_VERSION)
-            {
-                field_name_index_table = new Dictionary<string, int>(num, StringComparer.InvariantCulture);
-                caseInsensitiveNameIndexTable = new Dictionary<string, int>(num, StringComparer.InvariantCultureIgnoreCase);
-            }
-            else
-            {
-                field_name_index_table = new Dictionary<string, int>(num, KanaWidthInsensitiveComparer.INSTANCE);
-                caseInsensitiveNameIndexTable = new Dictionary<string, int>(num, KanaWidthCaseInsensitiveComparator.INSTANCE);
-            }
+            field_name_index_table = new Dictionary<string, int>(num, KanaWidthInsensitiveComparer.INSTANCE);
+            caseInsensitiveNameIndexTable = new Dictionary<string, int>(num, KanaWidthCaseInsensitiveComparator.INSTANCE);
             for (int i = 0; i != num; ++i)
             {
                 FieldData fd = BuildFieldData(stream, type_mapping);
@@ -217,8 +206,6 @@ namespace Npgsql
             int ret = -1;
             if(field_name_index_table.TryGetValue(fieldName, out ret) || caseInsensitiveNameIndexTable.TryGetValue(fieldName, out ret))
                 return ret;
-            else if(_compatVersion < GET_ORDINAL_THROW_EXCEPTION)
-                return -1;
             else
                 throw new IndexOutOfRangeException("Field not found");
         }

--- a/tests/DataReaderTests.cs
+++ b/tests/DataReaderTests.cs
@@ -800,18 +800,6 @@ namespace NpgsqlTests
         }
 
         [Test]
-        public void FieldNameDoesntExistBackwardsCompat()
-        {
-            using (var backCompatCon = new NpgsqlConnection(ConnectionString + ";Compatible=2.0.2"))
-                using (var command = new NpgsqlCommand("select field_serial from data", backCompatCon))
-                {
-                    backCompatCon.Open();
-                    using (var rdr = command.ExecuteReader())
-                        Assert.AreEqual(rdr.GetOrdinal("field_int"), -1);
-                }
-        }
-
-        [Test]
         [ExpectedException(typeof(IndexOutOfRangeException))]
         public void FieldNameDoesntExist()
         {


### PR DESCRIPTION
We have a mechanism where Npgsql behaves like older versions based on a connstring param, to help users in cases of breaking changes.

Removed support for the old compatibility versions, but keeping the connstring param in case we want to introduce breaking changes within a major version again.
