### PR TITLE
Add support for NativeToBackendTypeConverterOptions to EF code.

### DIFF
--- a/Npgsql.EntityFramework/NpgsqlServices.cs
+++ b/Npgsql.EntityFramework/NpgsqlServices.cs
@@ -13,6 +13,7 @@ using System.Data.Common.CommandTrees;
 using System.Data.Metadata.Edm;
 #endif
 using Npgsql.SqlGenerators;
+using NpgsqlTypes;
 
 namespace Npgsql
 {
@@ -23,6 +24,8 @@ namespace Npgsql
 #endif
     {
         private static readonly NpgsqlServices _instance = new NpgsqlServices();
+
+        NativeToBackendTypeConverterOptions _convertOptions;
 
 #if ENTITIES6
         public NpgsqlServices()
@@ -91,6 +94,8 @@ namespace Npgsql
                 throw new ArgumentException();
             }
 
+            sqlGenerator.ConverterOptions = _convertOptions;
+
             sqlGenerator.BuildCommand(command);
         }
 
@@ -102,6 +107,7 @@ namespace Npgsql
             UsingPostgresDBConnection((NpgsqlConnection)connection, conn =>
             {
                 serverVersion = conn.ServerVersion;
+                _convertOptions = conn.Connector.NativeToBackendTypeConverterOptions;
             });
             return serverVersion;
         }

--- a/Npgsql.EntityFramework/SqlGenerators/SqlBaseGenerator.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/SqlBaseGenerator.cs
@@ -9,6 +9,7 @@ using System.Data.Common.CommandTrees;
 using System.Data.Metadata.Edm;
 #endif
 using System.Linq;
+using NpgsqlTypes;
 
 namespace Npgsql.SqlGenerators
 {
@@ -36,6 +37,8 @@ namespace Npgsql.SqlGenerators
         protected SqlBaseGenerator()
         {
         }
+
+        public NativeToBackendTypeConverterOptions ConverterOptions { get; set; }
 
         private void EnterExpression(PendingProjectsNode n)
         {
@@ -740,7 +743,7 @@ namespace Npgsql.SqlGenerators
             // may require some formatting depending on the type
             //throw new NotImplementedException();
             // TODO: this is just for testing
-            return new ConstantExpression(expression.Value, expression.ResultType);
+            return new ConstantExpression(expression.Value, expression.ResultType, ConverterOptions);
         }
 
         public override VisitedExpression Visit(DbComparisonExpression expression)

--- a/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
+++ b/Npgsql.EntityFramework/SqlGenerators/VisitedExpression.cs
@@ -98,8 +98,9 @@ namespace Npgsql.SqlGenerators
     {
         private PrimitiveTypeKind _primitiveType;
         private object _value;
+        private NativeToBackendTypeConverterOptions _converterOptions;
 
-        public ConstantExpression(object value, TypeUsage edmType)
+        public ConstantExpression(object value, TypeUsage edmType, NativeToBackendTypeConverterOptions converterOptions)
         {
             if (edmType == null)
                 throw new ArgumentNullException("edmType");
@@ -107,6 +108,7 @@ namespace Npgsql.SqlGenerators
                 throw new ArgumentException("Require primitive EdmType", "edmType");
             _primitiveType = ((PrimitiveType)edmType.EdmType).PrimitiveTypeKind;
             _value = value;
+            _converterOptions = converterOptions;
         }
 
         internal override void WriteSql(StringBuilder sqlText)
@@ -222,7 +224,7 @@ namespace Npgsql.SqlGenerators
                     // Check https://github.com/franciscojunior/Npgsql2/pull/10 for more info.
                     // NativeToBackendTypeConverterOptions.Default should provide the correct
                     // formatting rules for any backend >= 8.0.
-                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false)));
+                    sqlText.Append(BackendEncoding.UTF8Encoding.GetString(typeInfo.ConvertToBackend(_value, false, _converterOptions)));
                     break;
                 case PrimitiveTypeKind.Time:
                     sqlText.AppendFormat(ni, "INTERVAL '{0}'", (NpgsqlInterval)(TimeSpan)_value);


### PR DESCRIPTION
Now, EF code will use the NativeToBackendTypeConverterOptions related to
the connection being used.

Fix #515