### PR TITLE
Fix inappropriate messages.

### DIFF
--- a/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/NpgsqlCommand.cs
@@ -1781,7 +1781,7 @@ namespace Npgsql
                 case ConnectorState.CopyOut:
                     throw new InvalidOperationException("A COPY operation is in progress and must complete first.");
                 default:
-                    throw new ArgumentOutOfRangeException("Unknown state: " + Connector.State);
+                    throw new ArgumentOutOfRangeException("Connector.State", "Unknown state: " + Connector.State);
             }
         }
 

--- a/Npgsql/NpgsqlCommandBuilder.cs
+++ b/Npgsql/NpgsqlCommandBuilder.cs
@@ -470,7 +470,7 @@ namespace Npgsql
             if (unquotedIdentifier == null)
 
             {
-                throw new ArgumentNullException("Unquoted identifier parameter cannot be null");
+                throw new ArgumentNullException("unquotedIdentifier", "Unquoted identifier parameter cannot be null");
             }
 
             return String.Format("{0}{1}{2}", this.QuotePrefix, unquotedIdentifier, this.QuoteSuffix);
@@ -493,7 +493,7 @@ namespace Npgsql
             if (quotedIdentifier == null)
 
             {
-                throw new ArgumentNullException("Quoted identifier parameter cannot be null");
+                throw new ArgumentNullException("quotedIdentifier", "Quoted identifier parameter cannot be null");
             }
 
             string unquotedIdentifier = quotedIdentifier.Trim();

--- a/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/NpgsqlConnection.cs
@@ -498,7 +498,7 @@ namespace Npgsql
                     case ConnectorState.CopyOut:
                         return ConnectionState.Closed | ConnectionState.Fetching;
                     default:
-                        throw new ArgumentOutOfRangeException("Unknown connector state: " + Connector.State);
+                        throw new ArgumentOutOfRangeException("Connector.State", "Unknown connector state: " + Connector.State);
                 }
             }
         }

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -231,7 +231,7 @@ namespace Npgsql
                     case ConnectorState.Broken:
                         return false;
                     default:
-                        throw new ArgumentOutOfRangeException("Unknown state: " + State);
+                        throw new ArgumentOutOfRangeException("State", "Unknown state: " + State);
                 }
             }
         }
@@ -256,7 +256,7 @@ namespace Npgsql
                     case ConnectorState.Broken:
                         return false;
                     default:
-                        throw new ArgumentOutOfRangeException("Unknown state: " + State);
+                        throw new ArgumentOutOfRangeException("State", "Unknown state: " + State);
                 }
             }
         }


### PR DESCRIPTION
Fix two inappropriate messages.

1)
code:
throw new ArgumentNullException("Unquoted identifier parameter cannot be null")

message:
System.ArgumentNullException: Value cannot be null.
Parameter name: Unquoted identifier parameter cannot be null

2)
code:
throw new ArgumentOutOfRangeException("Unknown state: " + "Connector.State")

messaage:
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: Unknown state: Connector.State
