### PR TITLE
Fix EntityFramework6 support library assembly name

### DIFF
--- a/test/EntityFramework6.Npgsql.Tests/App.config
+++ b/test/EntityFramework6.Npgsql.Tests/App.config
@@ -9,7 +9,7 @@
   </startup>
   <entityFramework>
     <providers>
-      <provider invariantName="Npgsql" type="Npgsql.NpgsqlServices, Npgsql.EntityFramework6"></provider>
+      <provider invariantName="Npgsql" type="Npgsql.NpgsqlServices, EntityFramework6.Npgsql"></provider>
     </providers>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>


### PR DESCRIPTION
Modification needed to reflect EntityFramework 6 support assembly rename done here: 
https://github.com/npgsql/npgsql/commit/92cda84e72b4834d3993f9c4fddd6f17b1066ddb

This makes Entity Framework 6 tests run again.