### PR TITLE
Initial EF support for NativeToBackendTypeConverterOptions usage 

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlMigrationSqlGenerator.cs
+++ b/Npgsql.EntityFramework/NpgsqlMigrationSqlGenerator.cs
@@ -158,7 +158,7 @@ namespace Npgsql
         {
             foreach (var command in historyOperation.CommandTrees)
             {
-                AddStatment(NpgsqlServices.Instance.CreateDbCommand(command).CommandText);
+                AddStatment(NpgsqlServices.Instance.CreateDbCommand(command, null).CommandText);
             }
         }
 

--- a/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
+++ b/Npgsql.EntityFramework/NpgsqlProviderManifest.cs
@@ -10,15 +10,26 @@ using System.Data.Metadata.Edm;
 #endif
 using System.Xml;
 using System.Data;
+using NpgsqlTypes;
 
 namespace Npgsql
 {
     internal class NpgsqlProviderManifest : DbXmlEnabledProviderManifest
     {
+
+        static NativeToBackendTypeConverterOptions _redshiftConverterOptions = new NativeToBackendTypeConverterOptions(false, false, false, null);
+
         public NpgsqlProviderManifest(string serverVersion)
             : base(CreateXmlReaderForResource("Npgsql.NpgsqlProviderManifest.Manifest.xml"))
         {
+
+            if (serverVersion == "8.0.2")
+                ConverterOptions = _redshiftConverterOptions;
+            else
+                ConverterOptions = NativeToBackendTypeConverterOptions.Default;
         }
+
+        public NativeToBackendTypeConverterOptions ConverterOptions { get; private set; }
 
         protected override XmlReader GetDbInformation(string informationType)
         {

--- a/Npgsql.EntityFramework/NpgsqlServices.cs
+++ b/Npgsql.EntityFramework/NpgsqlServices.cs
@@ -13,6 +13,7 @@ using System.Data.Common.CommandTrees;
 using System.Data.Metadata.Edm;
 #endif
 using Npgsql.SqlGenerators;
+using NpgsqlTypes;
 
 namespace Npgsql
 {
@@ -39,10 +40,10 @@ namespace Npgsql
 
         protected override DbCommandDefinition CreateDbCommandDefinition(DbProviderManifest providerManifest, DbCommandTree commandTree)
         {
-            return CreateCommandDefinition(CreateDbCommand(commandTree));
+            return CreateCommandDefinition(CreateDbCommand(commandTree, ((NpgsqlProviderManifest)providerManifest).ConverterOptions));
         }
 
-        internal DbCommand CreateDbCommand(DbCommandTree commandTree)
+        internal DbCommand CreateDbCommand(DbCommandTree commandTree, NativeToBackendTypeConverterOptions options)
         {
             if (commandTree == null)
                 throw new ArgumentNullException("commandTree");
@@ -56,12 +57,12 @@ namespace Npgsql
                 command.Parameters.Add(dbParameter);
             }
 
-            TranslateCommandTree(commandTree, command);
+            TranslateCommandTree(commandTree, command, options);
 
             return command;
         }
 
-        private void TranslateCommandTree(DbCommandTree commandTree, DbCommand command)
+        private void TranslateCommandTree(DbCommandTree commandTree, DbCommand command, NativeToBackendTypeConverterOptions options)
         {
             SqlBaseGenerator sqlGenerator = null;
 
@@ -71,19 +72,19 @@ namespace Npgsql
             DbDeleteCommandTree delete;
             if ((select = commandTree as DbQueryCommandTree) != null)
             {
-                sqlGenerator = new SqlSelectGenerator(select);
+                sqlGenerator = new SqlSelectGenerator(select, options);
             }
             else if ((insert = commandTree as DbInsertCommandTree) != null)
             {
-                sqlGenerator = new SqlInsertGenerator(insert);
+                sqlGenerator = new SqlInsertGenerator(insert, options);
             }
             else if ((update = commandTree as DbUpdateCommandTree) != null)
             {
-                sqlGenerator = new SqlUpdateGenerator(update);
+                sqlGenerator = new SqlUpdateGenerator(update, options);
             }
             else if ((delete = commandTree as DbDeleteCommandTree) != null)
             {
-                sqlGenerator = new SqlDeleteGenerator(delete);
+                sqlGenerator = new SqlDeleteGenerator(delete, options);
             }
             else
             {

--- a/Npgsql.EntityFramework/SqlGenerators/SqlBaseGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlBaseGenerator.cs
@@ -9,6 +9,7 @@ using System.Data.Common.CommandTrees;
 using System.Data.Metadata.Edm;
 #endif
 using System.Linq;
+using NpgsqlTypes;
 
 namespace Npgsql.SqlGenerators
 {
@@ -18,6 +19,7 @@ namespace Npgsql.SqlGenerators
         protected Dictionary<string, PendingProjectsNode> _refToNode = new Dictionary<string, PendingProjectsNode>();
         protected HashSet<InputExpression> _currentExpressions = new HashSet<InputExpression>();
         protected uint _aliasCounter = 0;
+        NativeToBackendTypeConverterOptions _options;
 
         private static Dictionary<string, string> AggregateFunctionNames = new Dictionary<string, string>()
         {
@@ -33,8 +35,14 @@ namespace Npgsql.SqlGenerators
             {"VarP","var_pop"},
         };
 
+        protected SqlBaseGenerator(NativeToBackendTypeConverterOptions options)
+        {
+            _options = options;
+        }
+        
         protected SqlBaseGenerator()
         {
+            
         }
 
         private void EnterExpression(PendingProjectsNode n)
@@ -740,7 +748,7 @@ namespace Npgsql.SqlGenerators
             // may require some formatting depending on the type
             //throw new NotImplementedException();
             // TODO: this is just for testing
-            return new ConstantExpression(expression.Value, expression.ResultType);
+            return new ConstantExpression(expression.Value, expression.ResultType, _options);
         }
 
         public override VisitedExpression Visit(DbComparisonExpression expression)

--- a/Npgsql.EntityFramework/SqlGenerators/SqlDeleteGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlDeleteGenerator.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Data.Common;
 #if ENTITIES6
 using System.Data.Entity.Core.Common.CommandTrees;
+using NpgsqlTypes;
 #else
 using System.Data.Common.CommandTrees;
+using NpgsqlTypes;
 #endif
 
 namespace Npgsql.SqlGenerators
@@ -14,7 +16,8 @@ namespace Npgsql.SqlGenerators
         private DbDeleteCommandTree _commandTree;
         private string _tableName;
 
-        public SqlDeleteGenerator(DbDeleteCommandTree commandTree)
+        public SqlDeleteGenerator(DbDeleteCommandTree commandTree, NativeToBackendTypeConverterOptions options)
+            :base ( options )
         {
             _commandTree = commandTree;
         }

--- a/Npgsql.EntityFramework/SqlGenerators/SqlInsertGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlInsertGenerator.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Data.Common;
 #if ENTITIES6
 using System.Data.Entity.Core.Common.CommandTrees;
+using NpgsqlTypes;
 #else
 using System.Data.Common.CommandTrees;
+using NpgsqlTypes;
 #endif
 
 namespace Npgsql.SqlGenerators
@@ -14,7 +16,8 @@ namespace Npgsql.SqlGenerators
         private DbInsertCommandTree _commandTree;
         private string _tableName;
 
-        public SqlInsertGenerator(DbInsertCommandTree commandTree)
+        public SqlInsertGenerator(DbInsertCommandTree commandTree, NativeToBackendTypeConverterOptions options)
+            :base ( options )
         {
             _commandTree = commandTree;
         }

--- a/Npgsql.EntityFramework/SqlGenerators/SqlSelectGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlSelectGenerator.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Data.Common;
 #if ENTITIES6
 using System.Data.Entity.Core.Common.CommandTrees;
+using NpgsqlTypes;
 #else
 using System.Data.Common.CommandTrees;
+using NpgsqlTypes;
 #endif
 
 namespace Npgsql.SqlGenerators
@@ -12,10 +14,13 @@ namespace Npgsql.SqlGenerators
     internal class SqlSelectGenerator : SqlBaseGenerator
     {
         private DbQueryCommandTree _commandTree;
+        
 
-        public SqlSelectGenerator(DbQueryCommandTree commandTree)
+        public SqlSelectGenerator(DbQueryCommandTree commandTree, NativeToBackendTypeConverterOptions options)
+            :base (options)
         {
             _commandTree = commandTree;
+            
         }
 
         protected SqlSelectGenerator()

--- a/Npgsql.EntityFramework/SqlGenerators/SqlUpdateGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlUpdateGenerator.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Data.Common;
 #if ENTITIES6
 using System.Data.Entity.Core.Common.CommandTrees;
+using NpgsqlTypes;
 #else
 using System.Data.Common.CommandTrees;
+using NpgsqlTypes;
 #endif
 
 namespace Npgsql.SqlGenerators
@@ -14,7 +16,8 @@ namespace Npgsql.SqlGenerators
         private DbUpdateCommandTree _commandTree;
         private string _tableName;
 
-        public SqlUpdateGenerator(DbUpdateCommandTree commandTree)
+        public SqlUpdateGenerator(DbUpdateCommandTree commandTree, NativeToBackendTypeConverterOptions options)
+            :base ( options )
         {
             _commandTree = commandTree;
         }

--- a/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
@@ -98,8 +98,9 @@ namespace Npgsql.SqlGenerators
     {
         private PrimitiveTypeKind _primitiveType;
         private object _value;
-
-        public ConstantExpression(object value, TypeUsage edmType)
+        NativeToBackendTypeConverterOptions _options;
+        
+        public ConstantExpression(object value, TypeUsage edmType, NativeToBackendTypeConverterOptions options)
         {
             if (edmType == null)
                 throw new ArgumentNullException("edmType");
@@ -107,6 +108,8 @@ namespace Npgsql.SqlGenerators
                 throw new ArgumentException("Require primitive EdmType", "edmType");
             _primitiveType = ((PrimitiveType)edmType.EdmType).PrimitiveTypeKind;
             _value = value;
+            _options = options;
+
         }
 
         internal override void WriteSql(StringBuilder sqlText)
@@ -222,7 +225,7 @@ namespace Npgsql.SqlGenerators
                     // Check https://github.com/franciscojunior/Npgsql2/pull/10 for more info.
                     // NativeToBackendTypeConverterOptions.Default should provide the correct
                     // formatting rules for any backend >= 8.0.
-                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false)));
+                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false, _options)));
                     break;
                 case PrimitiveTypeKind.Time:
                     sqlText.AppendFormat(ni, "INTERVAL '{0}'", (NpgsqlInterval)(TimeSpan)_value);

--- a/tests/EntityFrameworkBasicTests.cs
+++ b/tests/EntityFrameworkBasicTests.cs
@@ -209,6 +209,7 @@ namespace NpgsqlTests
 			DateTime createdOnDate = new DateTime(2014, 05, 08);
 			using (var context = new BloggingContext(ConnectionStringEF))
 			{
+                context.Database.Log = Console.Out.WriteLine;
 				var blog = new Blog()
 				{
 					Name = "Special Characters Test"


### PR DESCRIPTION
This fix sending string parameters without E'' when running on redshift server.