### PR TITLE
Additional SchemaTable support (PR #508) for 2.2

### DIFF
--- a/tests/DataReaderTests.cs
+++ b/tests/DataReaderTests.cs
@@ -676,28 +676,146 @@ namespace NpgsqlTests
             }
         }
 
+        #region GetSchemaTable
+
         [Test]
         public void PrimaryKeyFieldsMetadataSupport()
         {
+            ExecuteNonQuery("DROP TABLE IF EXISTS DATA2 CASCADE");
+            ExecuteNonQuery(@"CREATE TABLE DATA2 (
+                                field_pk1                      INT2 NOT NULL,
+                                field_pk2                      INT2 NOT NULL,
+                                field_serial                   SERIAL,
+                                CONSTRAINT data2_pkey PRIMARY KEY (field_pk1, field_pk2)
+                                ) WITH OIDS");
+
+            using (var command = new NpgsqlCommand("SELECT * FROM DATA2", Conn))
+            {
+                using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
+                {
+                    dr.Read();
+                    var metadata = dr.GetSchemaTable();
+                    int keyCount = 0;
+
+                    foreach (DataRow r in metadata.Rows)
+                    {
+                        if ((Boolean)r["IsKey"])
+                        {
+                            switch (keyCount)
+                            {
+                                case 0:
+                                    Assert.AreEqual("field_pk1", r["ColumnName"]);
+                                    break;
+                                case 1:
+                                    Assert.AreEqual("field_pk2", r["ColumnName"]);
+                                    break;
+                                default:
+                                    break;
+                            }
+
+                            keyCount++;
+                        }
+
+                    }
+                    if (keyCount == 0)
+                        Assert.Fail("No primary key found!");
+                    else if (keyCount != 2)
+                        Assert.Fail(string.Format("Expected 2 primary keys but {0} were found.", keyCount));
+                }
+            }
+
+            ExecuteNonQuery("DROP TABLE IF EXISTS DATA2 CASCADE");
+        }
+
+        [Test]
+        public void PrimaryKeyFieldMetadataSupport()
+        {
+            using (var command = new NpgsqlCommand("SELECT * FROM data", Conn))
+            {
+                using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
+                {
+                    dr.Read();
+                    var metadata = dr.GetSchemaTable();
+                    var keyfound = false;
+
+                    foreach (DataRow r in metadata.Rows)
+                    {
+                        if ((Boolean)r["IsKey"])
+                        {
+                            Assert.AreEqual("field_pk", r["ColumnName"]);
+                            keyfound = true;
+                        }
+
+                    }
+                    if (!keyfound)
+                        Assert.Fail("No primary key found!");
+                }
+            }
+        }
+
+        [Test]
+        public void IsAutoIncrementMetadataSupport()
+        {
             var command = new NpgsqlCommand("SELECT * FROM data", Conn);
+
             using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
             {
                 var metadata = dr.GetSchemaTable();
-                var keyfound = false;
 
                 foreach (DataRow r in metadata.Rows)
                 {
-                    if ((Boolean) r["IsKey"])
+                    switch ((string)r["ColumnName"])
                     {
-                        Assert.AreEqual("field_pk", r["ColumnName"]);
-                        keyfound = true;
+                        case "field_serial":
+                        case "field_bigserial":
+                        case "field_smallserial": // 9.2 and later
+                            Assert.IsTrue((bool)r["IsAutoIncrement"]);
+                            break;
+                        default:
+                            break;
                     }
-
                 }
-                if (!keyfound)
-                    Assert.Fail("No primary key found!");
             }
         }
+
+        [Test]
+        public void IsReadOnlyMetadataSupport()
+        {
+            ExecuteNonQuery("CREATE OR REPLACE VIEW DataView (field_pk, field_int2) AS select field_pk, field_int2 + field_int2 as field_int2 from data");
+
+            var command = new NpgsqlCommand("SELECT * FROM DataView", Conn);
+
+            using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))
+            {
+                var metadata = dr.GetSchemaTable();
+
+                foreach (DataRow r in metadata.Rows)
+                {
+                    switch ((string)r["ColumnName"])
+                    {
+                        case "field_pk":
+                            if (Conn.PostgreSqlVersion < new Version("9.4"))
+                            {
+                                // 9.3 and earlier: IsUpdatable = False
+                                Assert.IsTrue((bool)r["IsReadonly"], "field_pk");
+                            }
+                            else
+                            {
+                                // 9.4: IsUpdatable = True
+                                Assert.IsFalse((bool)r["IsReadonly"], "field_pk");
+                            }
+                            break;
+                        case "field_int2":
+                            Assert.IsTrue((bool)r["IsReadonly"], "field_int2");
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+
+        #endregion
 
         [Test]
         public void IsIdentityMetadataSupport()
@@ -717,7 +835,7 @@ namespace NpgsqlTests
                 {
                     if (((string)r["ColumnName"]) == "field_serial")
                     {
-                        Assert.IsTrue((bool) r["IsAutoIncrement"]);
+                        Assert.IsTrue((bool)r["IsAutoIncrement"]);
                         return;
                     }
                 }

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -240,6 +240,7 @@ namespace NpgsqlTests
             {
                 sb.Append(",").AppendLine();
                 sb.Append(@"field_serial                  SERIAL,
+                            field_bigserial               BIGSERIAL,
                             field_bit                     BIT,
                             field_time                    TIME,
                             field_timestamp_with_timezone TIMESTAMP WITH TIME ZONE,
@@ -261,6 +262,8 @@ namespace NpgsqlTests
                 if (Conn.PostgreSqlVersion >= new Version(9, 2)) {
                     sb.Append(",").AppendLine();
                     sb.Append(@"field_json JSON");
+                    sb.Append(",").AppendLine();
+                    sb.Append(@"field_smallserial SMALLSERIAL");
                 }
 
                 if (Conn.PostgreSqlVersion >= new Version(9, 4)) {


### PR DESCRIPTION
- Using `information_schema.columns.is_updatable` instead of `pg_column_is_updatable`.