### PR TITLE
Full text querying support in LINQ (tsvector)

### DIFF
--- a/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
+++ b/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
@@ -63,6 +63,7 @@
     <Compile Include="NpgsqlMigrationSqlGenerator.cs" />
     <Compile Include="NpgsqlServices.cs" />
     <Compile Include="NpgsqlProviderManifest.cs" />
+    <Compile Include="Linq\PgSqlTextFunctions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlGenerators\PendingProjectsNode.cs" />
     <Compile Include="SqlGenerators\SqlBaseGenerator.cs" />

--- a/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
+++ b/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
@@ -59,6 +59,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Linq\DbFunctionStoreNameAttribute.cs" />
     <Compile Include="NpgsqlConnectionFactory.cs" />
     <Compile Include="NpgsqlMigrationSqlGenerator.cs" />
     <Compile Include="NpgsqlServices.cs" />

--- a/src/EntityFramework6.Npgsql/Linq/DbFunctionStoreNameAttribute.cs
+++ b/src/EntityFramework6.Npgsql/Linq/DbFunctionStoreNameAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Npgsql.Linq
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    class DbFunctionStoreNameAttribute : Attribute
+    {
+        public string StoreName { get; set; }
+
+        public DbFunctionStoreNameAttribute(string storeName)
+        {
+            StoreName = storeName;
+        }
+    }
+}

--- a/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
+++ b/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
@@ -20,20 +20,44 @@ namespace Npgsql.Linq
         /// &lt;<paramref name="tsvector" />&gt; and &lt;<paramref name="tsquery" />&gt; are replaced 
         /// with their respective resolved expressions.
         /// </remarks>
-        [DbFunction("Npgsql", "Match")]
+        [DbFunction("Npgsql", "Match"), DbFunctionStoreName("OperatorMatch")]
         public static bool Match(string tsvector, string tsquery)
         {
             throw new NotSupportedException();
         }
         
-        [DbFunction("Npgsql", "ToTsVector")]
+        [DbFunction("Npgsql", "ToTsVector"), DbFunctionStoreName("to_tsvector")]
         public static string ToTsVector(string text)
         {
             throw new NotSupportedException();
         }
 
-        [DbFunction("Npgsql", "PlainToTsQuery")]
+        [DbFunction("Npgsql", "ToTsVector"), DbFunctionStoreName("to_tsvector")]
+        public static string ToTsVector(string config, string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "PlainToTsQuery"), DbFunctionStoreName("plainto_tsquery")]
         public static string PlainToTsQuery(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "PlainToTsQuery"), DbFunctionStoreName("plainto_tsquery")]
+        public static string PlainToTsQuery(string config, string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "ToTsQuery"), DbFunctionStoreName("to_tsquery")]
+        public static string ToTsQuery(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "ToTsQuery"), DbFunctionStoreName("to_tsquery")]
+        public static string ToTsQuery(string config, string text)
         {
             throw new NotSupportedException();
         }

--- a/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
+++ b/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Data.Entity;
+
+namespace Npgsql.Linq
+{
+    /// <summary>
+    /// Use this class in LINQ queries to generate
+    /// full-text search expressions using tsvector 
+    /// and tsquery.
+    /// </summary>
+    public static class PgSqlTextFunctions
+    {
+        /// <summary>
+        /// This method generates the "@@" match operator.
+        /// See http://www.postgresql.org/docs/9.1/static/textsearch-intro.html#TEXTSEARCH-MATCHING
+        /// </summary>
+        /// <remarks>
+        /// Generated SQL: &lt;<paramref name="tsvector" />&gt; @@ &lt;<paramref name="tsquery" />&gt;
+        /// 
+        /// &lt;<paramref name="tsvector" />&gt; and &lt;<paramref name="tsquery" />&gt; are replaced 
+        /// with their respective resolved expressions.
+        /// </remarks>
+        [DbFunction("Npgsql", "Match")]
+        public static bool Match(string tsvector, string tsquery)
+        {
+            throw new NotSupportedException();
+        }
+        
+        [DbFunction("Npgsql", "ToTsVector")]
+        public static string ToTsVector(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "PlainToTsQuery")]
+        public static string PlainToTsQuery(string text)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
+++ b/src/EntityFramework6.Npgsql/Linq/PgSqlTextFunctions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.Entity;
+using NpgsqlTypes;
 
 namespace Npgsql.Linq
 {
@@ -58,6 +59,12 @@ namespace Npgsql.Linq
 
         [DbFunction("Npgsql", "ToTsQuery"), DbFunctionStoreName("to_tsquery")]
         public static string ToTsQuery(string config, string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        [DbFunction("Npgsql", "SetWeight"), DbFunctionStoreName("setweight")]
+        public static string SetWeight(string tsvector, string weightAbcd)
         {
             throw new NotSupportedException();
         }

--- a/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
@@ -28,6 +28,7 @@ using System.Data.Common;
 #if ENTITIES6
 using System.Data.Entity.Core.Common;
 using System.Data.Entity.Core.Metadata.Edm;
+using System.Collections.ObjectModel;
 #else
 using System.Data.Metadata.Edm;
 #endif
@@ -364,6 +365,108 @@ namespace Npgsql
         public override bool SupportsInExpression()
         {
             return true;
+        }
+
+        public override ReadOnlyCollection<EdmFunction> GetStoreFunctions()
+        {
+            var functions = new List<EdmFunction>();
+
+            functions.Add(
+                EdmFunction.Create(
+                    "Match",
+                    "Npgsql",
+                    DataSpace.SSpace,
+                    new EdmFunctionPayload
+                    {
+                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
+                        Schema = string.Empty,
+                        IsBuiltIn = true,
+                        IsAggregate = false,
+                        IsFromProviderManifest = true,
+                        StoreFunctionName = "OperatorName",
+                        ReturnParameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "ReturnType",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Boolean),
+                                ParameterMode.ReturnValue)
+                        },
+                        Parameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "tsvector",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.In),
+
+                            FunctionParameter.Create(
+                                "tsquery",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.In)
+                        }
+                    },
+                    new List<MetadataProperty>()));
+
+            functions.Add(
+                EdmFunction.Create(
+                    "ToTsVector",
+                    "Npgsql",
+                    DataSpace.SSpace,
+                    new EdmFunctionPayload
+                    {
+                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
+                        Schema = string.Empty,
+                        IsBuiltIn = true,
+                        IsAggregate = false,
+                        IsFromProviderManifest = true,
+                        StoreFunctionName = "to_tsvector",
+                        ReturnParameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "ReturnType",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.ReturnValue)
+                        },
+                        Parameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "text",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.In)
+                        }
+                    },
+                    new List<MetadataProperty>()));
+
+            functions.Add(
+                EdmFunction.Create(
+                    "PlainToTsQuery",
+                    "Npgsql",
+                    DataSpace.SSpace,
+                    new EdmFunctionPayload
+                    {
+                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
+                        Schema = string.Empty,
+                        IsBuiltIn = true,
+                        IsAggregate = false,
+                        IsFromProviderManifest = true,
+                        StoreFunctionName = "plainto_tsquery",
+                        ReturnParameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "ReturnType",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.ReturnValue)
+                        },
+                        Parameters = new[]
+                        {
+                            FunctionParameter.Create(
+                                "text",
+                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
+                                ParameterMode.In)
+                        }
+                    },
+                    new List<MetadataProperty>()));
+
+            return functions.AsReadOnly();
         }
 #endif
     }

--- a/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
@@ -29,11 +29,15 @@ using System.Data.Common;
 using System.Data.Entity.Core.Common;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Collections.ObjectModel;
+using System.Linq;
+using Npgsql.Linq;
 #else
 using System.Data.Metadata.Edm;
 #endif
 using System.Xml;
 using System.Data;
+using System.Data.Entity;
+using System.Reflection;
 using NpgsqlTypes;
 
 namespace Npgsql
@@ -371,102 +375,81 @@ namespace Npgsql
         {
             var functions = new List<EdmFunction>();
 
-            functions.Add(
-                EdmFunction.Create(
-                    "Match",
-                    "Npgsql",
-                    DataSpace.SSpace,
-                    new EdmFunctionPayload
-                    {
-                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
-                        Schema = string.Empty,
-                        IsBuiltIn = true,
-                        IsAggregate = false,
-                        IsFromProviderManifest = true,
-                        StoreFunctionName = "OperatorName",
-                        ReturnParameters = new[]
+            functions.AddRange(
+                typeof(PgSqlTextFunctions).GetTypeInfo()
+                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .Select(
+                        x => new
                         {
-                            FunctionParameter.Create(
-                                "ReturnType",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Boolean),
-                                ParameterMode.ReturnValue)
-                        },
-                        Parameters = new[]
-                        {
-                            FunctionParameter.Create(
-                                "tsvector",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.In),
-
-                            FunctionParameter.Create(
-                                "tsquery",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.In)
-                        }
-                    },
-                    new List<MetadataProperty>()));
-
-            functions.Add(
-                EdmFunction.Create(
-                    "ToTsVector",
-                    "Npgsql",
-                    DataSpace.SSpace,
-                    new EdmFunctionPayload
-                    {
-                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
-                        Schema = string.Empty,
-                        IsBuiltIn = true,
-                        IsAggregate = false,
-                        IsFromProviderManifest = true,
-                        StoreFunctionName = "to_tsvector",
-                        ReturnParameters = new[]
-                        {
-                            FunctionParameter.Create(
-                                "ReturnType",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.ReturnValue)
-                        },
-                        Parameters = new[]
-                        {
-                            FunctionParameter.Create(
-                                "text",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.In)
-                        }
-                    },
-                    new List<MetadataProperty>()));
-
-            functions.Add(
-                EdmFunction.Create(
-                    "PlainToTsQuery",
-                    "Npgsql",
-                    DataSpace.SSpace,
-                    new EdmFunctionPayload
-                    {
-                        ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
-                        Schema = string.Empty,
-                        IsBuiltIn = true,
-                        IsAggregate = false,
-                        IsFromProviderManifest = true,
-                        StoreFunctionName = "plainto_tsquery",
-                        ReturnParameters = new[]
-                        {
-                            FunctionParameter.Create(
-                                "ReturnType",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.ReturnValue)
-                        },
-                        Parameters = new[]
-                        {
-                            FunctionParameter.Create(
-                                "text",
-                                PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String),
-                                ParameterMode.In)
-                        }
-                    },
-                    new List<MetadataProperty>()));
+                            DbFunction = x.GetCustomAttribute<DbFunctionAttribute>(),
+                            DbFunctionStoreName = x.GetCustomAttribute<DbFunctionStoreNameAttribute>(),
+                            Method = x
+                        })
+                    .Where(x => x.DbFunction != null && x.DbFunctionStoreName != null)
+                    .Select(
+                        x => CreateFullTextEdmFunction(
+                            x.DbFunction.FunctionName,
+                            x.DbFunction.NamespaceName,
+                            x.DbFunctionStoreName.StoreName,
+                            MapTypeToPrimitiveTypeKind(x.Method.ReturnType),
+                            x.Method.GetParameters()
+                                .ToDictionary(p => p.Name, p => MapTypeToPrimitiveTypeKind(p.ParameterType)))));
 
             return functions.AsReadOnly();
+        }
+
+        private static EdmFunction CreateFullTextEdmFunction(
+            string name,
+            string namespaceName,
+            string dbFunctionName,
+            PrimitiveTypeKind returnKind,
+            IReadOnlyCollection<KeyValuePair<string, PrimitiveTypeKind>> parameters)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "name");
+            }
+
+            if (string.IsNullOrWhiteSpace(dbFunctionName))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "dbFunctionName");
+            }
+
+            return EdmFunction.Create(
+                name,
+                namespaceName,
+                DataSpace.SSpace,
+                new EdmFunctionPayload
+                {
+                    ParameterTypeSemantics = ParameterTypeSemantics.AllowImplicitConversion,
+                    Schema = string.Empty,
+                    IsBuiltIn = true,
+                    IsAggregate = false,
+                    IsFromProviderManifest = true,
+                    StoreFunctionName = dbFunctionName,
+                    ReturnParameters = new[]
+                    {
+                        FunctionParameter.Create(
+                            "ReturnType",
+                            PrimitiveType.GetEdmPrimitiveType(returnKind),
+                            ParameterMode.ReturnValue)
+                    },
+                    Parameters = parameters.Select(
+                        x => FunctionParameter.Create(
+                            x.Key,
+                            PrimitiveType.GetEdmPrimitiveType(x.Value),
+                            ParameterMode.In)).ToList()
+                },
+                new List<MetadataProperty>());
+        }
+
+        private static PrimitiveTypeKind MapTypeToPrimitiveTypeKind(Type type)
+        {
+            if (type == typeof(string)) return PrimitiveTypeKind.String;
+            if (type == typeof(bool)) return PrimitiveTypeKind.Boolean;
+
+            throw new NotSupportedException(
+                string.Format("Unsupported type for mapping to EdmType: {0}", type.FullName));
         }
 #endif
     }

--- a/src/EntityFramework6.Npgsql/SqlGenerators/SqlBaseGenerator.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/SqlBaseGenerator.cs
@@ -1121,6 +1121,16 @@ namespace Npgsql.SqlGenerators
             }
 
 #if ENTITIES6
+            if (function.NamespaceName == "Npgsql" && function.Name == "Match")
+            {
+                if (args.Count != 2)
+                {
+                    throw new ArgumentException("Invalid number of operator arguments. Expected 2.", "args");
+                }
+
+                return new MatchOperatorExpression(args[0].Accept(this), args[1].Accept(this));
+            }
+
             FunctionExpression customFuncCall = string.IsNullOrEmpty(function.Schema) ?
                 new FunctionExpression(QuoteIdentifier(function.StoreFunctionNameAttribute)) :
                 new FunctionExpression(

--- a/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
@@ -1230,4 +1230,26 @@ namespace Npgsql.SqlGenerators
             base.WriteSql(sqlText);
         }
     }
+
+    internal class MatchOperatorExpression : VisitedExpression
+    {
+        private readonly VisitedExpression _leftHand;
+        private readonly VisitedExpression _rightHand;
+
+        public MatchOperatorExpression(VisitedExpression leftHand, VisitedExpression rightHand)
+        {
+            if (leftHand == null) throw new ArgumentNullException("leftHand");
+            if (rightHand == null) throw new ArgumentNullException("rightHand");
+
+            _leftHand = leftHand;
+            _rightHand = rightHand;
+        }
+
+        internal override void WriteSql(StringBuilder sqlText)
+        {
+            _leftHand.WriteSql(sqlText);
+            sqlText.Append(" @@ ");
+            _rightHand.WriteSql(sqlText);
+        }
+    }
 }

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
@@ -739,11 +739,16 @@ namespace EntityFramework6.Npgsql.Tests
             {
                 context.Database.Log = Console.Out.WriteLine;
 
-                var blog = new Blog
+                var blog1 = new Blog
                 {
                     Name = "The quick brown fox jumps over the lazy dog."
                 };
-                context.Blogs.Add(blog);
+                var blog2 = new Blog
+                {
+                    Name = "Jackdaws loves my big sphinx of quartz."
+                };
+                context.Blogs.Add(blog1);
+                context.Blogs.Add(blog2);
                 context.SaveChanges();
 
                 var foundBlog = context
@@ -754,7 +759,37 @@ namespace EntityFramework6.Npgsql.Tests
                             PgSqlTextFunctions.PlainToTsQuery("jump")));
 
                 Assert.That(foundBlog != null);
-                Assert.That(foundBlog.Name, Is.EqualTo(blog.Name));
+                Assert.That(foundBlog.Name, Is.EqualTo(blog1.Name));
+
+                foundBlog = context
+                    .Blogs
+                    .FirstOrDefault(
+                        x => PgSqlTextFunctions.Match(
+                            PgSqlTextFunctions.ToTsVector(x.Name),
+                            PgSqlTextFunctions.ToTsQuery("jump & dog")));
+
+                Assert.That(foundBlog != null);
+                Assert.That(foundBlog.Name, Is.EqualTo(blog1.Name));
+
+                foundBlog = context
+                    .Blogs
+                    .FirstOrDefault(
+                        x => PgSqlTextFunctions.Match(
+                            PgSqlTextFunctions.ToTsVector("english", x.Name),
+                            PgSqlTextFunctions.PlainToTsQuery("english", "jump")));
+
+                Assert.That(foundBlog != null);
+                Assert.That(foundBlog.Name, Is.EqualTo(blog1.Name));
+
+                foundBlog = context
+                    .Blogs
+                    .FirstOrDefault(
+                        x => PgSqlTextFunctions.Match(
+                            PgSqlTextFunctions.ToTsVector("english", x.Name),
+                            PgSqlTextFunctions.ToTsQuery("english", "jump & dog")));
+
+                Assert.That(foundBlog != null);
+                Assert.That(foundBlog.Name, Is.EqualTo(blog1.Name));
             }
         }
     }


### PR DESCRIPTION
Here's my stab at implementing a limited form of what is described in http://blog.devart.com/using-postgresql-full-text-search-in-entity-framework.html in Npgsql. This is related to #999 

So far, I've got to_tsquery, plainto_tsquery, and to_tsvector working. Will try with more functions as time permits.

Let me know if I messed something up.