### PR TITLE
Fix NullReferenceException when disposing transactions (race conditon (?))

### DIFF
--- a/Npgsql/Npgsql/NpgsqlTransaction.cs
+++ b/Npgsql/Npgsql/NpgsqlTransaction.cs
@@ -125,7 +125,7 @@ namespace Npgsql
         {
             if (disposing && this._conn != null)
             {
-                if (_conn.Connector.Transaction != null)
+                if (_conn.Connector != null && _conn.Connector.Transaction != null)
                 {
                     if ((Thread.CurrentThread.ThreadState & (ThreadState.Aborted | ThreadState.AbortRequested)) != 0)
                     {


### PR DESCRIPTION
When running in a relatively heavy load scenario, Npgsql will occasionally (very rarely) fail when disposing transactions that aborted prematurely. I am unable to reproduce the issue consistently, but have a patch which (I think) fixes the problem.

When this exception occurs the logged stack trace I am seeing is this:
```
An exception of type System.NullReferenceException was thrown: Object reference not set to an instance of an object. 
Stack trace: 
  at Npgsql.NpgsqlTransaction.Dispose(Boolean disposing) 
  at System.Data.Common.DbTransaction.Dispose()
  at System.Data.Entity.Infrastructure.Interception.DbTransactionDispatcher.b__12(DbTransaction t, DbTransactionInterceptionContext c) 
  at System.Data.Entity.Infrastructure.Interception.InternalDispatcher`1.Dispatch[TTarget,TInterceptionContext](TTarget target, Action`2 operation, TInterceptionContext interceptionContext, Action`3 executing, Action`3 executed)
  at System.Data.Entity.Infrastructure.Interception.DbTransactionDispatcher.Dispose(DbTransaction transaction, DbInterceptionContext interceptionContext) 
  at System.Data.Entity.Core.EntityClient.EntityTransaction.Dispose(Boolean disposing) at System.Data.Common.DbTransaction.Dispose() 
  at System.Data.Entity.Core.Objects.ObjectContext.d__3d`1.MoveNext()
```

This pull request guards against `NpgsqlConnector` references being `null`. I cannot be certain that the connector reference is the culprit, but since running with the patch in place I have not observed any more `NullReferenceException`s.
