### PR TITLE
try fixing bug when enum type is used on composite key column

### DIFF
--- a/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
+++ b/Npgsql/NpgsqlTypes/NpgsqlTypesHelper.cs
@@ -178,6 +178,16 @@ namespace NpgsqlTypes
             {
                 return true;
             }
+
+            if (type.IsEnum)
+            {
+                var t = type.GetEnumUnderlyingType();
+                if (NativeTypeMapping.TryGetValue(t, out typeInfo))
+                {
+                    return true;
+                }
+            }
+
             // At this point there is no direct mapping, so we see if we have an array or IEnumerable<T>.
             // Note that we checked for a direct mapping first, so if there is a direct mapping of a class
             // which implements IEnumerable<T> we will use that (currently this is only string, which


### PR DESCRIPTION
We encountered an problem when using a model like this:  

```
class Model
{
        [Key, Column(Order = 0)]
        public virtual string Key { get; set; }

        [Key, Column(Order = 1)]
        public virtual TokenType TokenType { get; set; } // <--- This line causing the InvalidCastException: Can't cast TokenType into any valid DbType. 
// TokenType is a enum.
}
```

We managed to circumvent the problem using this patch, wanna make sure this won't raise other issues. Thanks.
