### PR TITLE
add hint for WaitAsync(cancellationToken)

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1200,6 +1200,8 @@ namespace Npgsql
         /// Waits asynchronously until an asynchronous PostgreSQL messages (e.g. a notification)
         /// arrives, and exits immediately. The asynchronous message is delivered via the normal events
         /// (<see cref="Notification"/>, <see cref="Notice"/>).
+        /// CancelationToken can not cancel wait operation if underlying NetworkStream does not support it
+        /// (see https://stackoverflow.com/questions/12421989/networkstream-readasync-with-a-cancellation-token-never-cancels ).
         /// </summary>
         public async Task WaitAsync(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Currently there is no way to cancel WaitAsnyc with help of CancelationToken.
Example:
```
using Npgsql;
using System;
using System.Threading;

namespace NpgsqlTestListen
{
	class Program
	{
		static void Main(string[] args)
		{
			using (CancellationTokenSource cancel = new CancellationTokenSource())
			{
				Console.CancelKeyPress += (sender, e) =>
				{
					cancel.Cancel();
					e.Cancel = true;
				};
				Console.WriteLine("press ctrl-c to cancel");
				using (var con = new NpgsqlConnection("Server=localhost;Port=5432;Database=test;User Id=postgres;Password=test"))
				{
					con.Open();
					con.Notification += (sender, e) => Console.WriteLine(e.AdditionalInformation);
					using (var cmd = con.CreateCommand())
					{
						cmd.CommandText = "LISTEN test";
						cmd.ExecuteNonQuery();
					}
					while (!cancel.Token.IsCancellationRequested)
						con.WaitAsync(cancel.Token).Wait();
				}
			}
			Console.WriteLine("we should read this after ctrl-c / press enter now");
			Console.ReadLine();
		}
	}
}
```