### PR TITLE
 Avoid unnecessary connection string parsing

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -75,7 +75,7 @@ namespace Npgsql
         /// <summary>
         /// The parsed connection string set by the user
         /// </summary>
-        internal NpgsqlConnectionStringBuilder Settings { get; private set; }
+        NpgsqlConnectionStringBuilder _settings;
 
         /// <summary>
         /// The actual string provided by the user for the connection string
@@ -121,7 +121,7 @@ namespace Npgsql
         /// Initializes a new instance of the
         /// <see cref="NpgsqlConnection">NpgsqlConnection</see> class.
         /// </summary>
-        public NpgsqlConnection() : this(String.Empty) {}
+        public NpgsqlConnection() : this(new NpgsqlConnectionStringBuilder()) {}
 
         /// <summary>
         /// Initializes a new instance of the
@@ -129,7 +129,12 @@ namespace Npgsql
         /// and sets the <see cref="NpgsqlConnection.ConnectionString">ConnectionString</see>.
         /// </summary>
         /// <param name="builder">The connection used to open the PostgreSQL database.</param>
-        public NpgsqlConnection(NpgsqlConnectionStringBuilder builder) : this(builder.ConnectionString) { }
+        public NpgsqlConnection(NpgsqlConnectionStringBuilder builder)
+        {
+            GC.SuppressFinalize(this);
+            Settings = builder;
+            Init();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -268,10 +273,23 @@ namespace Npgsql
                 if (value == null) {
                     value = string.Empty;
                 }
-                Settings = new NpgsqlConnectionStringBuilder(value);
+                _settings = new NpgsqlConnectionStringBuilder(value);
                 // Note that settings.ConnectionString is canonical and may therefore be different from
                 // the provided value
-                _connectionString = Settings.ConnectionString;
+                _connectionString = _settings.ConnectionString;
+            }
+        }
+
+        /// <summary>
+        /// The parsed connection string set by the user
+        /// </summary>
+        internal NpgsqlConnectionStringBuilder Settings
+        {
+            get { return _settings; }
+            set
+            {
+                _connectionString = value.ConnectionString;
+                _settings = value;
             }
         }
 


### PR DESCRIPTION
This optimizes the NpgsqlConnection constructor with NpgsqlConnectionStringBuilder as a argument. This fixes the performance problem with unnecessary connection string parsing when NpgsqlConnectionStringBuilder is passed as the argument to the constructor. This improves the performance when NpgsqlConnectionStringBuilder is used to initialize the NpgsqlConnector. This way the user can optimize their code by avoiding the parsing step of the connection string.

This can be used as a workaround for #1174 and http://fxjr.blogspot.fi/2013/06/performance-improvements-when-creating.html.

This PR does not optimize the connection string constructor as discussed in the above posts. It might be an expected behaviour that the connection string is parsed when passed as the constructor argument.