### PR TITLE
Add AmazonRedshift connectionstring parameter support.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -233,6 +233,7 @@ namespace Npgsql
             valueDescriptions.Add(Keywords.Compatible, new ValueDescription(THIS_VERSION));
             valueDescriptions.Add(Keywords.ApplicationName, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.AlwaysPrepare, new ValueDescription(typeof(bool)));
+            valueDescriptions.Add(Keywords.AmazonRedshift, new ValueDescription(typeof(bool)));
         }
 
         public NpgsqlConnectionStringBuilder()
@@ -865,6 +866,17 @@ namespace Npgsql
             set { SetValue(GetKeyName(Keywords.AlwaysPrepare), Keywords.AlwaysPrepare, value); }
         }
 
+        private bool _amazon_redshift;
+        /// <summary>
+        /// Gets or sets a value indicating whether to be compatible with AmazonRedshift.
+        /// Currently this means Npgsql won't use lc_monetary setting.
+        /// </summary>
+        public bool AmazonRedshift 
+        {
+            get { return _amazon_redshift; }
+            set { SetValue(GetKeyName(Keywords.AmazonRedshift), Keywords.AmazonRedshift, value); }
+        }
+
         #endregion
         #region DeprecatedProperties
 
@@ -962,6 +974,8 @@ namespace Npgsql
                     return Keywords.ApplicationName;
                 case "ALWAYSPREPARE":
                     return Keywords.AlwaysPrepare;
+                case "AMAZONREDSHIFT":
+                    return Keywords.AmazonRedshift;
                 default:
                     throw new ArgumentException(resman.GetString("Exception_WrongKeyVal"), key);
             }
@@ -1025,6 +1039,8 @@ namespace Npgsql
                     return "APPLICATIONNAME";
                 case Keywords.AlwaysPrepare:
                     return "ALWAYSPREPARE";
+                case Keywords.AmazonRedshift:
+                    return "AMAZONREDSHIFT";
                 default:
                     return keyword.ToString().ToUpperInvariant();
             }
@@ -1194,6 +1210,8 @@ namespace Npgsql
                         return this._application_name = Convert.ToString(value);
                     case Keywords.AlwaysPrepare:
                         return this._always_prepare = Convert.ToBoolean(value);
+                    case Keywords.AmazonRedshift:
+                        return this._amazon_redshift = Convert.ToBoolean(value);
                 }
             }
             catch (InvalidCastException exception)
@@ -1213,6 +1231,7 @@ namespace Npgsql
                     case Keywords.SSL:
                     case Keywords.Pooling:
                     case Keywords.SyncNotification:
+                    case Keywords.AmazonRedshift:
                         exception_template = resman.GetString("Exception_InvalidBooleanKeyVal");
                         break;
 #pragma warning disable 618
@@ -1298,6 +1317,8 @@ namespace Npgsql
                     return this._application_name;
                 case Keywords.AlwaysPrepare:
                     return this._always_prepare;
+                case Keywords.AmazonRedshift:
+                    return this._amazon_redshift;
                 default:
                     return null;
 
@@ -1391,6 +1412,7 @@ namespace Npgsql
         ApplicationName,
         AlwaysPrepare,
         IncludeRealm,
+        AmazonRedshift,
     }
 
     public enum SslMode

--- a/Npgsql/Npgsql/NpgsqlStartupPacket.cs
+++ b/Npgsql/Npgsql/NpgsqlStartupPacket.cs
@@ -57,7 +57,11 @@ namespace Npgsql
             parameters.Add("DateStyle", "ISO");
             parameters.Add("client_encoding", "UTF8");
             parameters.Add("extra_float_digits", "2");
-            parameters.Add("lc_monetary", "C");
+
+            if (!settings.AmazonRedshift)
+            {
+                parameters.Add("lc_monetary", "C");
+            }
 
             if (! string.IsNullOrEmpty(settings.ApplicationName))
             {

--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -498,5 +498,23 @@ namespace NpgsqlTests
             DataTable metaDataCollections = Conn.GetSchema(System.Data.Common.DbMetaDataCollectionNames.ReservedWords);
             Assert.IsTrue(metaDataCollections.Rows.Count > 0, "There should be one or more ReservedWords returned.");
         }
+
+        [Test]
+        public void AmazonRedshiftConnectionStringSupport()
+        {
+            NpgsqlConnectionStringBuilder sb = new NpgsqlConnectionStringBuilder(ConnectionString + ";AmazonRedshift=true");
+
+            Assert.IsTrue(sb.AmazonRedshift, "AmazonRedshift connection string parameter should be true");
+
+            var sb2 = sb.Clone();
+
+            Assert.IsTrue(sb2.AmazonRedshift);
+
+
+
+
+        }
+
+
     }
 }


### PR DESCRIPTION
When using Npgsql with Amazon Redshift, Npgsql tries to set lc_monetary
parameter which causes problems. With this patch, if user specifies
AmazonRedshift=true in the connection string, Npgsql won't try to set
this parameter.

Thanks @mateusaubin for initial work on this issue.

Fix #476