### PR TITLE
Make pruning timer inside ConnectorPool non static

### DIFF
--- a/src/Npgsql/PoolManager.cs
+++ b/src/Npgsql/PoolManager.cs
@@ -84,7 +84,7 @@ namespace Npgsql
         /// </summary>
         int _clearCounter;
 
-        static Timer _pruningTimer;
+        Timer _pruningTimer;
         readonly TimeSpan _pruningInterval;
 
         static readonly NpgsqlLogger Log = NpgsqlLogManager.GetCurrentClassLogger();


### PR DESCRIPTION
This fixes a bug causing only a single pruning timer to be available accross all connection pools. This PR is a follow up from 3.2 PR #1216.