### PR TITLE
Corrected ConnectionTests.WithKeepAlive

### DIFF
--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -460,7 +460,7 @@ namespace Npgsql.Tests
 
         [Test, Description("Breaks a connector while it's in the pool, with a keepalive and without")]
         [TestCase(false, TestName = "WithoutKeepAlive")]
-        [TestCase(false, TestName = "WithKeepAlive")]
+        [TestCase(true, TestName = "WithKeepAlive")]
         public void BreakConnectorInPool(bool keepAlive)
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString) { MaxPoolSize = 1 };


### PR DESCRIPTION
The "WithKeepAlive" connnection test was setup to test with a "false" value duplicating the "WithoutKeepAlive" connection test and by the context obviously incorrect.

I have corrected this test, but the test now fails, possibly due to divergent behavior surrounding the ConnectorPool since this test was first implemented.  Pushing this small fix, so the correct test conditions are setup, and either the test can be corrected or the relevant code can be fixed.

Added issue for defect tracking: #1049