### PR TITLE
#372 Change connection pool to use a list like a stack.

### DIFF
--- a/Npgsql/NpgsqlConnectorPool.cs
+++ b/Npgsql/NpgsqlConnectorPool.cs
@@ -41,112 +41,107 @@ namespace Npgsql
     internal class NpgsqlConnectorPool
     {
         /// <summary>
+        /// Maintains information for the pool about a connector
+        /// </summary>
+        private class PooledConnector
+        {
+            public NpgsqlConnector Connector { get; private set; }
+            public DateTime ExpirationDateTime { get; set; }
+
+            public PooledConnector(NpgsqlConnector connector, DateTime expirationDateTime)
+            {
+                Connector = connector;
+                ExpirationDateTime = expirationDateTime;
+            }
+        }
+
+        /// <summary>
         /// A queue with an extra Int32 for keeping track of busy connections.
         /// </summary>
+        //[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "The parent class will clean up the timer.")]
         private class ConnectorQueue
         {
             /// <summary>
             /// Connections available to the end user
             /// </summary>
-            public Queue<NpgsqlConnector> Available = new Queue<NpgsqlConnector>();
+            public List<PooledConnector> Available = new List<PooledConnector>(20);
 
             /// <summary>
             /// Connections currently in use
             /// </summary>
-            public Dictionary<NpgsqlConnector, object> Busy = new Dictionary<NpgsqlConnector, object>();
+            public Dictionary<NpgsqlConnector, PooledConnector> Busy = new Dictionary<NpgsqlConnector, PooledConnector>();
 
-            public Int32 ConnectionLifeTime;
+            public Int32 ConnectionLifeTime { get; private set; }
             public Int32 InactiveTime = 0;
             public Int32 MinPoolSize;
+
+            public delegate void CleanupInactiveConnectorsHandler(ConnectorQueue queue);
+            public event CleanupInactiveConnectorsHandler CleanupInactiveConnectorsTick;
+
+            /// <value>Timer for tracking unused connections in pools.</value>
+            // I used System.Timers.Timer because of bad experience with System.Threading.Timer
+            // on Windows - it's going mad sometimes and don't respect interval was set.
+            private Timer Timer;
+            private object timerLock = new object();
+
+            public ConnectorQueue(Int32 connectionLifeTime)
+            {
+                ConnectionLifeTime = connectionLifeTime;
+
+                // If the connection life time of this connection is not set
+                // there is no need to periodically close connections.
+                if (connectionLifeTime > 0)
+                {
+                    Timer = new Timer(connectionLifeTime * 1000);
+                    Timer.AutoReset = false;
+                    Timer.Elapsed += new ElapsedEventHandler(TimerElapsedHandler);
+                    Timer.Start();
+                }
+            }
+
+            public void TimerElapsedHandler(object sender, ElapsedEventArgs e)
+            {
+                if (CleanupInactiveConnectorsTick != null)
+                {
+                    CleanupInactiveConnectorsTick(this);
+                }
+            }
+
+            public void StartTimer()
+            {
+                if (Timer != null)
+                {
+                    lock (timerLock)
+                    {
+                        Timer.Start();
+                    }
+                }
+            }
+
+            public void StopTimer()
+            {
+                if (Timer != null)
+                {
+                    lock (timerLock)
+                    {
+                        Timer.Stop();
+                    }
+                }
+            }
+
+            public void CleanUpTimer()
+            {
+                lock (timerLock)
+                {
+                    Timer.Dispose();
+                }
+            }
         }
 
-        /// <value>Unique static instance of the connector pool
-        /// mamager.</value>
+        /// <value>Unique static instance of the connector pool manager.</value>
         internal static NpgsqlConnectorPool ConnectorPoolMgr = new NpgsqlConnectorPool();
 
         private object locker = new object();
-
-        public NpgsqlConnectorPool()
-        {
-            PooledConnectors = new Dictionary<string, ConnectorQueue>();
-
-            Timer = new Timer(1000);
-            Timer.AutoReset = false;
-            Timer.Elapsed += new ElapsedEventHandler(TimerElapsedHandler);
-        }
-
-        private void StartTimer()
-        {
-            lock (locker)
-            {
-                Timer.Start();
-            }
-        }
-
-        private void TimerElapsedHandler(object sender, ElapsedEventArgs e)
-        {
-            NpgsqlConnector Connector;
-            var activeConnectionsExist = false;
-
-            lock (locker)
-            {
-                try
-                {
-                    foreach (ConnectorQueue Queue in PooledConnectors.Values)
-                    {
-                        lock (Queue)
-                        {
-                            if (Queue.Available.Count > 0)
-                            {
-                                if (Queue.Available.Count + Queue.Busy.Count > Queue.MinPoolSize)
-                                {
-                                    if (Queue.InactiveTime >= Queue.ConnectionLifeTime)
-                                    {
-                                        Int32 diff = Queue.Available.Count + Queue.Busy.Count - Queue.MinPoolSize;
-                                        Int32 toBeClosed = (diff + 1) / 2;
-                                        toBeClosed = Math.Min(toBeClosed, Queue.Available.Count);
-
-                                        if (diff < 2)
-                                        {
-                                            diff = 2;
-                                        }
-
-                                        Queue.InactiveTime -= Queue.ConnectionLifeTime / (int)(Math.Log(diff) / Math.Log(2));
-
-                                        for (Int32 i = 0; i < toBeClosed; ++i)
-                                        {
-                                            Connector = Queue.Available.Dequeue();
-                                            Connector.Close();
-                                        }
-                                    }
-                                    else
-                                    {
-                                        Queue.InactiveTime++;
-                                    }
-                                }
-                                else
-                                {
-                                    Queue.InactiveTime = 0;
-                                }
-                                if (Queue.Available.Count > 0 || Queue.Busy.Count > 0)
-                                    activeConnectionsExist = true;
-                            }
-                            else
-                            {
-                                Queue.InactiveTime = 0;
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    if (activeConnectionsExist)
-                        Timer.Start();
-                    else
-                        Timer.Stop();
-                }
-            }
-        }
 
         /// <value>Map of index to unused pooled connectors, avaliable to the
         /// next RequestConnector() call.</value>
@@ -154,10 +149,83 @@ namespace Npgsql
         /// This key will hold a list of queues of pooled connectors available to be used.</remarks>
         private readonly Dictionary<string, ConnectorQueue> PooledConnectors;
 
-        /// <value>Timer for tracking unused connections in pools.</value>
-        // I used System.Timers.Timer because of bad experience with System.Threading.Timer
-        // on Windows - it's going mad sometimes and don't respect interval was set.
-        private Timer Timer;
+        public NpgsqlConnectorPool()
+        {
+            PooledConnectors = new Dictionary<string, ConnectorQueue>();
+        }
+
+        private void TimerElapsedHandler(ConnectorQueue queue)
+        {
+            if (queue == null) return;
+
+            try
+            {
+                // Determine if we need to process this queue at all.  If not a lock can be skipped.
+                if (queue.Available.Count > 0 && queue.Available.Count + queue.Busy.Count > queue.MinPoolSize)
+                {
+                    lock (queue)
+                    {
+                        // Check again after getting the lock.
+                        if (queue.Available.Count > 0 && queue.Available.Count + queue.Busy.Count > queue.MinPoolSize)
+                        {
+                            // Determine the maximum number of connectors that could be closed.
+                            Int32 diff = queue.Available.Count + queue.Busy.Count - queue.MinPoolSize;
+
+                            // Only close at most half of the closable connectors per execution.
+                            Int32 toBeClosed = (diff + 1) / 2;
+                            toBeClosed = Math.Min(toBeClosed, queue.Available.Count);
+
+                            Int32 closedConnectors = 0;
+
+                            // Populate a new list of unexpired connectors.  By not using the RemoveAt method, which is O(Count - Index),
+                            // on the current available list multiple array walks are prevented.
+                            List<PooledConnector> newAvailableList = new List<PooledConnector>(queue.Available.Capacity);
+
+                            // Start from the beginning because that is where all the stale connectors should be.
+                            foreach (PooledConnector pooledConnector in queue.Available)
+                            {
+                                if (toBeClosed > closedConnectors && pooledConnector.ExpirationDateTime <= DateTime.Now)
+                                {
+                                    pooledConnector.Connector.Close();
+
+                                    // Keep track of how many have been closed so that
+                                    // too many aren't closed in one tick.
+                                    closedConnectors++;
+                                }
+                                else
+                                {
+                                    // The connection is ok so added it to the new list.
+                                    newAvailableList.Add(pooledConnector);
+                                }
+                            }
+
+                            // Only replace the current available list if it was modified.
+                            if (closedConnectors > 0)
+                            {
+                                // Remove all references to connectors in the list that is going to be derefernced
+                                // so that closed connectors can be garabage collected sooner.
+                                queue.Available.Clear();
+
+                                // Set the Available list to the new list that does not contain stale connectors.
+                                queue.Available = newAvailableList;
+                            }
+                            else
+                            {
+                                // Clear our temporary list to ensure there are no straggling references to connectors.
+                                newAvailableList.Clear();
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (queue.Available.Count > 0 || queue.Busy.Count > 0)
+                    queue.StartTimer();
+                else
+                    queue.StopTimer();
+            }
+        }
 
         /// <summary>
         /// Searches the pooled connector lists for a matching connector object or creates a new one.
@@ -202,8 +270,6 @@ namespace Npgsql
                     throw new Exception("Connection pool exceeds maximum size.");
                 }
             }
-
-            StartTimer();
 
             return Connector;
         }
@@ -280,29 +346,31 @@ namespace Npgsql
 
                 lock (locker)
                 {
-
                     // Try to find a queue.
                     if (!PooledConnectors.TryGetValue(Connection.ConnectionString, out Queue))
                     {
-
-                        Queue = new ConnectorQueue();
-                        Queue.ConnectionLifeTime = Connection.ConnectionLifeTime;
+                        Queue = new ConnectorQueue(Connection.ConnectionLifeTime);
                         Queue.MinPoolSize = Connection.MinPoolSize;
+                        Queue.CleanupInactiveConnectorsTick += TimerElapsedHandler;
                         PooledConnectors[Connection.ConnectionString] = Queue;
                     }
                 }
 
                 // Now we can simply lock on the pool itself.
-                lock (Queue)
+                if (Queue.Available.Count > 0)
                 {
-                    if (Queue.Available.Count > 0)
+                    lock (Queue)
                     {
-                        // Found a queue with connectors.  Grab the top one.
+                        if (Queue.Available.Count > 0)
+                        {
+                            // Found a queue with connectors.  Grab the top one.
 
-                        // Check if the connector is still valid.
-
-                        Connector = Queue.Available.Dequeue();
-                        Queue.Busy.Add(Connector, null);
+                            // Check if the connector is still valid.
+                            PooledConnector pooledConnector = Queue.Available[Queue.Available.Count - 1];
+                            Connector = pooledConnector.Connector;
+                            Queue.Available.RemoveAt(Queue.Available.Count - 1);
+                            Queue.Busy.Add(pooledConnector.Connector, pooledConnector);
+                        }
                     }
                 }
 
@@ -310,12 +378,16 @@ namespace Npgsql
 
             if (Connector != null) return Connector;
 
-            lock (Queue)
+
+            if (Queue.Available.Count + Queue.Busy.Count < Connection.MaxPoolSize)
             {
-                if (Queue.Available.Count + Queue.Busy.Count < Connection.MaxPoolSize)
+                lock (Queue)
                 {
-                    Connector = new NpgsqlConnector(Connection);
-                    Queue.Busy.Add(Connector, null);
+                    if (Queue.Available.Count + Queue.Busy.Count < Connection.MaxPoolSize)
+                    {
+                        Connector = new NpgsqlConnector(Connection);
+                        Queue.Busy.Add(Connector, new PooledConnector(Connector, DateTime.Now.AddSeconds(Queue.ConnectionLifeTime)));
+                    }
                 }
             }
 
@@ -347,29 +419,32 @@ namespace Npgsql
                 // Meet the MinPoolSize requirement if needed.
                 if (Connection.MinPoolSize > 1)
                 {
-
-                    lock (Queue)
+                    if (Queue.Available.Count + Queue.Busy.Count < Connection.MinPoolSize)
                     {
-
-                        while (Queue.Available.Count + Queue.Busy.Count < Connection.MinPoolSize)
+                        lock (Queue)
                         {
-                            NpgsqlConnector Spare = new NpgsqlConnector(Connection);
+                            while (Queue.Available.Count + Queue.Busy.Count < Connection.MinPoolSize)
+                            {
+                                NpgsqlConnector Spare = new NpgsqlConnector(Connection);
 
-                            Spare.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
-                            Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
-                            Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
-                            Spare.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
-                            Spare.ValidateRemoteCertificateCallback += Connection.ValidateRemoteCertificateCallbackDelegate;
+                                Spare.ProvideClientCertificatesCallback += Connection.ProvideClientCertificatesCallbackDelegate;
+                                Spare.CertificateSelectionCallback += Connection.CertificateSelectionCallbackDelegate;
+                                Spare.CertificateValidationCallback += Connection.CertificateValidationCallbackDelegate;
+                                Spare.PrivateKeySelectionCallback += Connection.PrivateKeySelectionCallbackDelegate;
+                                Spare.ValidateRemoteCertificateCallback += Connection.ValidateRemoteCertificateCallbackDelegate;
 
-                            Spare.Open();
+                                Spare.Open();
 
-                            Spare.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
-                            Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
-                            Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
-                            Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
-                            Spare.ValidateRemoteCertificateCallback -= Connection.ValidateRemoteCertificateCallbackDelegate;
+                                Spare.ProvideClientCertificatesCallback -= Connection.ProvideClientCertificatesCallbackDelegate;
+                                Spare.CertificateSelectionCallback -= Connection.CertificateSelectionCallbackDelegate;
+                                Spare.CertificateValidationCallback -= Connection.CertificateValidationCallbackDelegate;
+                                Spare.PrivateKeySelectionCallback -= Connection.PrivateKeySelectionCallbackDelegate;
+                                Spare.ValidateRemoteCertificateCallback -= Connection.ValidateRemoteCertificateCallbackDelegate;
 
-                            Queue.Available.Enqueue(Spare);
+                                Queue.Available.Add(new PooledConnector(Spare, DateTime.Now.AddSeconds(Connection.ConnectionLifeTime)));
+                            }
+
+                            Queue.StartTimer();
                         }
                     }
                 }
@@ -473,8 +548,18 @@ namespace Npgsql
             if (inQueue)
                 lock (queue)
                 {
-                    queue.Busy.Remove(Connector);
-                    queue.Available.Enqueue(Connector);
+                    PooledConnector pooledConnector = null;
+                    if (queue.Busy.TryGetValue(Connector, out pooledConnector))
+                    {
+                        queue.Busy.Remove(Connector);
+
+                        // Set the new expiration time of the connection and add it the front
+                        // of the available pool.
+                        pooledConnector.ExpirationDateTime = DateTime.Now.AddSeconds(queue.ConnectionLifeTime);
+                        queue.Available.Add(pooledConnector);
+
+                        queue.StartTimer();
+                    }
                 }
             else
                 lock (queue)
@@ -493,22 +578,26 @@ namespace Npgsql
 
             lock (Queue)
             {
+                //Clear the busy list first so that the current connections don't get re-added to the available list.
+                Queue.Busy.Clear();
+
                 while (Queue.Available.Count > 0)
                 {
-                    NpgsqlConnector connector = Queue.Available.Dequeue();
+                    // Process the list from the end to prevent it from being reshuffled after every remove call.
+                    NpgsqlConnector connector = Queue.Available[Queue.Available.Count - 1].Connector;
+                    Queue.Available.RemoveAt(Queue.Available.Count - 1);
 
                     try
                     {
                         connector.Close();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Maybe we should log something here to say we got an exception while closing connector?
+                        System.Diagnostics.Debug.WriteLine(ex);
                     }
                 }
 
-                //Clear the busy list so that the current connections don't get re-added to the queue
-                Queue.Busy.Clear();
+                Queue.CleanUpTimer();
             }
         }
 
@@ -523,6 +612,8 @@ namespace Npgsql
                 {
                     ClearQueue(queue);
 
+                    queue.CleanupInactiveConnectorsTick -= TimerElapsedHandler;
+
                     PooledConnectors.Remove(Connection.ConnectionString);
                 }
             }
@@ -536,8 +627,102 @@ namespace Npgsql
                 {
                     ClearQueue(Queue);
                 }
+
                 PooledConnectors.Clear();
             }
+        }
+
+        /// <summary>
+        /// Gets the number of unique pools (unique connection strings) currently in the pool.
+        /// </summary>
+        /// <returns></returns>
+        public static int ConnectionPoolCount
+        {
+            get { return ConnectorPoolMgr.PooledConnectors.Count; }
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently open in the pool identified by the <paramref name="connectionString"/>.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <returns>The number of connections currently open.</returns>
+        public static int TotalConnectionsInPool(string connectionString)
+        {
+            ConnectorQueue queue = null;
+            if (ConnectorPoolMgr.PooledConnectors.TryGetValue(connectionString, out queue))
+            {
+                return queue.Available.Count + queue.Busy.Count;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently open in the pool identified by the <paramref name="connection"/>.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns>The number of connections currently open.</returns>
+        public static int TotalConnectionsInPool(NpgsqlConnection connection)
+        {
+            return TotalConnectionsInPool(connection.ConnectionString);
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently idle in the pool identified by the <paramref name="connectionString"/>.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <returns>The number of connections currently idle.</returns>
+        public static int AvailableConnectionsInPool(string connectionString)
+        {
+            ConnectorQueue queue = null;
+            if (ConnectorPoolMgr.PooledConnectors.TryGetValue(connectionString, out queue))
+            {
+                return queue.Available.Count;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently idle in the pool identified by the <paramref name="connection"/>.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns>The number of connections currently idle.</returns>
+        public static int AvailableConnectionsInPool(NpgsqlConnection connection)
+        {
+            return AvailableConnectionsInPool(connection.ConnectionString);
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently executing a command in the pool identified by the <paramref name="connectionString"/>.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <returns>The number of connections currently executing a command.</returns>
+        public static int BusyConnectionsInPool(string connectionString)
+        {
+            ConnectorQueue queue = null;
+            if (ConnectorPoolMgr.PooledConnectors.TryGetValue(connectionString, out queue))
+            {
+                return queue.Busy.Count;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of connections currently executing a command in the pool identified by the <paramref name="connection"/>.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns>The number of connections currently executing a command.</returns>
+        public static int BusyConnectionsInPool(NpgsqlConnection connection)
+        {
+            return BusyConnectionsInPool(connection.ConnectionString);
         }
     }
 }

--- a/tests/Npgsql.Tests/SpeedTests.cs
+++ b/tests/Npgsql.Tests/SpeedTests.cs
@@ -137,7 +137,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         dataParameter.Value = "yo";
                         command.ExecuteScalar();
@@ -166,7 +166,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         command.Prepare();
 
@@ -186,7 +186,7 @@ namespace Npgsql.Tests
                 command.CommandText = "SELECT :data";
 
                 byte[] data = new byte[100000];
-                for (int i = 0  ; i < data.Length ; i++)
+                for (int i = 0; i < data.Length; i++)
                 {
                     data[i] = (byte)(i % 255);
                 }
@@ -201,7 +201,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         var data2 = (byte[])command.ExecuteScalar();
                         metrics.IncrementIterations();
@@ -218,7 +218,7 @@ namespace Npgsql.Tests
                 command.CommandType = CommandType.Text;
                 command.CommandText = "SELECT :data1, :data2, :data3, :data4, :data5, :data6, :data7, :data8, :data9, :data10";
 
-                for (int i = 0 ; i < 10 ; i++)
+                for (int i = 0; i < 10; i++)
                 {
                     NpgsqlParameter dataParameter = command.CreateParameter();
                     dataParameter.Direction = ParameterDirection.Input;
@@ -232,7 +232,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         using (IDataReader r = command.ExecuteReader())
                         {
@@ -255,7 +255,7 @@ namespace Npgsql.Tests
 
                 Int64[] data = new Int64[1000];
 
-                for (int i = 0 ; i < 1000 ; i++)
+                for (int i = 0; i < 1000; i++)
                 {
                     data[i] = (Int64)i + 0xFFFFFFFFFFFFFFF;
                 }
@@ -271,7 +271,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         command.ExecuteScalar();
                         metrics.IncrementIterations();
@@ -290,7 +290,7 @@ namespace Npgsql.Tests
 
                 string[] data = new string[1000];
 
-                for (int i = 0 ; i < 1000 ; i++)
+                for (int i = 0; i < 1000; i++)
                 {
                     data[i] = string.Format("A string with the number {0}, a ', a \", and a \\.", i);
                 }
@@ -306,7 +306,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         try
                         {
@@ -339,7 +339,7 @@ namespace Npgsql.Tests
                 command.CommandText = "SELECT :data";
 
                 byte[] bytes = new byte[50000];
-                for (int i = 0  ; i < bytes.Length ; i++)
+                for (int i = 0; i < bytes.Length; i++)
                 {
                     bytes[i] = (byte)(i % 255);
                 }
@@ -356,7 +356,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         try
                         {
@@ -390,7 +390,7 @@ namespace Npgsql.Tests
 
                 decimal[] data = new decimal[1000];
 
-                for (int i = 0 ; i < 1000 ; i++)
+                for (int i = 0; i < 1000; i++)
                 {
                     data[i] = i;
                 }
@@ -406,7 +406,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         command.ExecuteScalar();
                         metrics.IncrementIterations();
@@ -425,7 +425,7 @@ namespace Npgsql.Tests
 
                 decimal[] data = new decimal[1000];
 
-                for (int i = 0 ; i < 1000 ; i++)
+                for (int i = 0; i < 1000; i++)
                 {
                     data[i] = i;
                 }
@@ -441,7 +441,7 @@ namespace Npgsql.Tests
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         command.ExecuteScalar();
                         metrics.IncrementIterations();
@@ -471,6 +471,66 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test, Description("connect and disconnect with pool using many threads to request connections.")]
+        [TestCase(2), TestCase(4), TestCase(16), TestCase(32)]
+        public void ConnectWithPoolFromManyThreads(int threads)
+        {
+            NpgsqlConnectionStringBuilder csb = new NpgsqlConnectionStringBuilder(Conn.ConnectionString);
+            String conStr = csb.ConnectionString;
+            System.Threading.Thread[] workerThreads = new System.Threading.Thread[threads];
+
+            int createdThreads = 0;
+            while (createdThreads < threads)
+            {
+                var p = new System.Threading.ParameterizedThreadStart(OpenCloseConnection);
+                var t = new System.Threading.Thread(p);
+                workerThreads[createdThreads++] = t;
+            }
+            
+            using (var metrics = TestMetrics.Start(TestRunTime, true))
+            {
+                var param = new OpenCloseConnectionParams() { Metrics = metrics, ConnectionString = conStr };
+
+                foreach (System.Threading.Thread thread in workerThreads)
+                {
+                    thread.Start(param);
+                }
+
+                while (!metrics.TimesUp)
+                {
+                    System.Threading.Thread.Sleep(1000);
+                }            
+            }
+            
+            foreach (System.Threading.Thread thread in workerThreads)
+            {
+                if (thread.ThreadState == System.Threading.ThreadState.Running)
+                {
+                    thread.Abort();
+                    thread.Join();
+                }
+            }
+
+            // Output the maximum number of connections that were created in the pool during the test.  The larger
+            // the pool the more threads that could not find an available connection at the requested time.
+            Console.WriteLine("Total connections in pool: " + NpgsqlConnectorPool.TotalConnectionsInPool(conStr));
+        }
+
+        internal class OpenCloseConnectionParams { public TestMetrics Metrics; public string ConnectionString; }
+
+        private void OpenCloseConnection(object state) //String conStr, TestMetrics metrics)
+        {
+            OpenCloseConnectionParams param = (OpenCloseConnectionParams)state;
+
+            while (!param.Metrics.TimesUp)
+            {
+                var con = new NpgsqlConnection(param.ConnectionString);
+                con.Open();
+                con.Dispose();
+                param.Metrics.IncrementIterations();
+            }
+        }
+
         [Test, Description("Many parameter substitution test")]
         public void ParameterizedPrepareManyFields()
         {
@@ -484,14 +544,14 @@ namespace Npgsql.Tests
 
                 command.CommandText = sql.ToString();
 
-                for (int i = 0 ; i < 20 ; i++)
+                for (int i = 0; i < 20; i++)
                 {
                     command.Parameters.AddWithValue(string.Format("p{0:00}", i + 1), NpgsqlDbType.Text, string.Format("String parameter value {0}", i + 1));
                 }
 
                 using (var metrics = TestMetrics.Start(TestRunTime, true))
                 {
-                    while (! metrics.TimesUp)
+                    while (!metrics.TimesUp)
                     {
                         command.Prepare();
                         metrics.IncrementIterations();
@@ -501,13 +561,13 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        [TestCase(1,    true)]
-        [TestCase(10,   true)]
-        [TestCase(100,  true)]
+        [TestCase(1, true)]
+        [TestCase(10, true)]
+        [TestCase(100, true)]
         [TestCase(1000, true)]
-        [TestCase(1,    false)]
-        [TestCase(10,   false)]
-        [TestCase(100,  false)]
+        [TestCase(1, false)]
+        [TestCase(10, false)]
+        [TestCase(100, false)]
         [TestCase(1000, false)]
         private void PerformanceWithNParameters(int n, bool differentCase)
         {

--- a/tests/Npgsql.Tests/TestMetrics.cs
+++ b/tests/Npgsql.Tests/TestMetrics.cs
@@ -13,10 +13,17 @@ namespace Npgsql.Tests
         private static Process process = Process.GetCurrentProcess();
 
         private bool running;
+
+        int _iterations;
         /// <summary>
         /// The number of iterations accumulated.
         /// </summary>
-        public int Iterations { get; private set; }
+        public int Iterations
+        {
+            get { return _iterations; }
+            private set { _iterations = value; }
+        }
+
         private TimeSpan systemCPUTime;
         private TimeSpan userCPUTime;
         private Stopwatch stopwatch;
@@ -52,7 +59,8 @@ namespace Npgsql.Tests
         /// </summary>
         public void IncrementIterations()
         {
-            Iterations++;
+            // Thread safe incrementing.
+            System.Threading.Interlocked.Increment(ref _iterations);
         }
 
         /// <summary>
@@ -60,7 +68,7 @@ namespace Npgsql.Tests
         /// </summary>
         public void Stop()
         {
-            if (! running)
+            if (!running)
             {
                 return;
             }


### PR DESCRIPTION
Allows support for proper pruning of connections beyond their lifetime. It acts like a stack when getting and adding to the available pool by only adding (pushing) and removing (popping) from the end of the list, but gives the flexibility of iterating to find connections beyond their lifetime. My tests show that this performs just as well as the queue approach currently in use since contiguous arrays are used. All operations except pruning are O(1). I have enhanced and added pool tests to verify the function and performance of the pool.

This also changes the behavior of the order in which connections are reused. Today the pool cycles through all connections in the pool in a round robin fashion which means it would be hard for any connections to ever be removed from the pool when the ConnectionLifetime is specified in the connection string. With this implementation the most recently used connection is reused first leaving unused connections at the front of the list.

This also changes the clean-up interval. Each pool uses it's own timer that is based on its connection string's ConnectionLifetime parameter. If the value is less than equal to zero the timer is disabled. Otherwise the time is setup to tick based on the value no matter what activity has occurred in the pool. The method called by the timer first checks if there are any connections in the pool and secondly checks for any available connections. If no connections are in the pool or no connections are available it is impossible for there to be any stale connections so processing is skipped.
When there are potentially connections to be cleaned up a new list is created to receive all the connections are not stale and all stale connections are simply not added to this list. The current available list is then overwritten with the new list. This prevents an shuffling of the list internally by removing stale connections at the beginning or middle of the list.