### PR TITLE
Partially support NpgsqlDataAdapter.Update when SetAllValues = false.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlParameter.cs
+++ b/Npgsql/Npgsql/NpgsqlParameter.cs
@@ -400,6 +400,8 @@ namespace Npgsql
                 {
                     throw new InvalidCastException(String.Format(resman.GetString("Exception_ImpossibleToCast"), value));
                 }
+
+                backendTypeInfo = null;
             }
         }
 


### PR DESCRIPTION
Partially support SQL Update command via `NpgsqlDataAdapter.Update` method described at #352 

I have included rewritten Bug352 test, which shows workarounds of the issue, in DataAdapterTests.cs, NpgsqlTests.

`da.Update` method will throw `InvalidCastException` if any of following conditions meet:
- `cb.SetAllValues` is set to false (default is false).
- Include at least column type inside NpgsqlDataAdapter's select command.
 - field_date
 - field_timestamp
 - field_time
 - field_timestamp_with_timezone
 - field_inet
- SQL Update is invoked by `da.Update`.
- Not removing command parameters at `da.RowUpdating` event.
- `NpgsqlParameter.DbType` setter implements without `backendTypeInfo = null;`

`da` = NpgsqlDataAdapter
`cb` = NpgsqlCommandBuilder

The reason of exception is explained by Emill: ADO.NET internally reuses DbCommandParameter by setting another DbType for new data.
