### PR TITLE
added PostgisRawGeometry to handle other WkbTypes

### DIFF
--- a/src/Npgsql/NpgsqlTypes/PostgisTypes.cs
+++ b/src/Npgsql/NpgsqlTypes/PostgisTypes.cs
@@ -13,6 +13,7 @@ namespace NpgsqlTypes
     /// </summary>
     enum WkbIdentifier : uint
     {
+        Raw = 0,
         Point = 1,
         LineString = 2,
         Polygon = 3,
@@ -79,19 +80,128 @@ namespace NpgsqlTypes
         protected abstract int GetLenHelper();
         internal abstract WkbIdentifier Identifier { get;}
 
-        internal int GetLen()
+        internal virtual ByteOrder ByteOrder => ByteOrder.MSB;
+
+        public virtual uint WkbType => (uint)Identifier;
+
+        internal int GetLen(bool asSubGeometry)
         {
             // header =
             //      1 byte for the endianness of the structure
             //    + 4 bytes for the type identifier
             //   (+ 4 bytes for the SRID if present)
-            return 5 + (SRID == 0 ? 0 : 4) + GetLenHelper();
+            return 5 + (asSubGeometry || SRID == 0 ? 0 : 4) + GetLenHelper();
         }
 
         /// <summary>
         /// The Spatial Reference System Identifier of the geometry (0 if unspecified).
         /// </summary>
         public uint SRID { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an unparsed geometry.
+    /// </summary>
+    public class PostgisRawGeometry : PostgisGeometry, IEquatable<PostgisRawGeometry>
+    {
+        internal override WkbIdentifier Identifier => WkbIdentifier.Raw;
+        internal override ByteOrder ByteOrder => (ByteOrder)_wkb[0];
+
+        public override uint WkbType
+        {
+            get
+            {
+                return ByteOrder == ByteOrder.LSB
+                    ? (uint)(_wkb[1] | _wkb[2] << 8 | _wkb[3] << 16 | _wkb[4] << 24)
+                    : (uint)(_wkb[4] | _wkb[3] << 8 | _wkb[2] << 16 | _wkb[1] << 24);
+            }
+        }
+
+        readonly byte[] _wkb;
+
+        public byte[] Wkb
+        {
+            get
+            {
+                return _wkb;
+            }
+        }
+
+        protected override int GetLenHelper()
+        {
+            return _wkb.Length - 5;
+        }
+
+        public PostgisRawGeometry(uint srid, byte[] wkb)
+        {
+            if (wkb == null)
+            {
+                throw new ArgumentNullException(nameof(wkb));
+            }
+            SRID = srid;
+            _wkb = wkb;
+        }
+
+        public bool Equals([CanBeNull] PostgisRawGeometry other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (SRID != other.SRID || _wkb.Length != other._wkb.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < _wkb.Length; i++)
+            {
+                if (_wkb[i] != other._wkb[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals([CanBeNull] object obj)
+        {
+            return Equals(obj as PostgisRawGeometry);
+        }
+
+        public static bool operator ==([CanBeNull] PostgisRawGeometry x, [CanBeNull] PostgisRawGeometry y)
+        {
+            if (ReferenceEquals(x, null))
+                return ReferenceEquals(y, null);
+            return x.Equals(y);
+        }
+
+        public static bool operator !=(PostgisRawGeometry x, PostgisRawGeometry y)
+        {
+            return !(x == y);
+        }
+
+        public override int GetHashCode()
+        {
+            var ret = 266370105;//seed with something other than zero to make paths of all zeros hash differently.
+            ret ^= _wkb.Length.GetHashCode();
+            for (var i = 0; i < _wkb.Length; i++)
+            {
+                ret ^= _wkb[i] << (i % 24);
+            }
+            return ret;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Geom(SRID[{0}],WKB[{1}])", SRID, _wkb.Length);
+        }
     }
 
     /// <summary>
@@ -441,7 +551,7 @@ namespace NpgsqlTypes
             var n = 4;
             for (var i = 0; i < _lineStrings.Length; i++)
             {
-                n += _lineStrings[i].GetLen();
+                n += _lineStrings[i].GetLen(true);
             }
             return n;
         }
@@ -596,7 +706,7 @@ namespace NpgsqlTypes
             var n = 4;
             for (var i = 0; i < _polygons.Length; i++)
             {
-                n += _polygons[i].GetLen();
+                n += _polygons[i].GetLen(true);
             }
             return n;
         }
@@ -681,11 +791,12 @@ namespace NpgsqlTypes
             var n = 4;
             for (var i = 0; i < _geometries.Length; i++)
             {
-                n += _geometries[i].GetLen();
+                n += _geometries[i].GetLen(true);
             }
             return n;
         }
 
         public int GeometryCount => _geometries.Length;
     }
+    #pragma warning restore 1591
 }

--- a/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
+++ b/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
@@ -10,11 +10,23 @@ using NpgsqlTypes;
 namespace Npgsql.TypeHandlers
 {
     /// <summary>
+    /// Global PostgisConfig.
+    /// </summary>
+    public static class PostgisConfig
+    {
+        /// <summary>
+        /// Whether PostGIS geometries should be parsed.
+        /// </summary>
+        public static bool TryToParseGeometries = true;
+    }
+
+    /// <summary>
     /// Type Handler for the postgis geometry type.
     /// </summary>
     [TypeMapping("geometry", NpgsqlDbType.Geometry, new[]
     {
         typeof(PostgisGeometry),
+        typeof(PostgisRawGeometry),
         typeof(PostgisPoint),
         typeof(PostgisMultiPoint),
         typeof(PostgisLineString),
@@ -47,6 +59,9 @@ namespace Npgsql.TypeHandlers
         ReadBuffer _readBuf;
         WriteBuffer _writeBuf;
         ByteOrder _bo;
+        bool _tryToParseGeometry;
+        bool _isSubGeometry;
+        int _wkbPos;
         Coordinate2D[] _points;
         Coordinate2D[][] _rings;
         Coordinate2D[][][] _pols;
@@ -79,6 +94,9 @@ namespace Npgsql.TypeHandlers
         public override void PrepareRead(ReadBuffer buf, int len, FieldDescription fieldDescription = null)
         {
             Reset();
+            _tryToParseGeometry = PostgisConfig.TryToParseGeometries;
+            _isSubGeometry = false;
+            _wkbPos = 0;
             _readBuf = buf;
             _len = len;
             _srid = default(uint?);
@@ -119,6 +137,7 @@ namespace Npgsql.TypeHandlers
                     if (_readBuf.ReadBytesLeft < 4)
                         return false;
                     _srid = _readBuf.ReadUInt32(_bo);
+                    _id &= ~(uint)EwkbModifier.HasSRID;
                 }
                 else
                 {
@@ -126,7 +145,45 @@ namespace Npgsql.TypeHandlers
                 }
             }
 
-            switch ((WkbIdentifier)(_id & 7))
+            if (!_isSubGeometry && (!_tryToParseGeometry || _id > 7))
+            {
+                if (_bytes == null)
+                {
+                    _bytes = new byte[_srid.Value != 0 ? _len - 4 : _len];
+                    _bytes[0] = (byte)_bo;
+
+                    if (_bo == ByteOrder.LSB)
+                    {
+                        _bytes[1] = (byte)_id;
+                        _bytes[2] = (byte)(_id >> 8);
+                        _bytes[3] = (byte)(_id >> 16);
+                        _bytes[4] = (byte)(_id >> 24);
+                    }
+                    else
+                    {
+                        _bytes[1] = (byte)(_id >> 24);
+                        _bytes[2] = (byte)(_id >> 16);
+                        _bytes[3] = (byte)(_id >> 8);
+                        _bytes[4] = (byte)_id;
+                    }
+                    _wkbPos = 5;
+                }
+
+                var toRead = Math.Min(_bytes.Length - _wkbPos, _readBuf.ReadBytesLeft);
+                _readBuf.ReadBytes(_bytes, _wkbPos, toRead);
+                _wkbPos += toRead;
+                if (_wkbPos == _bytes.Length)
+                {
+                    result = new PostgisRawGeometry(_srid.Value, _bytes);
+                    _bytes = null;
+                    _readBuf = null;
+                    return true;
+                }
+
+                return false;
+            }
+
+            switch ((WkbIdentifier)_id)
             {
                 case WkbIdentifier.Point:
                     if (_readBuf.ReadBytesLeft < 16)
@@ -288,6 +345,7 @@ namespace Npgsql.TypeHandlers
                             return false;
                         _geoms.Push(new PostgisGeometry[_readBuf.ReadInt32(_bo)]);
                         _icol.Push(new Counter());
+                        _isSubGeometry = true;
                     }
                     _id = 0;
                     var g = _geoms.Peek();
@@ -339,7 +397,7 @@ namespace Npgsql.TypeHandlers
         {
             var asGeometry = value as PostgisGeometry;
             if (asGeometry != null)
-                return asGeometry.GetLen();
+                return asGeometry.GetLen(false);
 
             var asBytes = value as byte[];
             if (asBytes != null)
@@ -353,6 +411,8 @@ namespace Npgsql.TypeHandlers
             Reset();
             _writeBuf = buf;
             _icol.Clear();
+            _wkbPos = 0;
+            _isSubGeometry = false;
 
             _toWrite = value as PostgisGeometry;
             if (_toWrite != null)
@@ -374,29 +434,46 @@ namespace Npgsql.TypeHandlers
             throw new InvalidCastException("IGeometry type expected.");
         }
 
+        static uint AdjustByteOrder(uint x, bool swap)
+        {
+            return swap ? ((x & 0x000000FF) << 24) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8) | ((x & 0xFF000000) >> 24) : x;
+        }
+
         bool Write(PostgisGeometry geom)
         {
             if (_newGeom)
             {
-                if (geom.SRID == 0)
+                if (_isSubGeometry || geom.SRID == 0)
                 {
                     if (_writeBuf.WriteSpaceLeft < 5)
                         return false;
-                    _writeBuf.WriteByte(0); // We choose to ouput only XDR structure
-                    _writeBuf.WriteInt32((int)geom.Identifier);
+
+                    ByteOrder byteOrder = geom.ByteOrder;
+                    _writeBuf.WriteByte((byte)byteOrder);
+                    _writeBuf.WriteUInt32(AdjustByteOrder(geom.WkbType, byteOrder == ByteOrder.LSB));
                 }
                 else
                 {
                     if (_writeBuf.WriteSpaceLeft < 9)
                         return false;
-                    _writeBuf.WriteByte(0);
-                    _writeBuf.WriteInt32((int) ((uint)geom.Identifier | (uint)EwkbModifier.HasSRID));
-                    _writeBuf.WriteInt32((int) geom.SRID);
+
+                    ByteOrder byteOrder = geom.ByteOrder;
+                    _writeBuf.WriteByte((byte)byteOrder);
+                    _writeBuf.WriteUInt32(AdjustByteOrder(geom.WkbType | (uint)EwkbModifier.HasSRID, byteOrder == ByteOrder.LSB));
+                    _writeBuf.WriteUInt32(AdjustByteOrder(geom.SRID, byteOrder == ByteOrder.LSB));
                 }
                 _newGeom = false;
+                _wkbPos = 5;
             }
             switch (geom.Identifier)
             {
+                case WkbIdentifier.Raw:
+                    var raw = (PostgisRawGeometry)geom;
+                    var bytesToWrite = Math.Min(raw.Wkb.Length - _wkbPos, _writeBuf.WriteSpaceLeft);
+                    _writeBuf.WriteBytes(raw.Wkb, _wkbPos, bytesToWrite);
+                    _wkbPos += bytesToWrite;
+                    return _wkbPos == raw.Wkb.Length;
+
                 case WkbIdentifier.Point:
                     if (_writeBuf.WriteSpaceLeft < 16)
                         return false;
@@ -555,6 +632,7 @@ namespace Npgsql.TypeHandlers
                         _writeBuf.WriteInt32(coll.GeometryCount);
                         _icol.Push(new Counter());
                         _newGeom = true;
+                        _isSubGeometry = true;
                     }
                     for (var i = _icol.Peek(); i < coll.GeometryCount; i.Increment())
                     {


### PR DESCRIPTION
This is a suggestion on how to add an option to handle PostGIS geometries as raw WKB Byte arrays.
The new PostgisGeometry subclass PostgisRawGeometry just wraps the SRID and the raw WKB Bytes to be handled by any library that supports reading/writing of normal WKB (the EWKB to WKB conversion is done automatically without the need to copy the data).
There is a static flag to set whether npgsql should try to parse the geometries or whether it should always return PostgisRawGeometries. PostgisRawGeometry is also used when the WkbType is not recognized/supported by npgsql.

Another small change was done so that the SRID is only send for the main geometry but not for subgeometries. Although the PostGIS Server seems to handle it without a problem, many other libraries would have problems with it (e.g. GDAL/OGR). Npgsql itself would not correctly read those geometries (before or after the addition PostgisRawGeometry).