### PR TITLE
Add callbacks to NpgsqlConnectorPool functions

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/Npgsql/NpgsqlConnection.cs
@@ -1260,5 +1260,41 @@ namespace Npgsql
             }
         }
 #endif
+        public static void AddOnNewConnectorAction(Action<NpgsqlConnection> del)
+        {
+            NpgsqlConnectorPool.OnNewConnector = del;
+
+        }
+
+        public static void AddOnNewConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
+        {
+            NpgsqlConnectorPool.OnNewConnectorStackTrace = del;
+
+        }
+
+        public static void AddOnReleaseConnectorAction(Action<NpgsqlConnection> del)
+        {
+            NpgsqlConnectorPool.OnReleaseConnector = del;
+
+        }
+
+        public static void AddOnReleaseConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
+        {
+            NpgsqlConnectorPool.OnReleaseConnectorStackTrace = del;
+
+        }
+
+        public static void AddOnCloseConnectorAction(Action<NpgsqlConnection> del)
+        {
+            NpgsqlConnectorPool.OnCloseConnector = del;
+
+        }
+
+        public static void AddOnCloseConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
+        {
+            NpgsqlConnectorPool.OnCloseConnectorStackTrace = del;
+
+        }
+
     }
 }

--- a/Npgsql/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/Npgsql/NpgsqlConnection.cs
@@ -1260,40 +1260,49 @@ namespace Npgsql
             }
         }
 #endif
-        public static void AddOnNewConnectorAction(Action<NpgsqlConnection> del)
+
+
+        public static class Events
         {
-            NpgsqlConnectorPool.OnNewConnector = del;
 
-        }
 
-        public static void AddOnNewConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
-        {
-            NpgsqlConnectorPool.OnNewConnectorStackTrace = del;
+            public static Action<NpgsqlConnection> OnNewConnectorAction
+            {
+                set { NpgsqlConnectorPool.OnNewConnector = value; }
 
-        }
+            }
 
-        public static void AddOnReleaseConnectorAction(Action<NpgsqlConnection> del)
-        {
-            NpgsqlConnectorPool.OnReleaseConnector = del;
+            public static Action<NpgsqlConnection> OnReleaseConnectorAction
+            {
+                set { NpgsqlConnectorPool.OnReleaseConnector = value;}
 
-        }
+            }
 
-        public static void AddOnReleaseConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
-        {
-            NpgsqlConnectorPool.OnReleaseConnectorStackTrace = del;
+            public static Action<NpgsqlConnection> OnCloseConnectorAction
+            {
+                set { NpgsqlConnectorPool.OnCloseConnector = value;}
 
-        }
+            }
 
-        public static void AddOnCloseConnectorAction(Action<NpgsqlConnection> del)
-        {
-            NpgsqlConnectorPool.OnCloseConnector = del;
+            public static int GetAvailableConnectorsValue(NpgsqlConnection c)
+            {
+                return NpgsqlConnectorPool.ConnectorPoolMgr.GetAvailableConnectorsValue(c.ConnectionString);
+            }
 
-        }
+            public static int GetBusyConnectorsValue(NpgsqlConnection c)
+            {
+                return NpgsqlConnectorPool.ConnectorPoolMgr.GetBusyConnectorsValue(c.ConnectionString);
+            }
 
-        public static void AddOnCloseConnectorActionStackTrace(Action<System.Diagnostics.StackTrace> del)
-        {
-            NpgsqlConnectorPool.OnCloseConnectorStackTrace = del;
+            public static int GetAvailableConnectorsValue(String connectionString)
+            {
+                return NpgsqlConnectorPool.ConnectorPoolMgr.GetAvailableConnectorsValue(connectionString);
+            }
 
+            public static int GetBusyConnectorsValue(String connectionString)
+            {
+                return NpgsqlConnectorPool.ConnectorPoolMgr.GetBusyConnectorsValue(connectionString);
+            }
         }
 
     }

--- a/Npgsql/Npgsql/NpgsqlConnectorPool.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectorPool.cs
@@ -45,9 +45,33 @@ namespace Npgsql
         public static Action<NpgsqlConnection> OnReleaseConnector;
         public static Action<NpgsqlConnection> OnCloseConnector;
 
-        public static Action<System.Diagnostics.StackTrace> OnNewConnectorStackTrace;
-        public static Action<System.Diagnostics.StackTrace> OnReleaseConnectorStackTrace;
-        public static Action<System.Diagnostics.StackTrace> OnCloseConnectorStackTrace;
+        public int GetAvailableConnectorsValue(String connectionString)
+        {
+            ConnectorQueue queue = null;
+            lock (locker)
+            {
+
+                PooledConnectors.TryGetValue(connectionString, out queue);
+
+                return queue.Available.Count;
+            }
+
+        }
+
+
+        public int GetBusyConnectorsValue(String connectionString)
+        {
+            ConnectorQueue queue = null;
+            lock (locker)
+            {
+
+                PooledConnectors.TryGetValue(connectionString, out queue);
+
+                return queue.Busy.Count;
+            }
+
+        }
+
 
         /// <summary>
         /// A queue with an extra Int32 for keeping track of busy connections.
@@ -128,9 +152,6 @@ namespace Npgsql
                                             Connector.Close();
                                             if (OnCloseConnector!= null) {
                                                 OnCloseConnector(null);
-                                            }
-                                            if (OnCloseConnectorStackTrace!= null) {
-                                                OnCloseConnectorStackTrace(new System.Diagnostics.StackTrace(true));
                                             }
 
                                         }
@@ -385,9 +406,6 @@ namespace Npgsql
                     if (OnNewConnector != null) {
                         OnNewConnector(Connection);
                     }
-                    if (OnNewConnectorStackTrace != null) {
-                        OnNewConnectorStackTrace(new System.Diagnostics.StackTrace(true));
-                    }
 
                 }
             }
@@ -565,9 +583,6 @@ namespace Npgsql
                         OnReleaseConnector(Connection);
                     }
 
-                    if (OnReleaseConnectorStackTrace != null) {
-                        OnReleaseConnectorStackTrace(new System.Diagnostics.StackTrace(true));
-                    }
                 }
             else
                 lock (queue)


### PR DESCRIPTION
Those callsbacks are called when NpgsqlConnectorPool creates, releases and closes a NpgsqlConnector.

This will help users to diagnostic strange behaviors within NpgsqlConnectorPool.

Thanks @mythz for the idea and initial code.

Note: WIP Don't merge this pull request yet. 