### PR TITLE
Add check for lc_monetary parameter support.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -138,6 +138,8 @@ namespace Npgsql
 
         private Boolean _supportsSslRenegotiationLimit = false;
 
+        private Boolean _supportsLcMonetary = false;
+
         private Boolean _isInitialized;
 
         private readonly Boolean _pooled;
@@ -706,6 +708,11 @@ namespace Npgsql
             get { return _supportsDiscard; }
         }
 
+        internal Boolean SupportsLcMonetary
+        {
+            get { return _supportsLcMonetary; }
+        }
+
         /// <summary>
         /// Options that control certain aspects of native to backend conversions that depend
         /// on backend version and status.
@@ -735,6 +742,7 @@ namespace Npgsql
                      (ServerVersion >= new Version(8, 1, 20) && ServerVersion < new Version(8, 2, 0)) ||
                      (ServerVersion >= new Version(8, 0, 24) && ServerVersion < new Version(8, 1, 0)) ||
                      (ServerVersion >= new Version(7, 4, 28) && ServerVersion < new Version(8, 0, 0)) );
+            this._supportsLcMonetary = (ServerVersion >= new Version(8, 1, 0));
 
             // Per the PG documentation, E string literal prefix support appeared in PG version 8.1.
             // Note that it is possible that support for this prefix will vanish in some future version
@@ -826,6 +834,11 @@ namespace Npgsql
             if (SupportsSslRenegotiationLimit)
             {
                 sbInitQueries.WriteLine("SET ssl_renegotiation_limit=0;");
+            }
+
+            if (SupportsLcMonetary)
+            {
+                sbInitQueries.WriteLine("SET lc_monetary='C';");
             }
 
             initQueries = sbInitQueries.ToString();

--- a/Npgsql/Npgsql/NpgsqlStartupPacket.cs
+++ b/Npgsql/Npgsql/NpgsqlStartupPacket.cs
@@ -57,7 +57,6 @@ namespace Npgsql
             parameters.Add("DateStyle", "ISO");
             parameters.Add("client_encoding", "UTF8");
             parameters.Add("extra_float_digits", "2");
-            parameters.Add("lc_monetary", "C");
 
             if (! string.IsNullOrEmpty(settings.ApplicationName))
             {


### PR DESCRIPTION
Only servers 8.1 and above will have the lc_monetary parameter set.
This will fix Amazon Redshift errors when connecting.

Fix #476