### PR TITLE
Fix using Unspecified for pg's UTC data

### DIFF
--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimeStampHandler.cs
@@ -98,7 +98,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 date += 730119; // 730119 = days since era (0001-01-01) for 2000-01-01
                 time *= 10; // To 100ns
 
-                return new NpgsqlDateTime(new NpgsqlDate(date), new TimeSpan(time));
+                return new NpgsqlDateTime(new NpgsqlDate(date), new TimeSpan(time), DateTimeKind.UTC);
             } else {
                 value = -value;
                 int date = (int)(value / 86400000000L);


### PR DESCRIPTION
This specifies the DateTime Kind property instead of returning Unspecified when querying a postgresql server. Now it returns UTC so a programmer can KNOW it's UTC and not maybe local time.