### PR TITLE
Complete full text support in LINQ (tsvector + tsquery) against master

### DIFF
--- a/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
+++ b/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
@@ -61,8 +61,11 @@
   <ItemGroup>
     <Compile Include="NpgsqlConnectionFactory.cs" />
     <Compile Include="NpgsqlMigrationSqlGenerator.cs" />
+    <Compile Include="NpgsqlRankingNormalization.cs" />
     <Compile Include="NpgsqlServices.cs" />
     <Compile Include="NpgsqlProviderManifest.cs" />
+    <Compile Include="NpgsqlTextFunctions.cs" />
+    <Compile Include="NpgsqlWeightLabel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlGenerators\PendingProjectsNode.cs" />
     <Compile Include="SqlGenerators\SqlBaseGenerator.cs" />

--- a/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
@@ -401,6 +401,7 @@ namespace Npgsql
                     IsAggregate = false,
                     IsFromProviderManifest = true,
                     StoreFunctionName = dbFunctionInfo.FunctionName,
+                    IsComposable = true,
                     ReturnParameters = new[]
                     {
                         FunctionParameter.Create(

--- a/src/EntityFramework6.Npgsql/NpgsqlRankingNormalization.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlRankingNormalization.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Specifies whether and how a document's length should impact its rank.
+    /// This is used with the ranking functions in <see cref="NpgsqlTextFunctions" />.
+    /// 
+    /// See http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+    /// for more information about the behaviors that are controlled by this value.
+    /// </summary>
+    [Flags]
+    public enum NpgsqlRankingNormalization
+    {
+        /// <summary>
+        /// Ignores the document length.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Divides the rank by 1 + the logarithm of the document length.
+        /// </summary>
+        DivideBy1PlusLogLength = 1,
+
+        /// <summary>
+        /// Divides the rank by the document length.
+        /// </summary>
+        DivideByLength = 2,
+
+        /// <summary>
+        /// Divides the rank by the mean harmonic distance between extents (this is implemented only by ts_rank_cd).
+        /// </summary>
+        DivideByMeanHarmonicDistanceBetweenExtents = 4,
+
+        /// <summary>
+        /// Divides the rank by the number of unique words in document.
+        /// </summary>
+        DivideByUniqueWordCount = 8,
+
+        /// <summary>
+        /// Divides the rank by 1 + the logarithm of the number of unique words in document.
+        /// </summary>
+        DividesBy1PlusLogUniqueWordCount = 16,
+
+        /// <summary>
+        /// Divides the rank by itself + 1.
+        /// </summary>
+        DivideByItselfPlusOne = 32
+    }
+}

--- a/src/EntityFramework6.Npgsql/NpgsqlTextFunctions.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlTextFunctions.cs
@@ -1,0 +1,372 @@
+﻿using System;
+using System.Data.Entity;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Use this class in LINQ queries to generate full-text search expressions using tsvector and tsquery. 
+    /// None of these functions can be called directly.
+    /// See http://www.postgresql.org/docs/current/static/functions-textsearch.html for the latest documentation.
+    /// </summary>
+    [SuppressMessage("ReSharper", "UnusedParameter.Global")]
+    public static class NpgsqlTextFunctions
+    {
+        /// <summary>
+        /// Cast <paramref name="vector" /> to the tsvector data type.
+        /// </summary>
+        [DbFunction("Npgsql", "as_tsvector")]
+        public static string AsTsVector(string vector)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Reduce <paramref name="document" /> to tsvector.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS
+        /// </summary>
+        [DbFunction("Npgsql", "to_tsvector")]
+        public static string ToTsVector(string document)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Reduce <paramref name="document" /> to tsvector using the text search configuration specified
+        /// by <paramref name="config" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS
+        /// </summary>
+        [DbFunction("Npgsql", "to_tsvector")]
+        public static string ToTsVector(string config, string document)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Cast <paramref name="query" /> to the tsquery data type.
+        /// </summary>
+        [DbFunction("Npgsql", "as_tsquery")]
+        public static string AsTsQuery(string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Produce tsquery from <paramref name="query" /> ignoring punctuation.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </summary>
+        [DbFunction("Npgsql", "plainto_tsquery")]
+        public static string PlainToTsQuery(string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Produce tsquery from <paramref name="query" /> ignoring punctuation and using the text search
+        /// configuration specified by <paramref name="config" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </summary>
+        [DbFunction("Npgsql", "plainto_tsquery")]
+        public static string PlainToTsQuery(string config, string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Normalize words in <paramref name="query" /> and convert to tsquery. If your input
+        /// contains punctuation that should not be treated as text search operators, use 
+        /// <see cref="PlainToTsQuery(string)" /> instead.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </summary>
+        [DbFunction("Npgsql", "to_tsquery")]
+        public static string ToTsQuery(string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Normalize words in <paramref name="query" /> and convert to tsquery using the text search
+        /// configuration specified by <paramref name="config" />. If your input contains punctuation 
+        /// that should not be treated as text search operators, use <see cref="PlainToTsQuery(string, string)" /> 
+        /// instead.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+        /// </summary>
+        [DbFunction("Npgsql", "to_tsquery")]
+        public static string ToTsQuery(string config, string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// AND tsquerys together. Generates the "&amp;&amp;" operator.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "operator_tsquery_and")]
+        public static string QueryAnd(string tsquery1, string tsquery2)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// OR tsquerys together. Generates the "||" operator.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "operator_tsquery_or")]
+        public static string QueryOr(string tsquery1, string tsquery2)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Negate a tsquery. Generates the "!!" operator.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "operator_tsquery_negate")]
+        public static string QueryNot(string tsquery)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="tsquery1" /> contains <paramref name="tsquery2" />.
+        /// Generates the "@&gt;" operator.
+        /// http://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        [DbFunction("Npgsql", "operator_tsquery_contains")]
+        public static bool QueryContains(string tsquery1, string tsquery2)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="tsquery1" /> is contained within <paramref name="tsquery2" />.
+        /// Generates the "&lt;@" operator.
+        /// http://www.postgresql.org/docs/current/static/functions-textsearch.html
+        /// </summary>
+        [DbFunction("Npgsql", "operator_tsquery_is_contained")]
+        public static bool QueryIsContained(string tsquery1, string tsquery2)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// This method generates the "@@" match operator.
+        /// http://www.postgresql.org/docs/current/static/textsearch-intro.html#TEXTSEARCH-MATCHING
+        /// </summary>
+        [DbFunction("Npgsql", "@@")]
+        public static bool Match(string tsvector, string tsquery)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Assign weight to each element of <paramref name="tsvector" /> and return a new
+        /// weighted tsvector.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
+        /// </summary>
+        [DbFunction("Npgsql", "setweight")]
+        public static string SetWeight(string tsvector, NpgsqlWeightLabel label)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns the number of lexemes in <paramref name="tsvector" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
+        /// </summary>
+        [DbFunction("Npgsql", "length")]
+        public static int Length(string tsvector)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns the number of lexemes plus operators in <paramref name="tsquery" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "numnode")]
+        public static int NumNode(string tsquery)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Removes weights and positions from <paramref name="tsvector" /> and returns
+        /// a new stripped tsvector.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSVECTOR
+        /// </summary>
+        [DbFunction("Npgsql", "strip")]
+        public static string Strip(string tsvector)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Get indexable part of <paramref name="query" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "querytree")]
+        public static string QueryTree(string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns a string suitable for display containing a query match.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-HEADLINE
+        /// </summary>
+        [DbFunction("Npgsql", "ts_headline")]
+        public static string TsHeadline(string document, string tsquery, string options)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Returns a string suitable for display containing a query match using the text
+        /// search configuration specified by <paramref name="config" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-HEADLINE
+        /// </summary>
+        [DbFunction("Npgsql", "ts_headline")]
+        public static string TsHeadline(string config, string document, string tsquery, string options)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank")]
+        public static float TsRank(
+            string vector,
+            string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> while normalizing 
+        /// the result according to the behaviors specified by <paramref name="normalization" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank")]
+        public static float TsRank(
+            string vector,
+            string query,
+            NpgsqlRankingNormalization normalization)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> with custom 
+        /// weighting for word instances depending on their labels (D, C, B or A).
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank")]
+        public static float TsRank(
+            float weightD,
+            float weightC,
+            float weightB,
+            float weightA,
+            string vector,
+            string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> while normalizing 
+        /// the result according to the behaviors specified by <paramref name="normalization" /> 
+        /// and using custom weighting for word instances depending on their labels (D, C, B or A).
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank")]
+        public static float TsRank(
+            float weightD,
+            float weightC,
+            float weightB,
+            float weightA,
+            string vector,
+            string query,
+            NpgsqlRankingNormalization normalization)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> using the cover 
+        /// density method.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank_cd")]
+        public static float TsRankCd(
+            string vector,
+            string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> using the cover
+        /// density method while normalizing the result according to the behaviors specified by 
+        /// <paramref name="normalization" />.
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank_cd")]
+        public static float TsRankCd(
+            string vector,
+            string query,
+            NpgsqlRankingNormalization normalization)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> using the cover 
+        /// density method with custom weighting for word instances depending on their labels (D, C, B or A).
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank_cd")]
+        public static float TsRankCd(
+            float weightD,
+            float weightC,
+            float weightB,
+            float weightA,
+            string vector,
+            string query)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Calculates the rank of <paramref name="vector" /> for <paramref name="query" /> using the cover density
+        /// method while normalizing the result according to the behaviors specified by <paramref name="normalization" /> 
+        /// and using custom weighting for word instances depending on their labels (D, C, B or A).
+        /// http://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-RANKING
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rank_cd")]
+        public static float TsRankCd(
+            float weightD,
+            float weightC,
+            float weightB,
+            float weightA,
+            string vector,
+            string query,
+            NpgsqlRankingNormalization normalization)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Searchs <paramref name="query" /> for occurrences of <paramref name="target" />, and replaces 
+        /// each occurrence with a <paramref name="substitute" />. All parameters are of type tsquery.
+        /// http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-MANIPULATE-TSQUERY
+        /// </summary>
+        [DbFunction("Npgsql", "ts_rewrite")]
+        public static string TsRewrite(string query, string target, string substitute)
+        {
+            throw new NotSupportedException();
+        }
+    }   
+}

--- a/src/EntityFramework6.Npgsql/NpgsqlWeightLabel.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlWeightLabel.cs
@@ -1,0 +1,28 @@
+﻿namespace Npgsql
+{
+    /// <summary>
+    /// Label given to positions in vectors.
+    /// </summary>
+    public enum NpgsqlWeightLabel
+    {
+        /// <summary>
+        /// D (Default).
+        /// </summary>
+        D = 0,
+
+        /// <summary>
+        /// C
+        /// </summary>
+        C = 1,
+
+        /// <summary>
+        /// B
+        /// </summary>
+        B = 2,
+
+        /// <summary>
+        /// A
+        /// </summary>
+        A = 3
+    }
+}

--- a/src/EntityFramework6.Npgsql/SqlGenerators/SqlBaseGenerator.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/SqlBaseGenerator.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 #if ENTITIES6
+using System.Globalization;
 using System.Data.Entity.Core.Common.CommandTrees;
 using System.Data.Entity.Core.Metadata.Edm;
 #else
@@ -62,6 +63,17 @@ namespace Npgsql.SqlGenerators
             {"Var","var_samp"},
             {"VarP","var_pop"},
         };
+
+#if ENTITIES6
+        private static readonly Dictionary<string, Operator> BinaryOperatorFunctionNames = new Dictionary<string, Operator>()
+        {
+            {"@@",Operator.QueryMatch},
+            {"operator_tsquery_and",Operator.QueryAnd},
+            {"operator_tsquery_or",Operator.QueryOr},
+            {"operator_tsquery_contains",Operator.QueryContains},
+            {"operator_tsquery_is_contained",Operator.QueryIsContained}
+        };
+#endif
 
         protected SqlBaseGenerator()
         {
@@ -1121,6 +1133,103 @@ namespace Npgsql.SqlGenerators
             }
 
 #if ENTITIES6
+            if (function.NamespaceName == "Npgsql")
+            {
+                Operator binaryOperator;
+                if (BinaryOperatorFunctionNames.TryGetValue(function.Name, out binaryOperator))
+                {
+                    if (args.Count != 2)
+                    {
+                        throw new ArgumentException(
+                            string.Format("Invalid number of {0} arguments. Expected 2.", function.Name),
+                            "args");
+                    }
+
+                    return OperatorExpression.Build(
+                        binaryOperator,
+                        _useNewPrecedences,
+                        args[0].Accept(this),
+                        args[1].Accept(this));
+                }
+
+                if (function.Name == "operator_tsquery_negate")
+                {
+                    if (args.Count != 1)
+                    {
+                        throw new ArgumentException(
+                            "Invalid number of operator_tsquery_not arguments. Expected 1.",
+                            "args");
+                    }
+
+                    return OperatorExpression.Build(Operator.QueryNegate, _useNewPrecedences, args[0].Accept(this));
+                }
+
+                if (function.Name == "ts_rank" || function.Name == "ts_rank_cd")
+                {
+                    if (args.Count > 4)
+                    {
+                        var weightD = args[0] as DbConstantExpression;
+                        var weightC = args[1] as DbConstantExpression;
+                        var weightB = args[2] as DbConstantExpression;
+                        var weightA = args[3] as DbConstantExpression;
+
+                        if (weightD == null || weightC == null || weightB == null || weightA == null)
+                        {
+                            throw new NotSupportedException("All weight values must be constant expressions.");
+                        }
+
+                        var newValue = string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{{ {0:r}, {1:r}, {2:r}, {3:r} }}",
+                            weightD.Value,
+                            weightC.Value,
+                            weightB.Value,
+                            weightA.Value);
+
+                        args = new[] { DbExpression.FromString(newValue) }.Concat(args.Skip(4)).ToList();
+                    }
+                }
+                else if (function.Name == "setweight")
+                {
+                    if (args.Count != 2)
+                    {
+                        throw new ArgumentException("Invalid number of setweight arguments. Expected 2.", "args");
+                    }
+
+                    var weightLabelExpression = args[1] as DbConstantExpression;
+                    if (weightLabelExpression == null)
+                    {
+                        throw new NotSupportedException("setweight label argument must be a constant expression.");
+                    }
+
+                    var weightLabel = (NpgsqlWeightLabel)weightLabelExpression.Value;
+                    if (!Enum.IsDefined(typeof(NpgsqlWeightLabel), weightLabelExpression.Value))
+                    {
+                        throw new NotSupportedException("Unsupported weight label value: " + weightLabel);
+                    }
+
+                    args = new[] { args[0], DbExpression.FromString(weightLabel.ToString()) };
+                }
+                else if (function.Name == "as_tsvector")
+                {
+                    if (args.Count != 1)
+                    {
+                        throw new ArgumentException("Invalid number of arguments. Expected 1.", "args");
+                    }
+
+                    return new CastExpression(args[0].Accept(this), "tsvector");
+                }
+                else if (function.Name == "as_tsquery")
+                {
+                    if (args.Count != 1)
+                    {
+                        throw new ArgumentException("Invalid number of arguments. Expected 1.", "args");
+                    }
+
+                    return new CastExpression(args[0].Accept(this), "tsquery");
+                }
+            }
+
             FunctionExpression customFuncCall = string.IsNullOrEmpty(function.Schema) ?
                 new FunctionExpression(QuoteIdentifier(function.StoreFunctionNameAttribute)) :
                 new FunctionExpression(

--- a/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
@@ -957,6 +957,13 @@ namespace Npgsql.SqlGenerators
         public static readonly Operator And = new Operator("AND", 2, 2);
         public static readonly Operator Or = new Operator("OR", 1, 1);
 
+        public static readonly Operator QueryMatch = new Operator("@@", 10, 8);
+        public static readonly Operator QueryAnd = new Operator("&&", 10, 8);
+        public static readonly Operator QueryOr = Concat;
+        public static readonly Operator QueryNegate = new Operator("!!", 10, 8, UnaryTypes.Prefix, true);
+        public static readonly Operator QueryContains = new Operator("@>", 10, 8);
+        public static readonly Operator QueryIsContained = new Operator("<@", 10, 8);
+
         public static readonly Dictionary<Operator, Operator> NegateDict;
 
         static Operator()

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
@@ -11,6 +11,7 @@ using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
 using Npgsql.Tests;
+using NpgsqlTypes;
 
 namespace EntityFramework6.Npgsql.Tests
 {
@@ -728,6 +729,570 @@ namespace EntityFramework6.Npgsql.Tests
                 Assert.AreEqual(directCallResult, 11);
                 Assert.IsTrue(directSQL.Contains("\"dbo\".\"StoredAddFunction\""));
                 CollectionAssert.AreEqual(localChangedIds, remoteChangedIds);
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_ConversionToTsVector()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                const string expected = "'a':5 'b':10";
+                var casted = context.Blogs.Select(x => NpgsqlTextFunctions.AsTsVector(expected)).First();
+                Assert.That(
+                    NpgsqlTsVector.Parse(casted).ToString(),
+                    Is.EqualTo(NpgsqlTsVector.Parse(expected).ToString()));
+
+                var converted = context.Blogs.Select(x => NpgsqlTextFunctions.ToTsVector("banana car")).First();
+                Assert.That(
+                    NpgsqlTsVector.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsVector.Parse("'banana':1 'car':2").ToString()));
+
+                converted = context.Blogs.Select(x => NpgsqlTextFunctions.ToTsVector("english", "banana car")).First();
+                Assert.That(
+                    NpgsqlTsVector.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsVector.Parse("'banana':1 'car':2").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_ConversionToTsQuery()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                const string expected = "'b' & 'c'";
+                var casted = context.Blogs.Select(x => NpgsqlTextFunctions.AsTsQuery(expected)).First();
+                Assert.That(
+                    NpgsqlTsQuery.Parse(casted).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse(expected).ToString()));
+
+                var converted = context.Blogs.Select(x => NpgsqlTextFunctions.ToTsQuery("b & c")).First();
+                Assert.That(
+                    NpgsqlTsQuery.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse(expected).ToString()));
+
+                converted = context.Blogs.Select(x => NpgsqlTextFunctions.ToTsQuery("english", "b & c")).First();
+                Assert.That(
+                    NpgsqlTsQuery.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse(expected).ToString()));
+
+                converted = context.Blogs.Select(x => NpgsqlTextFunctions.PlainToTsQuery("b & c")).First();
+                Assert.That(
+                    NpgsqlTsQuery.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse(expected).ToString()));
+
+                converted = context.Blogs.Select(x => NpgsqlTextFunctions.PlainToTsQuery("english", "b & c")).First();
+                Assert.That(
+                    NpgsqlTsQuery.Parse(converted).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse(expected).ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsVectorConcat()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x => NpgsqlTextFunctions.AsTsVector("a:1 b:2")
+                         + NpgsqlTextFunctions.AsTsVector("c:1 d:2 b:3")).First();
+
+                Assert.That(
+                    NpgsqlTsVector.Parse(result).ToString(),
+                    Is.EqualTo(NpgsqlTsVector.Parse("'a':1 'b':2,5 'c':3 'd':4").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsQueryAnd()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x => NpgsqlTextFunctions.QueryAnd(
+                        NpgsqlTextFunctions.AsTsQuery("fat | rat"),
+                        NpgsqlTextFunctions.AsTsQuery("cat"))).First();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(result).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("( 'fat' | 'rat' ) & 'cat'").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsQueryOr()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x => NpgsqlTextFunctions.QueryOr(
+                        NpgsqlTextFunctions.AsTsQuery("fat | rat"),
+                        NpgsqlTextFunctions.AsTsQuery("cat"))).First();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(result).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("( 'fat' | 'rat' ) | 'cat'").ToString()));
+
+                result = context.Blogs.Select(
+                    x => NpgsqlTextFunctions.AsTsQuery("fat | rat")
+                         + NpgsqlTextFunctions.AsTsQuery("cat")).First();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(result).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("( 'fat' | 'rat' ) | 'cat'").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsQueryNot()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x => NpgsqlTextFunctions.QueryNot(NpgsqlTextFunctions.AsTsQuery("cat"))).First();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(result).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("! 'cat'").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsContains()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x =>
+                        NpgsqlTextFunctions.QueryContains(
+                            NpgsqlTextFunctions.AsTsQuery("cat"),
+                            NpgsqlTextFunctions.AsTsQuery("cat & rat"))).First();
+
+                Assert.That(result, Is.False);
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsIsContained()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                context.Blogs.Add(new Blog { Name = "_" });
+                context.SaveChanges();
+
+                var result = context.Blogs.Select(
+                    x =>
+                        NpgsqlTextFunctions.QueryIsContained(
+                            NpgsqlTextFunctions.AsTsQuery("cat"),
+                            NpgsqlTextFunctions.AsTsQuery("cat & rat"))).First();
+
+                Assert.That(result, Is.True);
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_Match()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "The quick brown fox jumps over the lazy dog."
+                };
+                var blog2 = new Blog
+                {
+                    Name = "Jackdaws loves my big sphinx of quartz."
+                };
+                context.Blogs.Add(blog1);
+                context.Blogs.Add(blog2);
+                context.SaveChanges();
+
+                var foundBlog = context
+                    .Blogs
+                    .FirstOrDefault(
+                        x =>
+                            NpgsqlTextFunctions.Match(
+                                NpgsqlTextFunctions.ToTsVector(x.Name),
+                                NpgsqlTextFunctions.ToTsQuery("jump & dog")));
+
+                Assert.That(foundBlog != null);
+                Assert.That(foundBlog.Name, Is.EqualTo(blog1.Name));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_SetWeight()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "The quick brown fox jumps over the lazy dog."
+                };
+                context.Blogs.Add(blog1);
+
+                var post1 = new Post
+                {
+                    Blog = blog1,
+                    Title = "Lorem ipsum",
+                    Content = "Dolor sit amet",
+                    Rating = 5
+                };
+                context.Posts.Add(post1);
+
+                var post2 = new Post
+                {
+                    Blog = blog1,
+                    Title = "consectetur adipiscing elit",
+                    Content = "Sed sed rhoncus",
+                    Rating = 4
+                };
+                context.Posts.Add(post2);
+                context.SaveChanges();
+
+                var foundPost = context.Posts.FirstOrDefault(
+                    x => NpgsqlTextFunctions.Match(
+                        NpgsqlTextFunctions.SetWeight(
+                            NpgsqlTextFunctions.ToTsVector(x.Title ?? string.Empty),
+                            NpgsqlWeightLabel.D)
+                        + NpgsqlTextFunctions.SetWeight(
+                            NpgsqlTextFunctions.ToTsVector(x.Content ?? string.Empty),
+                            NpgsqlWeightLabel.C),
+                        NpgsqlTextFunctions.PlainToTsQuery("dolor")));
+
+                Assert.That(foundPost != null);
+                Assert.That(foundPost.Title, Is.EqualTo(post1.Title));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_Length()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog = new Blog
+                {
+                    Name = "cooky cookie cookies piano pianos"
+                };
+                context.Blogs.Add(blog);
+                context.SaveChanges();
+
+                var lexemeCount = context
+                    .Blogs
+                    .Select(x => NpgsqlTextFunctions.Length(NpgsqlTextFunctions.ToTsVector(x.Name)))
+                    .FirstOrDefault();
+
+                Assert.That(lexemeCount, Is.EqualTo(2));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_NumNode()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog = new Blog
+                {
+                    Name = "_"
+                };
+                context.Blogs.Add(blog);
+                context.SaveChanges();
+
+                var nodeCount = context
+                    .Blogs
+                    .Select(x => NpgsqlTextFunctions.NumNode(NpgsqlTextFunctions.ToTsQuery("(fat & rat) | cat")))
+                    .FirstOrDefault();
+
+                Assert.That(nodeCount, Is.EqualTo(5));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_Strip()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog = new Blog
+                {
+                    Name = "cooky cookie cookies piano pianos"
+                };
+                context.Blogs.Add(blog);
+                context.SaveChanges();
+
+                var strippedTsVector = context
+                    .Blogs
+                    .Select(x => NpgsqlTextFunctions.Strip(NpgsqlTextFunctions.ToTsVector(x.Name)))
+                    .FirstOrDefault();
+
+                Assert.That(
+                    NpgsqlTsVector.Parse(strippedTsVector).ToString(),
+                    Is.EqualTo(NpgsqlTsVector.Parse("'cooki' 'piano'").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_QueryTree()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog = new Blog
+                {
+                    Name = "_"
+                };
+                context.Blogs.Add(blog);
+                context.SaveChanges();
+
+                var queryTree = context
+                    .Blogs
+                    .Select(x => NpgsqlTextFunctions.QueryTree(NpgsqlTextFunctions.ToTsQuery("foo & ! bar")))
+                    .FirstOrDefault();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(queryTree).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("'foo'").ToString()));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsHeadline()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "cooky cookie piano pianos"
+                };
+                context.Blogs.Add(blog1);
+
+                var blog2 = new Blog
+                {
+                    Name = "blue crab denominates elephant"
+                };
+                context.Blogs.Add(blog2);
+                context.SaveChanges();
+
+                var headlines = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsHeadline(
+                            x.Name,
+                            NpgsqlTextFunctions.ToTsQuery("cookie"),
+                            "StartSel=<i> StopSel=</i>"))
+                    .ToList();
+
+                Assert.That(headlines.Count, Is.EqualTo(2));
+                Assert.That(headlines[0], Is.EqualTo("<i>cooky</i> <i>cookie</i> piano pianos"));
+                Assert.That(headlines[1], Is.EqualTo(blog2.Name));
+
+                headlines = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsHeadline(
+                            "english",
+                            x.Name,
+                            NpgsqlTextFunctions.ToTsQuery("piano"),
+                            "StartSel=<i> StopSel=</i>"))
+                    .ToList();
+
+                Assert.That(headlines.Count, Is.EqualTo(2));
+                Assert.That(headlines[0], Is.EqualTo("cooky cookie <i>piano</i> <i>pianos</i>"));
+                Assert.That(headlines[1], Is.EqualTo(blog2.Name));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsRank()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "cooky cookie piano pianos"
+                };
+                context.Blogs.Add(blog1);
+                context.SaveChanges();
+
+                var rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRank(
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie")))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRank(
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie"),
+                            NpgsqlRankingNormalization.DivideByLength
+                            | NpgsqlRankingNormalization.DivideByUniqueWordCount))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRank(
+                            0.1f, 0.2f, 0.4f, 1.0f,
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie")))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRank(
+                            0.1f, 0.2f, 0.4f, 1.0f,
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie"),
+                            NpgsqlRankingNormalization.DivideByLength
+                            | NpgsqlRankingNormalization.DivideByUniqueWordCount))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsRankCd()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "cooky cookie piano pianos"
+                };
+                context.Blogs.Add(blog1);
+                context.SaveChanges();
+
+                var rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRankCd(
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie")))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRankCd(
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie"),
+                            NpgsqlRankingNormalization.DivideByLength
+                            | NpgsqlRankingNormalization.DivideByUniqueWordCount))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRankCd(
+                            0.1f, 0.2f, 0.4f, 1.0f,
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie")))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+
+                rank = context
+                    .Blogs
+                    .Select(
+                        x => NpgsqlTextFunctions.TsRankCd(
+                            0.1f, 0.2f, 0.4f, 1.0f,
+                            NpgsqlTextFunctions.ToTsVector(x.Name),
+                            NpgsqlTextFunctions.PlainToTsQuery("cookie"),
+                            NpgsqlRankingNormalization.DivideByLength
+                            | NpgsqlRankingNormalization.DivideByUniqueWordCount))
+                    .FirstOrDefault();
+                Assert.That(rank, Is.GreaterThan(0));
+            }
+        }
+
+        [Test]
+        public void TestFullTextSearch_TsRewrite()
+        {
+            using (var context = new BloggingContext(ConnectionStringEF))
+            {
+                context.Database.Log = Console.Out.WriteLine;
+
+                var blog1 = new Blog
+                {
+                    Name = "_"
+                };
+                context.Blogs.Add(blog1);
+                context.SaveChanges();
+
+                var newQuery = context
+                    .Blogs.Select(
+                        x =>
+                            NpgsqlTextFunctions.TsRewrite(
+                                "a & b",
+                                "a",
+                                "foo|bar"))
+                    .FirstOrDefault();
+
+                Assert.That(
+                    NpgsqlTsQuery.Parse(newQuery).ToString(),
+                    Is.EqualTo(NpgsqlTsQuery.Parse("'b' & ( 'foo' | 'bar' )").ToString()));
             }
         }
     }


### PR DESCRIPTION
Same as #1003 with all of @Emill's comments addressed. Related to #999.

After digging in EF source code, I understood how DbFunctionAttribute is used, and I removed my superfluous attribute, and cleaned up all whitespace issues and added XML docs for the helper class.

Requesting feedback :+1: 