### PR TITLE
Alternative model for dealing with unknown types.

### DIFF
--- a/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
+++ b/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
@@ -65,6 +65,7 @@
     <Compile Include="NpgsqlServices.cs" />
     <Compile Include="NpgsqlProviderManifest.cs" />
     <Compile Include="NpgsqlTextFunctions.cs" />
+    <Compile Include="NpgsqlTypeFunctions.cs" />
     <Compile Include="NpgsqlWeightLabel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlGenerators\PendingProjectsNode.cs" />

--- a/src/EntityFramework6.Npgsql/NpgsqlServices.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlServices.cs
@@ -79,7 +79,9 @@ namespace Npgsql
             {
                 NpgsqlParameter dbParameter = new NpgsqlParameter();
                 dbParameter.ParameterName = parameter.Key;
-                dbParameter.NpgsqlDbType = NpgsqlProviderManifest.GetNpgsqlDbType(((PrimitiveType)parameter.Value.EdmType).PrimitiveTypeKind);
+                dbParameter.NpgsqlDbType = NpgsqlProviderManifest.GetNpgsqlDbType(
+                    ((PrimitiveType)parameter.Value.EdmType).PrimitiveTypeKind,
+                    !(commandTree is DbQueryCommandTree));
                 command.Parameters.Add(dbParameter);
             }
 

--- a/src/EntityFramework6.Npgsql/NpgsqlTypeFunctions.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlTypeFunctions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Data.Entity;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Use this class in LINQ queries to emit type manipulation SQL fragments.
+    /// </summary>
+    public static class NpgsqlTypeFunctions
+    {
+        /// <summary>
+        /// Emits an explicit cast for unknown types sent as strings to their correct postgresql type.
+        /// </summary>
+        [DbFunction("Npgsql", "cast")]
+        public static string Cast(string unknownTypeValue, string postgresTypeName)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/EntityFramework6.Npgsql/SqlGenerators/SqlSelectGenerator.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/SqlSelectGenerator.cs
@@ -39,6 +39,8 @@ namespace Npgsql.SqlGenerators
     {
         private DbQueryCommandTree _commandTree;
 
+        protected override bool TreatStringAsUnknown { get { return false; } }
+
         public SqlSelectGenerator(DbQueryCommandTree commandTree)
         {
             _commandTree = commandTree;

--- a/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
+++ b/src/EntityFramework6.Npgsql/SqlGenerators/VisitedExpression.cs
@@ -242,7 +242,7 @@ namespace Npgsql.SqlGenerators
                     sqlText.Append("::uuid");
                     break;
                 case PrimitiveTypeKind.String:
-                    sqlText.Append("E'").Append(((string)_value).Replace(@"\", @"\\").Replace("'", @"\'")).Append("'");
+                    sqlText.Append("E'").Append(((string)_value).Replace(@"\", @"\\").Replace("'", @"\'")).Append("'::varchar");
                     break;
                 case PrimitiveTypeKind.Time:
                     sqlText.AppendFormat(ni, "INTERVAL '{0}'", (NpgsqlTimeSpan)(TimeSpan)_value);

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
@@ -57,8 +57,8 @@ namespace EntityFramework6.Npgsql.Tests
                 }
                 var someParameter = "Some";
                 Assert.IsTrue(context.Posts.Any(p => p.Title.StartsWith(someParameter)));
-                Assert.IsTrue(context.Posts.Select(p => p.VarbitColumn == varbitVal).First());
-                Assert.IsTrue(context.Posts.Select(p => p.VarbitColumn == "10011").First());
+                Assert.IsTrue(context.Posts.Select(p => p.VarbitColumn == NpgsqlTypeFunctions.Cast(varbitVal, "varbit")).First());
+                Assert.IsTrue(context.Posts.Select(p => p.VarbitColumn == NpgsqlTypeFunctions.Cast("10011", "varbit")).First());
                 Assert.AreEqual(1, context.NoColumnsEntities.Count());
             }
         }


### PR DESCRIPTION
* Remove string hack for SELECTs and introduce an explicit Cast function for LINQ.

Requesting ideas / comments. This fixes #837 but introduces a change in behavior that can break existing code. 