### PR TITLE
Removed extra_float_digits setting on startup

### DIFF
--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -307,7 +307,6 @@ namespace Npgsql
 
             // Some connection parameters for protocol 3 had been sent in the startup packet.
             // The rest will be setted here.
-            sbInitQueries.WriteLine("SET extra_float_digits=3;");
             sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;");
 
             _initQueries = sbInitQueries.ToString();

--- a/Npgsql/NpgsqlStartupPacket.cs
+++ b/Npgsql/NpgsqlStartupPacket.cs
@@ -51,7 +51,6 @@ namespace Npgsql
 
             parameters.Add("DateStyle", "ISO");
             parameters.Add("client_encoding", "UTF8");
-            parameters.Add("extra_float_digits", "2");
             parameters.Add("lc_monetary", "C");
 
             if (! string.IsNullOrEmpty(settings.ApplicationName))

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -1319,15 +1319,16 @@ namespace NpgsqlTests
         }
 
         [Test]
-        public void Bug1010992DoubleValueSupport()
+        public void DoubleWithoutPrepared()
         {
             var command = new NpgsqlCommand("select :field_float8", Conn);
             command.Parameters.Add(new NpgsqlParameter(":field_float8", NpgsqlDbType.Double));
-            double x = 1d/7d;
-            //double value = 0.12345678901234561D;
+            double x = 1d/7d;;
             command.Parameters[0].Value = x;
             var valueReturned = command.ExecuteScalar();
-            Assert.AreEqual(x, valueReturned);
+            Assert.That(valueReturned, Is.EqualTo(x).Within(100).Ulps);
+            Console.WriteLine("Actual=  {0}", valueReturned);
+            Console.WriteLine("Expected={0}", x);
         }
 
         [Test]
@@ -3006,9 +3007,7 @@ namespace NpgsqlTests
                     cmd.Prepare();
 
                 var retVal = (float[])cmd.ExecuteScalar();
-                Assert.AreEqual(inVal.Length, retVal.Length);
-                Assert.AreEqual(inVal[0], retVal[0]);
-                Assert.AreEqual(inVal[1], retVal[1]);
+                Assert.That(retVal, Is.EqualTo(inVal).Within(100).Ulps);
             }
         }
 

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -469,18 +469,6 @@ namespace NpgsqlTests
         }
 
         [Test]
-        public void CheckExtraFloatingDigitsHigherThanTwo()
-        {
-
-            using (NpgsqlCommand c = new NpgsqlCommand("show extra_float_digits", Conn))
-            {
-                string extraDigits = (string)c.ExecuteScalar();
-                Assert.AreEqual(extraDigits, "3");
-            }
-        }
-
-
-        [Test]
         public void GetConnectionState()
         {
             // Test created to PR #164


### PR DESCRIPTION
No longer set extra_float_digits upon connection, let the user manage this as they see fit.

Fixes #324 

@franciscojunior (and anyone else), let me know if you're OK with this.
