### PR TITLE
Support StoreType argument

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
@@ -29,6 +29,7 @@ using System.Globalization;
 using System.Text;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Spatial;
+using System.Text.RegularExpressions;
 
 namespace Npgsql
 {
@@ -605,6 +606,13 @@ namespace Npgsql
 
         private void AppendColumnType(ColumnModel column, StringBuilder sql, bool setSerial)
         {
+            if (column.StoreType != null)
+            {
+                if (Regex.IsMatch(column.StoreType, "^[a-zA-Z]+$"))
+                    throw new ArgumentException("StoreType has SQL Injection:" + column.StoreType);
+                sql.Append(column.StoreType);
+                return;
+            }
             switch (column.Type)
             {
                 case PrimitiveTypeKind.Binary:


### PR DESCRIPTION
In entity framework code first.
I need map DateTime type to SQL Date type.
So I add Support StoreType argument code.

reference:
http://stackoverflow.com/questions/5658216/entity-framework-code-first-date-field-creation