### PR TITLE
An aggressive attempt to try out usable version strings of dependencies

### DIFF
--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -16,8 +16,8 @@
     "EntityFramework.Core": "7.0.0-rc2-16563",
     "EntityFramework.Relational": "7.0.0-rc2-16563",
     "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-*",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-*",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",
     "Npgsql": "3.1.0-*"
   },

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -13,9 +13,9 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16563",
-    "EntityFramework.Relational": "7.0.0-rc2-16563",
-    "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
+    "EntityFramework.Core": "7.0.0-rc2-16649",
+    "EntityFramework.Relational": "7.0.0-rc2-16649",
+    "EntityFramework.Relational.Design": "7.0.0-rc2-16649",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -12,12 +12,12 @@
   "compilationOptions": {
     "keyFile": "../../Npgsql.snk"
   },
-  "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16563",
-    "EntityFramework.Relational": "7.0.0-rc2-16563",
+  "dependencies": {
+    "EntityFramework.Core": "7.0.0-rc2-*",
+    "EntityFramework.Relational": "7.0.0-rc2-*",
     "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-15882",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-15882",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",
     "Npgsql": "3.1.0-*"
   },

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -41,8 +41,7 @@
       }
     },
     "dotnet54": {
-      "dependencies": {
-      }
+      "dependencies": { }
     }
   }
 }

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "EntityFramework.Core": "7.0.0-rc2-*",
     "EntityFramework.Relational": "7.0.0-rc2-*",
-    "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
+    "EntityFramework.Relational.Design": "7.0.0-rc2-16596",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
     "EntityFramework7.Npgsql": "3.1.0-*",

--- a/src/EntityFramework7.Npgsql.Design/project.json
+++ b/src/EntityFramework7.Npgsql.Design/project.json
@@ -13,11 +13,11 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16649",
-    "EntityFramework.Relational": "7.0.0-rc2-16649",
-    "EntityFramework.Relational.Design": "7.0.0-rc2-16649",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
+    "EntityFramework.Core": "7.0.0-rc2-16563",
+    "EntityFramework.Relational": "7.0.0-rc2-16563",
+    "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-15882",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-15882",
     "EntityFramework7.Npgsql": "3.1.0-*",
     "Npgsql": "3.1.0-*"
   },

--- a/src/EntityFramework7.Npgsql/project.json
+++ b/src/EntityFramework7.Npgsql/project.json
@@ -14,10 +14,10 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16649",
-    "EntityFramework.Relational": "7.0.0-rc2-16649",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
+    "EntityFramework.Core": "7.0.0-rc2-*",
+    "EntityFramework.Relational": "7.0.0-rc2-*",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "<1.0.0-rc2-20000",
+    "Microsoft.Extensions.DependencyInjection": "<1.0.0-rc2-20000",
     "Npgsql": "3.1.0-*"
   },
   "frameworks": {

--- a/src/EntityFramework7.Npgsql/project.json
+++ b/src/EntityFramework7.Npgsql/project.json
@@ -13,11 +13,11 @@
   "compilationOptions": {
     "keyFile": "../../Npgsql.snk"
   },
-  "dependencies" : {
+  "dependencies": {
     "EntityFramework.Core": "7.0.0-rc2-*",
     "EntityFramework.Relational": "7.0.0-rc2-*",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "<1.0.0-rc2-20000",
-    "Microsoft.Extensions.DependencyInjection": "<1.0.0-rc2-20000",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Npgsql": "3.1.0-*"
   },
   "frameworks": {

--- a/src/EntityFramework7.Npgsql/project.json
+++ b/src/EntityFramework7.Npgsql/project.json
@@ -14,10 +14,10 @@
     "keyFile": "../../Npgsql.snk"
   },
   "dependencies" : {
-    "EntityFramework.Core": "7.0.0-rc2-16583",
-    "EntityFramework.Relational": "7.0.0-rc2-16583",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-*",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-*",
+    "EntityFramework.Core": "7.0.0-rc2-16649",
+    "EntityFramework.Relational": "7.0.0-rc2-16649",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
     "Npgsql": "3.1.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
for the designer:

    "dependencies": {
      "EntityFramework.Core": "7.0.0-rc2-*",
      "EntityFramework.Relational": "7.0.0-rc2-*",
      "EntityFramework.Relational.Design": "7.0.0-rc2-16563",
      "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-16059",
      "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc2-16059",
      "EntityFramework7.Npgsql": "3.1.0-*",
      "Npgsql": "3.1.0-*"
    },
