### PR TITLE
Allow enums to be treated as text for compatability with v2 #763

### DIFF
--- a/src/Npgsql/TypeHandlers/EnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/EnumHandler.cs
@@ -33,6 +33,38 @@ using System.Text;
 namespace Npgsql.TypeHandlers
 {
     internal interface IEnumHandler { }
+
+    // Default handler for enums that are not registered. Treats reads and writes as text
+    internal class EnumTextHandler : TypeHandler<String>, ISimpleTypeReader<string>, ISimpleTypeWriter
+    {
+        public string Read(NpgsqlBuffer buf, int len, FieldDescription fieldDescription)
+        {
+            var str = buf.ReadString(len);
+            return str;
+        }
+
+        public int ValidateAndGetLength(object value, NpgsqlParameter parameter)
+        {
+            string str = value.ToString();
+            return Encoding.UTF8.GetByteCount(str);
+        }
+
+        public void Write(object value, NpgsqlBuffer buf, NpgsqlParameter parameter)
+        {
+            string str = value.ToString();
+            buf.WriteString(str);
+        }
+        internal EnumTextHandler Clone()
+        {
+            return new EnumTextHandler();
+        }
+
+        internal Type GetFieldType()
+        {
+            return typeof(string);
+        }
+    }
+
     internal class EnumHandler<TEnum> : TypeHandler<TEnum>, IEnumHandler,
         ISimpleTypeReader<TEnum>, ISimpleTypeWriter
         where TEnum : struct


### PR DESCRIPTION
* Add EnumTextHandler implementation
* Register new handler when there are no enumRegistrations for a type
* Re-order some logic so that registered enums handlers get picked
  before the text one

This is in respect of:   https://github.com/npgsql/npgsql/issues/763

I made the changes against master as develop had compiler errors (issue with `Precision` but I wasn't able to resolve it). If you want me to try to apply it to develop branch  I can try some more.

Tested on win8.1 with PG9.3

I had most of it done when @roji said he would pick it up but I didn't have access to email or pc today. 

Hopefully it is still useful....
