### PR TITLE
force using DependencyInjection.1.0.0-rc2-16059

### DIFF
--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -16,8 +16,8 @@
     "EntityFramework.Core": "7.0.0-rc2-16563",
     "EntityFramework.Relational": "7.0.0-rc2-16563",
     "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-*",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-*",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",
     "Npgsql": "3.1.0-*"
   },

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -13,9 +13,9 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16563",
-    "EntityFramework.Relational": "7.0.0-rc2-16563",
-    "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
+    "EntityFramework.Core": "7.0.0-rc2-16649",
+    "EntityFramework.Relational": "7.0.0-rc2-16649",
+    "EntityFramework.Relational.Design": "7.0.0-rc2-16649",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -13,11 +13,11 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16649",
-    "EntityFramework.Relational": "7.0.0-rc2-16649",
-    "EntityFramework.Relational.Design": "7.0.0-rc2-16649",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
+    "EntityFramework.Core": "7.0.0-rc2-16563",
+    "EntityFramework.Relational": "7.0.0-rc2-16563",
+    "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-15882",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-15882",
     "EntityFramework7.Npgsql": "3.1.0-*",
     "Npgsql": "3.1.0-*"
   },

--- a/src/EntityFramework7.Npgsql/project.json
+++ b/src/EntityFramework7.Npgsql/project.json
@@ -14,10 +14,10 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16583",
-    "EntityFramework.Relational": "7.0.0-rc2-16583",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-*",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-*",
+    "EntityFramework.Core": "7.0.0-rc2-16649",
+    "EntityFramework.Relational": "7.0.0-rc2-16649",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Npgsql": "3.1.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
The lastest version of Microsoft.Extensions.DependencyInjection targeting .NET Standard 1.1 (1.3 for rc2-20100), unfortunately the building system can't solve the moniker change from dotnet5.4 to netstandard1.1, and neither the latest nor the specified version of EntityFramework packages targets .NET Standard moniker(s), so we have to specify version `1.0.0-rc2-1####` for Microsoft.Extensions.DependencyInjection, until somebody fixes the dependency hell problem