### PR TITLE
Fix AsyncGenerator NugetTools path property to work on non Windows OS.

### DIFF
--- a/AsyncGenerator/.nuget/NuGet.targets
+++ b/AsyncGenerator/.nuget/NuGet.targets
@@ -25,15 +25,10 @@
         -->
     </ItemGroup>
 
-    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
-        <!-- Windows specific commands -->
+    <PropertyGroup>
         <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir), ".nuget"))</NuGetToolsPath>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
-        <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
-        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
-    </PropertyGroup>
 
     <PropertyGroup>
         <PackagesProjectConfig Condition=" '$(OS)' == 'Windows_NT'">$(MSBuildProjectDirectory)\packages.$(MSBuildProjectName.Replace(' ', '_')).config</PackagesProjectConfig>


### PR DESCRIPTION
When running under mono on non windows OS, the property wasn't correctly
being set. It was missing an directory separator.

See comment https://github.com/npgsql/npgsql/pull/378#issuecomment-58804628 where this problem is discussed.
