### PR TITLE
UAP 10.0 target

### DIFF
--- a/src/Npgsql/Common.cs
+++ b/src/Npgsql/Common.cs
@@ -149,7 +149,7 @@ namespace Npgsql
 
     #region Component model attributes missing from CoreCLR
 
-#if DNXCORE50 || DOTNET
+#if DNXCORE50 || UAP10_0 || DOTNET
     [AttributeUsage(AttributeTargets.Property)]
     class DisplayNameAttribute : Attribute
     {

--- a/src/Npgsql/Npgsql.xproj
+++ b/src/Npgsql/Npgsql.xproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>9d13b739-62b1-4190-b386-7a9547304eb3</ProjectGuid>
+    <ProjectGuid>89d1d4af-cad8-481f-9d5f-eaa2c9a2ccba</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
   </PropertyGroup>

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -49,7 +49,7 @@ namespace Npgsql
 #if WITHDESIGN
     [System.Drawing.ToolboxBitmapAttribute(typeof(NpgsqlCommand)), ToolboxItem(true)]
 #endif
-#if DNXCORE50 || DOTNET
+#if DNXCORE50 || UAP10_0 || DOTNET
     public sealed partial class NpgsqlCommand : DbCommand
 #else
     // ReSharper disable once RedundantNameQualifier

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -50,7 +50,7 @@ namespace Npgsql
 #if WITHDESIGN
     [System.Drawing.ToolboxBitmapAttribute(typeof(NpgsqlConnection))]
 #endif
-#if DNXCORE50 || DOTNET
+#if DNXCORE50 || UAP10_0 || DOTNET
     public sealed partial class NpgsqlConnection : DbConnection
 #else
     // ReSharper disable once RedundantNameQualifier

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -518,7 +518,7 @@ namespace Npgsql
                         else
                         {
                             var sslStream = new SslStream(_stream, false, certificateValidationCallback);
-#if DNXCORE50
+#if DNXCORE50 || UAP10_0
                             // CoreCLR removed sync methods from SslStream, see https://github.com/dotnet/corefx/pull/4868.
                             // Consider exactly what to do here.
                             sslStream.AuthenticateAsClientAsync(Host, clientCertificates, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false).Wait();
@@ -660,7 +660,7 @@ namespace Npgsql
                 Log.Trace("Attempting to connect to " + ips[i], Id);
                 var ep = new IPEndPoint(ips[i], Port);
                 var socket = new Socket(ep.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-#if DNXCORE50
+#if DNXCORE50 || UAP10_0
                 var connectTask = socket.ConnectAsync(ep);
 #else
                 var connectTask = Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, ep, null);

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -42,7 +42,7 @@ namespace Npgsql
 #if WITHDESIGN
     [TypeConverter(typeof(NpgsqlParameterConverter))]
 #endif
-#if DNXCORE50 || DOTNET
+#if DNXCORE50 || UAP10_0 || DOTNET
     public sealed class NpgsqlParameter : DbParameter
 #else
     public sealed class NpgsqlParameter : DbParameter, ICloneable

--- a/src/Npgsql/project.json
+++ b/src/Npgsql/project.json
@@ -34,16 +34,12 @@
     "keyFile": "../../Npgsql.snk"
   },
   "commands": {
-    "rewrite-async": "AsyncRewriter"
   },
   "scripts": {
-    "prebuild": [
-      "dnx rewrite-async"
-    ]
   },
   "dependencies": {
-    "AsyncRewriter": { "version": "0.7.8", "type": "build" }
   },
+  "runtimes": {"win": {}},
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
@@ -79,6 +75,40 @@
       }
     },
     "dnxcore50": {
+      "dependencies": {
+        "System.Collections.Concurrent": "4.0.11-*",
+        "System.Console": "4.0.0-*",
+        "System.ComponentModel": "4.0.1-*",
+        "System.ComponentModel.TypeConverter": "4.0.1-*",
+        "System.Data.Common": "4.0.1-*",
+        "System.Diagnostics.Contracts": "4.0.1-*",
+        "System.Diagnostics.Tools": "4.0.1-*",
+        "System.Globalization": "4.0.11-*",
+        "System.Globalization.Extensions": "4.0.1-*",
+        "System.Linq": "4.0.1-*",
+        "System.Net.NameResolution": "4.0.0-*",
+        "System.Net.Primitives": "4.0.11-*",
+        "System.Net.Sockets": "4.1.0-*",
+        "System.Net.Security": "4.0.0-*",
+        "System.Net.NetworkInformation": "4.1.0-*",
+        "System.Runtime": "4.0.21-*",
+        "System.Runtime.Extensions": "4.0.11-*",
+        "System.Runtime.InteropServices": "4.0.21-*",
+        "System.Runtime.Numerics": "4.0.1-*",
+        "System.Reflection": "4.1.0-*",
+        "System.Reflection.TypeExtensions": "4.0.1-*",
+        "System.Security.Cryptography.Primitives": "4.0.0-*",
+        "System.Security.Cryptography.Algorithms": "4.0.0-*",
+        "System.Security.Cryptography.X509Certificates": "4.0.0-*",
+        "System.Security.Principal": "4.0.1-*",
+        "System.Text.Encoding.Extensions": "4.0.11-*",
+        "System.Text.RegularExpressions": "4.0.11-*",
+        "System.Threading": "4.0.11-*",
+        "System.Threading.Thread": "4.0.0-*",
+        "System.Threading.Timer": "4.0.1-*"
+      }
+    },
+    "uap10.0": {
       "dependencies": {
         "System.Collections.Concurrent": "4.0.11-*",
         "System.Console": "4.0.0-*",

--- a/src/Npgsql/project.json
+++ b/src/Npgsql/project.json
@@ -114,7 +114,7 @@
         "System.Console": "4.0.0-*",
         "System.ComponentModel": "4.0.1-*",
         "System.ComponentModel.TypeConverter": "4.0.1-*",
-        "System.Data.Common": "4.0.1-*",
+        "System.Data.Common": "4.0.0-*",
         "System.Diagnostics.Contracts": "4.0.1-*",
         "System.Diagnostics.Tools": "4.0.1-*",
         "System.Globalization": "4.0.11-*",


### PR DESCRIPTION
Made another target with Windows Universal apps. Looks like these are distinct from the DNXCore targets. Seems there's a lot of confusion still going around about how to do this right. I'm also learning this myself. Refer to : https://oren.codes/2015/07/29/targeting-net-core/

Note that this change isn't complete, as the AsyncRewriter dependency needs to make a similar change to be compatible. But since it's just used as a pre-process step, I was able to successfully get a build out with this once the code was generated.

Note the drop in the version requirement for System.Data.Common. that fixes the:
 "Assembly 'Npgsql' with identity 'Npgsql, Version=3.1.0.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7' uses 'System.Data.Common, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Data.Common' with identity 'System.Data.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'	DataAccess	D:\Users\ncoder\code\ChainOfCommand\DataAccess\CSC		
"
 error for me. Looks like this may be related to this? https://github.com/npgsql/npgsql/issues/834

