### PR TITLE
Add a bug reproduce test case for issues #252

### DIFF
--- a/tests/ConnectionTests.cs
+++ b/tests/ConnectionTests.cs
@@ -572,5 +572,41 @@ namespace NpgsqlTests
                 conn.Open();
             }
         }
+
+        [Test]
+        //A bug reproduce test case for https://github.com/npgsql/Npgsql/issues/252
+        public void Bug252_BufferedStream()
+        {
+            var receivedNotification = false;
+            var Cmd = Conn.CreateCommand();
+            Cmd.CommandText = "listen notifytest1";
+            Cmd.ExecuteNonQuery();
+            Conn.Notification += (o, e) => receivedNotification = true;
+
+            Cmd.CommandText = "select generate_series(1,10000)";
+            var reader = Cmd.ExecuteReader();
+
+            //After "notify notifytest1", a notification message will be sent to client, 
+            //And so the notification message will stick with the last response message of "select generate_series(1,10000)" in Npgsql's tcp receiving buffer.
+            using (var connection = new NpgsqlConnection(ConnectionString))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "notify notifytest1";
+                    command.ExecuteNonQuery();
+                }
+            }
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(1, reader.GetValue(0));
+            reader.Close();
+
+            Cmd.CommandText = "select 1";
+            Assert.AreEqual(1, Cmd.ExecuteScalar());//A System.NotSupportedException from BufferedStream will occurs here!
+
+            Assert.IsTrue(receivedNotification);
+
+        }
     }
 }


### PR DESCRIPTION
This is a bug reproduce test case for issues #252 , the reason of this bug is BufferedStream. Although the current master source has switch BufferedStream to NpgsqlBuffer,but the NpgsqlBuffer seems to be have similar probleam.

NpgsqlTests.ConnectionTests("9.4").Bug252_BufferedStream:
System.InvalidOperationException : Connection property has not been initialized.

at Npgsql.NpgsqlCommand.Prechecks() in d:\github\Npgsql2\Npgsql\NpgsqlCommand.cs:line 1644
at Npgsql.NpgsqlCommand.Execute(CommandBehavior behavior) in d:\github\Npgsql2\Npgsql\NpgsqlCommand.cs:line 1174
at Npgsql.NpgsqlCommand.ExecuteScalarInternal() in d:\github\Npgsql2\Npgsql\NpgsqlCommand.cs:line 1366
at Npgsql.NpgsqlCommand.ExecuteScalar() in d:\github\Npgsql2\Npgsql\NpgsqlCommand.cs:line 1324
at NpgsqlTests.ConnectionTests.Bug252_BufferedStream() in d:\github\Npgsql2\tests\ConnectionTests.cs:line 607