### PR TITLE
Added krbsrvname parameter and use hostname for SSPI authentication

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -171,6 +171,7 @@ namespace Npgsql
             valueDescriptions.Add(Keywords.Database, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.UserName, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.Password, new ValueDescription(typeof(string)));
+            valueDescriptions.Add(Keywords.Krbsrvname, new ValueDescription("POSTGRES"));
             valueDescriptions.Add(Keywords.SSL, new ValueDescription(typeof(bool)));
             valueDescriptions.Add(Keywords.SslMode, new ValueDescription(typeof(SslMode)));
             valueDescriptions.Add(Keywords.Timeout, new ValueDescription((Int32)15));
@@ -534,6 +535,25 @@ namespace Npgsql
             set { SetValue(GetKeyName(Keywords.Password), Keywords.Password, value); }
         }
 
+        private string _krbsrvname;
+        /// <summary>
+        /// Sets the krbsrvname.
+        /// </summary>
+#if !DNXCORE50
+        [Category("DataCategory_Security")]
+        [NpgsqlConnectionStringKeyword(Keywords.Krbsrvname)]
+        [NpgsqlConnectionStringAcceptableKeyword("KRBSRVNAME")]
+        [DisplayName("ConnectionProperty_Display_Krbsrvname")]
+        [Description("ConnectionProperty_Description_Krbsrvname")]
+        [RefreshProperties(RefreshProperties.All)]
+        [PasswordPropertyText(true)]
+#endif
+        public string Krbsrvname
+        {
+            get { return _krbsrvname; }
+            set { SetValue(GetKeyName(Keywords.Krbsrvname), Keywords.Krbsrvname, value); }
+        }
+
         private bool _ssl;
         /// <summary>
         /// Gets or sets a value indicating whether to attempt to use SSL.
@@ -836,6 +856,8 @@ namespace Npgsql
                 case "PSW":
                 case "PWD":
                     return Keywords.Password;
+                case "KRBSRVNAME":
+                    return Keywords.Krbsrvname;
                 case "SSL":
                     return Keywords.SSL;
                 case "SSLMODE":
@@ -897,6 +919,8 @@ namespace Npgsql
                     return "USER ID";
                 case Keywords.Password:
                     return "PASSWORD";
+                case Keywords.Krbsrvname:
+                    return "KRBSRVNAME";
                 case Keywords.SSL:
                     return "SSL";
                 case Keywords.SslMode:
@@ -1049,6 +1073,8 @@ namespace Npgsql
                         return this._username = Convert.ToString(value);
                     case Keywords.Password:
                         return this._password = value as string;
+                    case Keywords.Krbsrvname:
+                        return this._krbsrvname = Convert.ToString(value);
                     case Keywords.SSL:
                         return this._ssl = ToBoolean(value);
                     case Keywords.SslMode:
@@ -1161,6 +1187,8 @@ namespace Npgsql
                     return this._username;
                 case Keywords.Password:
                     return this._password;
+                case Keywords.Krbsrvname:
+                    return this._krbsrvname;
                 case Keywords.SSL:
                     return this._ssl;
                 case Keywords.SslMode:
@@ -1223,6 +1251,7 @@ namespace Npgsql
         Database,
         UserName,
         Password,
+        Krbsrvname,
         SSL,
         SslMode,
         Timeout,

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -573,9 +573,7 @@ namespace Npgsql
 #if DNXCORE50
                     throw new NotSupportedException("SSPI not yet supported in .NET Core");
 #else
-                    // For SSPI we have to get the IP-Address (hostname doesn't work)
-                    var ipAddressString = ((IPEndPoint)Socket.RemoteEndPoint).Address.ToString();
-                    SSPI = new SSPIHandler(ipAddressString, Krbsrvname, false);
+                    SSPI = new SSPIHandler(Host, Krbsrvname, false);
                     passwordMessage = new PasswordMessage(SSPI.Continue(null));
                     break;
 #endif

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -202,6 +202,7 @@ namespace Npgsql
         internal string Database { get { return _settings.ContainsKey(Keywords.Database) ? _settings.Database : _settings.UserName; } }
         internal string UserName { get { return _settings.UserName; } }
         internal string Password { get { return _settings.Password; } }
+        internal string Krbsrvname { get { return _settings.Krbsrvname; } }
         internal bool SSL { get { return _settings.SSL; } }
         internal SslMode SslMode { get { return _settings.SslMode; } }
         internal int BufferSize { get { return _settings.BufferSize; } }
@@ -560,7 +561,7 @@ namespace Npgsql
                     throw new NotSupportedException("SSPI not yet supported in .NET Core");
 #else
                     // For GSSAPI we have to use the supplied hostname
-                    SSPI = new SSPIHandler(Host, "POSTGRES", true);
+                    SSPI = new SSPIHandler(Host, Krbsrvname, true);
                     passwordMessage = new PasswordMessage(SSPI.Continue(null));
                     break;
 #endif
@@ -574,7 +575,7 @@ namespace Npgsql
 #else
                     // For SSPI we have to get the IP-Address (hostname doesn't work)
                     var ipAddressString = ((IPEndPoint)Socket.RemoteEndPoint).Address.ToString();
-                    SSPI = new SSPIHandler(ipAddressString, "POSTGRES", false);
+                    SSPI = new SSPIHandler(ipAddressString, Krbsrvname, false);
                     passwordMessage = new PasswordMessage(SSPI.Continue(null));
                     break;
 #endif


### PR DESCRIPTION
The GSS and SSPI authentication needs the kerberos service name of the PostgreSQL server. The default value is POSTGRES but this value can be changed. The ODBC driver allows to set this value using the configuration option "krbsrvname". This patch allows to send this parameter in the connection string.

If the ip address is used instead of the hostname, the SSPI authentication process uses NTLM authentication. By using the host name it tries first to use Kerberos and if this is not possible NTLM is used.