### PR TITLE
Pool manager concurrency improvement

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1459,12 +1459,7 @@ namespace Npgsql
         /// <summary>
         /// Clear connection pool.
         /// </summary>
-        public static void ClearPool(NpgsqlConnection connection)
-        {
-            ConnectorPool pool;
-            if (PoolManager.Pools.TryGetValue(connection.Settings, out pool))
-                pool.Clear();
-        }
+        public static void ClearPool(NpgsqlConnection connection) => PoolManager.Clear(connection.Settings);
 
         /// <summary>
         /// Clear all connection pools.

--- a/src/Npgsql/PoolManager.cs
+++ b/src/Npgsql/PoolManager.cs
@@ -91,7 +91,7 @@ namespace Npgsql
         /// </summary>
         int _clearCounter;
 
-        static Timer _pruningTimer;
+        Timer _pruningTimer;
         readonly TimeSpan _pruningInterval;
         readonly List<NpgsqlConnector> _prunedConnectors;
 

--- a/src/Npgsql/PoolManager.cs
+++ b/src/Npgsql/PoolManager.cs
@@ -53,6 +53,15 @@ namespace Npgsql
             return Pools[connString];
         }
 
+        internal static void Clear(NpgsqlConnectionStringBuilder connString)
+        {
+            Debug.Assert(connString != null);
+
+            ConnectorPool pool;
+            if (Pools.TryGetValue(connString, out pool))
+                pool.Clear();
+        }
+
         internal static void ClearAll()
         {
             foreach (var kvp in Pools)


### PR DESCRIPTION
- close pruned idle connectors outside lock to avoid long locking and lock contesting
- pool manager clear all uses ConcurrentDictionary enumerator instead of Values property to avoid copying and full locking of the dictionary
- moved pool clear logic to pool manager for cosmetics