### PR TITLE
UsingPostgresDBConnection copies Password property.

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlServices.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlServices.cs
@@ -197,7 +197,8 @@ namespace Npgsql
             var connectionBuilder = new NpgsqlConnectionStringBuilder(connection.ConnectionString)
             {
                 Database = connection.EntityAdminDatabase ?? "template1",
-                Pooling = false
+                Pooling = false,
+                Password = connection.Password,
             };
 
             using (var masterConnection = new NpgsqlConnection(connectionBuilder.ConnectionString))


### PR DESCRIPTION
Fix
- System.Exception: No password has been provided but the backend requires one (in MD5)