### PR TITLE
ToUniversalTime() and ToLocalTime() should consider current DST

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -179,7 +179,7 @@ namespace NpgsqlTypes
             case InternalType.FiniteUnspecified:
                 // Treat as Local
             case InternalType.FiniteLocal:
-                return new NpgsqlDateTime(Subtract(TimeZoneInfo.Local.BaseUtcOffset).Ticks, DateTimeKind.Utc);
+                return new NpgsqlDateTime(this.DateTime.ToUniversalTime());
             case InternalType.FiniteUtc:
             case InternalType.Infinity:
             case InternalType.NegativeInfinity:
@@ -195,7 +195,7 @@ namespace NpgsqlTypes
             case InternalType.FiniteUnspecified:
                 // Treat as UTC
             case InternalType.FiniteUtc:
-                return new NpgsqlDateTime(Add(TimeZoneInfo.Local.BaseUtcOffset).Ticks, DateTimeKind.Local);
+                return new NpgsqlDateTime(this.DateTime.ToLocalTime());
             case InternalType.FiniteLocal:
             case InternalType.Infinity:
             case InternalType.NegativeInfinity:

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampTzHandler.cs
@@ -70,10 +70,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 var ts = (NpgsqlDateTime)value;
                 switch (ts.Kind)
                 {
-                case DateTimeKind.Unspecified:
-                    // Treat as Local
                 case DateTimeKind.Utc:
                     break;
+                case DateTimeKind.Unspecified:
+                    // Treat as Local
                 case DateTimeKind.Local:
                     ts = ts.ToUniversalTime();
                     break;
@@ -89,10 +89,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 var dt = (DateTime)value;
                 switch (dt.Kind)
                 {
-                case DateTimeKind.Unspecified:
-                // Treat as Local
                 case DateTimeKind.Utc:
                     break;
+                case DateTimeKind.Unspecified:
+                    // Treat as Local
                 case DateTimeKind.Local:
                     dt = dt.ToUniversalTime();
                     break;


### PR DESCRIPTION
There are some changes in time handling in Npgsql version 3. While looking through I found convertings between local and universal time. I think, we should consider more than only the base utc offset. The offset between local time and universal time depends also on daylight saving time. Why not use the DateTime functions?