### PR TITLE
Only change ssl_renegotiation setting if the connection is on SSL.

### DIFF
--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -406,8 +406,9 @@ namespace Npgsql
             // Some connection parameters for protocol 3 had been sent in the startup packet.
             // The rest will be setted here.
 
-            // Set ssl_renegotiation_limit only on secured connections.
-            if (IsSecure) { sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;"); }
+            // Set ssl_renegotiation_limit only on secured connections and running under mono.
+            // See https://github.com/npgsql/npgsql/pull/453 for more info.
+            if (IsSecure && (Type.GetType("Mono.Runtime") != null)) { sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;"); }
 
             _initQueries = sbInitQueries.ToString();
 

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -405,7 +405,9 @@ namespace Npgsql
 
             // Some connection parameters for protocol 3 had been sent in the startup packet.
             // The rest will be setted here.
-            sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;");
+
+            // Set ssl_renegotiation_limit only on secured connections.
+            if (IsSecure) { sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;"); }
 
             _initQueries = sbInitQueries.ToString();
 
@@ -651,6 +653,7 @@ namespace Npgsql
                 _messagesToSend.Clear();
             }
         }
+
 
         /// <summary>
         /// Sends a single frontend message, used for simple messages such as rollback, etc.
@@ -1298,7 +1301,7 @@ namespace Npgsql
         {
             ExecuteBlind(PregeneratedMessage.DiscardAll);
 
-            // The initial connection parameters will be restored via IsValid() when get connector from pool later 
+            // The initial connection parameters will be restored via IsValid() when get connector from pool later
         }
 
         internal void ReleaseRegisteredListen()


### PR DESCRIPTION
Before that Npgsql was sending the ssl renegotiation statement regardless if
the connection was secured or not.