### PR TITLE
ToUniversalTime() and ToLocalTime() should consider current DST

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -179,7 +179,7 @@ namespace NpgsqlTypes
             case InternalType.FiniteUnspecified:
                 // Treat as Local
             case InternalType.FiniteLocal:
-                return new NpgsqlDateTime(Subtract(TimeZoneInfo.Local.BaseUtcOffset).Ticks, DateTimeKind.Utc);
+                return new NpgsqlDateTime(this.DateTime.ToUniversalTime());
             case InternalType.FiniteUtc:
             case InternalType.Infinity:
             case InternalType.NegativeInfinity:
@@ -195,7 +195,7 @@ namespace NpgsqlTypes
             case InternalType.FiniteUnspecified:
                 // Treat as UTC
             case InternalType.FiniteUtc:
-                return new NpgsqlDateTime(Add(TimeZoneInfo.Local.BaseUtcOffset).Ticks, DateTimeKind.Local);
+                return new NpgsqlDateTime(this.DateTime.ToLocalTime());
             case InternalType.FiniteLocal:
             case InternalType.Infinity:
             case InternalType.NegativeInfinity:


### PR DESCRIPTION
There are some changes in time handling in Npgsql version 3. While looking through I found converts between local and universal time. I think, we should consider more than only the base utc offset. The offset between local time and universal time depends also on daylight saving time. Why not use the DateTime functions?