### PR TITLE
Allow any value setting to NpgsqlParameter.Value in spite of assigned DbType.

### DIFF
--- a/Npgsql/Npgsql/NpgsqlParameter.cs
+++ b/Npgsql/Npgsql/NpgsqlParameter.cs
@@ -653,8 +653,26 @@ namespace Npgsql
                 }
                 else
                 {
-                    this.npgsqlValue = backendTypeInfo.ConvertToProviderType(value);
-                    this.value = backendTypeInfo.ConvertToFrameworkType(npgsqlValue);
+                    try
+                    {
+                        this.npgsqlValue = backendTypeInfo.ConvertToProviderType(value);
+                        this.value = backendTypeInfo.ConvertToFrameworkType(npgsqlValue);
+                    }
+                    catch (InvalidCastException)
+                    {
+                        if (!NpgsqlTypesHelper.TryGetNativeTypeInfo(value.GetType(), out type_info))
+                        {
+                            throw new InvalidCastException(String.Format(resman.GetString("Exception_ImpossibleToCast"), value.GetType()));
+                        }
+
+                        if (!NpgsqlTypesHelper.TryGetBackendTypeInfo(type_info.Name, out backendTypeInfo))
+                        {
+                            throw new InvalidCastException(String.Format(resman.GetString("Exception_ImpossibleToCast"), value.GetType()));
+                        }
+
+                        this.npgsqlValue = backendTypeInfo.ConvertToProviderType(value);
+                        this.value = backendTypeInfo.ConvertToFrameworkType(npgsqlValue);
+                    }
 
                     bound = false;
                 }

--- a/Npgsql/Npgsql/NpgsqlParameter.cs
+++ b/Npgsql/Npgsql/NpgsqlParameter.cs
@@ -400,6 +400,8 @@ namespace Npgsql
                 {
                     throw new InvalidCastException(String.Format(resman.GetString("Exception_ImpossibleToCast"), value));
                 }
+
+                backendTypeInfo = null;
             }
         }
 

--- a/tests/DataAdapterTests.cs
+++ b/tests/DataAdapterTests.cs
@@ -469,12 +469,8 @@ namespace NpgsqlTests
             var da = new NpgsqlDataAdapter("SELECT field_pk,field_date,field_int4 FROM data", Conn);
             da.Fill(ds, "data");
 
-            da.RowUpdating += (sender2, e2) => {
-                // this workaround needs to be before you getting NpgsqlCommandBuilder.
-                e2.Command.Parameters.Clear();
-            };
-
             var cb = new NpgsqlCommandBuilder(da as NpgsqlDataAdapter);
+            Assert.IsFalse(cb.SetAllValues);
             //cb.SetAllValues = false; // default is false
             //cb.SetAllValues = true; // System.InvalidCastException won't be raised if set to true.
             cb.ConflictOption = ConflictOption.OverwriteChanges;


### PR DESCRIPTION
Grab a new type_info from given value, when InvalidCastException is thrown at NpgsqlParameter.Value setter.

This pr will fix #352 issue.

Npgsql tests work fine on 9.0-9.4 servers with some yellow marks.