### PR TITLE
Re-introduce large object support, now using Stream as base class for opened large objects

### DIFF
--- a/Npgsql/Npgsql.csproj
+++ b/Npgsql/Npgsql.csproj
@@ -307,6 +307,8 @@
     <Compile Include="BackendMessages\RowDescriptionMessage.cs" />
     <Compile Include="BackendMessages\DataRowSequentialMessage.cs" />
     <Compile Include="FrontendMessages\CopyFailMessage.cs" />
+    <Compile Include="NpgsqlLargeObjectManager.cs" />
+    <Compile Include="NpgsqlLargeObjectStream.cs" />
     <Compile Include="NpgsqlBinaryExporter.cs" />
     <Compile Include="NpgsqlBinaryImporter.cs" />
     <Compile Include="NpgsqlNotice.cs" />

--- a/Npgsql/NpgsqlBinaryImporter.cs
+++ b/Npgsql/NpgsqlBinaryImporter.cs
@@ -174,7 +174,7 @@ namespace Npgsql
                         len = directBuf.Size == 0 ? directBuf.Buffer.Length : directBuf.Size;
                         _buf.WriteInt32(len);
                         Flush();
-                        _buf.Underlying.Write(directBuf.Buffer, 0, len);
+                        _buf.Underlying.Write(directBuf.Buffer, directBuf.Offset, len);
                         directBuf.Buffer = null;
                         directBuf.Size = 0;
                     }

--- a/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/NpgsqlConnector.cs
@@ -684,7 +684,7 @@ namespace Npgsql
                         // through our buffer
                         if (directBuf.Buffer != null)
                         {
-                            Buffer.Underlying.Write(directBuf.Buffer, 0, directBuf.Size == 0 ? directBuf.Buffer.Length : directBuf.Size);
+                            Buffer.Underlying.Write(directBuf.Buffer, directBuf.Offset, directBuf.Size == 0 ? directBuf.Buffer.Length : directBuf.Size);
                             directBuf.Buffer = null;
                             directBuf.Size = 0;
                         }

--- a/Npgsql/NpgsqlLargeObjectManager.cs
+++ b/Npgsql/NpgsqlLargeObjectManager.cs
@@ -1,0 +1,192 @@
+﻿using Npgsql.FrontendMessages;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Large object manager. This class can be used to store very large files in a PostgreSQL database.
+    /// </summary>
+    public class NpgsqlLargeObjectManager
+    {
+        const int INV_WRITE = 0x00020000;
+        const int INV_READ = 0x00040000;
+
+        internal readonly NpgsqlConnection _connection;
+
+        /// <summary>
+        /// The largest chunk size (in bytes) read and write operations will read/write each roundtrip to the network. Default 4 MB.
+        /// </summary>
+        public int MaxTransferBlockSize { get; set; }
+
+        /// <summary>
+        /// Creates an NpgsqlLargeObjectManager for this connection. The connection must be opened to perform remote operations.
+        /// </summary>
+        /// <param name="connection"></param>
+        public NpgsqlLargeObjectManager(NpgsqlConnection connection)
+        {
+            _connection = connection;
+            MaxTransferBlockSize = 4 * 1024 * 1024; // 4MB
+        }
+
+        /// <summary>
+        /// Execute a function
+        /// </summary>
+        /// <param name="function"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        [GenerateAsync]
+        internal T ExecuteFunction<T>(string function, params object[] arguments)
+        {
+            _connection.CheckConnectionReady();
+            using (var command = new NpgsqlCommand(function, _connection))
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.CommandText = function;
+                foreach (var argument in arguments)
+                {
+                    command.Parameters.Add(new NpgsqlParameter() { Value = argument });
+                }
+                return (T)command.ExecuteScalar();
+            }
+        }
+
+        /// <summary>
+        /// Execute a function that returns a byte array
+        /// </summary>
+        /// <param name="function"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        [GenerateAsync]
+        internal int ExecuteFunctionGetBytes(string function, byte[] buffer, int offset, int len, params object[] arguments)
+        {
+            _connection.CheckConnectionReady();
+            using (var command = new NpgsqlCommand(function, _connection))
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                foreach (var argument in arguments)
+                {
+                    command.Parameters.Add(new NpgsqlParameter() { Value = argument });
+                }
+                using (var reader = command.ExecuteReader(System.Data.CommandBehavior.SequentialAccess))
+                {
+                    reader.Read();
+                    return (int)reader.GetBytes(0, 0, buffer, offset, len);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create an empty large object in the database. If an oid is specified but is already in use, an NpgsqlException will be thrown.
+        /// </summary>
+        /// <param name="preferredOid">A preferred oid, or specify 0 if one should be automatically assigned</param>
+        /// <returns>The oid for the large object created</returns>
+        /// <exception cref="NpgsqlException">If an oid is already in use</exception>
+        [GenerateAsync]
+        [CLSCompliant(false)]
+        public uint Create(uint preferredOid = 0)
+        {
+
+            return ExecuteFunction<uint>("lo_create", (int)preferredOid);
+        }
+
+        /// <summary>
+        /// Opens a large object on the backend, returning a stream controlling this remote object.
+        /// A transaction snapshot is taken by the backend when the object is opened with only read permissions.
+        /// When reading from this object, the contents reflects the time when the snapshot was taken.
+        /// Note that this method, as well as operations on the stream must be wrapped inside a transaction.
+        /// </summary>
+        /// <param name="oid">Oid of the object</param>
+        /// <returns>An NpgsqlLargeObjectStream</returns>
+        [GenerateAsync]
+        public NpgsqlLargeObjectStream OpenRead(uint oid)
+        {
+            var fd = ExecuteFunction<int>("lo_open", (int)oid, INV_READ);
+            return new NpgsqlLargeObjectStream(this, oid, fd, false);
+        }
+
+        /// <summary>
+        /// Opens a large object on the backend, returning a stream controlling this remote object.
+        /// Note that this method, as well as operations on the stream must be wrapped inside a transaction.
+        /// </summary>
+        /// <param name="oid">Oid of the object</param>
+        /// <returns>An NpgsqlLargeObjectStream</returns>
+        [GenerateAsync]
+        public NpgsqlLargeObjectStream OpenReadWrite(uint oid)
+        {
+            var fd = ExecuteFunction<int>("lo_open", (int)oid, INV_READ | INV_WRITE);
+            return new NpgsqlLargeObjectStream(this, oid, fd, true);
+        }
+
+        /// <summary>
+        /// Deletes a large object on the backend.
+        /// </summary>
+        /// <param name="oid">Oid of the object to delete</param>
+        [GenerateAsync]
+        public void Unlink(uint oid)
+        {
+            ExecuteFunction<object>("lo_unlink", (int)oid);
+        }
+
+        /// <summary>
+        /// Exports a large object stored in the database to a file on the backend. This requires superuser permissions.
+        /// </summary>
+        /// <param name="oid">Oid of the object to export</param>
+        /// <param name="path">Path to write the file on the backend</param>
+        [GenerateAsync]
+        public void ExportRemote(uint oid, string path)
+        {
+            ExecuteFunction<object>("lo_export", (int)oid, path);
+        }
+
+        /// <summary>
+        /// Imports a large object to be stored as a large object in the database from a file stored on the backend. This requires superuser permissions.
+        /// </summary>
+        /// <param name="path">Path to read the file on the backend</param>
+        /// <param name="oid">A preferred oid, or specify 0 if one should be automatically assigned</param>
+        [GenerateAsync]
+        public void ImportRemote(string path, uint oid = 0)
+        {
+            ExecuteFunction<object>("lo_import", path, (int)oid);
+        }
+
+        /// <summary>
+        /// Since PostgreSQL 9.3, large objects larger than 2GB can be handled, up to 4TB.
+        /// This property returns true whether the PostgreSQL version is >= 9.3.
+        /// </summary>
+        public bool Has64BitSupport { get { return _connection.PostgreSqlVersion >= new Version(9, 3); } }
+
+        /*
+        internal enum Function : uint
+        {
+            lo_open = 952,
+            lo_close = 953,
+            loread = 954,
+            lowrite = 955,
+            lo_lseek = 956,
+            lo_lseek64 = 3170, // Since PostgreSQL 9.3
+            lo_creat = 957,
+            lo_create = 715,
+            lo_tell = 958,
+            lo_tell64 = 3171, // Since PostgreSQL 9.3
+            lo_truncate = 1004,
+            lo_truncate64 = 3172, // Since PostgreSQL 9.3
+
+            // These four are available since PostgreSQL 9.4
+            lo_from_bytea = 3457,
+            lo_get = 3458,
+            lo_get_fragment = 3459,
+            lo_put = 3460,
+
+            lo_unlink = 964,
+
+            lo_import = 764,
+            lo_import_with_oid = 767,
+            lo_export = 765,
+        }
+        */
+    }
+}

--- a/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/Npgsql/NpgsqlLargeObjectStream.cs
@@ -40,6 +40,12 @@ namespace Npgsql
         }
 
         /// <summary>
+        /// Since PostgreSQL 9.3, large objects larger than 2GB can be handled, up to 4TB.
+        /// This property returns true whether the PostgreSQL version is >= 9.3.
+        /// </summary>
+        public bool Has64BitSupport { get { return _manager._connection.PostgreSqlVersion >= new Version(9, 3); } }
+
+        /// <summary>
         /// Reads <i>count</i> bytes from the large object. The only case when fewer bytes are read is when end of stream is reached.
         /// </summary>
         /// <param name="buffer">The buffer where read data should be stored.</param>
@@ -203,7 +209,7 @@ namespace Npgsql
         {
             if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
                 throw new ArgumentException("Invalid origin");
-            if (!_manager.Has64BitSupport && offset != (long)(int)offset)
+            if (!Has64BitSupport && offset != (long)(int)offset)
                 throw new ArgumentOutOfRangeException("offset", "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
             Contract.EndContractBlock();
 

--- a/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/Npgsql/NpgsqlLargeObjectStream.cs
@@ -40,44 +40,14 @@ namespace Npgsql
         }
 
         /// <summary>
-        /// Reads up to <i>count</i> bytes from the large object into the buffer.
-        /// A return value of 0 indicates end of file.
+        /// Reads <i>count</i> bytes from the large object. The only case when fewer bytes are read is when end of stream is reached.
         /// </summary>
         /// <param name="buffer">The buffer where read data should be stored.</param>
-        /// <param name="offset">The offset in the buffer where the first byte should be stored.</param>
+        /// <param name="offset">The offset in the buffer where the first byte should be read.</param>
         /// <param name="count">The maximum number of bytes that should be read.</param>
         /// <returns>How many bytes actually read, or 0 if end of file was already reached.</returns>
         [GenerateAsync]
         public override int Read(byte[] buffer, int offset, int count)
-        {
-            if (buffer == null)
-                throw new ArgumentNullException("buffer");
-            if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset");
-            if (count < 0)
-                throw new ArgumentOutOfRangeException("count");
-            if (buffer.Length - offset < count)
-                throw new ArgumentException("Invalid offset or count for this buffer");
-            Contract.EndContractBlock();
-
-            CheckDisposed();
-
-            count = Math.Min(count, _manager.MaxTransferBlockSize);
-
-            var bytesRead = _manager.ExecuteFunctionGetBytes("loread", buffer, offset, count, _fd, count);
-            _pos += bytesRead;
-            return bytesRead;
-        }
-
-        /// <summary>
-        /// Reads <i>count</i> bytes from the large object. The only case when fewer bytes are read is when end of stream is reached.
-        /// </summary>
-        /// <param name="buffer">The buffer where read data should be stored.</param>
-        /// <param name="offset">The offset in the buffer where the first byte should be stored.</param>
-        /// <param name="count">The maximum number of bytes that should be read.</param>
-        /// <returns>How many bytes actually read, or 0 if end of file was already reached.</returns>
-        [GenerateAsync]
-        public int ReadAll(byte[] buffer, int offset, int count)
         {
             if (buffer == null)
                 throw new ArgumentNullException("buffer");
@@ -153,7 +123,7 @@ namespace Npgsql
         {
             get
             {
-                return false; // TODO
+                return false; // TODO?
             }
         }
 
@@ -205,7 +175,7 @@ namespace Npgsql
             get { return GetLengthInternal(); }
         }
 
-        // TODO: uncomment this
+        // TODO: uncomment this when finally implementing async
         /*public Task<long> GetLengthAsync()
         {
             return GetLengthInternalAsync();

--- a/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/Npgsql/NpgsqlLargeObjectStream.cs
@@ -1,0 +1,306 @@
+﻿using Npgsql.FrontendMessages;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// An interface to remotely control the seekable stream for an opened large object on a PostgreSQL server.
+    /// Note that the OpenRead/OpenReadWrite method as well as all operations performed on this stream must be wrapped inside a database transaction.
+    /// </summary>
+    public class NpgsqlLargeObjectStream : Stream
+    {
+        NpgsqlLargeObjectManager _manager;
+        uint _oid;
+        int _fd;
+        long _pos;
+        bool _writeable;
+        bool _disposed;
+
+        private NpgsqlLargeObjectStream() { }
+
+        internal NpgsqlLargeObjectStream(NpgsqlLargeObjectManager manager, uint oid, int fd, bool writeable)
+        {
+            _manager = manager;
+            _oid = oid;
+            _fd = fd;
+            _pos = 0;
+            _writeable = writeable;
+        }
+
+        void CheckDisposed()
+        {
+            if (_disposed)
+                throw new InvalidOperationException("Object disposed");
+        }
+
+        /// <summary>
+        /// Reads up to <i>count</i> bytes from the large object into the buffer.
+        /// A return value of 0 indicates end of file.
+        /// </summary>
+        /// <param name="buffer">The buffer where read data should be stored.</param>
+        /// <param name="offset">The offset in the buffer where the first byte should be stored.</param>
+        /// <param name="count">The maximum number of bytes that should be read.</param>
+        /// <returns>How many bytes actually read, or 0 if end of file was already reached.</returns>
+        [GenerateAsync]
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count");
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Invalid offset or count for this buffer");
+            Contract.EndContractBlock();
+
+            CheckDisposed();
+
+            count = Math.Min(count, _manager.MaxTransferBlockSize);
+
+            var bytesRead = _manager.ExecuteFunctionGetBytes("loread", buffer, offset, count, _fd, count);
+            _pos += bytesRead;
+            return bytesRead;
+        }
+
+        /// <summary>
+        /// Reads <i>count</i> bytes from the large object. The only case when fewer bytes are read is when end of stream is reached.
+        /// </summary>
+        /// <param name="buffer">The buffer where read data should be stored.</param>
+        /// <param name="offset">The offset in the buffer where the first byte should be stored.</param>
+        /// <param name="count">The maximum number of bytes that should be read.</param>
+        /// <returns>How many bytes actually read, or 0 if end of file was already reached.</returns>
+        [GenerateAsync]
+        public int ReadAll(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count");
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Invalid offset or count for this buffer");
+            Contract.EndContractBlock();
+
+            CheckDisposed();
+
+            int chunkCount = Math.Min(count, _manager.MaxTransferBlockSize);
+            int read = 0;
+
+            while (read < count)
+            {
+                var bytesRead = _manager.ExecuteFunctionGetBytes("loread", buffer, offset + read, count - read, _fd, chunkCount);
+                _pos += bytesRead;
+                read += bytesRead;
+                if (bytesRead < chunkCount)
+                {
+                    return read;
+                }
+            }
+            return read;
+        }
+
+        /// <summary>
+        /// Writes <i>count</i> bytes to the large object.
+        /// </summary>
+        /// <param name="buffer">The buffer to write data from.</param>
+        /// <param name="offset">The offset in the buffer at which to begin copying bytes.</param>
+        /// <param name="count">The number of bytes to write.</param>
+        [GenerateAsync]
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count");
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Invalid offset or count for this buffer");
+            Contract.EndContractBlock();
+
+            CheckDisposed();
+
+            if (!_writeable)
+                throw new NotSupportedException("Write cannot be called on a stream opened with no write permissions");
+
+            int totalWritten = 0;
+
+            while (totalWritten < count)
+            {
+                var chunkSize = Math.Min(count - totalWritten, _manager.MaxTransferBlockSize);
+                var bytesWritten = _manager.ExecuteFunction<int>("lowrite", _fd, new ArraySegment<byte>(buffer, offset + totalWritten, chunkSize));
+                totalWritten += bytesWritten;
+
+                if (bytesWritten != chunkSize)
+                    throw PGUtil.ThrowIfReached();
+
+                _pos += bytesWritten;
+            }
+        }
+
+        /// <summary>
+        /// CanTimeout always returns false.
+        /// </summary>
+        public override bool CanTimeout
+        {
+            get
+            {
+                return false; // TODO
+            }
+        }
+
+        /// <summary>
+        /// CanRead always returns true, unless the stream has been closed.
+        /// </summary>
+        public override bool CanRead
+        {
+            get { return true && !_disposed; }
+        }
+
+        /// <summary>
+        /// CanWrite returns true if the stream was opened with write permissions, and the stream has not been closed.
+        /// </summary>
+        public override bool CanWrite
+        {
+            get { return _writeable && !_disposed; }
+        }
+
+        /// <summary>
+        /// CanSeek always returns true, unless the stream has been closed.
+        /// </summary>
+        public override bool CanSeek
+        {
+            get { return true && !_disposed; }
+        }
+
+        /// <summary>
+        /// Returns the current position in the stream. Getting the current position does not need a round-trip to the server, however setting the current position does.
+        /// </summary>
+        public override long Position
+        {
+            get
+            {
+                CheckDisposed();
+                return _pos;
+            }
+            set
+            {
+                Seek(value, SeekOrigin.Begin);
+            }
+        }
+
+        /// <summary>
+        /// Gets the length of the large object. This internally seeks to the end of the stream to retrieve the length, and then back again.
+        /// </summary>
+        public override long Length
+        {
+            get { return GetLengthInternal(); }
+        }
+
+        // TODO: uncomment this
+        /*public Task<long> GetLengthAsync()
+        {
+            return GetLengthInternalAsync();
+        }*/
+
+        [GenerateAsync]
+        long GetLengthInternal()
+        {
+            CheckDisposed();
+            long old = _pos;
+            long retval = Seek(0, SeekOrigin.End);
+            if (retval != old)
+                Seek(old, SeekOrigin.Begin);
+            return retval;
+        }
+
+        /// <summary>
+        /// Seeks in the stream to the specified position. This requires a round-trip to the backend.
+        /// </summary>
+        /// <param name="offset">A byte offset relative to the <i>origin</i> parameter.</param>
+        /// <param name="origin">A value of type SeekOrigin indicating the reference point used to obtain the new position.</param>
+        /// <returns></returns>
+        [GenerateAsync]
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
+                throw new ArgumentException("Invalid origin");
+            if (!_manager.Has64BitSupport && offset != (long)(int)offset)
+                throw new ArgumentOutOfRangeException("offset", "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
+            Contract.EndContractBlock();
+
+            CheckDisposed();
+
+            if (_manager.Has64BitSupport)
+                return _pos = _manager.ExecuteFunction<long>("lo_lseek64", _fd, offset, (int)origin);
+            else
+                return _pos = _manager.ExecuteFunction<int>("lo_lseek", _fd, (int)offset, (int)origin);
+        }
+
+        /// <summary>
+        /// Does nothing.
+        /// </summary>
+        [GenerateAsync]
+        public override void Flush()
+        {
+        }
+
+        /// <summary>
+        /// Truncates or enlarges the large object to the given size. If enlarging, the large object is extended with null bytes.
+        /// For PostgreSQL versions earlier than 9.3, the value must fit in an Int32.
+        /// </summary>
+        /// <param name="value">Number of bytes to either truncate or enlarge the large object.</param>
+        [GenerateAsync]
+        public override void SetLength(long value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException("value");
+            if (!_manager.Has64BitSupport && value != (long)(int)value)
+                throw new ArgumentOutOfRangeException("value", "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
+            Contract.EndContractBlock();
+
+            CheckDisposed();
+
+            if (!_writeable)
+                throw new NotSupportedException("SetLength cannot be called on a stream opened with no write permissions");
+
+            if (_manager.Has64BitSupport)
+                _manager.ExecuteFunction<int>("lo_truncate64", _fd, value);
+            else
+                _manager.ExecuteFunction<int>("lo_truncate", _fd, (int)value);
+        }
+
+        /// <summary>
+        /// Releases resources at the backend allocated for this stream.
+        /// </summary>
+        [GenerateAsync]
+        public override void Close()
+        {
+            if (!_disposed)
+            {
+                _manager.ExecuteFunction<int>("lo_close", _fd);
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases resources at the backend allocated for this stream, iff disposing is true.
+        /// </summary>
+        /// <param name="disposing">Whether to release resources allocated at the backend.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Close();
+            }
+        }
+    }
+}

--- a/Npgsql/TypeHandler.cs
+++ b/Npgsql/TypeHandler.cs
@@ -248,6 +248,7 @@ namespace Npgsql
     struct DirectBuffer
     {
         public byte[] Buffer;
+        public int Offset;
         public int Size;
     }
 

--- a/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -77,7 +77,7 @@ namespace Npgsql.TypeHandlers
             {
                 var arraySegment = (ArraySegment<byte>)value;
 
-                if (arraySegment == null)
+                if (arraySegment.Array == null)
                     throw new InvalidCastException("Array in ArraySegment<byte> is null");
 
                 return parameter == null || parameter.Size <= 0 || parameter.Size >= arraySegment.Count
@@ -100,11 +100,11 @@ namespace Npgsql.TypeHandlers
 
             if (value is ArraySegment<byte>)
             {
-                var arraySegment = (ArraySegment<byte>)value;
-                var len = parameter == null || parameter.Size <= 0 || parameter.Size >= arraySegment.Count
-                    ? arraySegment.Count
-                    : parameter.Size;
-                _value = new ArraySegment<byte>(arraySegment.Array, arraySegment.Offset, len);
+                _value = (ArraySegment<byte>)value;
+                if (!(parameter == null || parameter.Size <= 0 || parameter.Size >= _value.Count))
+                {
+                     _value = new ArraySegment<byte>(_value.Array, _value.Offset, parameter.Size);
+                }
             }
             else
             {

--- a/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.TypeHandlers
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-binary.html
     /// </remarks>
-    [TypeMapping("bytea", NpgsqlDbType.Bytea, DbType.Binary, typeof(byte[]))]
+    [TypeMapping("bytea", NpgsqlDbType.Bytea, DbType.Binary, new Type[] { typeof(byte[]), typeof(ArraySegment<byte>) })]
     internal class ByteaHandler : TypeHandler<byte[]>,
         IChunkingTypeReader<byte[]>, IChunkingTypeWriter
     {
@@ -69,24 +69,51 @@ namespace Npgsql.TypeHandlers
 
         #region Write
 
-        byte[] _value;
-        int _size;
+        ArraySegment<byte> _value;
 
         public int ValidateAndGetLength(object value, ref LengthCache lengthCache, NpgsqlParameter parameter=null)
         {
-            var bytea = (byte[])value;
-            return parameter == null || parameter.Size == 0 || parameter.Size >= bytea.Length
-                ? bytea.Length
-                : parameter.Size;
+            if (value is ArraySegment<byte>)
+            {
+                var arraySegment = (ArraySegment<byte>)value;
+
+                if (arraySegment == null)
+                    throw new InvalidCastException("Array in ArraySegment<byte> is null");
+
+                return parameter == null || parameter.Size <= 0 || parameter.Size >= arraySegment.Count
+                    ? arraySegment.Count
+                    : parameter.Size;
+            }
+            else
+            {
+                var array = (byte[])value;
+
+                return parameter == null || parameter.Size <= 0 || parameter.Size >= array.Length
+                    ? array.Length
+                    : parameter.Size;
+            }
         }
 
         public void PrepareWrite(object value, NpgsqlBuffer buf, LengthCache lengthCache, NpgsqlParameter parameter=null)
         {
             _buf = buf;
-            _value = (byte[])value;
-            _size = parameter == null || parameter.Size == 0 || parameter.Size >= _value.Length
-                ? _value.Length
-                : parameter.Size;
+
+            if (value is ArraySegment<byte>)
+            {
+                var arraySegment = (ArraySegment<byte>)value;
+                var len = parameter == null || parameter.Size <= 0 || parameter.Size >= arraySegment.Count
+                    ? arraySegment.Count
+                    : parameter.Size;
+                _value = new ArraySegment<byte>(arraySegment.Array, arraySegment.Offset, len);
+            }
+            else
+            {
+                var array = (byte[])value;
+                var len = parameter == null || parameter.Size <= 0 || parameter.Size >= array.Length
+                    ? array.Length
+                    : parameter.Size;
+                _value = new ArraySegment<byte>(array, 0, len);
+            }
         }
 
         // ReSharper disable once RedundantAssignment
@@ -94,16 +121,17 @@ namespace Npgsql.TypeHandlers
         {
             // If the entire array fits in our buffer, copy it as usual.
             // Otherwise, switch to direct write from the user-provided buffer
-            if (_size <= _buf.WriteSpaceLeft)
+            if (_value.Count <= _buf.WriteSpaceLeft)
             {
-                _buf.WriteBytesSimple(_value, 0, _size);
+                _buf.WriteBytesSimple(_value.Array, _value.Offset, _value.Count);
                 return true;
             }
 
             if (!_returnedBuffer)
             {
-                directBuf.Buffer = _value;
-                directBuf.Size = _size;
+                directBuf.Buffer = _value.Array;
+                directBuf.Offset = _value.Offset;
+                directBuf.Size = _value.Count;
                 _returnedBuffer = true;
                 return false;
             }

--- a/tests/Npgsql.Tests/LargeObjectTests.cs
+++ b/tests/Npgsql.Tests/LargeObjectTests.cs
@@ -26,7 +26,7 @@ namespace Npgsql.Tests
                     stream.Write(buf, 0, buf.Length);
                     stream.Seek(0, System.IO.SeekOrigin.Begin);
                     var buf2 = new byte[buf.Length];
-                    stream.ReadAll(buf2, 0, buf2.Length);
+                    stream.Read(buf2, 0, buf2.Length);
                     Assert.That(buf.SequenceEqual(buf2));
 
                     Assert.AreEqual(5, stream.Position);
@@ -41,7 +41,7 @@ namespace Npgsql.Tests
                     stream.Write(buf, 0, buf.Length);
                     stream.Seek(-5, System.IO.SeekOrigin.End);
                     var buf3 = new byte[100];
-                    Assert.AreEqual(5, stream.ReadAll(buf3, 0, 100));
+                    Assert.AreEqual(5, stream.Read(buf3, 0, 100));
                     Assert.That(buf.SequenceEqual(buf3.Take(5)));
 
                     stream.SetLength(43);

--- a/tests/Npgsql.Tests/LargeObjectTests.cs
+++ b/tests/Npgsql.Tests/LargeObjectTests.cs
@@ -1,0 +1,57 @@
+﻿using Npgsql;
+using Npgsql.Tests;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Npgsql.Tests
+{
+    [TestFixture]
+    public class LargeObjectTests : TestBase
+    {
+        public LargeObjectTests(string backendVersion) : base(backendVersion) { }
+
+        [Test]
+        public void Test()
+        {
+            using (var transaction = Conn.BeginTransaction())
+            {
+                var manager = new NpgsqlLargeObjectManager(Conn);
+                uint oid = manager.Create();
+                using (var stream = manager.OpenReadWrite(oid))
+                {
+                    var buf = Encoding.UTF8.GetBytes("Hello");
+                    stream.Write(buf, 0, buf.Length);
+                    stream.Seek(0, System.IO.SeekOrigin.Begin);
+                    var buf2 = new byte[buf.Length];
+                    stream.ReadAll(buf2, 0, buf2.Length);
+                    Assert.That(buf.SequenceEqual(buf2));
+
+                    Assert.AreEqual(5, stream.Position);
+
+                    Assert.AreEqual(5, stream.Length);
+
+                    stream.Seek(-1, System.IO.SeekOrigin.Current);
+                    Assert.AreEqual((int)'o', stream.ReadByte());
+
+                    manager.MaxTransferBlockSize = 3;
+
+                    stream.Write(buf, 0, buf.Length);
+                    stream.Seek(-5, System.IO.SeekOrigin.End);
+                    var buf3 = new byte[100];
+                    Assert.AreEqual(5, stream.ReadAll(buf3, 0, 100));
+                    Assert.That(buf.SequenceEqual(buf3.Take(5)));
+
+                    stream.SetLength(43);
+                    Assert.AreEqual(43, stream.Length);
+                }
+
+                manager.Unlink(oid);
+
+                transaction.Rollback();
+            }
+        }
+    }
+}

--- a/tests/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/tests/Npgsql.Tests/Npgsql.Tests.csproj
@@ -157,6 +157,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LargeObjectTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TransactionTests.cs" />
     <Compile Include="Types\ArrayTests.cs" />

--- a/tests/Npgsql.Tests/Types/ByteaTests.cs
+++ b/tests/Npgsql.Tests/Types/ByteaTests.cs
@@ -397,6 +397,46 @@ namespace Npgsql.Tests.Types
             Assert.AreEqual(-1, result);
         }
 
+        [Test]
+        public void ArraySegment()
+        {
+            using (var cmd = new NpgsqlCommand("select :bytearr", Conn))
+            {
+                var arr = new byte[20000];
+                for (var i = 0; i < arr.Length; i++)
+                {
+                    arr[i] = (byte)(i & 0xff);
+                }
+                
+                // Big value, should go through "direct buffer"
+                var segment = new ArraySegment<byte>(arr, 17, 18000);
+                cmd.Parameters.Add(new NpgsqlParameter("bytearr", DbType.Binary) { Value = segment });
+                var returned = (byte[])cmd.ExecuteScalar();
+                Assert.That(segment.SequenceEqual(returned));
+
+                cmd.Parameters[0].Size = 17000;
+                returned = (byte[])cmd.ExecuteScalar();
+                Assert.That(returned.SequenceEqual(new ArraySegment<byte>(segment.Array, segment.Offset, 17000)));
+
+                // Small value, should be written normally through the NpgsqlBuffer
+                segment = new ArraySegment<byte>(arr, 6, 10);
+                cmd.Parameters[0].Value = segment;
+                returned = (byte[])cmd.ExecuteScalar();
+                Assert.That(segment.SequenceEqual(returned));
+
+                cmd.Parameters[0].Size = 2;
+                returned = (byte[])cmd.ExecuteScalar();
+                Assert.That(returned.SequenceEqual(new ArraySegment<byte>(segment.Array, segment.Offset, 2)));
+            }
+
+            using (var cmd = new NpgsqlCommand("select :bytearr", Conn))
+            {
+                var segment = new ArraySegment<byte>(new byte[] { 1, 2, 3 }, 1, 2);
+                cmd.Parameters.AddWithValue("bytearr", segment);
+                Assert.That(segment.SequenceEqual((byte[])cmd.ExecuteScalar()));
+            }
+        }
+
         #region Utilities
 
         /// <summary>


### PR DESCRIPTION
PostgreSQL's large object support is good when the user wants to store very large files in the database. While PostgreSQL supports quite large bytea values, they are always buffered by the server both when sending and reading. So if you have a 1 GB file, that would need lots of RAM on the server. Npgsql is however capable of handling streams (with Sequential Access) so we don't need much RAM however...

One solution is to use PostgreSQL's large object support. It consists of some functions with a stream-like API (create, read, write, seek, close etc.) and internally it stores a large object in an internal table, splitted into to several rows (chunks). When reading or writing, we specify a small piece each time which means the whole object doesn't need to be stored in RAM while transferring.

I've wrapped these functions in two C# classes, NpgsqlLargeObjectManager to create/open/delete a large object, and NpgsqlLargeObjectStream which extends Stream. Does it the API look OK?

(I also made it possible to specify an ArraySegment<byte> instead of byte[] to the bytea type so we don't need to make an unnecessary copy)