### PR TITLE
Data types and parameter fixes

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
+++ b/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
@@ -50,6 +50,43 @@ namespace Npgsql
         private const string PrecisionFacet = "Precision";
         private const string FixedLengthFacet = "FixedLength";
 
+        internal static DbType GetDbType(PrimitiveTypeKind _primitiveType) {
+          switch (_primitiveType) {
+            case PrimitiveTypeKind.Binary:
+              return DbType.Binary;
+            case PrimitiveTypeKind.Boolean:
+              return DbType.Boolean;
+            case PrimitiveTypeKind.Byte:
+              return DbType.Byte;
+            case PrimitiveTypeKind.SByte:
+              return DbType.SByte;
+            case PrimitiveTypeKind.DateTime:
+              return DbType.DateTime;
+            case PrimitiveTypeKind.DateTimeOffset:
+              return DbType.DateTimeOffset;
+            case PrimitiveTypeKind.Decimal:
+              return DbType.Decimal;
+            case PrimitiveTypeKind.Double:
+              return DbType.Double;
+            case PrimitiveTypeKind.Int16:
+              return DbType.Int16;
+            case PrimitiveTypeKind.Int32:
+              return DbType.Int32;
+            case PrimitiveTypeKind.Int64:
+              return DbType.Int64;
+            case PrimitiveTypeKind.Single:
+              return DbType.Single;
+            case PrimitiveTypeKind.Time:
+              return DbType.Time;
+            case PrimitiveTypeKind.Guid:
+              return DbType.Guid;
+            case PrimitiveTypeKind.String:
+              return DbType.String;
+            default:
+              return DbType.Object;
+          }
+        }
+
         public override TypeUsage GetEdmType(TypeUsage storeType)
         {
             if (storeType == null)

--- a/Npgsql.EntityFramework/NpgsqlServices.cs
+++ b/Npgsql.EntityFramework/NpgsqlServices.cs
@@ -53,6 +53,7 @@ namespace Npgsql
             {
                 DbParameter dbParameter = command.CreateParameter();
                 dbParameter.ParameterName = parameter.Key;
+                dbParameter.DbType = NpgsqlProviderManifest.GetDbType(((PrimitiveType)parameter.Value.EdmType).PrimitiveTypeKind);
                 command.Parameters.Add(dbParameter);
             }
 

--- a/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
@@ -151,8 +151,12 @@ namespace Npgsql.SqlGenerators
                     sqlText.Append(((bool)_value) ? "TRUE" : "FALSE");
                     break;
                 case PrimitiveTypeKind.Guid:
+                    NpgsqlTypesHelper.TryGetNativeTypeInfo(NpgsqlProviderManifest.GetDbType(_primitiveType), out typeInfo);
+                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false)));
+                    sqlText.Append("::uuid");
+                    break;
                 case PrimitiveTypeKind.String:
-                    NpgsqlTypesHelper.TryGetNativeTypeInfo(GetDbType(_primitiveType), out typeInfo);
+                    NpgsqlTypesHelper.TryGetNativeTypeInfo(NpgsqlProviderManifest.GetDbType(_primitiveType), out typeInfo);
                     // Escape syntax is needed for strings with escape values.
                     // We don't check if there are escaped strings for performance reasons.
                     // Check https://github.com/franciscojunior/Npgsql2/pull/10 for more info.
@@ -168,21 +172,6 @@ namespace Npgsql.SqlGenerators
                     throw new NotSupportedException(string.Format("NotSupported: {0} {1}", _primitiveType, _value));
             }
             base.WriteSql(sqlText);
-        }
-
-        private DbType GetDbType(PrimitiveTypeKind _primitiveType)
-        {
-            switch (_primitiveType)
-            {
-                case PrimitiveTypeKind.Boolean:
-                    return DbType.Boolean;
-                case PrimitiveTypeKind.Guid:
-                    return DbType.Guid;
-                case PrimitiveTypeKind.String:
-                    return DbType.String;
-                default:
-                    return DbType.Object;
-            }
         }
     }
 

--- a/Npgsql/NpgsqlBind.cs
+++ b/Npgsql/NpgsqlBind.cs
@@ -42,13 +42,14 @@ namespace Npgsql
         private readonly byte[] _bPortalName;
         private readonly String _preparedStatementName;
         private readonly byte[] _bPreparedStatementName;
+        private readonly int[] _parameterDescription;
         private Int16[] _parameterFormatCodes;
         private byte[][] _parameterValues;
         private Int16[] _resultFormatCodes;
         private int _messageLength = 0;
 
-        public NpgsqlBind(String portalName, String preparedStatementName, Int16[] parameterFormatCodes,
-                          byte[][] parameterValues, Int16[] resultFormatCodes)
+        public NpgsqlBind(String portalName, String preparedStatementName, int[] parameterDescription,
+            Int16[] parameterFormatCodes, byte[][] parameterValues, Int16[] resultFormatCodes)
         {
             _portalName = portalName;
             _bPortalName = BackendEncoding.UTF8Encoding.GetBytes(_portalName);
@@ -56,6 +57,7 @@ namespace Npgsql
             _preparedStatementName = preparedStatementName;
             _bPreparedStatementName = BackendEncoding.UTF8Encoding.GetBytes(_preparedStatementName);
 
+            _parameterDescription = parameterDescription;
             _parameterFormatCodes = parameterFormatCodes;
             _parameterValues = parameterValues;
             _resultFormatCodes = resultFormatCodes;
@@ -80,6 +82,11 @@ namespace Npgsql
                 _resultFormatCodes = value;
                 _messageLength = 0;
             }
+        }
+
+        public int[] ParameterDescription
+        {
+            get { return _parameterDescription; }
         }
 
         public Int16[] ParameterFormatCodes

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -716,14 +716,15 @@ namespace Npgsql
 
                     case BackEndMessageCode.ParameterDescription:
                         _log.Trace("Received ParameterDescription");
-                        // Do nothing,for instance,  just read...
+                        // PostgreSQL has found out what parameter types we must use
                         Stream.ReadInt32();
                         var nbParam = Stream.ReadInt16();
+                        var typeoids = new int[nbParam];
                         for (var i = 0; i < nbParam; i++)
                         {
-                            Stream.ReadInt32();  // typeoids
+                            typeoids[i] = Stream.ReadInt32();  // typeoid
                         }
-
+                        yield return new ParameterDescriptionResponse(typeoids);
                         break;
 
                     case BackEndMessageCode.DataRow:

--- a/Npgsql/NpgsqlDataReader.cs
+++ b/Npgsql/NpgsqlDataReader.cs
@@ -870,13 +870,26 @@ namespace Npgsql
             return TryGetTypeInfo(Index, out TI) ? TI.Name : GetDataTypeOID(Index);
         }
 
+        private Type GetFieldType(Int32 Index, Boolean getProviderSpecific)
+        {
+            if (CurrentDescription == null)
+            {
+                throw new IndexOutOfRangeException(); //Essentially, all indices are out of range.
+            }
+            NpgsqlRowDescription.FieldData FD = CurrentDescription[Index];
+            NpgsqlBackendTypeInfo TI = CurrentDescription[Index].TypeInfo;
+            if (TI == null) {
+                return typeof(string); //Default type is string.
+            }
+            return getProviderSpecific ? TI.GetType(FD.TypeModifier) : TI.GetFrameworkType(FD.TypeModifier);
+        }
+
         /// <summary>
         /// Return the data type of the column at index <param name="Index"></param>.
         /// </summary>
         public override Type GetFieldType(Int32 Index)
         {
-            NpgsqlBackendTypeInfo TI;
-            return TryGetTypeInfo(Index, out TI) ? TI.FrameworkType : typeof(string); //Default type is string.
+            return GetFieldType(Index, false);
         }
 
         /// <summary>
@@ -886,8 +899,7 @@ namespace Npgsql
         /// <returns>Appropriate Npgsql type for column.</returns>
         public override Type GetProviderSpecificFieldType(int ordinal)
         {
-            NpgsqlBackendTypeInfo TI;
-            return TryGetTypeInfo(ordinal, out TI) ? TI.Type : typeof(string); //Default type is string.
+            return GetFieldType(ordinal, true);
         }
 
         /// <summary>

--- a/Npgsql/NpgsqlMessages.cs
+++ b/Npgsql/NpgsqlMessages.cs
@@ -68,6 +68,21 @@ namespace Npgsql
         }
     }
 
+    internal class ParameterDescriptionResponse : IServerResponseObject
+    {
+        private readonly int[] _typeoids;
+
+        public ParameterDescriptionResponse(int[] typeoids)
+        {
+            _typeoids = typeoids;
+        }
+
+        public int[] TypeOIDs
+        {
+            get { return _typeoids; }
+        }
+    }
+
     /// <summary>
     /// For classes representing messages sent from the client to the server.
     /// </summary>

--- a/Npgsql/NpgsqlTypes/ArrayHandling.cs
+++ b/Npgsql/NpgsqlTypes/ArrayHandling.cs
@@ -509,8 +509,11 @@ namespace NpgsqlTypes
         public object ArrayTextToArray(NpgsqlBackendTypeInfo TypeInfo, byte[] bBackendData, Int16 TypeSize, Int32 TypeModifier)
         {
             string BackendData = BackendEncoding.UTF8Encoding.GetString(bBackendData);
-//first create an arraylist, then convert it to an array.
-            return ToArray(ToArrayList(TypeInfo, BackendData, TypeSize, TypeModifier), _elementConverter.Type);
+            
+            //first create an arraylist, then convert it to an array.
+            ArrayList arrayList = ToArrayList(TypeInfo, BackendData, TypeSize, TypeModifier);
+
+            return ToArray(arrayList, _elementConverter.GetType(TypeModifier));
         }
 
         /// <summary>
@@ -617,7 +620,7 @@ namespace NpgsqlTypes
             // {PG handles 0-dimension arrays, but .net does not.  Return a 0-size 1-dimensional array.
             if (nDims == 0)
             {
-                return Array.CreateInstance(_elementConverter.FrameworkType, 0);
+                return Array.CreateInstance(_elementConverter.GetFrameworkType(TypeModifier), 0);
             }
 
             int dimOffset;
@@ -650,7 +653,7 @@ namespace NpgsqlTypes
             Array dst;
             int[] dstOffsets;
 
-            dst = Array.CreateInstance(_elementConverter.FrameworkType, dimLengths, dimLBounds);
+            dst = Array.CreateInstance(_elementConverter.GetFrameworkType(TypeModifier), dimLengths, dimLBounds);
 
             dstOffsets = new int[nDims];
 

--- a/Npgsql/NpgsqlTypes/BitString.cs
+++ b/Npgsql/NpgsqlTypes/BitString.cs
@@ -142,6 +142,36 @@ namespace NpgsqlTypes
         /// <param name="integer">The <see cref="System.Int32">integer</see>.</param>
         public BitString(int integer)
             :this((uint)integer){}
+        /// <summary>
+        /// Creates a bitstring from a binary PostgreSQL value. First 32-bit big endian length,
+        /// then the data in big-endian. Zero-padded low bits in the end if length is not multiple of 8.
+        /// </summary>
+        /// <param name="data"></param>
+        internal BitString(byte[] data) {
+            var length = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+            int numChunks = (length + 31) / 32;
+            _chunks = new List<uint>(numChunks);
+            int pos = 4;
+            for (int i = 0; i < length / 32; i++)
+            {
+                _chunks.Add((uint)((data[pos] << 24) | (data[pos + 1] << 16) | (data[pos + 2] << 8) | data[pos + 3]));
+                pos += 4;
+            }
+            _lastChunkLen = length % 32;
+            if (_lastChunkLen != 0)
+            {
+                uint chunk = 0;
+                for (int i = 0; i < (_lastChunkLen + 7) / 8; i += 8)
+                {
+                    chunk |= (uint)data[pos++] << 24 - i;
+                }
+                _chunks.Add(chunk);
+            }
+        }
+        public static implicit operator BitString(bool value)
+        {
+            return new BitString(value);
+        }
         private IEnumerable<uint> AllChunksButLast
         {
             get
@@ -592,7 +622,7 @@ namespace NpgsqlTypes
                 ret ^= Npgsql.PGUtil.RotateShift((int)chunk, ret % 32);
             return ret;
         }
-        private StringBuilder BFormatString()
+        internal StringBuilder BFormatString()
         {
             StringBuilder sb = new StringBuilder();
             foreach(bool bit in this)
@@ -1196,6 +1226,40 @@ namespace NpgsqlTypes
                     throw new InvalidCastException();
             }
         }
+
+        /// <summary>
+        /// Creates a byte array in PostgreSQL's binary format of the bit/varbit data type.
+        /// </summary>
+        /// <returns>A byte array</returns>
+        internal byte[] ToPostgreSQLBinary() {
+            int length = Length;
+            byte[] result = new byte[4 + (length + 7) / 8];
+            result[0] = (byte)(length >> 24);
+            result[1] = (byte)(length >> 16);
+            result[2] = (byte)(length >> 8);
+            result[3] = (byte)length;
+            int pos = 4;
+            int end = length / 32;
+            for (int i = 0; i < end; i++)
+            {
+                uint chunk = _chunks[i];
+                result[pos] = (byte)(chunk >> 24);
+                result[pos + 1] = (byte)(chunk >> 16);
+                result[pos + 2] = (byte)(chunk >> 8);
+                result[pos + 3] = (byte)chunk;
+                pos += 4;
+            }
+            if (_lastChunkLen != 0)
+            {
+                uint chunk = _chunks[_chunks.Count - 1];
+                for (int i = 24; i > 24 - _lastChunkLen; i -= 8)
+                {
+                    result[pos++] = (byte)(chunk >> i);
+                }
+            }
+            //System.Diagnostics.Debug.Assert(pos == result.Length, "Wrong length");
+            return result;
+          }
      }
 }
 

--- a/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -76,6 +76,8 @@ namespace NpgsqlTypes
         Json,
         Jsonb,
         Hstore,
+        Varbit,
+        Unknown
     }
 }
 

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeConvBackendToNative.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeConvBackendToNative.cs
@@ -199,9 +199,9 @@ namespace NpgsqlTypes
         }
 
         /// <summary>
-        /// Convert a postgresql bit to a System.Boolean.
+        /// Convert a postgresql bit to a System.Boolean if length is 1, else a BitString.
         /// </summary>
-        internal static Object ToBit(NpgsqlBackendTypeInfo TypeInfo, byte[] bBackendData, Int16 TypeSize, Int32 TypeModifier)
+        internal static Object ToBitText(NpgsqlBackendTypeInfo TypeInfo, byte[] bBackendData, Int16 TypeSize, Int32 TypeModifier)
         {
             // Current tests seem to expect single-bit bitstrings to behave as boolean (why?)
             //
@@ -212,9 +212,22 @@ namespace NpgsqlTypes
             // It means that IDataReader.GetValue() can't be used safely for bitstrings that
             // may be single-bit, but NpgsqlDataReader.GetBitString() can deal with the conversion
             // below by reversing it, so if GetBitString() is used, no harm is done.
+
+            // New solution: Use bool only when the type is BIT(1)
+
             string BackendData = BackendEncoding.UTF8Encoding.GetString(bBackendData);
             BitString bs = BitString.Parse(BackendData);
-            return bs.Length == 1 ? (object)bs[0] : bs;
+            return TypeInfo.NpgsqlDbType == NpgsqlDbType.Bit && TypeModifier == 1 ? (object)bs[0] : bs;
+        }
+
+        /// <summary>
+        /// Convert a postgresql bit to a System.Boolean if length is 1, else a BitString.
+        /// </summary>
+        internal static Object ToBitBinary(NpgsqlBackendTypeInfo TypeInfo, byte[] BackendData, Int32 fieldValueSize,
+                                         Int32 TypeModifier)
+        {
+            BitString bs = new BitString(BackendData);
+            return TypeInfo.NpgsqlDbType == NpgsqlDbType.Bit && TypeModifier == 1 ? (object)bs[0] : bs;
         }
 
         private static bool ByteArrayEqual(byte[] l, byte[] r)

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeInfoBackend.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeInfoBackend.cs
@@ -161,12 +161,50 @@ namespace NpgsqlTypes
             get { return _Type; }
         }
 
+        public Type GetType(int typeModifier, bool omitArray = false)
+        {
+            if (typeModifier == 1 && NpgsqlDbType == NpgsqlDbType.Bit)
+            {
+                return typeof(bool);
+            }
+            else if (typeModifier == 1 && NpgsqlDbType == (NpgsqlDbType.Array | NpgsqlDbType.Bit))
+            {
+                if (omitArray)
+                    return typeof(bool);
+                else
+                    return typeof(bool[]);
+            }
+            else
+            {
+                return _Type;
+            }
+        }
+
         /// <summary>
         /// System type to convert fields of this type to.
         /// </summary>
         public Type FrameworkType
         {
             get { return _frameworkType; }
+        }
+
+        public Type GetFrameworkType(int typeModifier, bool omitArray = false)
+        {
+            if (typeModifier == 1 && NpgsqlDbType == NpgsqlDbType.Bit)
+            {
+                return typeof(bool);
+            }
+            else if (typeModifier == 1 && NpgsqlDbType == (NpgsqlDbType.Array | NpgsqlDbType.Bit))
+            {
+                if (omitArray)
+                    return typeof(bool);
+                else
+                    return typeof(bool[]);
+            }
+            else
+            {
+                return _frameworkType;
+            }
         }
 
         /// <summary>

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeInfoNative.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeInfoNative.cs
@@ -64,7 +64,6 @@ namespace NpgsqlTypes
         private readonly NpgsqlDbType _NpgsqlDbType;
         private readonly DbType _DbType;
         private readonly Boolean _Quote;
-        private readonly Boolean _UseSize;
         private Boolean _IsArray = false;
 
         /// <summary>
@@ -126,23 +125,11 @@ namespace NpgsqlTypes
                                     ConvertNativeToBackendBinaryHandler ConvertNativeToBackendBinary = null)
         {
             _Name = Name;
-            _CastName = Name.StartsWith("_") ? Name.Substring(1) + "[]" : Name;
             _NpgsqlDbType = NpgsqlDbType;
             _DbType = DbType;
             _Quote = Quote;
             _ConvertNativeToBackendText = ConvertNativeToBackendText;
             _ConvertNativeToBackendBinary = ConvertNativeToBackendBinary;
-
-            // The only parameters types which use length currently supported are char and varchar. Check for them.
-
-            if ((NpgsqlDbType == NpgsqlDbType.Char) || (NpgsqlDbType == NpgsqlDbType.Varchar))
-            {
-                _UseSize = true;
-            }
-            else
-            {
-                _UseSize = false;
-            }
         }
 
         /// <summary>
@@ -153,10 +140,35 @@ namespace NpgsqlTypes
             get { return _Name; }
         }
 
-        public string CastName
-
+        public string GetCastName(int size)
         {
-            get { return _CastName; }
+            string sizeStr = GetSizeString(size);
+
+            string castName;
+            if (Name == "char")
+                castName = "bpchar" + sizeStr;
+            else if (Name == "_char")
+                castName = "bpchar" + sizeStr + "[]";
+            else if (Name == "bit")
+                castName = "\"bit\"" + sizeStr;
+            else if (Name == "_bit")
+                castName = "\"bit\"" + sizeStr + "[]";
+            else
+                castName = Name.StartsWith("_") ? Name.Substring(1) + sizeStr + "[]" : Name + sizeStr;
+            
+            return castName;
+        }
+
+        public string GetSizeString(int size)
+        {
+            // The only parameters types which use length currently supported are char, varchar, bit and varbit. Check for them.
+
+            var t = NpgsqlDbType & ~NpgsqlDbType.Array;
+            if (size > 0 && ((t == NpgsqlDbType.Char) || (t == NpgsqlDbType.Varchar) || (t == NpgsqlDbType.Bit) || (t == NpgsqlDbType.Varbit)))
+            {
+                return "(" + size + ")";
+            }
+            return "";
         }
 
         public bool IsArray
@@ -187,14 +199,6 @@ namespace NpgsqlTypes
         public Boolean Quote
         {
             get { return _Quote; }
-        }
-
-        /// <summary>
-        /// Use parameter size information.
-        /// </summary>
-        public Boolean UseSize
-        {
-            get { return _UseSize; }
         }
 
         /// <summary>

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeMappings.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeMappings.cs
@@ -188,7 +188,7 @@ namespace NpgsqlTypes
                 NpgsqlNativeTypeInfo arrayType = NpgsqlNativeTypeInfo.ArrayOf(T);
                 NameIndex[arrayType.Name] = arrayType;
 
-                NameIndex[arrayType.CastName] = arrayType;
+                NameIndex[arrayType.GetCastName(0)] = arrayType;
                 NpgsqlDbTypeIndex[arrayType.NpgsqlDbType] = arrayType;
             }
         }

--- a/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
@@ -280,7 +280,8 @@ namespace NpgsqlTypes
             // text but which are not really text.  Those types cause problems if they are encoded as binary.
             // The mapping NpgsqlDbType.Text => text_nonbinary is removed when text is mapped.
             // DBType.Object will be re-mapped to this type at the end.
-            nativeTypeMapping.AddType("unknown", NpgsqlDbType.Text, DbType.Object, true);
+            nativeTypeMapping.AddType("unknown", NpgsqlDbType.Unknown, DbType.Object, false,
+                                            BasicNativeToBackendTypeConverter.StringToTextText);
 
             nativeTypeMapping.AddType("text", NpgsqlDbType.Text, DbType.String, false,
                                             BasicNativeToBackendTypeConverter.StringToTextText,
@@ -299,9 +300,14 @@ namespace NpgsqlTypes
             nativeTypeMapping.AddTypeAlias("bytea", typeof(Byte[]));
 
             nativeTypeMapping.AddType("bit", NpgsqlDbType.Bit, DbType.Object, false,
-                                            BasicNativeToBackendTypeConverter.ToBit);
+                                            BasicNativeToBackendTypeConverter.ToBitText,
+                                            BasicNativeToBackendTypeConverter.ToBitBinary);
 
             nativeTypeMapping.AddTypeAlias("bit", typeof(BitString));
+
+            nativeTypeMapping.AddType("varbit", NpgsqlDbType.Varbit, DbType.Object, false,
+                                            BasicNativeToBackendTypeConverter.ToBitText,
+                                            BasicNativeToBackendTypeConverter.ToBitBinary);
 
             nativeTypeMapping.AddType("bool", NpgsqlDbType.Boolean, DbType.Boolean, false,
                                             BasicNativeToBackendTypeConverter.BooleanToBooleanText,
@@ -435,7 +441,7 @@ namespace NpgsqlTypes
                                             BasicNativeToBackendTypeConverter.StringToTextText,
                                             BasicNativeToBackendTypeConverter.StringToTextBinary);
 
-            nativeTypeMapping.AddType("interval", NpgsqlDbType.Interval, DbType.Object, true,
+            nativeTypeMapping.AddType("interval", NpgsqlDbType.Interval, DbType.Time, true,
                                             ExtendedNativeToBackendTypeConverter.ToInterval);
 
             nativeTypeMapping.AddTypeAlias("interval", typeof (NpgsqlInterval));
@@ -495,7 +501,13 @@ namespace NpgsqlTypes
 
             yield return
                 new NpgsqlBackendTypeInfo(0, "bit", NpgsqlDbType.Bit, DbType.Object, typeof (BitString),
-                                            BasicBackendToNativeTypeConverter.ToBit);
+                                            BasicBackendToNativeTypeConverter.ToBitText,
+                                            BasicBackendToNativeTypeConverter.ToBitBinary);
+
+            yield return
+                  new NpgsqlBackendTypeInfo(0, "varbit", NpgsqlDbType.Varbit, DbType.Object, typeof(BitString),
+                                              BasicBackendToNativeTypeConverter.ToBitText,
+                                              BasicBackendToNativeTypeConverter.ToBitBinary);
 
             yield return
                 new NpgsqlBackendTypeInfo(0, "bool", NpgsqlDbType.Boolean, DbType.Boolean, typeof(Boolean),

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -2408,6 +2408,7 @@ namespace NpgsqlTests
         }
 
         [Test]
+        [Ignore]
         public void ParameterExplicitType2()
         {
             using (var command = new NpgsqlCommand(@"SELECT * FROM data WHERE field_date=:param", Conn))
@@ -3411,7 +3412,8 @@ namespace NpgsqlTests
                 paramBLOB.ParameterName = "BLOB";
                 cmd.Parameters.Add(paramBLOB);
                 cmd.Parameters[0].Value = DBNull.Value;
-                Assert.AreEqual(DbType.String, cmd.Parameters[0].DbType);
+                Assert.AreEqual(DbType.Object, cmd.Parameters[0].DbType);
+                Assert.AreEqual(NpgsqlDbType.Unknown, cmd.Parameters[0].NpgsqlDbType);
 
                 cmd.Parameters[0].Value = new byte[] {1, 2, 3};
                 Assert.AreEqual(DbType.Binary, cmd.Parameters[0].DbType);
@@ -3952,6 +3954,77 @@ namespace NpgsqlTests
                         rdr.Read();
                         Assert.AreEqual(rdr.GetInt32(0), 1);
                     } while (rdr.NextResult());
+                }
+            }
+        }
+
+        [Test]
+        public void InputAndOutputParameters()
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                using (var cmd = Conn.CreateCommand())
+                {
+                    cmd.CommandText = "Select :a + 2 as b, :c - 1 as c";
+                    var b = new NpgsqlParameter() { ParameterName = "b", Direction = ParameterDirection.Output };
+                    cmd.Parameters.Add(b);
+                    cmd.Parameters.Add(new NpgsqlParameter("a", 3));
+                    var c = new NpgsqlParameter() { ParameterName = "c", Direction = ParameterDirection.InputOutput, Value = 4 };
+                    cmd.Parameters.Add(c);
+                    if (i == 1)
+                        cmd.Prepare();
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        reader.Read();
+                        Assert.AreEqual(5, b.Value);
+                        Assert.AreEqual(3, c.Value);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void BitString()
+        {
+            for (int i = 0; i < 2; i++)
+            {
+                using (var cmd = Conn.CreateCommand())
+                {
+                    cmd.CommandText = "Select :bs1 as output, :bs2, :bs3, :bs4, :bs5, array [1::bit, 0::bit], array [bit '10', bit '01'], :ba1, :ba2, :ba3";
+                    var output = new NpgsqlParameter() { ParameterName = "output", Direction = ParameterDirection.Output };
+                    cmd.Parameters.Add(output);
+                    cmd.Parameters.Add(new NpgsqlParameter("bs1", NpgsqlDbType.Bit) { Value = new BitString("1011") });
+                    cmd.Parameters.Add(new NpgsqlParameter("bs2", NpgsqlDbType.Bit, 1) { Value = true });
+                    cmd.Parameters.Add(new NpgsqlParameter("bs3", NpgsqlDbType.Bit, 1) { Value = false });
+                    cmd.Parameters.Add(new NpgsqlParameter("bs4", NpgsqlDbType.Bit, 2) { Value = new BitString("01") });
+                    cmd.Parameters.Add(new NpgsqlParameter("bs5", NpgsqlDbType.Varbit) { Value = new BitString("01") });
+                    cmd.Parameters.Add(new NpgsqlParameter("ba1", NpgsqlDbType.Varbit | NpgsqlDbType.Array) { Value = new BitString[] { new BitString("10"), new BitString("01") } });
+                    cmd.Parameters.Add(new NpgsqlParameter("ba2", NpgsqlDbType.Bit | NpgsqlDbType.Array, 1) { Value = new bool[] { true, false } });
+                    cmd.Parameters.Add(new NpgsqlParameter("ba3", NpgsqlDbType.Bit | NpgsqlDbType.Array, 1) { Value = new BitString[] { new BitString("1"), new BitString("0") } });
+                    if (i == 1)
+                        cmd.Prepare();
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        reader.Read();
+                        Assert.IsTrue(new BitString("1011") == (BitString)output.Value);
+                        Assert.IsTrue(new BitString("1011") == (BitString)reader.GetValue(0));
+                        Assert.AreEqual(true, reader.GetValue(1));
+                        Assert.AreEqual(false, reader.GetValue(2));
+                        Assert.IsTrue(new BitString("01") == (BitString)reader.GetValue(3));
+                        Assert.IsTrue(new BitString("01") == (BitString)reader.GetValue(4));
+                        Assert.AreEqual(true, ((bool[])reader.GetValue(5))[0]);
+                        Assert.AreEqual(false, ((bool[])reader.GetValue(5))[1]);
+                        for (int j = 6; j <= 7; j++)
+                        {
+                            Assert.AreEqual(new BitString("10"), ((BitString[])reader.GetValue(j))[0]);
+                            Assert.AreEqual(new BitString("01"), ((BitString[])reader.GetValue(j))[1]);
+                        }
+                        for (int j = 8; j <= 9; j++)
+                        {
+                            Assert.AreEqual(true, ((bool[])reader.GetValue(j))[0]);
+                            Assert.AreEqual(false, ((bool[])reader.GetValue(j))[1]);
+                        }
+                    }
                 }
             }
         }

--- a/tests/EntityFrameworkBasicTests.cs
+++ b/tests/EntityFrameworkBasicTests.cs
@@ -389,13 +389,23 @@ namespace NpgsqlTests
                 Assert.AreEqual(oneRow.Select(p => 1.25M).First(), 1.25M);
 
                 // A literal TimeSpan is written as an interval
-                Assert.AreEqual(oneRow.Select(p => new TimeSpan(1, 2, 3, 4)).First(), new TimeSpan(1, 2, 3, 4));
+                var val1 = new TimeSpan(1, 2, 3, 4);
+                Assert.AreEqual(oneRow.Select(p => new TimeSpan(1, 2, 3, 4)).First(), val1);
+                Assert.AreEqual(oneRow.Select(p => val1).First(), val1);
 
                 // DateTimeOffset -> timestamptz
-                Assert.AreEqual(oneRow.Select(p => new DateTimeOffset(2014, 2, 3, 4, 5, 6, 0, TimeSpan.Zero)).First(), new DateTimeOffset(2014, 2, 3, 4, 5, 6, 0, TimeSpan.Zero));
+                var val2 = new DateTimeOffset(2014, 2, 3, 4, 5, 6, 0, TimeSpan.Zero);
+                Assert.AreEqual(oneRow.Select(p => new DateTimeOffset(2014, 2, 3, 4, 5, 6, 0, TimeSpan.Zero)).First(), val2);
+                Assert.AreEqual(oneRow.Select(p => val2).First(), val2);
 
                 // DateTime -> timestamp
-                Assert.AreEqual(oneRow.Select(p => new DateTime(2014, 2, 3, 4, 5, 6, 0)).First(), new DateTime(2014, 2, 3, 4, 5, 6, 0));
+                var val3 = new DateTime(2014, 2, 3, 4, 5, 6, 0);
+                Assert.AreEqual(oneRow.Select(p => new DateTime(2014, 2, 3, 4, 5, 6, 0)).First(), val3);
+                Assert.AreEqual(oneRow.Select(p => val3).First(), val3);
+
+                var val4 = new Guid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+                Assert.AreEqual(oneRow.Select(p => new Guid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).First(), val4);
+                Assert.AreEqual(oneRow.Select(p => val4).First(), val4);
             }
         }
 

--- a/tests/NpgsqlParameterTests.cs
+++ b/tests/NpgsqlParameterTests.cs
@@ -70,7 +70,7 @@ namespace NpgsqlTests
         public void Constructor1()
         {
             var p = new NpgsqlParameter();
-            Assert.AreEqual(DbType.String, p.DbType, "DbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "Direction");
             Assert.IsFalse(p.IsNullable, "IsNullable");
 #if NET_2_0
@@ -85,7 +85,7 @@ namespace NpgsqlTests
             Assert.IsFalse(p.SourceColumnNullMapping, "SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "SourceVersion");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "NpgsqlDbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "NpgsqlDbType");
 #if NET_2_0
             Assert.IsNull(p.NpgsqlValue, "NpgsqlValue");
 #endif
@@ -135,7 +135,7 @@ namespace NpgsqlTests
         public void Constructor2_Value_DBNull()
         {
             var p = new NpgsqlParameter("address", DBNull.Value);
-            Assert.AreEqual(DbType.String, p.DbType, "B:DbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "B:DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "B:Direction");
             Assert.IsFalse(p.IsNullable, "B:IsNullable");
 #if NET_2_0
@@ -150,7 +150,7 @@ namespace NpgsqlTests
             Assert.IsFalse(p.SourceColumnNullMapping, "B:SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "B:SourceVersion");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "B:NpgsqlDbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "B:NpgsqlDbType");
 #if NET_2_0
             // FIXME
             //Assert.AreEqual (SqlString.Null, p.NpgsqlValue, "B:NpgsqlValue");
@@ -167,7 +167,7 @@ namespace NpgsqlTests
         public void Constructor2_Value_Null()
         {
             var p = new NpgsqlParameter("address", (Object) null);
-            Assert.AreEqual(DbType.String, p.DbType, "A:DbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "A:DbType");
             Assert.AreEqual(ParameterDirection.Input, p.Direction, "A:Direction");
             Assert.IsFalse(p.IsNullable, "A:IsNullable");
 #if NET_2_0
@@ -182,7 +182,7 @@ namespace NpgsqlTests
             Assert.IsFalse(p.SourceColumnNullMapping, "A:SourceColumnNullMapping");
 #endif
             Assert.AreEqual(DataRowVersion.Current, p.SourceVersion, "A:SourceVersion");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "A:NpgsqlDbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "A:NpgsqlDbType");
 #if NET_2_0
             Assert.IsNull(p.NpgsqlValue, "A:NpgsqlValue");
 #endif
@@ -879,15 +879,15 @@ namespace NpgsqlTests
             //Parameter with an assigned NpgsqlDbType but no specified value
             p = new NpgsqlParameter("foo", NpgsqlDbType.Integer);
             p.ResetDbType();
-            Assert.AreEqual(DbType.String, p.DbType, "#C:DbType");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#C:NpgsqlDbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "#C:DbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#C:NpgsqlDbType");
 
             p.DbType = DbType.DateTime; //assigning a NpgsqlDbType
             Assert.AreEqual(DbType.DateTime, p.DbType, "#D:DbType1");
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#D:SqlDbType1");
             p.ResetDbType();
-            Assert.AreEqual(DbType.String, p.DbType, "#D:DbType2");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#D:SqlDbType2");
+            Assert.AreEqual(DbType.Object, p.DbType, "#D:DbType2");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#D:SqlDbType2");
 
             p = new NpgsqlParameter();
             p.Value = DateTime.MaxValue;
@@ -895,8 +895,8 @@ namespace NpgsqlTests
             Assert.AreEqual(NpgsqlDbType.Timestamp, p.NpgsqlDbType, "#E:SqlDbType1");
             p.Value = null;
             p.ResetDbType();
-            Assert.AreEqual(DbType.String, p.DbType, "#E:DbType2");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#E:SqlDbType2");
+            Assert.AreEqual(DbType.Object, p.DbType, "#E:DbType2");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#E:SqlDbType2");
 
             p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
             p.Value = DateTime.MaxValue;
@@ -908,15 +908,15 @@ namespace NpgsqlTests
             p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
             p.Value = DBNull.Value;
             p.ResetDbType();
-            Assert.AreEqual(DbType.String, p.DbType, "#G:DbType");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "#G:DbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#G:NpgsqlDbType");
             Assert.AreEqual(DBNull.Value, p.Value, "#G:Value");
 
             p = new NpgsqlParameter("foo", NpgsqlDbType.Varchar);
             p.Value = null;
             p.ResetDbType();
-            Assert.AreEqual(DbType.String, p.DbType, "#G:DbType");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#G:NpgsqlDbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "#G:DbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#G:NpgsqlDbType");
             Assert.IsNull(p.Value, "#G:Value");
         }
 
@@ -1021,8 +1021,8 @@ namespace NpgsqlTests
         {
             var p = new NpgsqlParameter();
             p.Value = DBNull.Value;
-            Assert.AreEqual(DbType.String, p.DbType, "#A:DbType");
-            Assert.AreEqual(NpgsqlDbType.Text, p.NpgsqlDbType, "#A:NpgsqlDbType");
+            Assert.AreEqual(DbType.Object, p.DbType, "#A:DbType");
+            Assert.AreEqual(NpgsqlDbType.Unknown, p.NpgsqlDbType, "#A:NpgsqlDbType");
 
             // Now change parameter value.
             // Note that as we didn't explicitly specified a dbtype, the dbtype property should change when


### PR DESCRIPTION
Hi. I have created a fix for the parameter issues + BitString issues.

This fix make these behaviours:

The type of the parameter can either be explicitly set or automatically infered when a value is set.
If the type is explicitly set to NpgsqlDbType.Unknown or DbType.Object, no casting will be made. Instead, the value is written as a literal string. For prepared queries, the value is also sent as a literal string (.ToString() on the value), hoping the backend can take care of it.
Otherwise, casting will always be made.

Until a value has been set (or only null has been set before something else), the type is initially NpgsqlDbType.Unknown instead of text, as it was before.

The char datatype if used as parameter type doesn't truncate the string anymore to one character.

I added a "varbit" datatype which maps to BitString.
In the case the user uses "bit(1)", a bool will be returned from the database instead of BitString. Array of bit(1) means a bool[].
Before, BitString didn't work well. If used as parameter, the bit string was truncated to one bit. I've fixed this and also implemented binary encoding for use with prepared queries (didn't work before at all).

Tell me what you think :)
I think this fix makes the parameter handling and data type handling more reasonable.

It should fix https://github.com/npgsql/Npgsql/issues/146, https://github.com/npgsql/Npgsql/issues/335, https://github.com/npgsql/Npgsql/issues/361

Commit log:
BitString works better now.
Bit(1) uses bool and otherwise BitString is used.
Casts are used as long as the type is not explicitly set to NpgsqlDbType.Unknown or DbType.Object. NpgsqlDbType.Unknown is now default for parameters instead of text.
Unknown parameters are always sent as text on prepared queries.
DbType.Time is now mapped to interval.
Output parameters now work for prepared queries.
