### PR TITLE
New custom stream classes replacing BufferedStream and MemoryStream

### DIFF
--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -120,6 +120,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NpgsqlBufferedStream.cs" />
+    <Compile Include="NpgsqlMemoryStream.cs" />
+    <Compile Include="NpgsqlStream.cs" />
     <Compile Include="NpgsqlTypes\ArrayHandling.cs" />
     <Compile Include="NpgsqlTypes\BitString.cs" />
     <Compile Include="NpgsqlTypes\DateDatatypes.cs" />

--- a/Npgsql/NpgsqlAsciiRow.cs
+++ b/Npgsql/NpgsqlAsciiRow.cs
@@ -41,7 +41,7 @@ namespace Npgsql
         private readonly int _messageSize;
         private int? _nextFieldSize;
 
-        public StringRowReader(Stream inputStream)
+        public StringRowReader(NpgsqlStream inputStream)
             : base(inputStream)
         {
             _messageSize = inputStream.ReadInt32();
@@ -75,21 +75,18 @@ namespace Npgsql
 
             NpgsqlRowDescription.FieldData field_descr = FieldData;
 
-            byte[] buffer = new byte[fieldSize];
-            Stream.CheckedStreamRead(buffer, 0, fieldSize);
-
             try
             {
                 if (field_descr.FormatCode == FormatCode.Text)
                 {
                     return
-                        NpgsqlTypesHelper.ConvertBackendStringToSystemType(field_descr.TypeInfo, buffer,
+                        NpgsqlTypesHelper.ConvertBackendStringToSystemType(field_descr.TypeInfo, Stream, fieldSize,
                                                                            field_descr.TypeSize, field_descr.TypeModifier);
                 }
                 else
                 {
                     return
-                        NpgsqlTypesHelper.ConvertBackendBytesToSystemType(field_descr.TypeInfo, buffer, fieldSize,
+                        NpgsqlTypesHelper.ConvertBackendBytesToSystemType(field_descr.TypeInfo, Stream, fieldSize,
                                                                           field_descr.TypeModifier);
                 }
             }

--- a/Npgsql/NpgsqlBufferedStream.cs
+++ b/Npgsql/NpgsqlBufferedStream.cs
@@ -113,7 +113,7 @@ namespace Npgsql
                 throw new ArgumentOutOfRangeException("count");
             }
 
-            if (count <= 0)
+            if (count == 0)
             {
                 return 0;
             }
@@ -227,6 +227,21 @@ namespace Npgsql
                 {
                     stream.Dispose();
                 }
+            }
+        }
+
+        public override void Skip(int byteCount)
+        {
+            int skipped = 0;
+
+            while (skipped < byteCount)
+            {
+                PopulateReadBuffer(1);
+
+                int count = Math.Min(byteCount - skipped, readBufferCapacity - readBufferPosition);
+
+                readBufferPosition += count;
+                skipped += count;
             }
         }
 

--- a/Npgsql/NpgsqlBufferedStream.cs
+++ b/Npgsql/NpgsqlBufferedStream.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.IO;
+
+namespace Npgsql
+{
+    internal class NpgsqlBufferedStream : NpgsqlStream
+    {
+        public bool ownStream;
+
+        public NpgsqlBufferedStream(Stream stream, int bufferSize, bool performNetworkByteOrderSwap, bool ownStream)
+        {
+            this.Stream = stream;
+            this.BufferSize = bufferSize;
+            this.performNetworkByteOrderSwap = performNetworkByteOrderSwap;
+            this.ownStream = ownStream;
+        }
+
+        public Stream Stream
+        {
+            get;
+            private set;
+        }
+
+        public int BufferSize
+        {
+            get;
+            private set;
+        }
+
+        public int BufferedBytes
+        {
+            get { return readBufferCapacity - readBufferPosition; }
+        }
+
+        protected override bool PopulateReadBuffer(int count)
+        {
+            if (readBufferPosition + count <= readBufferCapacity)
+            {
+                return true;
+            }
+
+            if (readBuffer == null)
+            {
+                readBuffer = new byte[BufferSize];
+            }
+
+            if (readBufferPosition < readBufferCapacity)
+            {
+                Array.Copy(readBuffer, readBufferPosition, readBuffer, 0, readBufferCapacity - readBufferPosition);
+                readBufferCapacity = readBufferCapacity - readBufferPosition;
+            }
+            else
+            {
+                readBufferCapacity = 0;
+            }
+
+            readBufferPosition = 0;
+
+            readBufferCapacity += Stream.Read(readBuffer, readBufferCapacity, BufferSize - readBufferCapacity);
+
+            return (readBufferPosition + count <= readBufferCapacity);
+        }
+
+        private void EnsureWriteBuffer()
+        {
+            if (writeBuffer == null)
+            {
+                writeBuffer = new byte[BufferSize];
+            }
+        }
+
+        private void FlushWriteBuffer()
+        {
+            Stream.Write(writeBuffer, 0, writeBufferPosition);
+            writeBufferPosition = 0;
+        }
+
+        protected override void EnsureWriteBufferSpace(int count)
+        {
+            EnsureWriteBuffer();
+
+            if (writeBufferPosition + count > BufferSize)
+            {
+                FlushWriteBuffer();
+            }
+        }
+
+        protected override void EnsureWriteBufferSpace01()
+        {
+            EnsureWriteBuffer();
+
+            if (writeBufferPosition == BufferSize)
+            {
+                FlushWriteBuffer();
+            }
+        }
+
+        protected override void EnsureWriteBufferSpace02()
+        {
+            EnsureWriteBuffer();
+
+            if (writeBufferPosition + 2 > BufferSize)
+            {
+                FlushWriteBuffer();
+            }
+        }
+
+        protected override void EnsureWriteBufferSpace04()
+        {
+            EnsureWriteBuffer();
+
+            if (writeBufferPosition + 4 > BufferSize)
+            {
+                FlushWriteBuffer();
+            }
+        }
+
+        protected override void EnsureWriteBufferSpace08()
+        {
+            EnsureWriteBuffer();
+
+            if (writeBufferPosition + 8 > BufferSize)
+            {
+                FlushWriteBuffer();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            if (count <= 0)
+            {
+                return 0;
+            }
+
+            if (count < BufferSize || readBufferPosition > 0)
+            {
+                if (! PopulateReadBuffer(1))
+                {
+                    return 0;
+                }
+
+                int bytesRead = Math.Min(readBufferCapacity - readBufferPosition, count);
+
+                Array.Copy(readBuffer, readBufferPosition, buffer, offset, bytesRead);
+                readBufferPosition += bytesRead;
+
+                return bytesRead;
+            }
+            else
+            {
+                return Stream.Read(buffer, offset, count);
+            }
+        }
+
+        public override void Write(byte[] callersBuffer, int offset, int count)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (count > BufferSize)
+            {
+                if (writeBufferPosition > 0)
+                {
+                    FlushWriteBuffer();
+                }
+
+                Stream.Write(callersBuffer, offset, count);
+
+                return;
+            }
+
+            EnsureWriteBufferSpace(count);
+
+            Array.Copy(callersBuffer, offset, writeBuffer, writeBufferPosition, count);
+            writeBufferPosition += count;
+        }
+
+        public override void Flush()
+        {
+            if (writeBufferPosition > 0)
+            {
+                FlushWriteBuffer();
+                Stream.Flush();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (Stream != null)
+                {
+                    Stream.Dispose();
+                    Stream = null;
+                }
+            }
+        }
+
+        public new void CopyTo(Stream destination)
+        {
+            CopyTo(destination, 8192);
+        }
+
+        public new void CopyTo(Stream destination, int bufferSize)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -602,6 +602,15 @@ namespace Npgsql
             State = ConnectorState.Executing;
         }
 
+        [GenerateAsync]
+        internal void SendQuery(NpgsqlStream query)
+        {
+            _log.Debug("Sending query");
+            QueryManager.WriteQuery(Stream, query);
+            Stream.Flush();
+            State = ConnectorState.Executing;
+        }
+
         /// <summary>
         /// Sends a raw query message to the backend. The message must already contain the message code,
         /// length etc. - this methods simply writes it to the wire.

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -67,7 +67,7 @@ namespace Npgsql
         // This is a BufferedStream.
         // With SSL, this stream sits on top of the SSL stream, which sits on top of _baseStream.
         // Otherwise, this stream sits directly on top of _baseStream.
-        internal BufferedStream Stream { get; set; }
+        internal NpgsqlBufferedStream Stream { get; set; }
 
         /// <summary>
         /// Buffer used for reading data.
@@ -457,7 +457,7 @@ namespace Npgsql
 
             Socket = socket;
             BaseStream = baseStream;
-            Stream = new BufferedStream(sslStream ?? baseStream, 8192);
+            Stream = new NpgsqlBufferedStream(sslStream ?? baseStream, 8192, true, true);
             _log.DebugFormat("Connected to {0}:{1}", Host, Port);
         }
 
@@ -1143,6 +1143,7 @@ namespace Npgsql
         {
             Stream.WriteByte((byte)FrontEndMessageCode.CopyDone);
             Stream.WriteInt32(4); // message without data
+            Stream.Flush();
             ConsumeAll();
         }
 

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -457,7 +457,7 @@ namespace Npgsql
 
             Socket = socket;
             BaseStream = baseStream;
-            Stream = new NpgsqlBufferedStream(sslStream ?? baseStream, 8192, true, true);
+            Stream = new NpgsqlBufferedStream(sslStream ?? baseStream, 8192, true, BackendEncoding.UTF8Encoding, true);
             _log.DebugFormat("Connected to {0}:{1}", Host, Port);
         }
 
@@ -562,9 +562,8 @@ namespace Npgsql
                     }
                     else
                     {
-                        Stream
-                            .WriteInt32(value.Length)
-                            .WriteBytes(value);
+                        Stream.WriteInt32(value.Length);
+                        Stream.Write(value);
                     }
                 }
             }

--- a/Npgsql/NpgsqlMemoryStream.cs
+++ b/Npgsql/NpgsqlMemoryStream.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.IO;
+
+namespace Npgsql
+{
+    internal class NpgsqlMemoryStream : NpgsqlStream
+    {
+        public NpgsqlMemoryStream(bool performNetworkByteOrderSwap)
+        {
+            this.performNetworkByteOrderSwap = performNetworkByteOrderSwap;
+        }
+
+        protected override bool PopulateReadBuffer(int count)
+        {
+            return (readBufferPosition + count <= readBufferCapacity);
+        }
+
+        protected override void EnsureWriteBufferSpace(int count)
+        {
+            int target = writeBufferPosition + count;
+
+            if ((writeBuffer == null ? 0 : writeBuffer.Length) < target)
+            {
+                for (int i = 16 ; i < Int32.MaxValue ; i *= 2)
+                {
+                    if (i >= target)
+                    {
+                        readBuffer = new byte[i];
+
+                        if (writeBuffer != null)
+                        {
+                            Array.Copy(writeBuffer, 0, readBuffer, 0, writeBufferPosition);
+                        }
+
+                        writeBuffer = readBuffer;
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        protected override void EnsureWriteBufferSpace01()
+        {
+            EnsureWriteBufferSpace(1);
+        }
+
+        protected override void EnsureWriteBufferSpace02()
+        {
+            EnsureWriteBufferSpace(2);
+        }
+
+        protected override void EnsureWriteBufferSpace04()
+        {
+            EnsureWriteBufferSpace(4);
+        }
+
+        protected override void EnsureWriteBufferSpace08()
+        {
+            EnsureWriteBufferSpace(8);
+        }
+
+        protected override void FinalizeWrite()
+        {
+            if (writeBufferPosition > readBufferCapacity)
+            {
+                readBufferCapacity = writeBufferPosition;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            if (count == 0)
+            {
+                return 0;
+            }
+
+            if (! PopulateReadBuffer(1))
+            {
+                return 0;
+            }
+
+            int bytesRead = Math.Min(readBufferCapacity - readBufferPosition, count);
+
+            Array.Copy(readBuffer, readBufferPosition, buffer, offset, bytesRead);
+            readBufferPosition += bytesRead;
+
+            return bytesRead;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            EnsureWriteBufferSpace(count);
+
+            Array.Copy(buffer, offset, writeBuffer, writeBufferPosition, count);
+            writeBufferPosition += count;
+
+            FinalizeWrite();
+        }
+
+        public new void CopyTo(Stream destination)
+        {
+            CopyTo(destination, 8192);
+        }
+
+        public new void CopyTo(Stream destination, int bufferSize)
+        {
+            while (readBufferCapacity - readBufferPosition > 0)
+            {
+                int count = Math.Min(readBufferCapacity - readBufferPosition, bufferSize);
+
+                destination.Write(readBuffer, readBufferPosition, count);
+                readBufferPosition += count;
+            }
+        }
+
+        public byte[] ToArray()
+        {
+            byte[] result = new byte[readBufferCapacity];
+
+            Array.Copy(readBuffer, 0, result, 0, readBufferCapacity);
+
+            return result;
+        }
+    }
+}

--- a/Npgsql/NpgsqlMemoryStream.cs
+++ b/Npgsql/NpgsqlMemoryStream.cs
@@ -28,6 +28,40 @@ namespace Npgsql
             writeBuffer = readBuffer;
         }
 
+        public NpgsqlMemoryStream(bool performNetworkByteOrderSwap, Encoding textEncoding, byte[] buffer, int fixedOffset, int fixedLength, int writeOffset)
+        : base(performNetworkByteOrderSwap, textEncoding)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException("buffer");
+            }
+
+            if (fixedOffset < 0 || fixedOffset >= buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("fixedOffset");
+            }
+
+            if (fixedLength > buffer.Length - fixedOffset)
+            {
+                throw new ArgumentOutOfRangeException("fixedLength");
+            }
+
+            if (writeOffset < fixedOffset || writeOffset >= buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException("writeOffset");
+            }
+
+            fixedCapacity = true;
+            readBuffer = buffer;
+
+            writeBuffer = readBuffer;
+
+            readBufferCapacity = writeOffset;
+            readBufferPosition = fixedOffset;
+
+            writeBufferPosition = writeOffset;
+        }
+
         public override long Length
         {
             get { return readBufferCapacity; }
@@ -139,6 +173,14 @@ namespace Npgsql
             }
 
             throw new EndOfStreamException();
+        }
+
+        public override void Skip(int byteCount)
+        {
+            if (! PopulateReadBuffer(byteCount))
+           {
+                throw new EndOfStreamException();
+            }
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/Npgsql/NpgsqlMemoryStream.cs
+++ b/Npgsql/NpgsqlMemoryStream.cs
@@ -306,7 +306,7 @@ namespace Npgsql
 
             try
             {
-                count = Encoding.UTF8.GetBytes(text, charOffset, charCount, writeBuffer, writePosition);
+                count = textEncoding.GetBytes(text, charOffset, charCount, writeBuffer, writePosition);
 
                 if (count > textByteCount)
                 {

--- a/Npgsql/NpgsqlRow.cs
+++ b/Npgsql/NpgsqlRow.cs
@@ -244,11 +244,11 @@ namespace Npgsql
         /// </summary>
         protected abstract class Streamer : IStreamOwner
         {
-            protected readonly Stream _stream;
+            protected readonly NpgsqlStream _stream;
             protected int _remainingBytes;
             private int _alreadyRead = 0;
 
-            protected Streamer(Stream stream, int remainingBytes)
+            protected Streamer(NpgsqlStream stream, int remainingBytes)
             {
                 _stream = stream;
                 _remainingBytes = remainingBytes;
@@ -271,7 +271,7 @@ namespace Npgsql
         /// </summary>
         protected abstract class Streamer<T> : Streamer
         {
-            protected Streamer(Stream stream, int remainingBytes)
+            protected Streamer(NpgsqlStream stream, int remainingBytes)
                 : base(stream, remainingBytes)
             {
             }
@@ -306,7 +306,7 @@ namespace Npgsql
         /// </summary>
         protected sealed class CharStreamer : Streamer<char>
         {
-            public CharStreamer(Stream stream, int remainingBytes)
+            public CharStreamer(NpgsqlStream stream, int remainingBytes)
                 : base(stream, remainingBytes)
             {
             }
@@ -327,7 +327,7 @@ namespace Npgsql
         /// </summary>
         protected sealed class ByteStreamer : Streamer<byte>
         {
-            public ByteStreamer(Stream stream, int remainingBytes)
+            public ByteStreamer(NpgsqlStream stream, int remainingBytes)
                 : base(stream, remainingBytes)
             {
             }
@@ -345,11 +345,11 @@ namespace Npgsql
 
         protected static readonly Encoding UTF8Encoding = Encoding.UTF8;
         protected NpgsqlRowDescription _rowDesc;
-        private readonly Stream _stream;
+        private readonly NpgsqlStream _stream;
         private Streamer _streamer;
         protected int _currentField = -1;
 
-        public RowReader(Stream stream)
+        public RowReader(NpgsqlStream stream)
         {
             _stream = stream;
         }
@@ -437,7 +437,7 @@ namespace Npgsql
             }
         }
 
-        protected Stream Stream
+        protected NpgsqlStream Stream
         {
             get { return _stream; }
         }

--- a/Npgsql/NpgsqlStream.cs
+++ b/Npgsql/NpgsqlStream.cs
@@ -28,11 +28,14 @@ namespace Npgsql
         protected int writeBufferPosition;
         protected bool performNetworkByteOrderSwap;
         protected Encoding textEncoding;
+        protected int maxBytesPerChar;
 
         public NpgsqlStream(bool performNetworkByteOrderSwap, Encoding textEncoding)
         {
             this.performNetworkByteOrderSwap = performNetworkByteOrderSwap;
             this.textEncoding = textEncoding;
+
+            this.maxBytesPerChar = this.textEncoding.GetMaxByteCount(1);
         }
 
         protected abstract bool PopulateReadBuffer(int count);

--- a/Npgsql/NpgsqlStream.cs
+++ b/Npgsql/NpgsqlStream.cs
@@ -21,21 +21,21 @@ namespace Npgsql
 
     internal abstract class NpgsqlStream : Stream
     {
-        protected byte[] readBuffer;
-        protected int readBufferCapacity;
-        protected int readBufferPosition;
-        protected byte[] writeBuffer;
-        protected int writeBufferPosition;
-        protected bool performNetworkByteOrderSwap;
-        protected Encoding textEncoding;
-        protected int maxBytesPerChar;
+        protected byte[] _readBuffer;
+        protected int _readBufferCapacity;
+        protected int _readBufferPosition;
+        protected byte[] _writeBuffer;
+        protected int _writeBufferPosition;
+        protected bool _performNetworkByteOrderSwap;
+        protected Encoding _textEncoding;
+        protected int _maxBytesPerChar;
 
-        public NpgsqlStream(bool performNetworkByteOrderSwap, Encoding textEncoding)
+        public NpgsqlStream(bool _performNetworkByteOrderSwap, Encoding textEncoding)
         {
-            this.performNetworkByteOrderSwap = performNetworkByteOrderSwap;
-            this.textEncoding = textEncoding;
+            this._performNetworkByteOrderSwap = _performNetworkByteOrderSwap;
+            this._textEncoding = textEncoding;
 
-            this.maxBytesPerChar = this.textEncoding.GetMaxByteCount(1);
+            this._maxBytesPerChar = this._textEncoding.GetMaxByteCount(1);
         }
 
         protected abstract bool PopulateReadBuffer(int count);
@@ -126,6 +126,12 @@ namespace Npgsql
                 int bytesRead;
 
                 bytesRead = Read(buffer, totalBytesRead, count - totalBytesRead);
+
+                if (bytesRead == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
                 totalBytesRead += bytesRead;
             }
         }
@@ -137,7 +143,7 @@ namespace Npgsql
                 return -1;
             }
 
-            return readBuffer[readBufferPosition++];
+            return _readBuffer[_readBufferPosition++];
         }
 
         public virtual Int16 ReadInt16()
@@ -147,18 +153,18 @@ namespace Npgsql
                 throw new EndOfStreamException();
             }
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (Int16)(
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 00)
+                    (_readBuffer[_readBufferPosition++] << 08) |
+                    (_readBuffer[_readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (Int16)(
-                    (readBuffer[readBufferPosition++] << 00) |
-                    (readBuffer[readBufferPosition++] << 08)
+                    (_readBuffer[_readBufferPosition++] << 00) |
+                    (_readBuffer[_readBufferPosition++] << 08)
                 );
             }
         }
@@ -170,40 +176,40 @@ namespace Npgsql
                 throw new EndOfStreamException();
             }
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (UInt16)(
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 00)
+                    (_readBuffer[_readBufferPosition++] << 08) |
+                    (_readBuffer[_readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (UInt16)(
-                    (readBuffer[readBufferPosition++] << 00) |
-                    (readBuffer[readBufferPosition++] << 08)
+                    (_readBuffer[_readBufferPosition++] << 00) |
+                    (_readBuffer[_readBufferPosition++] << 08)
                 );
             }
         }
 
         protected virtual Int32 ReadInt32NoAdvance()
         {
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (Int32)(
-                    (readBuffer[readBufferPosition + 0] << 24) |
-                    (readBuffer[readBufferPosition + 1] << 16) |
-                    (readBuffer[readBufferPosition + 2] << 08) |
-                    (readBuffer[readBufferPosition + 3] << 00)
+                    (_readBuffer[_readBufferPosition + 0] << 24) |
+                    (_readBuffer[_readBufferPosition + 1] << 16) |
+                    (_readBuffer[_readBufferPosition + 2] << 08) |
+                    (_readBuffer[_readBufferPosition + 3] << 00)
                 );
             }
             else
             {
                 return (Int32)(
-                    (readBuffer[readBufferPosition + 0] << 00) |
-                    (readBuffer[readBufferPosition + 1] << 08) |
-                    (readBuffer[readBufferPosition + 2] << 16) |
-                    (readBuffer[readBufferPosition + 3] << 24)
+                    (_readBuffer[_readBufferPosition + 0] << 00) |
+                    (_readBuffer[_readBufferPosition + 1] << 08) |
+                    (_readBuffer[_readBufferPosition + 2] << 16) |
+                    (_readBuffer[_readBufferPosition + 3] << 24)
                 );
             }
         }
@@ -219,7 +225,7 @@ namespace Npgsql
 
             result = ReadInt32NoAdvance();
 
-            readBufferPosition += sizeof(Int32);
+            _readBufferPosition += sizeof(Int32);
 
             return result;
         }
@@ -231,22 +237,22 @@ namespace Npgsql
                 throw new EndOfStreamException();
             }
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (UInt32)(
-                    (readBuffer[readBufferPosition++] << 24) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 00)
+                    (_readBuffer[_readBufferPosition++] << 24) |
+                    (_readBuffer[_readBufferPosition++] << 16) |
+                    (_readBuffer[_readBufferPosition++] << 08) |
+                    (_readBuffer[_readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (UInt32)(
-                    (readBuffer[readBufferPosition++] << 00) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 24)
+                    (_readBuffer[_readBufferPosition++] << 00) |
+                    (_readBuffer[_readBufferPosition++] << 08) |
+                    (_readBuffer[_readBufferPosition++] << 16) |
+                    (_readBuffer[_readBufferPosition++] << 24)
                 );
             }
         }
@@ -258,30 +264,30 @@ namespace Npgsql
                 throw new EndOfStreamException();
             }
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (Int64)(
-                    ((Int64)readBuffer[readBufferPosition++] << 56) |
-                    ((Int64)readBuffer[readBufferPosition++] << 48) |
-                    ((Int64)readBuffer[readBufferPosition++] << 40) |
-                    ((Int64)readBuffer[readBufferPosition++] << 32) |
-                    ((Int64)readBuffer[readBufferPosition++] << 24) |
-                    ((Int64)readBuffer[readBufferPosition++] << 16) |
-                    ((Int64)readBuffer[readBufferPosition++] << 08) |
-                    ((Int64)readBuffer[readBufferPosition++] << 00)
+                    ((Int64)_readBuffer[_readBufferPosition++] << 56) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 48) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 40) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 32) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 24) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 16) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 08) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (Int64)(
-                    ((Int64)readBuffer[readBufferPosition++] << 00) |
-                    ((Int64)readBuffer[readBufferPosition++] << 08) |
-                    ((Int64)readBuffer[readBufferPosition++] << 16) |
-                    ((Int64)readBuffer[readBufferPosition++] << 24) |
-                    ((Int64)readBuffer[readBufferPosition++] << 32) |
-                    ((Int64)readBuffer[readBufferPosition++] << 40) |
-                    ((Int64)readBuffer[readBufferPosition++] << 48) |
-                    ((Int64)readBuffer[readBufferPosition++] << 56)
+                    ((Int64)_readBuffer[_readBufferPosition++] << 00) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 08) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 16) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 24) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 32) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 40) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 48) |
+                    ((Int64)_readBuffer[_readBufferPosition++] << 56)
                 );
             }
         }
@@ -293,30 +299,30 @@ namespace Npgsql
                 throw new EndOfStreamException();
             }
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (UInt64)(
-                    ((UInt64)readBuffer[readBufferPosition++] << 56) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 48) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 40) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 32) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 24) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 16) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 08) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 00)
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 56) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 48) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 40) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 32) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 24) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 16) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 08) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (UInt64)(
-                    ((UInt64)readBuffer[readBufferPosition++] << 00) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 08) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 16) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 24) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 32) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 40) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 48) |
-                    ((UInt64)readBuffer[readBufferPosition++] << 56)
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 00) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 08) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 16) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 24) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 32) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 40) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 48) |
+                    ((UInt64)_readBuffer[_readBufferPosition++] << 56)
                 );
             }
         }
@@ -332,7 +338,7 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(byte));
 
-            writeBuffer[writeBufferPosition++] = b;
+            _writeBuffer[_writeBufferPosition++] = b;
 
             FinalizeWrite();
         }
@@ -341,15 +347,15 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(Int16));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
             }
 
             FinalizeWrite();
@@ -361,15 +367,15 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(UInt16));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
             }
 
             FinalizeWrite();
@@ -381,19 +387,19 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(Int32));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
             }
 
             FinalizeWrite();
@@ -405,19 +411,19 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(UInt32));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
             }
 
             FinalizeWrite();
@@ -429,27 +435,27 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(Int64));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
             }
 
             FinalizeWrite();
@@ -461,27 +467,27 @@ namespace Npgsql
         {
             EnsureWriteBufferSpace(sizeof(UInt64));
 
-            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            if (_performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
             }
             else
             {
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
-                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                _writeBuffer[_writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
             }
 
             FinalizeWrite();

--- a/Npgsql/NpgsqlStream.cs
+++ b/Npgsql/NpgsqlStream.cs
@@ -1,0 +1,407 @@
+﻿using System;
+using System.IO;
+
+namespace Npgsql
+{
+    internal abstract class NpgsqlStream : Stream
+    {
+        protected byte[] readBuffer;
+        protected int readBufferCapacity;
+        protected int readBufferPosition;
+        protected byte[] writeBuffer;
+        protected int writeBufferPosition;
+        protected bool performNetworkByteOrderSwap;
+
+        protected abstract bool PopulateReadBuffer(int count);
+
+        protected abstract void EnsureWriteBufferSpace(int count);
+        protected abstract void EnsureWriteBufferSpace01();
+        protected abstract void EnsureWriteBufferSpace02();
+        protected abstract void EnsureWriteBufferSpace04();
+        protected abstract void EnsureWriteBufferSpace08();
+
+        protected virtual void FinalizeWrite() {}
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override long Length
+        {
+            get { throw new InvalidOperationException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new InvalidOperationException(); }
+            set { throw new InvalidOperationException(); }
+        }
+
+        public override void Flush() {}
+
+        public virtual int Read(byte[] buffer)
+        {
+            return Read(buffer, 0, buffer.Length);
+        }
+
+        public override int ReadByte()
+        {
+            if (! PopulateReadBuffer(sizeof(byte)))
+            {
+                return -1;
+            }
+
+            return readBuffer[readBufferPosition++];
+        }
+
+        public virtual Int16 ReadInt16()
+        {
+            if (! PopulateReadBuffer(sizeof(Int16)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (Int16)(
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (Int16)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08)
+                );
+            }
+        }
+
+        public virtual UInt16 ReadUInt16()
+        {
+            if (! PopulateReadBuffer(sizeof(UInt16)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (UInt16)(
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (UInt16)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08)
+                );
+            }
+        }
+
+        public virtual Int32 ReadInt32()
+        {
+            if (! PopulateReadBuffer(sizeof(Int32)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (Int32)(
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (Int32)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 24)
+                );
+            }
+        }
+
+        public virtual UInt32 ReadUInt32()
+        {
+            if (! PopulateReadBuffer(sizeof(UInt32)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (UInt32)(
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (UInt32)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 24)
+                );
+            }
+        }
+
+        public virtual Int64 ReadInt64()
+        {
+            if (! PopulateReadBuffer(sizeof(Int64)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (Int64)(
+                    (readBuffer[readBufferPosition++] << 56) |
+                    (readBuffer[readBufferPosition++] << 48) |
+                    (readBuffer[readBufferPosition++] << 40) |
+                    (readBuffer[readBufferPosition++] << 32) |
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (Int64)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 32) |
+                    (readBuffer[readBufferPosition++] << 40) |
+                    (readBuffer[readBufferPosition++] << 48) |
+                    (readBuffer[readBufferPosition++] << 56)
+                );
+            }
+        }
+
+        public virtual UInt64 ReadUInt64()
+        {
+            if (! PopulateReadBuffer(sizeof(UInt64)))
+            {
+                throw new EndOfStreamException();
+            }
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                return (UInt64)(
+                    (readBuffer[readBufferPosition++] << 56) |
+                    (readBuffer[readBufferPosition++] << 48) |
+                    (readBuffer[readBufferPosition++] << 40) |
+                    (readBuffer[readBufferPosition++] << 32) |
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 00)
+                );
+            }
+            else
+            {
+                return (UInt64)(
+                    (readBuffer[readBufferPosition++] << 00) |
+                    (readBuffer[readBufferPosition++] << 08) |
+                    (readBuffer[readBufferPosition++] << 16) |
+                    (readBuffer[readBufferPosition++] << 24) |
+                    (readBuffer[readBufferPosition++] << 32) |
+                    (readBuffer[readBufferPosition++] << 40) |
+                    (readBuffer[readBufferPosition++] << 48) |
+                    (readBuffer[readBufferPosition++] << 56)
+                );
+            }
+        }
+
+        public virtual void Write(byte[] buffer)
+        {
+            Write(buffer, 0, buffer.Length);
+        }
+
+        public virtual void Write(byte b)
+        {
+            EnsureWriteBufferSpace01();
+
+            writeBuffer[writeBufferPosition++] = b;
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(Int16 i)
+        {
+            EnsureWriteBufferSpace02();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(UInt16 i)
+        {
+            EnsureWriteBufferSpace02();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(Int32 i)
+        {
+            EnsureWriteBufferSpace04();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(UInt32 i)
+        {
+            EnsureWriteBufferSpace04();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(Int64 i)
+        {
+            EnsureWriteBufferSpace08();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public virtual void Write(UInt64 i)
+        {
+            EnsureWriteBufferSpace08();
+
+            if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+            }
+            else
+            {
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 00) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 08) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 16) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 24) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 32) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 40) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 48) & 0xFF);
+                writeBuffer[writeBufferPosition++] = (byte)((i >> 56) & 0xFF);
+            }
+
+            FinalizeWrite();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/Npgsql/NpgsqlStream.cs
+++ b/Npgsql/NpgsqlStream.cs
@@ -29,6 +29,8 @@ namespace Npgsql
         public abstract string ReadString(int byteCount);
         public abstract string ReadString();
 
+        public abstract void Skip(int byteCount);
+
         public abstract NpgsqlStream WriteString(string text, int byteCount = -1, bool nullTerminate = false);
 
         public override bool CanRead
@@ -62,6 +64,34 @@ namespace Npgsql
         public virtual int Read(byte[] buffer)
         {
             return Read(buffer, 0, buffer.Length);
+        }
+
+        public virtual void ReadExact(byte[] buffer, int offset, int count)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException("offset");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count");
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            int totalBytesRead = 0;
+
+            while (totalBytesRead < count)
+            {
+                int bytesRead;
+
+                bytesRead = Read(buffer, totalBytesRead, count - totalBytesRead);
+                totalBytesRead += bytesRead;
+            }
         }
 
         public override int ReadByte()
@@ -184,27 +214,27 @@ namespace Npgsql
             if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (Int64)(
-                    (readBuffer[readBufferPosition++] << 56) |
-                    (readBuffer[readBufferPosition++] << 48) |
-                    (readBuffer[readBufferPosition++] << 40) |
-                    (readBuffer[readBufferPosition++] << 32) |
-                    (readBuffer[readBufferPosition++] << 24) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 00)
+                    ((Int64)readBuffer[readBufferPosition++] << 56) |
+                    ((Int64)readBuffer[readBufferPosition++] << 48) |
+                    ((Int64)readBuffer[readBufferPosition++] << 40) |
+                    ((Int64)readBuffer[readBufferPosition++] << 32) |
+                    ((Int64)readBuffer[readBufferPosition++] << 24) |
+                    ((Int64)readBuffer[readBufferPosition++] << 16) |
+                    ((Int64)readBuffer[readBufferPosition++] << 08) |
+                    ((Int64)readBuffer[readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (Int64)(
-                    (readBuffer[readBufferPosition++] << 00) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 24) |
-                    (readBuffer[readBufferPosition++] << 32) |
-                    (readBuffer[readBufferPosition++] << 40) |
-                    (readBuffer[readBufferPosition++] << 48) |
-                    (readBuffer[readBufferPosition++] << 56)
+                    ((Int64)readBuffer[readBufferPosition++] << 00) |
+                    ((Int64)readBuffer[readBufferPosition++] << 08) |
+                    ((Int64)readBuffer[readBufferPosition++] << 16) |
+                    ((Int64)readBuffer[readBufferPosition++] << 24) |
+                    ((Int64)readBuffer[readBufferPosition++] << 32) |
+                    ((Int64)readBuffer[readBufferPosition++] << 40) |
+                    ((Int64)readBuffer[readBufferPosition++] << 48) |
+                    ((Int64)readBuffer[readBufferPosition++] << 56)
                 );
             }
         }
@@ -219,27 +249,27 @@ namespace Npgsql
             if (performNetworkByteOrderSwap && BitConverter.IsLittleEndian)
             {
                 return (UInt64)(
-                    (readBuffer[readBufferPosition++] << 56) |
-                    (readBuffer[readBufferPosition++] << 48) |
-                    (readBuffer[readBufferPosition++] << 40) |
-                    (readBuffer[readBufferPosition++] << 32) |
-                    (readBuffer[readBufferPosition++] << 24) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 00)
+                    ((UInt64)readBuffer[readBufferPosition++] << 56) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 48) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 40) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 32) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 24) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 16) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 08) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 00)
                 );
             }
             else
             {
                 return (UInt64)(
-                    (readBuffer[readBufferPosition++] << 00) |
-                    (readBuffer[readBufferPosition++] << 08) |
-                    (readBuffer[readBufferPosition++] << 16) |
-                    (readBuffer[readBufferPosition++] << 24) |
-                    (readBuffer[readBufferPosition++] << 32) |
-                    (readBuffer[readBufferPosition++] << 40) |
-                    (readBuffer[readBufferPosition++] << 48) |
-                    (readBuffer[readBufferPosition++] << 56)
+                    ((UInt64)readBuffer[readBufferPosition++] << 00) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 08) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 16) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 24) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 32) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 40) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 48) |
+                    ((UInt64)readBuffer[readBufferPosition++] << 56)
                 );
             }
         }

--- a/Npgsql/NpgsqlTypes/ArrayHandling.cs
+++ b/Npgsql/NpgsqlTypes/ArrayHandling.cs
@@ -206,22 +206,22 @@ namespace NpgsqlTypes
         public byte[] ArrayToArrayBinary(NpgsqlNativeTypeInfo TypeInfo, object oNativeData, NativeToBackendTypeConverterOptions options)
         {
             Array NativeData = (Array)oNativeData;
-            NpgsqlMemoryStream dst = new NpgsqlMemoryStream(true);
+            NpgsqlMemoryStream dst = new NpgsqlMemoryStream(true, BackendEncoding.UTF8Encoding);
 
             // Write the number of dimensions in the array.
-            dst.Write(NativeData.Rank);
+            dst.WriteInt32(NativeData.Rank);
             // Placeholder for null bitmap flag, which isn't used?
-            dst.Write(0);
+            dst.WriteInt32(0);
             // Write the OID of the elements of the array.
-            dst.Write(options.OidToNameMapping[_elementConverter.Name].OID);
+            dst.WriteInt32(options.OidToNameMapping[_elementConverter.Name].OID);
 
             // White dimension descriptors.
             for (int i = 0 ; i < NativeData.Rank ; i++)
             {
                 // Number of elements in the dimension.
-                dst.Write(NativeData.GetLength(i));
+                dst.WriteInt32(NativeData.GetLength(i));
                 // Lower bounds of the dimension, 1-based for SQL.
-                dst.Write(NativeData.GetLowerBound(i) + 1);
+                dst.WriteInt32(NativeData.GetLowerBound(i) + 1);
             }
 
             int[] dimensionOffsets = new int[NativeData.Rank];
@@ -263,7 +263,7 @@ namespace NpgsqlTypes
                     if (elementNative == null || elementNative == DBNull.Value)
                     {
                         // Write length identifier -1 indicating NULL value.
-                        dst.Write(-1);
+                        dst.WriteInt32(-1);
                     }
                     else
                     {
@@ -272,7 +272,7 @@ namespace NpgsqlTypes
                         elementBinary = (byte[])_elementConverter.ConvertToBackend(elementNative, true, options);
 
                         // Write lenght identifier.
-                        dst.Write(elementBinary.Length);
+                        dst.WriteInt32(elementBinary.Length);
                         // Write element data.
                         dst.Write(elementBinary, 0, elementBinary.Length);
                     }

--- a/Npgsql/NpgsqlTypes/ArrayHandling.cs
+++ b/Npgsql/NpgsqlTypes/ArrayHandling.cs
@@ -206,22 +206,22 @@ namespace NpgsqlTypes
         public byte[] ArrayToArrayBinary(NpgsqlNativeTypeInfo TypeInfo, object oNativeData, NativeToBackendTypeConverterOptions options)
         {
             Array NativeData = (Array)oNativeData;
-            MemoryStream dst = new MemoryStream();
+            NpgsqlMemoryStream dst = new NpgsqlMemoryStream(true);
 
             // Write the number of dimensions in the array.
-            dst.WriteInt32(NativeData.Rank);
+            dst.Write(NativeData.Rank);
             // Placeholder for null bitmap flag, which isn't used?
-            dst.WriteInt32(0);
+            dst.Write(0);
             // Write the OID of the elements of the array.
-            dst.WriteInt32(options.OidToNameMapping[_elementConverter.Name].OID);
+            dst.Write(options.OidToNameMapping[_elementConverter.Name].OID);
 
             // White dimension descriptors.
             for (int i = 0 ; i < NativeData.Rank ; i++)
             {
                 // Number of elements in the dimension.
-                dst.WriteInt32(NativeData.GetLength(i));
+                dst.Write(NativeData.GetLength(i));
                 // Lower bounds of the dimension, 1-based for SQL.
-                dst.WriteInt32(NativeData.GetLowerBound(i) + 1);
+                dst.Write(NativeData.GetLowerBound(i) + 1);
             }
 
             int[] dimensionOffsets = new int[NativeData.Rank];
@@ -235,7 +235,7 @@ namespace NpgsqlTypes
         /// <summary>
         /// Append all array data to the binary stream.
         /// </summary>
-        private void WriteBinaryArrayData(NpgsqlNativeTypeInfo TypeInfo, Array nativeData, NativeToBackendTypeConverterOptions options, MemoryStream dst, int dimensionOffset, int[] dimensionOffsets)
+        private void WriteBinaryArrayData(NpgsqlNativeTypeInfo TypeInfo, Array nativeData, NativeToBackendTypeConverterOptions options, NpgsqlMemoryStream dst, int dimensionOffset, int[] dimensionOffsets)
         {
             int dimensionLength = nativeData.GetLength(dimensionOffset);
             int dimensionLBound = nativeData.GetLowerBound(dimensionOffset);
@@ -263,7 +263,7 @@ namespace NpgsqlTypes
                     if (elementNative == null || elementNative == DBNull.Value)
                     {
                         // Write length identifier -1 indicating NULL value.
-                        dst.WriteInt32(-1);
+                        dst.Write(-1);
                     }
                     else
                     {
@@ -272,7 +272,7 @@ namespace NpgsqlTypes
                         elementBinary = (byte[])_elementConverter.ConvertToBackend(elementNative, true, options);
 
                         // Write lenght identifier.
-                        dst.WriteInt32(elementBinary.Length);
+                        dst.Write(elementBinary.Length);
                         // Write element data.
                         dst.Write(elementBinary, 0, elementBinary.Length);
                     }

--- a/Npgsql/NpgsqlTypes/NpgsqlTypeInfoBackend.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypeInfoBackend.cs
@@ -47,7 +47,7 @@ namespace NpgsqlTypes
     /// Delegate called to convert the given backend binary data to its native representation.
     /// </summary>
     internal delegate Object ConvertBackendBinaryToNativeHandler(
-        NpgsqlBackendTypeInfo TypeInfo, byte[] BackendData, Int32 fieldValueSize, Int32 TypeModifier);
+        NpgsqlBackendTypeInfo TypeInfo, NpgsqlStream BackendDataStream, Int32 fieldValueSize, Int32 TypeModifier);
 
     /// <summary>
     /// Represents a backend data type.
@@ -184,14 +184,18 @@ namespace NpgsqlTypes
         /// <param name="BackendData">Data sent from the backend.</param>
         /// <param name="fieldValueSize">fieldValueSize</param>
         /// <param name="TypeModifier">Type modifier field sent from the backend.</param>
-        public Object ConvertBackendBinaryToNative(Byte[] BackendData, Int32 fieldValueSize, Int32 TypeModifier)
+        public Object ConvertBackendBinaryToNative(NpgsqlStream BackendDataStream, Int32 fieldValueSize, Int32 TypeModifier)
         {
             if (! NpgsqlTypesHelper.SuppressBinaryBackendEncoding && _ConvertBackendBinaryToNative != null)
             {
-                return _ConvertBackendBinaryToNative(this, BackendData, fieldValueSize, TypeModifier);
+                return _ConvertBackendBinaryToNative(this, BackendDataStream, fieldValueSize, TypeModifier);
             }
             else
             {
+                byte[] BackendData = new byte[fieldValueSize];
+
+                BackendDataStream.ReadExact(BackendData, 0, fieldValueSize);
+
                 return BackendData;
             }
         }

--- a/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
@@ -213,15 +213,19 @@ namespace NpgsqlTypes
         /// The given TypeInfo is called upon to do the conversion.
         /// If no TypeInfo object is provided, no conversion is performed.
         /// </summary>
-        public static Object ConvertBackendBytesToSystemType(NpgsqlBackendTypeInfo TypeInfo, Byte[] data, Int32 fieldValueSize,
+        public static Object ConvertBackendBytesToSystemType(NpgsqlBackendTypeInfo TypeInfo, NpgsqlStream BackendDataStream, Int32 fieldValueSize,
                                                              Int32 typeModifier)
         {
             if (TypeInfo != null)
             {
-                return TypeInfo.ConvertBackendBinaryToNative(data, fieldValueSize, typeModifier);
+                return TypeInfo.ConvertBackendBinaryToNative(BackendDataStream, fieldValueSize, typeModifier);
             }
             else
             {
+                byte[] data = new byte[fieldValueSize];
+
+                BackendDataStream.ReadExact(data, 0, fieldValueSize);
+
                 return data;
             }
         }
@@ -232,16 +236,20 @@ namespace NpgsqlTypes
         /// The given TypeInfo is called upon to do the conversion.
         /// If no TypeInfo object is provided, no conversion is performed.
         /// </summary>
-        public static Object ConvertBackendStringToSystemType(NpgsqlBackendTypeInfo TypeInfo, Byte[] data, Int16 typeSize,
+        public static Object ConvertBackendStringToSystemType(NpgsqlBackendTypeInfo TypeInfo, NpgsqlStream BackendDataStream, Int32 Length, Int16 typeSize,
                                                               Int32 typeModifier)
         {
             if (TypeInfo != null)
             {
-                return TypeInfo.ConvertBackendTextToNative(data, typeSize, typeModifier);
+                byte[] BackendData = new byte[Length];
+
+                BackendDataStream.ReadExact(BackendData, 0, Length);
+
+                return TypeInfo.ConvertBackendTextToNative(BackendData, typeSize, typeModifier);
             }
             else
             {
-                return BackendEncoding.UTF8Encoding.GetString(data);
+                return BackendDataStream.ReadString(Length);
             }
         }
 

--- a/Npgsql/PGUtil.cs
+++ b/Npgsql/PGUtil.cs
@@ -405,58 +405,6 @@ namespace Npgsql
             return stream.WriteString(theString);
         }
 
-        ///<summary>
-        /// This method writes a C NULL terminated string to the network stream.
-        /// It appends a NULL terminator to the end of the String.
-        /// </summary>
-        [GenerateAsync]
-        public static Stream WriteStringNullTerminated(this Stream stream, String theString)
-        {
-            _log.Trace("Sending: " + theString);
-            byte[] bytes = BackendEncoding.UTF8Encoding.GetBytes(theString);
-            stream.Write(bytes, 0, bytes.Length);
-            stream.Write(ASCIIByteArrays.Byte_0, 0, 1);
-            return stream;
-        }
-
-        ///<summary>
-        /// This method writes a C NULL terminated string to the network stream.
-        /// It appends a NULL terminator to the end of the String.
-        /// </summary>
-        [GenerateAsync]
-        public static NpgsqlStream WriteStringNullTerminated(this NpgsqlStream stream, String theString)
-        {
-            _log.Trace("Sending: " + theString);
-            return stream.WriteString(theString, -1, true);
-        }
-
-        ///<summary>
-        /// This method writes a C NULL terminated string to the network stream.
-        /// It appends a NULL terminator to the end of the String.
-        /// </summary>
-        [GenerateAsync]
-        public static Stream WriteStringNullTerminated(this Stream stream, String format, params object[] parameters)
-        {
-            string theString = string.Format(format, parameters);
-            _log.Trace("Sending: " + theString);
-            byte[] bytes = BackendEncoding.UTF8Encoding.GetBytes(theString);
-            stream.Write(bytes, 0, bytes.Length);
-            stream.Write(ASCIIByteArrays.Byte_0, 0, 1);
-            return stream;
-        }
-
-        ///<summary>
-        /// This method writes a C NULL terminated string to the network stream.
-        /// It appends a NULL terminator to the end of the String.
-        /// </summary>
-        [GenerateAsync]
-        public static NpgsqlStream WriteStringFormatNullTerminated(this NpgsqlStream stream, String format, params object[] parameters)
-        {
-            string theString = string.Format(format, parameters);
-            _log.Trace("Sending: " + theString);
-            return stream.WriteString(theString, -1, true);
-        }
-
         /// <summary>
         /// This method writes a byte to the stream. It also enables logging of them.
         /// </summary>
@@ -465,18 +413,6 @@ namespace Npgsql
         {
             _log.Trace("Sending byte: {0}" + b[0]);
             stream.Write(b, 0, 1);
-            return stream;
-        }
-
-        /// <summary>
-        /// This method writes a byte to the stream. It also enables logging of them.
-        /// </summary>
-        [GenerateAsync]
-        public static Stream WriteByteNullTerminated(this Stream stream, byte[] b)
-        {
-            _log.Trace("Sending byte: " + b[0]);
-            stream.Write(b, 0, 1);
-            stream.Write(ASCIIByteArrays.Byte_0, 0, 1);
             return stream;
         }
 

--- a/Npgsql/PGUtil.cs
+++ b/Npgsql/PGUtil.cs
@@ -395,6 +395,17 @@ namespace Npgsql
         }
 
         ///<summary>
+        /// This method writes a string to the network stream.
+        /// </summary>
+        [GenerateAsync]
+        public static NpgsqlStream WriteStringFormat(this NpgsqlStream stream, String format, params object[] parameters)
+        {
+            string theString = string.Format(format, parameters);
+            _log.Trace("Sending: " + theString);
+            return stream.WriteString(theString);
+        }
+
+        ///<summary>
         /// This method writes a C NULL terminated string to the network stream.
         /// It appends a NULL terminator to the end of the String.
         /// </summary>
@@ -413,6 +424,17 @@ namespace Npgsql
         /// It appends a NULL terminator to the end of the String.
         /// </summary>
         [GenerateAsync]
+        public static NpgsqlStream WriteStringNullTerminated(this NpgsqlStream stream, String theString)
+        {
+            _log.Trace("Sending: " + theString);
+            return stream.WriteString(theString, -1, true);
+        }
+
+        ///<summary>
+        /// This method writes a C NULL terminated string to the network stream.
+        /// It appends a NULL terminator to the end of the String.
+        /// </summary>
+        [GenerateAsync]
         public static Stream WriteStringNullTerminated(this Stream stream, String format, params object[] parameters)
         {
             string theString = string.Format(format, parameters);
@@ -421,6 +443,18 @@ namespace Npgsql
             stream.Write(bytes, 0, bytes.Length);
             stream.Write(ASCIIByteArrays.Byte_0, 0, 1);
             return stream;
+        }
+
+        ///<summary>
+        /// This method writes a C NULL terminated string to the network stream.
+        /// It appends a NULL terminator to the end of the String.
+        /// </summary>
+        [GenerateAsync]
+        public static NpgsqlStream WriteStringFormatNullTerminated(this NpgsqlStream stream, String format, params object[] parameters)
+        {
+            string theString = string.Format(format, parameters);
+            _log.Trace("Sending: " + theString);
+            return stream.WriteString(theString, -1, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi all,

Per discussion with @roji, I implemented some Stream classes to replace BufferedStream and MemoryStream, and got them working in Npgsql.

This is really preliminary work, and just the start of a much bigger project that I don't have time to finish, but i think it provides part of the basis needed for Npgsql to really take control of its buffer management.

i did not implement a buffer pool, which may prove to be another important aspect of this project, but a buffer pool is really quite trivial to write, and adapting NpgsqlMemoryStream to it would also be trivial.

The hard, tedious work ahead will lie in refactoring Npgsql to extend and use these new streams to eliminate a lot more allocations and copy operations, partly by taking advantage of the fact that we can have full access to their buffers.

-Glen
