### PR TITLE
[EF6] No longer attempt to create the public schema

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
@@ -29,6 +29,7 @@ using System.Globalization;
 using System.Text;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Spatial;
+using System.Linq;
 
 namespace Npgsql
 {
@@ -178,7 +179,12 @@ namespace Npgsql
         private void Convert(CreateTableOperation createTableOperation)
         {
             StringBuilder sql = new StringBuilder();
-            CreateSchema(createTableOperation.Name);
+            int dotIndex = createTableOperation.Name.IndexOf('.');
+            if (dotIndex != -1)
+            {
+                CreateSchema(createTableOperation.Name.Remove(dotIndex));
+            }
+
             sql.Append("CREATE TABLE ");
             AppendTableName(createTableOperation.Name, sql);
             sql.Append('(');
@@ -187,7 +193,8 @@ namespace Npgsql
                 AppendColumn(column, sql);
                 sql.Append(",");
             }
-            sql.Remove(sql.Length - 1, 1);
+            if (createTableOperation.Columns.Any())
+                sql.Remove(sql.Length - 1, 1);
             if (createTableOperation.PrimaryKey != null)
             {
                 sql.Append(",");
@@ -230,10 +237,7 @@ namespace Npgsql
 
         private void CreateSchema(string schemaName)
         {
-            int dotIndex = schemaName.IndexOf('.');
-            if (dotIndex != -1)
-                schemaName = schemaName.Remove(dotIndex);
-            if (addedSchemas.Contains(schemaName))
+            if (schemaName == "public" || addedSchemas.Contains(schemaName))
                 return;
             addedSchemas.Add(schemaName);
             if (serverVersion.Major > 9 || (serverVersion.Major == 9 && serverVersion.Minor >= 3))

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
@@ -250,7 +250,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddColumnOperation()
+        public void AddColumnOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AddColumnOperation("tableName", new ColumnModel(PrimitiveTypeKind.Double)
@@ -263,7 +263,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddColumnOperationDefaultValue()
+        public void AddColumnOperationDefaultValue()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AddColumnOperation("tableName", new ColumnModel(PrimitiveTypeKind.Single)
@@ -277,7 +277,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddColumnOperationDefaultValueSql()
+        public void AddColumnOperationDefaultValueSql()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AddColumnOperation("tableName", new ColumnModel(PrimitiveTypeKind.Single)
@@ -291,7 +291,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAlterColumnOperation()
+        public void AlterColumnOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AlterColumnOperation("tableName", new ColumnModel(PrimitiveTypeKind.Double)
@@ -306,7 +306,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAlterColumnOperationDefaultAndNullable()
+        public void AlterColumnOperationDefaultAndNullable()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AlterColumnOperation("tableName", new ColumnModel(PrimitiveTypeKind.Double)
@@ -323,7 +323,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestCreateTableOperation()
+        public void CreateTableOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new CreateTableOperation("someSchema.someTable");
@@ -373,7 +373,23 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDropColumnOperation()
+        public void CreateTableWithoutSchema()
+        {
+            var statements = new NpgsqlMigrationSqlGenerator().Generate(new List<MigrationOperation> { new CreateTableOperation("some_table") }, BackendVersion.ToString()).ToList();
+            Assert.That(statements.Count, Is.EqualTo(1));
+            Assert.That(statements[0].Sql, Is.EqualTo("CREATE TABLE \"some_table\"()"));
+        }
+
+        [Test]
+        public void CreateTableInPublicSchema()
+        {
+            var statements = new NpgsqlMigrationSqlGenerator().Generate(new List<MigrationOperation> { new CreateTableOperation("public.some_table") }, BackendVersion.ToString()).ToList();
+            Assert.That(statements.Count, Is.EqualTo(1));
+            Assert.That(statements[0].Sql, Is.EqualTo("CREATE TABLE \"public\".\"some_table\"()"));
+        }
+
+        [Test]
+        public void DropColumnOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new DropColumnOperation("someTable", "someColumn"));
@@ -383,7 +399,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDropTableOperation()
+        public void DropTableOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new DropTableOperation("someTable"));
@@ -393,7 +409,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestRenameTableOperation()
+        public void RenameTableOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new RenameTableOperation("schema.someOldTableName", "someNewTablename"));
@@ -403,7 +419,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestHistoryOperation()
+        public void HistoryOperation()
         {
             var operations = new List<MigrationOperation>();
             //TODO: fill operations
@@ -412,7 +428,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDropIndexOperation()
+        public void DropIndexOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new DropIndexOperation()
@@ -426,7 +442,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDropIndexOperationTableNameWithSchema()
+        public void DropIndexOperationTableNameWithSchema()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new DropIndexOperation()
@@ -440,7 +456,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestCreateIndexOperation()
+        public void CreateIndexOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new CreateIndexOperation();
@@ -457,7 +473,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestCreateIndexOperationUnique()
+        public void CreateIndexOperationUnique()
         {
             var operations = new List<MigrationOperation>();
             var operation = new CreateIndexOperation();
@@ -474,7 +490,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestMoveTableOperation()
+        public void MoveTableOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new MoveTableOperation("someOldSchema.someTable", "someNewSchema"));
@@ -488,7 +504,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestMoveTableOperationNewSchemaIsNull()
+        public void MoveTableOperationNewSchemaIsNull()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new MoveTableOperation("someOldSchema.someTable", null));
@@ -502,7 +518,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddPrimaryKeyOperation()
+        public void AddPrimaryKeyOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new AddPrimaryKeyOperation();
@@ -519,7 +535,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddPrimaryKeyOperationClustered()
+        public void AddPrimaryKeyOperationClustered()
         {
             var operations = new List<MigrationOperation>();
             var operation = new AddPrimaryKeyOperation();
@@ -537,7 +553,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDropPrimaryKeyOperation()
+        public void DropPrimaryKeyOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new DropPrimaryKeyOperation();
@@ -550,7 +566,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestRenameColumnOperation()
+        public void RenameColumnOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new RenameColumnOperation("someTable", "someOldColumnName", "someNewColumnName"));
@@ -560,7 +576,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestSqlOperation()
+        public void SqlOperation()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new SqlOperation("SELECT someColumn FROM someTable"));
@@ -570,7 +586,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestUpdateDatabaseOperation()
+        public void UpdateDatabaseOperation()
         {
             var operations = new List<MigrationOperation>();
             //TODO: fill operations
@@ -579,7 +595,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddForeignKeyOperation()
+        public void AddForeignKeyOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new AddForeignKeyOperation();
@@ -597,7 +613,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestAddForeignKeyOperationCascadeDelete()
+        public void AddForeignKeyOperationCascadeDelete()
         {
             var operations = new List<MigrationOperation>();
             var operation = new AddForeignKeyOperation();
@@ -616,7 +632,7 @@ namespace EntityFramework6.Npgsql.Tests
 
 
         [Test]
-        public void TestDropForeignKeyOperation()
+        public void DropForeignKeyOperation()
         {
             var operations = new List<MigrationOperation>();
             var operation = new DropForeignKeyOperation();
@@ -632,7 +648,7 @@ namespace EntityFramework6.Npgsql.Tests
         }
 
         [Test]
-        public void TestDefaultTypes()
+        public void DefaultTypes()
         {
             var operations = new List<MigrationOperation>();
             operations.Add(new AddColumnOperation("someTable",


### PR DESCRIPTION
If a table's schema is public, don't send a CREATE SCHEMA statement.
This can be a workaround for users of PostgreSQL <= 9.2, which doesn't
have CREATE SCHEMA IF NOT EXISTS statement.