### PR TITLE
Added krbsrvname parameter and use hostname for SSPI authentication to 2.2

### DIFF
--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -577,6 +577,25 @@ namespace Npgsql
             set { SetValue(GetKeyName(Keywords.Password), Keywords.Password, value); }
         }
 
+        private string _krbsrvname;
+        /// <summary>
+        /// Gets or sets the krbsrvname.
+        /// </summary>
+#if !DNXCORE50
+        [Category("DataCategory_Security")]
+        [NpgsqlConnectionStringKeyword(Keywords.Krbsrvname)]
+        [NpgsqlConnectionStringAcceptableKeyword("KRBSRVNAME")]
+        [DisplayName("ConnectionProperty_Display_Krbsrvname")]
+        [Description("ConnectionProperty_Description_Krbsrvname")]
+        [RefreshProperties(RefreshProperties.All)]
+        [PasswordPropertyText(true)]
+#endif
+        public string Krbsrvname
+        {
+            get { return _krbsrvname; }
+            set { SetValue(GetKeyName(Keywords.Krbsrvname), Keywords.Krbsrvname, value); }
+        }
+
         private bool _ssl;
         /// <summary>
         /// Gets or sets a value indicating whether to attempt to use SSL.
@@ -919,6 +938,8 @@ namespace Npgsql
                 case "PSW":
                 case "PWD":
                     return Keywords.Password;
+                case "KRBSRVNAME":
+                    return Keywords.Krbsrvname;
                 case "SSL":
                     return Keywords.SSL;
                 case "SSLMODE":
@@ -985,6 +1006,8 @@ namespace Npgsql
                     return "USER ID";
                 case Keywords.Password:
                     return "PASSWORD";
+                case Keywords.Krbsrvname:
+                    return "KRBSRVNAME";
                 case Keywords.SSL:
                     return "SSL";
                 case Keywords.SslMode:
@@ -1143,6 +1166,8 @@ namespace Npgsql
                     case Keywords.Password:
                         this._password.Password = value as string;
                         return value as string;
+                    case Keywords.Krbsrvname:
+                        return this._krbsrvname = Convert.ToString(value);
                     case Keywords.SSL:
                         return this._ssl = ToBoolean(value);
                     case Keywords.SslMode:
@@ -1258,6 +1283,8 @@ namespace Npgsql
                     return this._username;
                 case Keywords.Password:
                     return this._password.Password;
+                case Keywords.Krbsrvname:
+                    return this._krbsrvname;
                 case Keywords.SSL:
                     return this._ssl;
                 case Keywords.SslMode:
@@ -1368,6 +1395,7 @@ namespace Npgsql
         Database,
         UserName,
         Password,
+        Krbsrvname,
         SSL,
         SslMode,
         [Obsolete("UTF-8 is always used regardless of this setting.")]

--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -212,6 +212,7 @@ namespace Npgsql
             valueDescriptions.Add(Keywords.Database, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.UserName, new ValueDescription(typeof(string)));
             valueDescriptions.Add(Keywords.Password, new ValueDescription(typeof(string)));
+            valueDescriptions.Add(Keywords.Krbsrvname, new ValueDescription("POSTGRES"));
             valueDescriptions.Add(Keywords.SSL, new ValueDescription(typeof(bool)));
             valueDescriptions.Add(Keywords.SslMode, new ValueDescription(typeof(SslMode)));
 #pragma warning disable 618

--- a/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.resx
+++ b/Npgsql/Npgsql/NpgsqlConnectionStringBuilder.resx
@@ -189,6 +189,12 @@
   <data name="ConnectionProperty_Display_Password" xml:space="preserve">
     <value>Password</value>
   </data>
+  <data name="ConnectionProperty_Description_Krbsrvname" xml:space="preserve">
+    <value>Krbsrvname</value>
+  </data>
+  <data name="ConnectionProperty_Display_Krbsrvname" xml:space="preserve">
+    <value>Krbsrvname</value>
+  </data>
   <data name="ConnectionProperty_Description_SSL" xml:space="preserve">
     <value>SSL</value>
   </data>

--- a/Npgsql/Npgsql/NpgsqlConnector.cs
+++ b/Npgsql/Npgsql/NpgsqlConnector.cs
@@ -253,6 +253,11 @@ namespace Npgsql
             get { return settings.PasswordAsByteArray; }
         }
 
+        internal String Krbsrvname
+        {
+            get { return settings.Krbsrvname; }
+        }
+
         internal Boolean SSL
         {
             get { return settings.SSL; }

--- a/Npgsql/Npgsql/NpgsqlState.BackendResponse.cs
+++ b/Npgsql/Npgsql/NpgsqlState.BackendResponse.cs
@@ -220,7 +220,7 @@ namespace Npgsql
                                         if (context.IntegratedSecurity)
                                         {
                                             // For GSSAPI we have to use the supplied hostname
-                                            context.SSPI = new SSPIHandler(context.Host, "POSTGRES", true);
+                                            context.SSPI = new SSPIHandler(context.Host, context.Krbsrvname, true);
                                             ChangeState(context, NpgsqlStartupState.Instance);
                                             context.Authenticate(context.SSPI.Continue(null));
                                             break;
@@ -236,9 +236,7 @@ namespace Npgsql
                                     {
                                         if (context.IntegratedSecurity)
                                         {
-                                            // For SSPI we have to get the IP-Address (hostname doesn't work)
-                                            string ipAddressString = ((IPEndPoint)context.Socket.RemoteEndPoint).Address.ToString();
-                                            context.SSPI = new SSPIHandler(ipAddressString, "POSTGRES", false);
+                                            context.SSPI = new SSPIHandler(context.Host, context.Krbsrvname, false);
                                             ChangeState(context, NpgsqlStartupState.Instance);
                                             context.Authenticate(context.SSPI.Continue(null));
                                             break;


### PR DESCRIPTION
The GSS and SSPI authentication needs the kerberos service name of the PostgreSQL server. The default value is POSTGRES but this value can be changed. The ODBC driver allows to set this value using the configuration option "krbsrvname". This patch allows to send this parameter in the connection string.

If the ip address is used instead of the hostname, the SSPI authentication process uses NTLM authentication. By using the host name it tries first to use Kerberos and if this is not possible NTLM is used.