### PR TITLE
Fix UsingPostgresDbConnection to use EntityTemplateDatabase

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlServices.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlServices.cs
@@ -196,7 +196,7 @@ namespace Npgsql
         {
             var connectionBuilder = new NpgsqlConnectionStringBuilder(connection.ConnectionString)
             {
-                Database = connection.EntityTemplateDatabase ?? "template1",
+                Database = connection.EntityAdminDatabase ?? "template1",
                 Pooling = false
             };
 

--- a/src/EntityFramework6.Npgsql/NpgsqlServices.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlServices.cs
@@ -196,7 +196,7 @@ namespace Npgsql
         {
             var connectionBuilder = new NpgsqlConnectionStringBuilder(connection.ConnectionString)
             {
-                Database = "template1",
+                Database = connection.EntityTemplateDatabase ?? "template1",
                 Pooling = false
             };
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -419,6 +419,7 @@ namespace Npgsql
         internal bool Enlist { get { return Settings.Enlist; } }
         internal int BufferSize { get { return Settings.BufferSize; } }
         internal string EntityTemplateDatabase { get { return Settings.EntityTemplateDatabase; } }
+        internal string EntityAdminDatabase { get { return Settings.EntityAdminDatabase; } }
 
         #endregion Configuration settings
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -848,6 +848,29 @@ namespace Npgsql
         }
         string _entityTemplateDatabase;
 
+        /// <summary>
+        /// The database admin to specify when creating and dropping a database in Entity Framework. This is needed because
+        /// Npgsql needs to connect to a database in order to send the create/drop database command.
+        /// If not specified, defaults to "template1". Check NpgsqlServices.UsingPostgresDBConnection for more information.
+        /// </summary>
+        #if !DNXCORE50
+        [Category("Entity Framework")]
+        [Description("The database admin to specify when creating and dropping a database in Entity Framework. If not specified, defaults to \"template1\".")]
+        #endif
+        [DisplayName("EF Admin Database")]
+        [NpgsqlConnectionStringProperty]
+        public string EntityAdminDatabase
+        {
+            get { return _entityAdminDatabase; }
+            set
+            {
+                _entityAdminDatabase = value;
+                // TODO: Replace literal name with nameof operator in C# 6.0
+                SetValue("EntityAdminDatabase", value);
+            }
+        }
+        string _entityAdminDatabase;
+
 #endregion
 
 #region Properties - Advanced


### PR DESCRIPTION
UsingPostgresDbConnection wasn't using the EntityTemplateDatabase connection string parameter.

This was spotted by @harpagornis comment in https://github.com/npgsql/npgsql/issues/804#issuecomment-144080822. 

He was using a user who didn't have access to template1 database. By checking where this database access was coming from, I could check it was using template1 hardcode when it should be using the EntityTemplateDatabase connection string parameter.