### PR TITLE
Add char column type support for NpgsqlCommandBuilder.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlCommandBuilder.cs
+++ b/Npgsql/Npgsql/NpgsqlCommandBuilder.cs
@@ -388,8 +388,22 @@ namespace Npgsql
                 parameter.SourceColumn = "";
             }
             else
+            {
+                NpgsqlBackendTypeInfo typeInfo;
+                if (row[SchemaTableColumn.ProviderType] != null
+                    && NpgsqlTypesHelper.TryGetBackendTypeInfo((String)row[SchemaTableColumn.ProviderType], out typeInfo)
+                ) {
+                    parameter.NpgsqlDbType = typeInfo.NpgsqlDbType;
+                }
+                else {
+                    parameter.NpgsqlDbType = NpgsqlTypesHelper.GetNativeTypeInfo((Type)row[SchemaTableColumn.DataType]).NpgsqlDbType;
+                }
 
-                parameter.NpgsqlDbType = NpgsqlTypesHelper.GetNativeTypeInfo((Type)row[SchemaTableColumn.DataType]).NpgsqlDbType;
+                if (row[SchemaTableColumn.ColumnSize] is int)
+                {
+                    parameter.Size = (int)row[SchemaTableColumn.ColumnSize];
+                }
+            }
 
         }
 

--- a/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
@@ -480,7 +480,7 @@ namespace NpgsqlTypes
                                             null,
                                             BasicBackendToNativeTypeConverter.TextBinaryToString);
 
-            yield return new NpgsqlBackendTypeInfo(0, "bpchar", NpgsqlDbType.Text, DbType.String, typeof(String),
+            yield return new NpgsqlBackendTypeInfo(0, "bpchar", NpgsqlDbType.Char, DbType.String, typeof(String),
                                             null,
                                             BasicBackendToNativeTypeConverter.TextBinaryToString);
 

--- a/tests/TestBase.cs
+++ b/tests/TestBase.cs
@@ -224,6 +224,7 @@ namespace NpgsqlTests
             sb.AppendFormat(@"CREATE TABLE data (
                                 field_pk                      {0},
                                 field_text                    TEXT,
+                                field_char                    CHAR,
                                 field_char5                   CHAR(5),
                                 field_varchar5                VARCHAR(5),
                                 field_int2                    INT2,


### PR DESCRIPTION
Add char column type support for NpgsqlCommandBuilder.

NpgsqlCommandBuilder causes concurrency violation in 2 reasons (#549):

1. Npgsql casts string to `text` type, even if server's column type is `char(x)` (aka bpchar). bpchar ignores trailing spaces, but text type minds them.
2. The `double precision` column type in query result differs between ODBC driver and Npgsql due to `extra_float_digits` setting.

This pr will fix 1.

- `bpchar` is now `NpgsqlDbType.Char`.
- Fill `NpgsqlParameter.NpgsqlDbType` from output of `TryGetBackendTypeInfo`. It can check `ProviderType` like "bpchar".
- Fill `NpgsqlParameter.Size` for `bpchar` and so on.