### PR TITLE
Throw NpgsqlException for backend errors only

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
@@ -263,7 +263,7 @@ namespace Npgsql
                 {
                     if (!AppendCommandReplacingParameterValues(commandBuilder, commandText, prepare, false))
                     {
-                        throw new NpgsqlException("Multiple queries not supported for stored procedures");
+                        throw new NotSupportedException("Multiple queries not supported for stored procedures");
                     }
                 }
                 else
@@ -293,7 +293,7 @@ namespace Npgsql
             {
                 if (!AppendCommandReplacingParameterValues(commandBuilder, commandText, prepare, !prepare))
                 {
-                    throw new NpgsqlException("Multiple queries not supported for prepared statements");
+                    throw new NotSupportedException("Multiple queries not supported for prepared statements");
                 }
             }
 

--- a/Npgsql/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.cs
@@ -432,8 +432,9 @@ namespace Npgsql
             {
                 Connection.ClearPool();
             }
-            catch (NpgsqlException)
+            catch (Exception e)
             {
+                _log.Warn("Exception caught while attempting to cancel command", e);
                 // Cancel documentation says the Cancel doesn't throw on failure
             }
         }
@@ -525,12 +526,6 @@ namespace Npgsql
             {
                 timeout = (int)NpgsqlConnectionStringBuilder.GetDefaultValue(Keywords.CommandTimeout);
             }
-        }
-
-        internal NpgsqlException ClearPoolAndCreateException(Exception e)
-        {
-            Connection.ClearPool();
-            return new NpgsqlException(L10N.ConnectionBroken, e);
         }
 
         /// <summary>

--- a/Npgsql/Npgsql/NpgsqlCopyIn.cs
+++ b/Npgsql/Npgsql/NpgsqlCopyIn.cs
@@ -26,6 +26,7 @@
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
+using System;
 using System.IO;
 
 namespace Npgsql
@@ -145,12 +146,12 @@ namespace Npgsql
                 _copyStream = _context.Mediator.CopyStream;
                 if (_copyStream == null && _context.State != NpgsqlState.CopyIn)
                 {
-                    throw new NpgsqlException("Not a COPY IN query: " + _cmd.CommandText);
+                    throw new InvalidOperationException("Not a COPY IN query: " + _cmd.CommandText);
                 }
             }
             else
             {
-                throw new NpgsqlException("Copy can only start in Ready state, not in " + _context.State);
+                throw new InvalidOperationException("Copy can only start in Ready state, not in " + _context.State);
             }
         }
 

--- a/Npgsql/Npgsql/NpgsqlCopyOut.cs
+++ b/Npgsql/Npgsql/NpgsqlCopyOut.cs
@@ -24,6 +24,7 @@
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
+using System;
 using System.IO;
 
 namespace Npgsql
@@ -135,12 +136,12 @@ namespace Npgsql
                 _copyStream = _context.Mediator.CopyStream;
                 if (_copyStream == null && _context.State != NpgsqlState.Ready)
                 {
-                    throw new NpgsqlException("Not a COPY OUT query: " + _cmd.CommandText);
+                    throw new InvalidOperationException("Not a COPY OUT query: " + _cmd.CommandText);
                 }
             }
             else
             {
-                throw new NpgsqlException("Copy can only start in Ready state, not in " + _context.State);
+                throw new InvalidOperationException("Copy can only start in Ready state, not in " + _context.State);
             }
         }
 

--- a/Npgsql/Npgsql/NpgsqlCopySerializer.cs
+++ b/Npgsql/Npgsql/NpgsqlCopySerializer.cs
@@ -117,7 +117,7 @@ namespace Npgsql
             {
                 if (IsActive)
                 {
-                    throw new NpgsqlException("Do not change stream of an active " + this);
+                    throw new InvalidOperationException("Do not change stream of an active " + this);
                 }
                 _toStream = value;
             }
@@ -133,7 +133,7 @@ namespace Npgsql
             {
                 if (IsActive)
                 {
-                    throw new NpgsqlException("Do not change delimiter of an active " + this);
+                    throw new InvalidOperationException("Do not change delimiter of an active " + this);
                 }
                 _delimiter = value ?? DEFAULT_DELIMITER;
                 _delimiterBytes = null;
@@ -164,7 +164,7 @@ namespace Npgsql
             {
                 if (IsActive)
                 {
-                    throw new NpgsqlException("Do not change separator of an active " + this);
+                    throw new InvalidOperationException("Do not change separator of an active " + this);
                 }
                 _separator = value ?? DEFAULT_SEPARATOR;
                 _separatorBytes = null;
@@ -195,7 +195,7 @@ namespace Npgsql
             {
                 if (IsActive)
                 {
-                    throw new NpgsqlException("Do not change escape symbol of an active " + this);
+                    throw new InvalidOperationException("Do not change escape symbol of an active " + this);
                 }
                 _escape = value ?? DEFAULT_ESCAPE;
                 _escapeBytes = null;
@@ -226,7 +226,7 @@ namespace Npgsql
             {
                 if (IsActive)
                 {
-                    throw new NpgsqlException("Do not change null symbol of an active " + this);
+                    throw new InvalidOperationException("Do not change null symbol of an active " + this);
                 }
                 _null = value ?? DEFAULT_NULL;
                 _nullBytes = null;
@@ -494,7 +494,7 @@ namespace Npgsql
             {
                 if (_atField >= _context.CopyFormat.FieldCount)
                 {
-                    throw new NpgsqlException("Tried to add too many fields to a copy record with " + _atField + " fields");
+                    throw new InvalidOperationException("Tried to add too many fields to a copy record with " + _atField + " fields");
                 }
                 AddBytes(DelimiterBytes);
             }

--- a/Npgsql/Npgsql/NpgsqlDataReader.cs
+++ b/Npgsql/Npgsql/NpgsqlDataReader.cs
@@ -30,6 +30,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Reflection;
@@ -222,9 +223,10 @@ namespace Npgsql
                 //CurrentRow = null;
                 return (CurrentRow = GetNextRow(true)) != null;
             }
-            catch (System.IO.IOException ex)
+            catch (IOException)
             {
-                throw _command.ClearPoolAndCreateException(ex);
+                _command.Connection.ClearPool();
+                throw;
             }
         }
 
@@ -326,9 +328,10 @@ namespace Npgsql
                 _hasRows = false; // set to false and let the reading code determine if the set has rows.
                 return (CurrentDescription = GetNextRowDescription()) != null;
             }
-            catch (System.IO.IOException ex)
+            catch (IOException)
             {
-                throw _command.ClearPoolAndCreateException(ex);
+                _command.Connection.ClearPool();
+                throw;
             }
         }
 

--- a/Npgsql/NpgsqlTypes/ArrayHandling.cs
+++ b/Npgsql/NpgsqlTypes/ArrayHandling.cs
@@ -611,7 +611,7 @@ namespace NpgsqlTypes
             // Sanity check.
             if (nDims < 0)
             {
-                throw new NpgsqlException("Invalid array dimension count encountered in binary array header");
+                throw new Exception("Invalid array dimension count encountered in binary array header");
             }
 
             // {PG handles 0-dimension arrays, but .net does not.  Return a 0-size 1-dimensional array.
@@ -627,7 +627,7 @@ namespace NpgsqlTypes
             // Sanity check.
             if (BackendData.Length < dataOffset + nDims * 8)
             {
-                throw new NpgsqlException("Insuffient backend data to describe all expected dimensions in binary array header");
+                throw new Exception("Insuffient backend data to describe all expected dimensions in binary array header");
             }
 
             int[] dimLengths;
@@ -687,7 +687,7 @@ namespace NpgsqlTypes
                     // Sanity check.
                     if (backendData.Length < dataOffset + 4)
                     {
-                        throw new NpgsqlException("Out of backend data while reading binary array");
+                        throw new Exception("Out of backend data while reading binary array");
                     }
 
                     int elementLength;
@@ -707,7 +707,7 @@ namespace NpgsqlTypes
                         // Sanity check.
                         if (backendData.Length < dataOffset + elementLength)
                         {
-                            throw new NpgsqlException("Out of backend data while reading binary array");
+                            throw new Exception("Out of backend data while reading binary array");
                         }
 
                         byte[] elementBinary;

--- a/Npgsql/NpgsqlTypes/FastPath.cs
+++ b/Npgsql/NpgsqlTypes/FastPath.cs
@@ -97,7 +97,7 @@ namespace NpgsqlTypes
             catch (IOException)
             {
                 conn.ClearPool();
-                throw new NpgsqlException("The Connection is broken.");
+                throw;
             }
         }
 
@@ -215,7 +215,7 @@ namespace NpgsqlTypes
                             //TODO: use size better
                             if (stream.ReadInt32() != 5)
                             {
-                                throw new NpgsqlException("Received Z");
+                                throw new Exception("Received Z");
                             }
                             //TODO: handle transaction status
                             Char l_tStatus = (Char) stream.ReadByte();
@@ -223,7 +223,7 @@ namespace NpgsqlTypes
                             break;
 
                         default:
-                            throw new NpgsqlException(string.Format("postgresql.fp.protocol received {0}", c));
+                            throw new Exception(string.Format("postgresql.fp.protocol received {0}", c));
                     }
                 }
 
@@ -327,8 +327,6 @@ namespace NpgsqlTypes
 
         /// <summary>
         /// This returns the function id associated by its name
-        /// If addFunction() or addFunctions() have not been called for this name,
-        /// then an NpgsqlException is thrown.
         /// </summary>
         /// <param name="name">Function name to lookup.</param>
         /// <returns>Function ID for fastpath call.</returns>

--- a/Npgsql/NpgsqlTypes/LargeObject.cs
+++ b/Npgsql/NpgsqlTypes/LargeObject.cs
@@ -62,7 +62,6 @@ namespace NpgsqlTypes
 
         /// <summary>
         /// This opens a large object.
-        /// If the object does not exist, then an NpgsqlException is thrown.
         /// </summary>
         /// <param name="fp">FastPath API for the connection to use.</param>
         /// <param name="oid">OID of the Large Object to open.</param>

--- a/Npgsql/NpgsqlTypes/LargeObjectManager.cs
+++ b/Npgsql/NpgsqlTypes/LargeObjectManager.cs
@@ -108,11 +108,6 @@ namespace NpgsqlTypes
 
                     using (IDataReader res = cmd.ExecuteReader())
                     {
-                        if (res == null)
-                        {
-                            throw new NpgsqlException("postgresql.lo.init");
-                        }
-
                         fp.AddFunctions(res);
                     }
                 }
@@ -161,7 +156,6 @@ namespace NpgsqlTypes
          *
          * @param mode a bitmask describing different attributes of the new object
          * @return oid of new object
-         * @exception NpgsqlException on error
          */
         /// <summary>
         /// This creates a large object, returning its OID.

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeConvBackendToNative.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeConvBackendToNative.cs
@@ -194,7 +194,7 @@ namespace NpgsqlTypes
                 case 2: return IPAddress.NetworkToHostOrder(BitConverter.ToInt16(BackendData, 0));
                 case 4: return IPAddress.NetworkToHostOrder(BitConverter.ToInt32(BackendData, 0));
                 case 8: return IPAddress.NetworkToHostOrder(BitConverter.ToInt64(BackendData, 0));
-                default: throw new NpgsqlException("Unexpected integer binary field length");
+                default: throw new Exception("Unexpected integer binary field length");
             }
         }
 
@@ -314,7 +314,7 @@ namespace NpgsqlTypes
             {
                 case 4: return BitConverter.ToSingle(PGUtil.HostNetworkByteOrderSwap(BackendData), 0);
                 case 8: return BitConverter.ToDouble(PGUtil.HostNetworkByteOrderSwap(BackendData), 0);
-                default: throw new NpgsqlException("Unexpected float binary field length");
+                default: throw new Exception("Unexpected float binary field length");
             }
         }
     }

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -22,6 +22,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 using System;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -165,21 +166,12 @@ namespace NpgsqlTests
         }
 
         [Test]
+        [ExpectedException(typeof(SocketException))]
         public void ConnectionRefused()
         {
-            Assert.That(() => {
-              var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j");
-              conn.Open();
-            }, Throws.Exception.TypeOf<NpgsqlException>()
-                               .With.Message.EqualTo(String.Format(L10N.FailedConnection, "127.0.0.1")));
-        }
-
-        [Test]
-        [ExpectedException(typeof(NpgsqlException))]
-        public void ConnectionStringWithEqualSignValue()
-        {
-            var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j==");
-            conn.Open();
+            using (var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password=j")) {
+                conn.Open();
+            }
         }
 
         [Test]
@@ -199,14 +191,6 @@ namespace NpgsqlTests
         public void InvalidConnectionString()
         {
             var conn = new NpgsqlConnection("Server=127.0.0.1;User Id=npgsql_tests;Pooling:false");
-            conn.Open();
-        }
-
-        [Test]
-        [ExpectedException(typeof(NpgsqlException))]
-        public void ConnectionStringWithSemicolonSignValue()
-        {
-            var conn = new NpgsqlConnection("Server=127.0.0.1;Port=44444;User Id=npgsql_tets;Password='j;'");
             conn.Open();
         }
 

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -147,13 +147,25 @@ namespace NpgsqlTests
                         if (Conn != null && Conn.State == ConnectionState.Open)
                             Conn.Close();
                     }
-                    catch { }
+                    catch
+                    {
+                    }
                     if (e.Code == "3D000")
                         Assert.Inconclusive("Please create a database npgsql_tests, owned by user npgsql_tests");
                     else if (e.Code == "28P01")
-                        Assert.Inconclusive("Please create a user npgsql_tests as follows: create user npgsql_tests with password 'npgsql_tests'");
+                        Assert.Inconclusive(
+                            "Please create a user npgsql_tests as follows: create user npgsql_tests with password 'npgsql_tests'");
                     else
                         throw;
+                }
+                catch
+                {
+                    try {
+                        if (Conn != null && Conn.State == ConnectionState.Open)
+                            Conn.Close();
+                    }
+                    catch {}
+                    throw;
                 }
             }
 


### PR DESCRIPTION
- We now throw NpgsqlException only in case of a backend-generated issue, as per the DbException/SqlException specs.
#330
