### PR TITLE
Suggest clearing  the callback delegates of NpgsqlConnector in a simple way.

### DIFF
--- a/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/NpgsqlConnection.cs
@@ -667,6 +667,12 @@ namespace Npgsql
             Connector.Notification -= NotificationDelegate;
             Connector.Notice -= NoticeDelegate;
 
+            Connector.ProvideClientCertificatesCallback -= ProvideClientCertificatesCallbackDelegate;
+            Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
+            Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
+            Connector.PrivateKeySelectionCallback -= PrivateKeySelectionCallbackDelegate;
+            Connector.ValidateRemoteCertificateCallback -= ValidateRemoteCertificateCallbackDelegate;
+
             /*if (SyncNotification)
             {
                 
@@ -678,11 +684,6 @@ namespace Npgsql
             }
             else
             {
-                Connector.ProvideClientCertificatesCallback -= ProvideClientCertificatesCallbackDelegate;
-                Connector.CertificateSelectionCallback -= CertificateSelectionCallbackDelegate;
-                Connector.CertificateValidationCallback -= CertificateValidationCallbackDelegate;
-                Connector.PrivateKeySelectionCallback -= PrivateKeySelectionCallbackDelegate;
-                Connector.ValidateRemoteCertificateCallback -= ValidateRemoteCertificateCallbackDelegate;
 
                 if (Connector.Transaction != null)
                 {

--- a/Npgsql/NpgsqlConnectorPool.cs
+++ b/Npgsql/NpgsqlConnectorPool.cs
@@ -400,12 +400,6 @@ namespace Npgsql
                 return; // Queue may be emptied by connection problems. See ClearPool below.
             }
 
-            Connector.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
-            Connector.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
-            Connector.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
-            Connector.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
-            Connector.ValidateRemoteCertificateCallback -= Connection.ValidateRemoteCertificateCallbackDelegate;
-
             /*bool inQueue = false;
 
             lock (queue)


### PR DESCRIPTION
I suggest that all the callback delegates of the NpgsqlConnector should be cleared explictly in the ReallyClose() method no matter if the connector is pooled and no matter if ungetting connector from the busy list , in condition that the connector is pooled,  is executed synchronously or asynchronously. 

Because the delegate ProvideClientCertificatesCallback and the other 4 callback delegates are cleared in two places currently
- One in the NpgsqlConnection.ReallyClose(), meaning the clear will be executed if the Connector is not pooled. 
- Another in the NpgsqlConnectorPool.UngetConnector(), meaning the clear will be executed if the Connector is pooled. 

I think there is no need to do this twice in the code. So I clear the callback delegate explictly in the ReallyClose() method to make the code simpler.

What do you think about it? 

Best regards