### PR TITLE
Leak removal: Set BaseStream to null when closing connections.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlReadyState.cs
+++ b/Npgsql/Npgsql/NpgsqlReadyState.cs
@@ -109,6 +109,7 @@ namespace Npgsql
             }
 
             context.Stream = null;
+            context.BaseStream = null;
             ChangeState(context, NpgsqlClosedState.Instance);
         }
     }

--- a/Npgsql/Npgsql/NpgsqlState.cs
+++ b/Npgsql/Npgsql/NpgsqlState.cs
@@ -243,6 +243,7 @@ namespace Npgsql
             {
             }
             context.Stream = null;
+            context.BaseStream = null;
             ChangeState(context, NpgsqlClosedState.Instance);
         }
 


### PR DESCRIPTION
Issue #505 identified several cases of resource starvation. This commit fixes leaking NpgsqlBaseStream instances.