### PR TITLE
allowed negative CommandTimeout to disable setting statement_timeout

### DIFF
--- a/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/NpgsqlCommand.cs
@@ -150,7 +150,14 @@ namespace Npgsql
         /// <summary>
         /// Used to execute internal commands.
         /// </summary>
-        internal NpgsqlCommand(String cmdText, NpgsqlConnector connector, int commandTimeout = 20)
+        internal NpgsqlCommand(String cmdText, NpgsqlConnector connector) 
+            : this(cmdText, connector, connector.Mediator.BackendCommandTimeout)
+        {}
+
+        /// <summary>
+        /// Used to execute internal commands.
+        /// </summary>
+        internal NpgsqlCommand(String cmdText, NpgsqlConnector connector, int commandTimeout)
         {
             _planName = String.Empty;
             _commandText = cmdText;
@@ -197,10 +204,6 @@ namespace Npgsql
             get { return _timeout; }
             set
             {
-                if (value < 0) {
-                    throw new ArgumentOutOfRangeException("value", L10N.CommandTimeoutLessZero);
-                }
-
                 _timeout = value;
                 _commandTimeoutSet = true;
             }

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -1512,7 +1512,7 @@ namespace Npgsql
             using (BlockNotificationThread())
             {
                 // Set statement timeout as needed.
-                SetBackendCommandTimeout(20);
+                SetBackendCommandTimeout(DefaultCommandTimeout);
 
                 // Write the Query message to the wire.
                 Query(query);
@@ -1612,6 +1612,9 @@ namespace Npgsql
         /// <param name="timeout">New timeout</param>
         internal void SetBackendCommandTimeout(int timeout)
         {
+            // For FoundationDb compatibility, do not set statement_timeout unless timeout is valid
+            if (timeout == -1) return;
+
             if (Mediator.BackendCommandTimeout == -1 || Mediator.BackendCommandTimeout != timeout)
             {
                 ExecuteSetStatementTimeoutBlind(timeout);


### PR DESCRIPTION
I was trying to use npgsql against a foundationdb instance
foundationdb was complaining about the statement_timeout being set
Basically, if the connection string indicates a CommandTimeout <0 or a command indicates a CommandTimeout <0 we skip setting statement_timeout

from postgresql documentation, we should not be setting it. Is there a reason npgsql always sets statement_timeout ?
