### PR TITLE
Command no longer subscribes to connection's state event

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommand.PrepareExecute.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.PrepareExecute.cs
@@ -247,12 +247,12 @@ namespace Npgsql
 
                 m_Connector.SetBackendCommandTimeout(CommandTimeout);
 
-                if (prepared == PrepareStatus.NeedsPrepare)
+                if (PrepareStatus == PrepareStatus.NeedsPrepare)
                 {
                     PrepareInternal();
                 }
 
-                if (prepared == PrepareStatus.NotPrepared)
+                if (PrepareStatus == PrepareStatus.NotPrepared)
                 {
                     NpgsqlQuery query;
                     byte[] commandText = GetCommandText();
@@ -263,7 +263,7 @@ namespace Npgsql
                     m_Connector.Query(query);
 
                     // Tell to mediator what command is being sent.
-                    if (prepared == PrepareStatus.NotPrepared)
+                    if (PrepareStatus == PrepareStatus.NotPrepared)
                     {
                         m_Connector.Mediator.SetSqlSent(commandText, NpgsqlMediator.SQLSentType.Simple);
                     }
@@ -423,13 +423,13 @@ namespace Npgsql
 
         private void UnPrepare()
         {
-            if (prepared == PrepareStatus.Prepared)
+            if (PrepareStatus == PrepareStatus.Prepared)
             {
                 ExecuteBlind(m_Connector, "DEALLOCATE " + planName);
                 bind = null;
                 execute = null;
                 currentRowDescription = null;
-                prepared = PrepareStatus.NeedsPrepare;
+                PrepareStatus = PrepareStatus.NeedsPrepare;
             }
 
             preparedCommandText = null;
@@ -525,7 +525,7 @@ namespace Npgsql
             bind = new NpgsqlBind(portalName, planName, new Int16[Parameters.Count], null, resultFormatCodes);
             execute = new NpgsqlExecute(portalName, 0);
 
-            prepared = PrepareStatus.Prepared;
+            PrepareStatus = PrepareStatus.Prepared;
         }
     }
 }

--- a/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.Rewrite.cs
@@ -77,7 +77,7 @@ namespace Npgsql
         {
             NpgsqlEventLog.LogMethodEnter(LogLevel.Debug, CLASSNAME, "GetCommandText");
 
-            byte[] ret = string.IsNullOrEmpty(planName) ? GetCommandText(false) : GetExecuteCommandText();
+            byte[] ret = IsPrepared ? GetExecuteCommandText() : GetCommandText(false);
 
             return ret;
         }

--- a/Npgsql/Npgsql/NpgsqlCommand.cs
+++ b/Npgsql/Npgsql/NpgsqlCommand.cs
@@ -54,13 +54,6 @@ namespace Npgsql
 
     public sealed partial class NpgsqlCommand : DbCommand, ICloneable
     {
-        private enum PrepareStatus
-        {
-            NotPrepared,
-            NeedsPrepare,
-            Prepared
-        }
-
         // Logging related values
         private static readonly String CLASSNAME = MethodBase.GetCurrentMethod().DeclaringType.Name;
         private static readonly ResourceManager resman = new ResourceManager(MethodBase.GetCurrentMethod().DeclaringType);
@@ -76,7 +69,14 @@ namespace Npgsql
         private String planName;
         private Boolean designTimeVisible;
 
-        private PrepareStatus prepared = PrepareStatus.NotPrepared;
+        private PrepareStatus _prepareStatus = PrepareStatus.NotPrepared;
+        /// <summary>
+        /// For prepared commands, captures the connection's <see cref="NpgsqlConnection.OpenCounter"/>
+        /// at the time the command was prepared. This allows us to know whether the connection was
+        /// closed since the command was prepared.
+        /// </summary>
+        private int _prepareConnectionOpenId;
+
         private byte[] preparedCommandText = null;
         private NpgsqlBind bind = null;
         private NpgsqlExecute execute = null;
@@ -314,18 +314,12 @@ namespace Npgsql
                     throw new InvalidOperationException(resman.GetString("Exception_SetConnectionInTransaction"));
                 }
 
-                if (connection != null) {
-                    connection.StateChange -= OnConnectionStateChange;
-                }
                 this.connection = value;
-                if (connection != null) {
-                    connection.StateChange += OnConnectionStateChange;
-                }
                 Transaction = null;
                 if (this.connection != null)
                 {
                     m_Connector = this.connection.Connector;
-                    prepared = m_Connector != null && m_Connector.AlwaysPrepare ? PrepareStatus.NeedsPrepare : PrepareStatus.NotPrepared;
+                    PrepareStatus = m_Connector != null && m_Connector.AlwaysPrepare ? PrepareStatus.NeedsPrepare : PrepareStatus.NotPrepared;
                 }
 
                 SetCommandTimeout();
@@ -344,32 +338,6 @@ namespace Npgsql
                 }
 
                 return m_Connector;
-            }
-        }
-
-        void OnConnectionStateChange(object sender, StateChangeEventArgs stateChangeEventArgs)
-        {
-            switch (stateChangeEventArgs.CurrentState)
-            {
-                case ConnectionState.Broken:
-                case ConnectionState.Closed:
-                    prepared = PrepareStatus.NotPrepared;
-                    break;
-                case ConnectionState.Open:
-                    switch (stateChangeEventArgs.OriginalState)
-                    {
-                        case ConnectionState.Closed:
-                        case ConnectionState.Broken:
-                            prepared = m_Connector != null && m_Connector.AlwaysPrepare ? PrepareStatus.NeedsPrepare : PrepareStatus.NotPrepared;
-                            break;
-                    }
-                    break;
-                case ConnectionState.Connecting:
-                case ConnectionState.Executing:
-                case ConnectionState.Fetching:
-                    return;
-                default:
-                    throw new ArgumentOutOfRangeException();
             }
         }
 
@@ -494,7 +462,7 @@ namespace Npgsql
         {
             get
             {
-                switch (prepared)
+                switch (PrepareStatus)
                 {
                     case PrepareStatus.NotPrepared:
                         return false;
@@ -503,6 +471,34 @@ namespace Npgsql
                         return true;
                     default:
                         throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        PrepareStatus PrepareStatus
+        {
+            get
+            {
+                switch (_prepareStatus)
+                {
+                    case PrepareStatus.NotPrepared:
+                    case PrepareStatus.NeedsPrepare:
+                        return _prepareStatus;
+
+                    case PrepareStatus.Prepared:
+                        if (connection == null || connection.Connector == null || _prepareConnectionOpenId != connection.OpenCounter) {
+                            _prepareStatus = PrepareStatus.NotPrepared;
+                        }
+                        return _prepareStatus;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            set
+            {
+                _prepareStatus = value;
+                if (_prepareStatus == PrepareStatus.Prepared) {
+                    _prepareConnectionOpenId = connection.OpenCounter;
                 }
             }
         }
@@ -604,7 +600,7 @@ namespace Npgsql
                 // We can implement a queue-based solution that will perform cleanup during the next possible
                 // window, but this isn't trivial (should not occur in transactions because of possible exceptions,
                 // etc.).
-                if (prepared == PrepareStatus.Prepared)
+                if (PrepareStatus == PrepareStatus.Prepared)
                     ExecuteBlind(m_Connector, "DEALLOCATE " + planName);
             }
             Transaction = null;
@@ -642,5 +638,12 @@ namespace Npgsql
             get { return designTimeVisible; }
             set { designTimeVisible = value; }
         }
+    }
+
+    enum PrepareStatus
+    {
+        NotPrepared,
+        NeedsPrepare,
+        Prepared
     }
 }

--- a/Npgsql/Npgsql/NpgsqlConnection.cs
+++ b/Npgsql/Npgsql/NpgsqlConnection.cs
@@ -138,6 +138,13 @@ namespace Npgsql
         private bool _postponingClose;
         private bool _postponingDispose;
 
+        /// <summary>
+        /// A counter that gets incremented every time the connection is (re-)opened.
+        /// This allows us to identify an "instance" of connection, which is useful since
+        /// some resources are released when a connection is closed (e.g. prepared statements).
+        /// </summary>
+        internal int OpenCounter { get; private set; }
+
         // Strong-typed ConnectionString values
         private NpgsqlConnectionStringBuilder settings;
 
@@ -664,8 +671,8 @@ namespace Npgsql
                 Promotable.Enlist(Transaction.Current);
             }
 
+            OpenCounter++;
             this.OnStateChange (new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open));
-
         }
 
         /// <summary>

--- a/tests/CommandTests.cs
+++ b/tests/CommandTests.cs
@@ -4244,6 +4244,7 @@ namespace NpgsqlTests
                     c.Close();
                     c.Open();
                     Assert.That(cmd.IsPrepared, Is.False);
+                    Assert.That(cmd.ExecuteScalar(), Is.EqualTo(1)); // Execute unprepared
                     cmd.Prepare();
                     Assert.That(cmd.ExecuteScalar(), Is.EqualTo(1));
                 }


### PR DESCRIPTION
NpgsqlCommand was listening to its connection's StateChange event so as to know when the latter was closed, in order to clear its prepared status. However, it seems that Entity Framework does not dispose of commands, which led to a leak (since commands never get unsubscribed from their connections).

Rewrote the mechanism without events: connection knows when it was last closed, command knows when it was prepared, check the times

Fixes #505