### PR TITLE
Add docker tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM microsoft/aspnet:1.0.0-rc1-update1-coreclr
+COPY . /app/
+WORKDIR /app
+RUN dnu restore --parallel -s NuGet --runtime coreclr50 src/Npgsql/project.json src/EntityFramework7.Npgsql/project.json test/EntityFramework7.Npgsql.Tests/project.json
+RUN dnu build --framework dnxcore50 src/Npgsql/project.json src/EntityFramework7.Npgsql/project.json
+ENTRYPOINT dnx -p test/EntityFramework7.Npgsql.Tests/project.json test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Npgsql - .NET Data Provider for PostgreSQL
 [![Stable nuget](https://img.shields.io/nuget/v/Npgsql.svg?label=stable%20nuget)](https://www.nuget.org/packages/Npgsql/)
 ![Unstable nuget](https://img.shields.io/myget/npgsql-unstable/v/npgsql.svg?label=unstable%20nuget)
 [![Build Status](https://img.shields.io/teamcity/http/build.npgsql.org/s/npgsql.svg?label=TeamCity)](http://build.npgsql.org/viewType.html?buildTypeId=npgsql&guest=1) [![Join the chat at https://gitter.im/npgsql/npsgl](https://img.shields.io/badge/GITTER-JOIN%20CHAT-brightgreen.svg)](https://gitter.im/npgsql/npgsql)
+[![Circle CI](https://circleci.com/gh/npgsql/npgsql.svg?style=svg)](https://circleci.com/gh/npgsql/npgsql)
 
 ###What Is Npgsql?
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+     - docker build -f Dockerfile.test -t npgsql .
+
+test:
+  override:
+    - docker run npgsql

--- a/test/EntityFramework7.Npgsql.Design.FunctionalTests/project.json
+++ b/test/EntityFramework7.Npgsql.Design.FunctionalTests/project.json
@@ -4,10 +4,11 @@
     "EntityFramework.Relational.Design.FunctionalTests": "7.0.0-rc1-final",
     "EntityFramework7.Npgsql.Design": "3.1.0-*",
     "EntityFramework7.Npgsql": "3.1.0-*",
-    "EntityFramework7.Npgsql.FunctionalTests": "1.0.0"
+    "EntityFramework7.Npgsql.FunctionalTests": "1.0.0",
+    "xunit.runner.dnx": "2.1.0-rc1-*"
   },
   "commands": {
-    "test": "xunit.runner.aspnet"
+    "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "net46": {

--- a/test/EntityFramework7.Npgsql.FunctionalTests/project.json
+++ b/test/EntityFramework7.Npgsql.FunctionalTests/project.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
     "EntityFramework.Relational.FunctionalTests": "7.0.0-rc1-final",
-    "EntityFramework7.Npgsql": "3.1.0-*"
+    "EntityFramework7.Npgsql": "3.1.0-*",
+    "xunit.runner.dnx": "2.1.0-rc1-*"
   },
   "commands": {
-    "test": "xunit.runner.aspnet"
+    "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "net46": {

--- a/test/EntityFramework7.Npgsql.Tests/project.json
+++ b/test/EntityFramework7.Npgsql.Tests/project.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
     "EntityFramework.Relational.FunctionalTests": "7.0.0-rc1-final",
-    "EntityFramework7.Npgsql": "3.1.0-*"
+    "EntityFramework7.Npgsql": "3.1.0-*",
+    "xunit.runner.dnx": "2.1.0-rc1-*"
   },
   "commands": {
-    "test": "xunit.runner.aspnet"
+    "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "net46": {


### PR DESCRIPTION
This adds builds and test running on coreclr in Docker on Linux. I think it's important that this build-chain is maintained, but it's especially important that the functional tests are run on Linux.

Currently, only the `EntityFramework7.Npgsql.Tests` project is executed, but this can be extended to run the functional tests with different versions of postgres.

This is currently failing. The cause of the failure is being addressed in https://github.com/npgsql/npgsql/issues/876

I commit to maintaining these builds and tests.