### PR TITLE
DO treat DateTimeKind.Unspecified as local

### DIFF
--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampTzHandler.cs
@@ -70,10 +70,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 var ts = (NpgsqlDateTime)value;
                 switch (ts.Kind)
                 {
-                case DateTimeKind.Unspecified:
-                    // Treat as Local
                 case DateTimeKind.Utc:
                     break;
+                case DateTimeKind.Unspecified:
+                    // Treat as Local
                 case DateTimeKind.Local:
                     ts = ts.ToUniversalTime();
                     break;
@@ -89,10 +89,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 var dt = (DateTime)value;
                 switch (dt.Kind)
                 {
-                case DateTimeKind.Unspecified:
-                // Treat as Local
                 case DateTimeKind.Utc:
                     break;
+                case DateTimeKind.Unspecified:
+                    // Treat as Local
                 case DateTimeKind.Local:
                     dt = dt.ToUniversalTime();
                     break;


### PR DESCRIPTION
As I understand the comments, DateTimeKind.Unspecified should be treated the same way as DateTimeKind.Local. So rearrangement of cases are needed. Am I right?