### PR TITLE
Change TypeMappingAttribute constructors to avoid an internal

### DIFF
--- a/Npgsql/TypeHandler.cs
+++ b/Npgsql/TypeHandler.cs
@@ -197,9 +197,15 @@ namespace Npgsql
         internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType, DbType[] dbTypes, Type[] types)
             : this(pgName, (NpgsqlDbType?)npgsqlDbType, dbTypes, types) {}
 
-        internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType, DbType[] dbTypes=null, Type type=null)
-            : this(pgName, npgsqlDbType, dbTypes, type == null ? null : new[] { type }) {}
-        
+        //internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType, DbType[] dbTypes=null, Type type=null)
+        //    : this(pgName, npgsqlDbType, dbTypes, type == null ? null : new[] { type }) {}
+
+        internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType)
+            : this(pgName, npgsqlDbType, new DbType[0], new Type[0]) { }
+
+        internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType, DbType[] dbTypes, Type type)
+            : this(pgName, npgsqlDbType, dbTypes, new[] {type}) { }
+
         internal TypeMappingAttribute(string pgName, NpgsqlDbType npgsqlDbType, DbType dbType, Type[] types)
             : this(pgName, npgsqlDbType, new[] { dbType }, types) {}
 


### PR DESCRIPTION
compiler error when using vs 2013.

vs2013 compiler throws an internal compiler error when using the
original constructor. Those two new constructors do the same thing
and don't make the compiler crash.