### PR TITLE
Fix cross-command cancellation bug

### DIFF
--- a/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/NpgsqlConnection.cs
@@ -481,21 +481,21 @@ namespace Npgsql
 
                 switch (Connector.State)
                 {
-                    case NpgsqlState.Closed:
+                    case ConnectorState.Closed:
                         return ConnectionState.Closed;
-                    case NpgsqlState.Connecting:
+                    case ConnectorState.Connecting:
                         return ConnectionState.Connecting;
-                    case NpgsqlState.Ready:
+                    case ConnectorState.Ready:
                         return ConnectionState.Open;
-                    case NpgsqlState.Executing:
+                    case ConnectorState.Executing:
                         return ConnectionState.Open | ConnectionState.Executing;
-                    case NpgsqlState.Fetching:
+                    case ConnectorState.Fetching:
                         return ConnectionState.Open | ConnectionState.Fetching;
-                    case NpgsqlState.Broken:
+                    case ConnectorState.Broken:
                         return ConnectionState.Broken;
-                    case NpgsqlState.CopyIn:
+                    case ConnectorState.CopyIn:
                         return ConnectionState.Open | ConnectionState.Fetching;
-                    case NpgsqlState.CopyOut:
+                    case ConnectorState.CopyOut:
                         return ConnectionState.Closed | ConnectionState.Fetching;
                     default:
                         throw new ArgumentOutOfRangeException("Unknown connector state: " + Connector.State);

--- a/Npgsql/NpgsqlConnectorPool.cs
+++ b/Npgsql/NpgsqlConnectorPool.cs
@@ -441,7 +441,7 @@ namespace Npgsql
 
             bool inQueue = queue.Busy.ContainsKey(Connector);
 
-            if (Connector.State == NpgsqlState.Ready)
+            if (Connector.State == ConnectorState.Ready)
             {
                 //If thread is good
                 if ((Thread.CurrentThread.ThreadState & (ThreadState.Aborted | ThreadState.AbortRequested)) == 0)

--- a/Npgsql/NpgsqlCopyIn.cs
+++ b/Npgsql/NpgsqlCopyIn.cs
@@ -76,7 +76,7 @@ namespace Npgsql
         /// </summary>
         public bool IsActive
         {
-            get { return _context != null && _context.State == NpgsqlState.CopyIn && _context.Mediator.CopyStream == _copyStream; }
+            get { return _context != null && _context.State == ConnectorState.CopyIn && _context.Mediator.CopyStream == _copyStream; }
         }
 
         /// <summary>
@@ -138,13 +138,13 @@ namespace Npgsql
         /// </summary>
         public void Start()
         {
-            if (_context.State == NpgsqlState.Ready)
+            if (_context.State == ConnectorState.Ready)
             {
                 _context.Mediator.CopyStream = _copyStream;
                 _cmd.ExecuteNonQuery();
                 _disposeCopyStream = _copyStream == null;
                 _copyStream = _context.Mediator.CopyStream;
-                if (_copyStream == null && _context.State != NpgsqlState.CopyIn)
+                if (_copyStream == null && _context.State != ConnectorState.CopyIn)
                 {
                     throw new InvalidOperationException("Not a COPY IN query: " + _cmd.CommandText);
                 }

--- a/Npgsql/NpgsqlCopyInStream.cs
+++ b/Npgsql/NpgsqlCopyInStream.cs
@@ -43,7 +43,7 @@ namespace Npgsql
         /// </summary>
         private bool IsActive
         {
-            get { return _context != null && _context.State == NpgsqlState.CopyIn && _context.Mediator.CopyStream == this; }
+            get { return _context != null && _context.State == ConnectorState.CopyIn && _context.Mediator.CopyStream == this; }
         }
 
         /// <summary>

--- a/Npgsql/NpgsqlCopyOut.cs
+++ b/Npgsql/NpgsqlCopyOut.cs
@@ -77,7 +77,7 @@ namespace Npgsql
             get
             {
                 return
-                    _context != null && _context.State == NpgsqlState.CopyOut && _context.Mediator.CopyStream == _copyStream;
+                    _context != null && _context.State == ConnectorState.CopyOut && _context.Mediator.CopyStream == _copyStream;
             }
         }
 
@@ -128,13 +128,13 @@ namespace Npgsql
         /// </summary>
         public void Start()
         {
-            if (_context.State == NpgsqlState.Ready)
+            if (_context.State == ConnectorState.Ready)
             {
                 _context.Mediator.CopyStream = _copyStream;
                 _cmd.ExecuteNonQuery();
                 _disposeCopyStream = _copyStream == null;
                 _copyStream = _context.Mediator.CopyStream;
-                if (_copyStream == null && _context.State != NpgsqlState.Ready)
+                if (_copyStream == null && _context.State != ConnectorState.Ready)
                 {
                     throw new InvalidOperationException("Not a COPY OUT query: " + _cmd.CommandText);
                 }

--- a/Npgsql/NpgsqlCopyOutStream.cs
+++ b/Npgsql/NpgsqlCopyOutStream.cs
@@ -45,7 +45,7 @@ namespace Npgsql
         /// </summary>
         private bool IsActive
         {
-            get { return _context != null && _context.State == NpgsqlState.CopyOut && _context.Mediator.CopyStream == this; }
+            get { return _context != null && _context.State == ConnectorState.CopyOut && _context.Mediator.CopyStream == this; }
         }
 
         /// <summary>

--- a/Npgsql/NpgsqlCopySerializer.cs
+++ b/Npgsql/NpgsqlCopySerializer.cs
@@ -97,7 +97,7 @@ namespace Npgsql
         /// </summary>
         public bool IsActive
         {
-            get { return _toStream != null && _context.Mediator.CopyStream == _toStream && _context.State == NpgsqlState.CopyIn; }
+            get { return _toStream != null && _context.Mediator.CopyStream == _toStream && _context.State == ConnectorState.CopyIn; }
         }
 
         /// <summary>

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -4009,5 +4009,22 @@ namespace NpgsqlTests
                 );
             }
         }
+
+        [Test, Description("Check that cancel only affects the command on which its was invoked")]
+        [Timeout(3000)]
+        public void CancelCrossCommand()
+        {
+            using (var cmd1 = new NpgsqlCommand("SELECT pg_sleep(2)", Conn))
+            using (var cmd2 = new NpgsqlCommand("SELECT 1", Conn))
+            {
+                var cancelTask = Task.Factory.StartNew(() =>
+                {
+                    Thread.Sleep(300);
+                    cmd2.Cancel();
+                });
+                Assert.That(() => cmd1.ExecuteNonQuery(), Throws.Nothing);
+                cancelTask.Wait();
+            }
+        }
     }
 }

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -63,7 +63,7 @@ namespace NpgsqlTests
                 conn.Open();
                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
                 Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
-                Assert.That(conn.Connector.State, Is.EqualTo(NpgsqlState.Ready));
+                Assert.That(conn.Connector.State, Is.EqualTo(ConnectorState.Ready));
                 Assert.That(eventOpen, Is.True);
 
                 using (var cmd = new NpgsqlCommand("SELECT 1", conn))
@@ -72,12 +72,12 @@ namespace NpgsqlTests
                     reader.Read();
                     Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open | ConnectionState.Fetching));
                     Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-                    Assert.That(conn.Connector.State, Is.EqualTo(NpgsqlState.Fetching));
+                    Assert.That(conn.Connector.State, Is.EqualTo(ConnectorState.Fetching));
                 }
 
                 Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-                Assert.That(conn.Connector.State, Is.EqualTo(NpgsqlState.Ready));
+                Assert.That(conn.Connector.State, Is.EqualTo(ConnectorState.Ready));
 
                 using (var cmd = new NpgsqlCommand("SELECT pg_sleep(1)", conn))
                 {
@@ -89,7 +89,7 @@ namespace NpgsqlTests
                             if (exitFlag) {
                                 Assert.Fail("Connection did not reach the Executing state");
                             }
-                            if (conn.Connector.State == NpgsqlState.Executing)
+                            if (conn.Connector.State == ConnectorState.Executing)
                             {
                                 Assert.That(conn.FullState & ConnectionState.Executing, Is.Not.EqualTo(0));
                                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
@@ -110,7 +110,7 @@ namespace NpgsqlTests
                 conn.Open();
                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
                 Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
-                Assert.That(conn.Connector.State, Is.EqualTo(NpgsqlState.Ready));
+                Assert.That(conn.Connector.State, Is.EqualTo(ConnectorState.Ready));
 
                 // TODO: Broken, when implemented
             }


### PR DESCRIPTION
Cancel will now only work if the command is actually being executed. Previously, if you had two commands, calling cancel on one could cancel the second (see test).

Introduced a state mechanism into NpgsqlCommand to manage this.
