### PR TITLE
Full text search: mark the full text search functions as composable (against develop)

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
@@ -401,6 +401,7 @@ namespace Npgsql
                     IsAggregate = false,
                     IsFromProviderManifest = true,
                     StoreFunctionName = dbFunctionInfo.FunctionName,
+                    IsComposable = true,
                     ReturnParameters = new[]
                     {
                         FunctionParameter.Create(


### PR DESCRIPTION
This fix corresponds to the last commit I added to #1005, but for the develop branch pull request #1006 which got merged by @Emill which was related to #999.

For correctness and validation sake, mark full text search functions as composable to block "out" parameters.