### PR TITLE
Do not restart the timer if it's already running

### DIFF
--- a/src/Npgsql/NpgsqlConnectorPool.cs
+++ b/src/Npgsql/NpgsqlConnectorPool.cs
@@ -79,7 +79,11 @@ namespace Npgsql
         {
             lock (locker)
             {
-                _timer.Change(TimerInterval, Timeout.Infinite);
+                if (!timerStarted)
+                {
+                    _timer.Change(TimerInterval, Timeout.Infinite);
+                    timerStarted = true;
+                }
             }
         }
 
@@ -140,8 +144,11 @@ namespace Npgsql
                 }
                 finally
                 {
+                    timerStarted = false;
                     if (activeConnectionsExist)
-                        _timer.Change(TimerInterval, Timeout.Infinite);
+                    {
+                        StartTimer();
+                    }
                 }
             }
         }
@@ -153,6 +160,7 @@ namespace Npgsql
         private readonly Dictionary<string, ConnectorQueue> PooledConnectors;
 
         readonly Timer _timer;
+        bool timerStarted = false;
 
         const int TimerInterval = 1000;
 


### PR DESCRIPTION
Previously we restarted the timer every time a connection was
requested. If a server (not database) had a connection request per
second or more then the timer would never actually fire and the pool
will never get cleaned up. The solution then is to just not fire the
timer if it's already running.

Fixes #1019.