### PR TITLE
Fix prepared dispose after connection close

### DIFF
--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -4026,5 +4026,22 @@ namespace NpgsqlTests
                 cancelTask.Wait();
             }
         }
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/393")]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/299")]
+        public void DisposePreparedAfterCommandClose()
+        {
+            using (var c = new NpgsqlConnection(ConnectionString))
+            {
+                using (var cmd = c.CreateCommand())
+                {
+                    c.Open();
+                    cmd.CommandText = "select 1";
+                    cmd.Prepare();
+                    c.Close();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
NpgsqlCommand now listens to its connection's open/close events. On close, sets its prepare status to NotPrepared, avoiding the DEALLOCATE on Dispose().

A bit of additional cleanup around command/connection relations, but further work is needed for cases where the same command gets transferred across connections.

Fixes #393
Relates to #299
