### PR TITLE
EFv5 support on Npgsql develop

### DIFF
--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4A5A60DD-41B6-40BF-B677-227A921ECCC8}"
 	ProjectSection(SolutionItems) = preProject
@@ -18,6 +18,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework6.Npgsql", "src\EntityFramework6.Npgsql\EntityFramework6.Npgsql.csproj", "{3EC85CBA-5B79-11E3-8104-0022198AB089}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework5.Npgsql", "src\EntityFramework5.Npgsql\EntityFramework5.Npgsql.csproj", "{100998C4-5B85-11E3-911C-0022198AB089}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E9C258D7-0D8E-4E6A-9857-5C6438591755} = {E9C258D7-0D8E-4E6A-9857-5C6438591755}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.Tests", "test\Npgsql.Tests\Npgsql.Tests.csproj", "{E9C258D7-0D8E-4E6A-9857-5C6438591755}"
 EndProject
@@ -32,6 +35,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework7.Npgsql.Design", "src\EntityFramework7.Npgsql.Design\EntityFramework7.Npgsql.Design.csproj", "{8EDCED17-2D1D-45BE-9B61-0F715876DA94}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework7.Npgsql.Design.FunctionalTests", "test\EntityFramework7.Npgsql.Design.FunctionalTests\EntityFramework7.Npgsql.Design.FunctionalTests.csproj", "{1410D291-C519-4E74-AE3D-6BC6C4A7C1DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework5.Npgsql.Tests", "test\EntityFramework5.Npgsql.Tests\EntityFramework5.Npgsql.Tests.csproj", "{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,6 +84,10 @@ Global
 		{1410D291-C519-4E74-AE3D-6BC6C4A7C1DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1410D291-C519-4E74-AE3D-6BC6C4A7C1DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1410D291-C519-4E74-AE3D-6BC6C4A7C1DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +103,7 @@ Global
 		{E1D99AD4-D88B-42BA-86DF-90B98B2E9A01} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 		{8EDCED17-2D1D-45BE-9B61-0F715876DA94} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{1410D291-C519-4E74-AE3D-6BC6C4A7C1DC} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
+		{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Npgsql.csproj

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -5,6 +5,7 @@
   <repository path="..\src\EntityFramework7.Npgsql.Design\packages.config" />
   <repository path="..\src\Npgsql\packages.config" />
   <repository path="..\src\NpgsqlDdexProvider\packages.config" />
+  <repository path="..\test\EntityFramework5.Npgsql.Tests\packages.config" />
   <repository path="..\test\EntityFramework6.Npgsql.Tests\packages.config" />
   <repository path="..\test\EntityFramework7.Npgsql.FunctionalTests\packages.config" />
   <repository path="..\test\EntityFramework7.Npgsql.Design.FunctionalTests\packages.config" />

--- a/src/Npgsql/NpgsqlFactory.cs
+++ b/src/Npgsql/NpgsqlFactory.cs
@@ -93,20 +93,20 @@ namespace Npgsql
                 if (_legacyEntityFrameworkServices != null)
                     return _legacyEntityFrameworkServices;
 
-                // First time, attempt to find the Npgsql.EntityFrameworkLegacy assembly and load the type via reflection
+                // First time, attempt to find the EntityFramework5.Npgsql assembly and load the type via reflection
                 var assemblyName = typeof(NpgsqlFactory).GetTypeInfo().Assembly.GetName();
-                assemblyName.Name = "Npgsql.EntityFrameworkLegacy";
+                assemblyName.Name = "EntityFramework5.Npgsql";
                 Assembly npgsqlEfAssembly;
                 try {
                     npgsqlEfAssembly = Assembly.Load(new AssemblyName(assemblyName.FullName));
                 } catch (Exception e) {
-                    throw new Exception("Could not load Npgsql.EntityFrameworkLegacy assembly, is it installed?", e);
+                    throw new Exception("Could not load EntityFramework5.Npgsql assembly, is it installed?", e);
                 }
 
                 Type npgsqlServicesType;
                 if ((npgsqlServicesType = npgsqlEfAssembly.GetType("Npgsql.NpgsqlServices")) == null ||
                     npgsqlServicesType.GetProperty("Instance") == null)
-                    throw new Exception("Npgsql.EntityFrameworkLegacy assembly does not seem to contain the correct type!");
+                    throw new Exception("EntityFramework5.Npgsql assembly does not seem to contain the correct type!");
 
                 return _legacyEntityFrameworkServices = npgsqlServicesType.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static).GetMethod.Invoke(null, new object[0]);
             }

--- a/test/EntityFramework5.Npgsql.Tests/App.config
+++ b/test/EntityFramework5.Npgsql.Tests/App.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v12.0" />
+      </parameters>
+    </defaultConnectionFactory>
+  </entityFramework>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+</configuration>

--- a/test/EntityFramework5.Npgsql.Tests/EntityFramework5.Npgsql.Tests.csproj
+++ b/test/EntityFramework5.Npgsql.Tests/EntityFramework5.Npgsql.Tests.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4EB6FD81-6A30-4C35-AA89-BD2B0EDDAFF3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EntityFramework5.Npgsql.Tests</RootNamespace>
+    <AssemblyName>EntityFramework5.Npgsql.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.5.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EntityFrameworkBasicTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EntityFramework5.Npgsql\EntityFramework5.Npgsql.csproj">
+      <Project>{100998c4-5b85-11e3-911c-0022198ab089}</Project>
+      <Name>EntityFramework5.Npgsql</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Npgsql\Npgsql.csproj">
+      <Project>{9d13b739-62b1-4190-b386-7a9547304eb3}</Project>
+      <Name>Npgsql</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Npgsql.Tests\Npgsql.Tests.csproj">
+      <Project>{e9c258d7-0d8e-4e6a-9857-5c6438591755}</Project>
+      <Name>Npgsql.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/EntityFramework5.Npgsql.Tests/EntityFrameworkBasicTests.cs
+++ b/test/EntityFramework5.Npgsql.Tests/EntityFrameworkBasicTests.cs
@@ -1,0 +1,44 @@
+﻿#region License
+// The PostgreSQL License
+//
+// Copyright (C) 2015 The Npgsql Development Team
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement is hereby granted, provided that the above copyright notice
+// and this paragraph and the following two paragraphs appear in all copies.
+//
+// IN NO EVENT SHALL THE NPGSQL DEVELOPMENT TEAM BE LIABLE TO ANY PARTY
+// FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+// INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+// DOCUMENTATION, EVEN IF THE NPGSQL DEVELOPMENT TEAM HAS BEEN ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE NPGSQL DEVELOPMENT TEAM SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
+// ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#endregion
+
+using Npgsql;
+using NUnit.Framework;
+using System.Data.Common;
+using Npgsql.Tests;
+
+namespace EntityFramework5.Npgsql.Tests {
+    [TestFixture]
+    public class EntityFrameworkBasicTests : TestBase {
+        public EntityFrameworkBasicTests(string backendVersion)
+            : base(backendVersion) {
+        }
+
+        [Test]
+        public void GetServiceTest() {
+            Assert.IsInstanceOf(
+                typeof(DbProviderServices), 
+                NpgsqlFactory.Instance.GetService(typeof(System.Data.Common.DbProviderServices))
+                );
+        }
+    }
+}

--- a/test/EntityFramework5.Npgsql.Tests/Properties/AssemblyInfo.cs
+++ b/test/EntityFramework5.Npgsql.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,54 @@
+﻿//
+// Author:
+//     Francisco Figueiredo Jr. <fxjrlists@yahoo.com>
+//
+//    Copyright (C) 2002 The Npgsql Development Team
+//    npgsql-general@gborg.postgresql.org
+//    http://gborg.postgresql.org/project/npgsql/projdisplay.php
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following
+// attributes.
+//
+// change them to the information which is associated with the assembly
+// you compile.
+
+[assembly: AssemblyTitle("")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has following format :
+//
+// Major.Minor.Build.Revision
+//
+// You can specify all values by your own or you can build default build and revision
+// numbers with the '*' character (the default):
+
+[assembly: AssemblyVersion("1.0.0.0")]
+
+// The following attributes specify the key for the sign of your assembly. See the
+// .NET Framework documentation for more information about signing.
+// This is not required, if you don't want signing let these attributes like they're.
+[assembly: AssemblyDelaySign(false)]
+[assembly: AssemblyKeyFile("")]

--- a/test/EntityFramework5.Npgsql.Tests/packages.config
+++ b/test/EntityFramework5.Npgsql.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="5.0.0" targetFramework="net46" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Fix NpgsqlFactory.GetService:
- Rename from `Npgsql.EntityFrameworkLegacy` to `EntityFramework5.Npgsql`

Please do not merge this yet. todo:
- [x] Test on app
- ~~Test on ddex~~ This is done by #718.
- [x] Add EntityFramework5.Npgsql.