### PR TITLE
TypeHandlerRegistry considers type namespace now.

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -950,7 +950,7 @@ namespace Npgsql
                 // Transparently dereference cursors returned from functions
                 if (CommandType == CommandType.StoredProcedure &&
                     reader.FieldCount == 1 &&
-                    reader.GetDataTypeName(0) == "refcursor")
+                    reader.GetDataTypeName(0) == "pg_catalog.refcursor")
                 {
                     var sb = new StringBuilder();
                     while (reader.Read()) {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -999,19 +999,16 @@ namespace Npgsql
         /// To register the type for a specific connection, use the <see cref="RegisterEnum{T}"/> method.
         /// </remarks>
         /// <param name="pgName">
-        /// A PostgreSQL type name for the corresponding enum type in the database.
-        /// If null, the .NET type's name in lowercase will be used
+        /// A PostgreSQL full type name for the corresponding enum type in the database.
         /// </param>
         /// <typeparam name="TEnum">The .NET enum type to be associated</typeparam>
-        public static void RegisterEnumGlobally<TEnum>(string pgName = null) where TEnum : struct
+        public static void RegisterEnumGlobally<TEnum>(string pgFullName) where TEnum : struct
         {
             if (!typeof(TEnum).GetTypeInfo().IsEnum)
                 throw new ArgumentException("An enum type must be provided");
-            if (pgName != null && pgName.Trim() == "")
-                throw new ArgumentException("pgName can't be empty", "pgName");
             Contract.EndContractBlock();
 
-            TypeHandlerRegistry.RegisterEnumTypeGlobally<TEnum>(pgName ?? typeof(TEnum).Name.ToLower());
+            TypeHandlerRegistry.RegisterEnumTypeGlobally<TEnum>(pgFullName);
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1136,7 +1136,7 @@ namespace Npgsql
             CheckOrdinal(ordinal);
             Contract.EndContractBlock();
 
-            return _rowDescription[ordinal].Handler.PgName;
+            return _rowDescription[ordinal].Handler.PgFullName;
         }
 
         /// <summary>
@@ -1266,7 +1266,7 @@ namespace Npgsql
             var elementType = t.GetElementType();
             var arrayHandler = handler as ArrayHandler;
             if (arrayHandler == null) {
-                throw new InvalidCastException(String.Format("Can't cast database type {0} to {1}", fieldDescription.Handler.PgName, typeof(T).Name));
+                throw new InvalidCastException(String.Format("Can't cast database type {0} to {1}", fieldDescription.Handler.PgFullName, typeof(T).Name));
             }
 
             if (arrayHandler.GetElementFieldType(fieldDescription) == elementType)
@@ -1277,7 +1277,7 @@ namespace Npgsql
             {
                 return (T)GetProviderSpecificValue(ordinal);
             }
-            throw new InvalidCastException(String.Format("Can't cast database type {0} to {1}", handler.PgName, typeof(T).Name));
+            throw new InvalidCastException(String.Format("Can't cast database type {0} to {1}", handler.PgFullName, typeof(T).Name));
         }
 
         /// <summary>

--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -8,6 +8,8 @@ using NpgsqlTypes;
 
 namespace Npgsql.TypeHandlers
 {
+    // TODO It doesn't work now because hstore type is added by an extension so 
+    // we don't know to which schema it belongs.
     [TypeMapping("hstore", NpgsqlDbType.Hstore)]
     class HstoreHandler : TypeHandler<IDictionary<string, string>>,
         IChunkingTypeWriter, IChunkingTypeReader<IDictionary<string, string>>, IChunkingTypeReader<string>

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -20,7 +20,7 @@ namespace Npgsql.TypeHandlers
         public RangeHandler(TypeHandler<TElement> elementHandler, string name)
         {
             ElementHandler = elementHandler;
-            PgName = name;
+            PgFullName = name;
         }
 
         #region State

--- a/src/Npgsql/TypeHandlers/UnrecognizedTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnrecognizedTypeHandler.cs
@@ -21,7 +21,7 @@ namespace Npgsql.TypeHandlers
         internal UnrecognizedTypeHandler()
         {
             OID = 0;
-            PgName = "<unknown>";
+            PgFullName = "<unknown>";
         }
 
         internal override void PrepareRead(NpgsqlBuffer buf, FieldDescription fieldDescription, int len)

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -176,7 +176,7 @@ namespace Npgsql.Tests
             var command = new NpgsqlCommand(@"SELECT 1::INT4 AS some_column", Conn);
             var dr = command.ExecuteReader();
             dr.Read();
-            Assert.That(dr.GetDataTypeName(0), Is.EqualTo("int4"));
+            Assert.That(dr.GetDataTypeName(0), Is.EqualTo("pg_catalog.int4"));
             command.Dispose();
         }
 

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Tests.Types
         [Test]
         public void LateRegistration()
         {
-            Conn.RegisterEnum<Mood>("mood");
+            Conn.RegisterEnum<Mood>("public.mood");
             const Mood expected = Mood.Ok;
             var cmd = new NpgsqlCommand("SELECT @p1::MOOD, @p2::MOOD", Conn);
             var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Enum) { EnumType = typeof(Mood), Value = expected };
@@ -41,8 +41,8 @@ namespace Npgsql.Tests.Types
         [Test]
         public void DualEnums()
         {
-            Conn.RegisterEnum<Mood>("mood");
-            Conn.RegisterEnum<TestEnum>("test_enum");
+            Conn.RegisterEnum<Mood>("public.mood");
+            Conn.RegisterEnum<TestEnum>("public.test_enum");
             var cmd = new NpgsqlCommand("SELECT @p1", Conn);
             var expected = new Mood[] { Mood.Ok, Mood.Sad };
             var p = new NpgsqlParameter("p1", NpgsqlDbType.Enum | NpgsqlDbType.Array) { EnumType = typeof(Mood), Value = expected };
@@ -54,7 +54,7 @@ namespace Npgsql.Tests.Types
         [Test]
         public void GlobalRegistration()
         {
-            NpgsqlConnection.RegisterEnumGlobally<Mood>();
+            NpgsqlConnection.RegisterEnumGlobally<Mood>("public.mood");
             var myconn = new NpgsqlConnection(ConnectionString);
             myconn.Open();
             const Mood expected = Mood.Ok;
@@ -76,7 +76,7 @@ namespace Npgsql.Tests.Types
         [Test]
         public void Array()
         {
-            Conn.RegisterEnum<Mood>("mood");
+            Conn.RegisterEnum<Mood>("public.mood");
             var expected = new[] { Mood.Ok, Mood.Happy };
             var cmd = new NpgsqlCommand("SELECT @p1::MOOD[], @p2::MOOD[]", Conn);
             var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Enum | NpgsqlDbType.Array) { EnumType=typeof(Mood), Value = expected };
@@ -100,7 +100,7 @@ namespace Npgsql.Tests.Types
         [Test]
         public void TestEnumType()
         {
-            Conn.RegisterEnum<TestEnum>("test_enum");
+            Conn.RegisterEnum<TestEnum>("public.test_enum");
             using (var cmd = Conn.CreateCommand())
             {
                 cmd.CommandText = "Select :p1, :p2, :p3, :p4, :p5";

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -48,7 +48,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetValue(i),                 Is.True);
                 Assert.That(reader.GetProviderSpecificValue(i), Is.True);
                 Assert.That(reader.GetFieldType(i),             Is.EqualTo(typeof (bool)));
-                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("bool"));
+                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("pg_catalog.bool"));
             }
 
             reader.Close();
@@ -205,7 +205,7 @@ namespace Npgsql.Tests.Types
 
         static void CheckUnrecognizedType()
         {
-            Assert.That(TypeHandlerRegistry.HandlerTypes.Values.All(x => x.Mapping.PgName != "regproc"), "Test requires an unrecognized type to work");
+            Assert.That(TypeHandlerRegistry.HandlerTypes.Values.All(x => x.Mapping.PgFullName != "regproc"), "Test requires an unrecognized type to work");
         }
 
         [Test, Description("Attempts to retrieve an unrecognized type without marking it as unknown, triggering an exception")]

--- a/test/Npgsql.Tests/Types/NumericTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTypeTests.cs
@@ -54,7 +54,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetValue(i),                 Is.EqualTo(8));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(8));
                 Assert.That(reader.GetFieldType(i),             Is.EqualTo(typeof(short)));
-                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("int2"));
+                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("pg_catalog.int2"));
             }
 
             reader.Dispose();
@@ -89,7 +89,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetValue(i),                 Is.EqualTo(8));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(8));
                 Assert.That(reader.GetFieldType(i),             Is.EqualTo(typeof(int)));
-                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("int4"));
+                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("pg_catalog.int4"));
             }
 
             reader.Dispose();
@@ -137,7 +137,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetValue(i),                 Is.EqualTo(8));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(8));
                 Assert.That(reader.GetFieldType(i),             Is.EqualTo(typeof(long)));
-                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("int8"));
+                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("pg_catalog.int8"));
             }
 
             reader.Dispose();
@@ -246,7 +246,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetValue(i),                 Is.EqualTo(8));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(8));
                 Assert.That(reader.GetFieldType(i),             Is.EqualTo(typeof(decimal)));
-                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("numeric"));
+                Assert.That(reader.GetDataTypeName(i),          Is.EqualTo("pg_catalog.numeric"));
             }
 
             reader.Dispose();


### PR DESCRIPTION
Hello! I have tried to fix #632.
This implementation breaks ```hstore``` extension handling though:
It doesn't work because hstore type is added by an extension so  we don't know to which schema it belongs beforehand.
The only possible way to solve this problem that I see is to try to support both names and names with namespaces. Perhaps it is worth to create something like ```PgTypeName```. But this will complicate the lookup code and perhaps slightly decrease performance. With unified ```string``` name lookup is done with standard ```Dictionary```.
Do you have any other thoughts or suggestions?
**UPDATE**: I will add specific test cases after we decide what implementation we prefer.