### PR TITLE
Add support for user-defined enum types

### DIFF
--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -324,7 +324,9 @@
     <Compile Include="NpgsqlTypes\NpgsqlRange.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTsQuery.cs" />
     <Compile Include="NpgsqlTypes\NpgsqlTsVector.cs" />
+    <Compile Include="NpgsqlTypes\NpgsqlUserTypes.cs" />
     <Compile Include="TypeHandlers\BitStringHandler.cs" />
+    <Compile Include="TypeHandlers\EnumHandler.cs" />
     <Compile Include="TypeHandlers\FullTextSearchHandlers\TsQueryHandler.cs" />
     <Compile Include="TypeHandlers\FullTextSearchHandlers\TsVectorHandler.cs" />
     <Compile Include="TypeHandlers\GeometricHandlers\BoxHandler.cs" />

--- a/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -37,9 +37,7 @@ namespace NpgsqlTypes
         // Binary or with other values. E.g. Array of Box is NpgsqlDbType.Array | NpgsqlDbType.Box
 
         Array = int.MinValue,
-        Enum = 0x40000000,
-        Range = 0x20000000,
-        Composite = 0x10000000,
+        Range = 0x40000000,
 
         Bigint = 1,
 
@@ -90,6 +88,9 @@ namespace NpgsqlTypes
 
         TsVector,
         TsQuery,
+
+        Enum,
+        Composite,
     }
 }
 

--- a/Npgsql/NpgsqlTypes/NpgsqlUserTypes.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlUserTypes.cs
@@ -1,0 +1,51 @@
+﻿using Npgsql;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Text;
+
+namespace NpgsqlTypes
+{
+    /// <summary>
+    /// Handles user types, such as enums and composite types.
+    /// </summary>
+    public static class NpgsqlUserTypes
+    {
+        /// <summary>
+        /// Registers an enum type by setting up a mapping between a .NET enum type and a PosgreSQL type.
+        /// TEnum must be a .NET enum type. The enum labels should have the same values in both the .NET enum and the database.
+        /// If another label is used in the database, this can be specified for each label with a EnumLabelAttribute.
+        /// This method must be called before connecting the first time to a PostgreSQL database in your application, preferably at application start.
+        /// </summary>
+        /// <typeparam name="TEnum">A System.Enum type.</typeparam>
+        /// <param name="typeName">The name of the enum type in the PostgreSQL database.</param>
+        public static void RegisterEnum<TEnum>(string typeName)
+        {
+            if (!typeof(TEnum).IsEnum)
+                throw new ArgumentException("The enumType is not an enum type", "enumType");
+            if (string.IsNullOrEmpty(typeName))
+                throw new ArgumentException("typeName cannot be empty", "typeName");
+            Contract.EndContractBlock();
+
+            TypeHandlerRegistry.AddEnumType(typeof(TEnum), typeName);
+        }
+    }
+
+    /// <summary>
+    /// Indicates that the PostgreSQL enum value differs from the .NET value.
+    /// </summary>
+    public class EnumLabelAttribute : Attribute
+    {
+        public string Label { get; private set; }
+
+        /// <summary>
+        /// Indicates that the PostgreSQL enum value differs from the .NET value.
+        /// </summary>
+        /// <param name="label">What label to use instead.</param>
+        public EnumLabelAttribute(string label)
+        {
+            Label = label;
+        }
+    }
+}

--- a/Npgsql/TypeHandlerRegistry.cs
+++ b/Npgsql/TypeHandlerRegistry.cs
@@ -24,6 +24,7 @@ namespace Npgsql
         readonly Dictionary<DbType, TypeHandler> _byDbType;
         readonly Dictionary<NpgsqlDbType, TypeHandler> _byNpgsqlDbType;
         readonly Dictionary<Type, TypeHandler> _byType;
+        readonly Dictionary<Type, TypeHandler> _byEnumTypeAsArray;
 
         readonly TypeHandler _unrecognizedTypeHandler;
 
@@ -34,6 +35,9 @@ namespace Npgsql
         static readonly Dictionary<Type, DbType> TypeToDbType;
         static readonly ConcurrentDictionary<string, TypeHandlerRegistry> RegistryCache = new ConcurrentDictionary<string, TypeHandlerRegistry>();
         static readonly ILog Log = LogManager.GetCurrentClassLogger();
+
+        static readonly Dictionary<Type, EnumInfo> EnumTypeToEnumInfo;
+        static readonly Dictionary<string, EnumInfo> EnumNameToEnumInfo;
 
         #endregion
 
@@ -62,6 +66,7 @@ namespace Npgsql
             _byDbType = new Dictionary<DbType, TypeHandler>();
             _byNpgsqlDbType = new Dictionary<NpgsqlDbType, TypeHandler>();
             _byType = new Dictionary<Type, TypeHandler>();
+            _byEnumTypeAsArray = new Dictionary<Type, TypeHandler>();
             _unrecognizedTypeHandler = new UnrecognizedTypeHandler { OID=0 };
 
             // Below we'll be sending in a query to load OIDs from the backend, but parsing those results will depend
@@ -115,6 +120,11 @@ namespace Npgsql
                 }
             }
 
+            foreach (var enumName in EnumNameToEnumInfo.Keys)
+            {
+                inList.AppendFormat("{0}'{1}'", ((inList.Length > 0) ? "," : ""), enumName);
+            }
+
             const string query = @"SELECT typname, pg_type.oid, typtype, typarray, typdelim, rngsubtype " +
                                  @"FROM pg_type LEFT OUTER JOIN pg_range ON (pg_type.oid = pg_range.rngtypid) " +
                                  @"WHERE typname in ({0}) OR typtype = 'r' ORDER BY typtype";
@@ -143,6 +153,9 @@ namespace Npgsql
                                 var rangeSubtypeOID = UInt32.Parse(dr.GetString(5));
                                 Contract.Assume(rangeSubtypeOID != 0);
                                 RegisterRangeType(name, oid, arrayOID, textDelimiter, rangeSubtypeOID);
+                                continue;
+                            case 'e':
+                                RegisterEnumType(name, oid, arrayOID);
                                 continue;
                             default:
                                 Log.Error("Unknown type of type encountered, skipping: " + typtype);
@@ -202,6 +215,21 @@ namespace Npgsql
             _byNpgsqlDbType.Add(NpgsqlDbType.Range | NpgsqlDbType.Array | elementHandler.NpgsqlDbType, handler);
         }
 
+        void RegisterEnumType(string name, uint oid, uint arrayOID)
+        {
+            var enumInfo = EnumNameToEnumInfo[name];
+            var enumHandlerType = typeof(EnumHandler<>).MakeGenericType(enumInfo.Type);
+            var handler = (TypeHandler)Activator.CreateInstance(enumHandlerType, enumInfo);
+            handler.OID = oid;
+            _oidIndex[oid] = handler;
+            _byType[enumInfo.Type] = handler;
+
+            var arrayHandler = CreateArrayHandler(handler, ',');
+            arrayHandler.OID = arrayOID;
+            _oidIndex[arrayOID] = arrayHandler;
+            _byEnumTypeAsArray[enumInfo.Type] = arrayHandler;
+        }
+
         static ArrayHandler CreateArrayHandler(TypeHandler elementHandler, char textDelimiter)
         {
             ArrayHandler arrayHandler;
@@ -227,6 +255,74 @@ namespace Npgsql
             return arrayHandler;
         }
 
+        internal static void AddEnumType(Type enumType, string typeName)
+        {
+            EnumInfo existingEnumType;
+            EnumInfo existingTypeName;
+            EnumTypeToEnumInfo.TryGetValue(enumType, out existingEnumType);
+            EnumNameToEnumInfo.TryGetValue(typeName, out existingTypeName);
+
+            if (existingEnumType != null && existingEnumType != existingTypeName)
+                throw new ArgumentException("Enum type already registered with another name");
+            if (existingTypeName != null && existingEnumType != existingTypeName)
+                throw new ArgumentException("Enum name is already registered with another enum type");
+
+            var enumToLabel = new Dictionary<Enum, string>();
+            var labelToEnum = new Dictionary<string, Enum>();
+            var fields = enumType.GetFields(BindingFlags.Static | BindingFlags.Public);
+            foreach (var field in fields)
+            {
+                var attribute = (EnumLabelAttribute)field.GetCustomAttributes(typeof(NpgsqlTypes.EnumLabelAttribute)).FirstOrDefault();
+                var enumName = attribute == null ? field.Name : attribute.Label;
+                var enumValue = (Enum)field.GetValue(null);
+                enumToLabel[enumValue] = enumName;
+                labelToEnum[enumName] = enumValue;
+            }
+
+            var enumInfo = new EnumInfo(enumType, typeName, enumToLabel, labelToEnum);
+            EnumTypeToEnumInfo[enumType] = enumInfo;
+            EnumNameToEnumInfo[typeName] = enumInfo;
+            TypeToNpgsqlDbType[enumType] = NpgsqlDbType.Enum;
+        }
+
+        internal class EnumInfo
+        {
+            public Type Type { get; private set; }
+            public string Name { get; private set; }
+            Dictionary<Enum, string> _enumToLabel;
+            Dictionary<string, Enum> _labelToEnum;
+
+            public EnumInfo(Type type, string name, Dictionary<Enum, string> enumToLabel, Dictionary<string, Enum> labelToEnum)
+            {
+                Type = type;
+                Name = name;
+                _enumToLabel = enumToLabel;
+                _labelToEnum = labelToEnum;
+            }
+
+            public string this[Enum enumValue]
+            {
+                get
+                {
+                    string value;
+                    if (!_enumToLabel.TryGetValue(enumValue, out value))
+                        return null;
+                    return value;
+                }
+            }
+
+            public Enum this[string stringValue]
+            {
+                get
+                {
+                    Enum value;
+                    if (!_labelToEnum.TryGetValue(stringValue, out value))
+                        return null;
+                    return value;
+                }
+            }
+        }
+
         #endregion
 
         #region Lookups
@@ -249,13 +345,27 @@ namespace Npgsql
             set { _oidIndex[oid] = value; }
         }
 
-        internal TypeHandler this[NpgsqlDbType npgsqlDbType]
+        internal TypeHandler this[NpgsqlDbType npgsqlDbType, Type enumType = null]
         {
             get
             {
                 TypeHandler handler;
                 var exists = _byNpgsqlDbType.TryGetValue(npgsqlDbType, out handler);
-                Contract.Assume(exists);
+                if (!exists && enumType != null && (npgsqlDbType & ~NpgsqlDbType.Array) == NpgsqlDbType.Enum)
+                {
+                    if ((npgsqlDbType & NpgsqlDbType.Array) == NpgsqlDbType.Array)
+                        exists = _byEnumTypeAsArray.TryGetValue(enumType, out handler);
+                    else
+                        exists = _byType.TryGetValue(enumType, out handler);
+                    if (!exists)
+                    {
+                        throw new NotSupportedException("This enum type is not supported. (Have you registered it in Npsql and set the EnumType property of NpgsqlParameter?)");
+                    }
+                }
+                if (!exists)
+                {
+                    throw new NotSupportedException("This NpgsqlDbType is not supported in Npgsql: " + npgsqlDbType);
+                }
                 return handler;
             }
         }
@@ -294,10 +404,11 @@ namespace Npgsql
         {
             get
             {
-                if (type.IsArray) {
-                    return type == typeof(byte[])
-                        ? this[NpgsqlDbType.Bytea]
-                        : this[NpgsqlDbType.Array | this[type.GetElementType()].NpgsqlDbType];
+                if (type.IsArray && type != typeof(byte[])) {
+                    var arrayHandler = this[NpgsqlDbType.Array | this[type.GetElementType()].NpgsqlDbType, type.GetElementType()];
+                    if (arrayHandler != null)
+                        return arrayHandler;
+                    // if not found fallthrough to the error message below
                 }
 
                 TypeHandler handler;
@@ -317,6 +428,9 @@ namespace Npgsql
         {
             if (type.IsArray) {
                 return NpgsqlDbType.Array | ToNpgsqlDbType(type.GetElementType());
+            }
+            if (type.IsEnum) {
+                return NpgsqlDbType.Enum;
             }
             return TypeToNpgsqlDbType[type];
         }
@@ -344,6 +458,9 @@ namespace Npgsql
             DbTypeToNpgsqlDbType = new Dictionary<DbType, NpgsqlDbType>();
             TypeToNpgsqlDbType = new Dictionary<Type, NpgsqlDbType>();
             TypeToDbType = new Dictionary<Type, DbType>();
+
+            EnumTypeToEnumInfo = new Dictionary<Type, EnumInfo>();
+            EnumNameToEnumInfo = new Dictionary<string, EnumInfo>();
 
             foreach (var t in Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsSubclassOf(typeof(TypeHandler))))
             {

--- a/Npgsql/TypeHandlers/EnumHandler.cs
+++ b/Npgsql/TypeHandlers/EnumHandler.cs
@@ -1,0 +1,43 @@
+﻿using Npgsql.Messages;
+using NpgsqlTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Npgsql.TypeHandlers
+{
+    internal class EnumHandler<TEnum> : TypeHandler<TEnum>, ISimpleTypeReader<TEnum>, ISimpleTypeWriter
+    {
+        TypeHandlerRegistry.EnumInfo EnumInfo { get; set; }
+
+        public EnumHandler(TypeHandlerRegistry.EnumInfo enumInfo)
+        {
+            NpgsqlDbType = NpgsqlDbType.Enum;
+            EnumInfo = enumInfo;
+        }
+
+        public TEnum Read(NpgsqlBuffer buf, FieldDescription fieldDescription, int len)
+        {
+            var str = buf.ReadStringSimple(len);
+            var enumValue = EnumInfo[str];
+            if (enumValue == null)
+                return default(TEnum); // TODO: Should we throw an exception?
+            return (TEnum)(object)enumValue;
+        }
+
+        public int GetLength(object value)
+        {
+            var str = EnumInfo[(Enum)value];
+            if (str == null)
+                throw new InvalidCastException("Invalid enum value (" + value + ") of type " + typeof(TEnum));
+            return Encoding.UTF8.GetByteCount(str);
+        }
+
+        public void Write(object value, NpgsqlBuffer buf)
+        {
+            var str = EnumInfo[(Enum)value];
+            buf.WriteStringSimple(str);
+        }
+    }
+}

--- a/tests/NpgsqlTests.csproj
+++ b/tests/NpgsqlTests.csproj
@@ -179,6 +179,7 @@
     </Compile>
     <Compile Include="NpgsqlBufferedStreamTests.cs" />
     <Compile Include="SecurityTests.cs" />
+    <Compile Include="Types\EnumTests.cs" />
     <Compile Include="Types\GeometricTypeTests.cs" />
     <Compile Include="Types\NetworkTypeTests.cs" />
     <Compile Include="Types\NumericTypeTests.cs" />

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -139,6 +139,7 @@ namespace NpgsqlTests
                 {
                     Conn = new NpgsqlConnection(ConnectionString);
                     Conn.Open();
+                    CreateTypes();
                     CreateSchema();
                     Console.WriteLine("Schema created successfully. Backend version is " + Conn.PostgreSqlVersion);
                 }
@@ -190,6 +191,12 @@ namespace NpgsqlTests
         {
             try { Conn.Close(); }
             finally { Conn = null; }
+        }
+
+        private void CreateTypes()
+        {
+            if (ExecuteScalar("SELECT 1 FROM pg_type WHERE typname = 'test_enum'") == null)
+                ExecuteNonQuery("CREATE TYPE test_enum AS ENUM ('label1', 'label2', 'label3')");
         }
 
         private void CreateSchema()

--- a/tests/Types/EnumTests.cs
+++ b/tests/Types/EnumTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace NpgsqlTests.Types
+{
+    class EnumTests : TestBase
+    {
+        public EnumTests(string backendVersion) : base(backendVersion) {}
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetup()
+        {
+            NpgsqlUserTypes.RegisterEnum<TestEnum>("test_enum");
+            base.TestFixtureSetup();
+        }
+
+        [Test]
+        public void TestEnumType()
+        {
+            using (var cmd = Conn.CreateCommand())
+            {
+                cmd.CommandText = "Select :p1, :p2, :p3, :p4, :p5";
+                
+                cmd.Parameters.AddWithValue("p1", TestEnum.label1);
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p2", NpgsqlDbType = NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = TestEnum.label2 });
+                cmd.Parameters.AddWithValue("p3", new[] { TestEnum.label1, TestEnum.Label3 });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p4", NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = new[] { TestEnum.label1, TestEnum.Label3 } });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p5", NpgsqlDbType = NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = DBNull.Value });
+
+                Assert.AreEqual(NpgsqlDbType.Enum, cmd.Parameters[0].NpgsqlDbType);
+                Assert.AreEqual(typeof(TestEnum), cmd.Parameters[0].EnumType);
+                Assert.AreEqual(NpgsqlDbType.Array | NpgsqlDbType.Enum, cmd.Parameters[2].NpgsqlDbType);
+                Assert.AreEqual(typeof(TestEnum), cmd.Parameters[2].EnumType);
+
+                using (var rdr = cmd.ExecuteReader())
+                {
+                    rdr.Read();
+                    Assert.AreEqual(typeof(TestEnum), rdr.GetValue(0).GetType());
+                    Assert.AreEqual(TestEnum.label1, rdr.GetValue(0));
+                    Assert.AreEqual(typeof(TestEnum), rdr.GetValue(1).GetType());
+                    Assert.AreEqual(TestEnum.label2, rdr.GetValue(1));
+                    Assert.AreEqual(typeof(TestEnum[]), rdr.GetValue(2).GetType());
+                    Assert.IsTrue(new[] { TestEnum.label1, TestEnum.Label3 }.SequenceEqual((TestEnum[])rdr.GetValue(2)));
+                    Assert.AreEqual(typeof(TestEnum[]), rdr.GetValue(3).GetType());
+                    Assert.IsTrue(new[] { TestEnum.label1, TestEnum.Label3 }.SequenceEqual((TestEnum[])rdr.GetValue(3)));
+                    Assert.AreEqual(typeof(TestEnum), rdr.GetFieldType(4));
+                }
+            }
+        }
+
+        enum TestEnum
+        {
+            label1,
+            label2,
+            [EnumLabel("label3")]
+            Label3
+        }
+    }
+}


### PR DESCRIPTION
This adds support for user-defined enum types.

If a user has created an enum like this in the database:

    CREATE TYPE test_enum AS ENUM ('label1', 'label2', 'label3')

and has defined a .NET type like this:

    enum TestEnum
    {
        label1,
        
        label2,
        
        [EnumLabel("label3")]
        Label3
    }

the user can register it for use in Npgsql like this:

    NpgsqlUserTypes.RegisterEnum<TestEnum>("test_enum");

Then it can be used in parameters in these different ways:

    cmd.CommandText = "Select :p1, :p2, :p3, :p4, :p5";
    
    cmd.Parameters.AddWithValue("p1", TestEnum.label1);
    cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p2", NpgsqlDbType = NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = TestEnum.label2 });
    cmd.Parameters.AddWithValue("p3", new[] { TestEnum.label1, TestEnum.Label3 });
    cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p4", NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = new[] { TestEnum.label1, TestEnum.Label3 } });
    cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p5", NpgsqlDbType = NpgsqlDbType.Enum, EnumType = typeof(TestEnum), Value = DBNull.Value });

A data reader's GetValue() will return the value converted to the enum type the user has registered.

Some questions:
* EnumLabelAttribute can be used to specify that the value is named differently in the datbase, for example to deal with case style. But now the name of the type is passed as an argument to RegisterEnum. Would it be better to have an attribute of the enum class instead, and if such an attribute is missing, the name of the enum type is used instead?
* Now RegisterEnum is a generic method. Would it be better to have the method take a Type parameter instead?
* RegisterEnum is not thread safe. Is that a problem?
* RegisterEnum must also be called before the Connector is created (before the type handler registry is set up). This is so the type handler registry can find the type OIDs to use. Another possibility would be to decrease the demands so it must be called before the Connection is created, but that would add complexity to the type handler registry if OIDs could be added after creation (must be added to each idle connector in the pool). What do you think here? It shouldn't be that hard for the users to add their mappings at launch of their applications, I think...