### PR TITLE
Remove the NpgsqlConnector.IsValid() method.

### DIFF
--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -1621,6 +1621,7 @@ namespace Npgsql
 
         internal void Reset()
         {
+            if ( String.IsNullOrWhiteSpace(_initQueries) ) { return; }
 
             ExecuteOrDefer(_initQueries);
 

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -687,6 +687,7 @@ namespace Npgsql
             }
         }
 
+
         [GenerateAsync]
         internal void SendMessage(FrontendMessage msg)
         {
@@ -1271,7 +1272,7 @@ namespace Npgsql
         {
             ExecuteBlind(QueryManager.DiscardAll);
 
-            // The initial connection parameters will be restored via IsValid() when get connector from pool later 
+            // The initial connection parameters will be restored via IsValid() when get connector from pool later
         }
 
         internal void ReleaseRegisteredListen()
@@ -1612,6 +1613,18 @@ namespace Npgsql
 
         int _planIndex;
         const String PlanNamePrefix = "s";
+
+        /// <summary>
+        /// Reset connector state.
+        /// Restore initial connection parameters resetted by "Discard ALL"
+        /// </summary>
+
+        internal void Reset()
+        {
+
+            ExecuteOrDefer(_initQueries);
+
+        }
 
         /// <summary>
         /// This method checks if the connector is still ok.

--- a/Npgsql/NpgsqlConnectorPool.cs
+++ b/Npgsql/NpgsqlConnectorPool.cs
@@ -261,54 +261,42 @@ namespace Npgsql
             ConnectorQueue Queue = null;
             NpgsqlConnector Connector = null;
 
-            do
+            // We only need to lock all pools when trying to get one pool or create one.
+
+            lock (locker)
             {
-                if (Connector != null)
-                {
-                    //This means Connector was found to be invalid at the end of the loop
 
-                    lock (Queue)
-                    {
-                        Queue.Busy.Remove(Connector);
-                    }
-
-                    Connector.Close();
-                    Connector = null;
-                }
-
-                // We only need to lock all pools when trying to get one pool or create one.
-
-                lock (locker)
+                // Try to find a queue.
+                if (!PooledConnectors.TryGetValue(Connection.ConnectionString, out Queue))
                 {
 
-                    // Try to find a queue.
-                    if (!PooledConnectors.TryGetValue(Connection.ConnectionString, out Queue))
-                    {
-
-                        Queue = new ConnectorQueue();
-                        Queue.ConnectionLifeTime = Connection.ConnectionLifeTime;
-                        Queue.MinPoolSize = Connection.MinPoolSize;
-                        PooledConnectors[Connection.ConnectionString] = Queue;
-                    }
+                    Queue = new ConnectorQueue();
+                    Queue.ConnectionLifeTime = Connection.ConnectionLifeTime;
+                    Queue.MinPoolSize = Connection.MinPoolSize;
+                    PooledConnectors[Connection.ConnectionString] = Queue;
                 }
+            }
 
-                // Now we can simply lock on the pool itself.
-                lock (Queue)
+            // Now we can simply lock on the pool itself.
+            lock (Queue)
+            {
+                if (Queue.Available.Count > 0)
                 {
-                    if (Queue.Available.Count > 0)
-                    {
-                        // Found a queue with connectors.  Grab the top one.
+                    // Found a queue with connectors.  Grab the top one.
 
-                        // Check if the connector is still valid.
+                    // Check if the connector is still valid.
 
-                        Connector = Queue.Available.Dequeue();
-                        Queue.Busy.Add(Connector, null);
-                    }
+                    Connector = Queue.Available.Dequeue();
+                    Queue.Busy.Add(Connector, null);
                 }
+            }
 
-            } while (Connector != null && !Connector.IsValid());
+            if (Connector != null) {
+                // Reset connector with init queries.
+                Connector.Reset();
 
-            if (Connector != null) return Connector;
+                return Connector;
+            }
 
             lock (Queue)
             {


### PR DESCRIPTION
Npgsql no longer checks if the connector is valid avoiding roundtrips to the server just to check that.
IsValid also run the initQueries used to reset the Connector state using user configurations. This reset
was moved to a Reset() method. Now NpgsqlConnectorPool resets the connector using this method
before returning it from the pool.