### PR TITLE
Connection string option for defining persistent statement idle lifetime

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -882,6 +882,46 @@ namespace Npgsql
         bool _persistPrepared;
 
         /// <summary>
+        /// The time to wait before deallocating unused persistent prepared statement.
+        /// Set to 0 (the default) to disable.
+        /// </summary>
+        /// <value>The time (in seconds) to wait. The default value is 0 (disabled).</value>
+        [Category("Advanced")]
+        [Description("The time to wait before deallocating unused persistent prepared statement.")]
+        [DisplayName("Persist Prepared Idle Lifetime")]
+        [NpgsqlConnectionStringProperty]
+        public int PersistPreparedIdleLifetime
+        {
+            get { return _persistPreparedIdleLifetime; }
+            set
+            {
+                _persistPreparedIdleLifetime = value;
+                SetValue(nameof(PersistPreparedIdleLifetime), value);
+            }
+        }
+        int _persistPreparedIdleLifetime;
+
+        /// <summary>
+        /// How many seconds the connection waits before attempting to prune idle persistent prepared statements that are beyond idle lifetime.
+        /// </summary>
+        /// <value>The interval (in seconds). The default value is 10.</value>
+        [Category("Advanced")]
+        [Description("How many seconds the connection waits before attempting to prune idle persistent prepared statements that are beyond idle lifetime.")]
+        [DisplayName("Persist Prepared Pruning Interval")]
+        [NpgsqlConnectionStringProperty]
+        [DefaultValue(10)]
+        public int PersistPreparedPruningInterval
+        {
+            get { return _persistPreparedPruningInterval; }
+            set
+            {
+                _persistPreparedPruningInterval = value;
+                SetValue(nameof(PersistPreparedPruningInterval), value);
+            }
+        }
+        int _persistPreparedPruningInterval;
+
+        /// <summary>
         /// If set to true, a pool connection's state won't be reset when it is closed (improves performance).
         /// Do not specify this unless you know what you're doing.
         /// </summary>

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -197,13 +197,24 @@ namespace Npgsql
         readonly UserAction _userAction;
         readonly Timer _keepAliveTimer;
 
+        readonly TimeSpan _preparedStatementPruningInterval;
+        readonly Timer _preparedStatementPruningTimer;
+
         internal HashSet<string> PreparedStatements { get; } = new HashSet<string>();
 
         /// <summary>
         /// For all persistent prepared statements, maps their SQL to their prepared statement info.
         /// </summary>
-        internal Dictionary<string, PreparedStatementInfo> PersistentPreparedStatements { get; }
-            = new Dictionary<string, PreparedStatementInfo>();
+        internal PreparedStatementCollection PersistentPreparedStatements { get; } = new PreparedStatementCollection();
+
+        /// <summary>
+        /// A lock that's taken while <see cref="PreparedStatements"/> and <see cref="PersistentPreparedStatements"/> 
+        /// collections are accessed
+        /// </summary>
+        internal object PreparedStatementsLock { get; } = new object();
+
+        readonly List<string> _closedStatements = new List<string>();
+        readonly List<string> _prunedStatements = new List<string>();
 
         /// <summary>
         /// If pooled, the timestamp when this connector was returned to the pool.
@@ -280,6 +291,12 @@ namespace Npgsql
                 _keepAliveTimer = new Timer(PerformKeepAlive, null, Timeout.Infinite, Timeout.Infinite);
                 _keepAliveLock = new SemaphoreSlim(1, 1);
             }
+
+            if (IsPersistentStatementPruningEnabled)
+            {
+                _preparedStatementPruningInterval = TimeSpan.FromSeconds(PersistPreparedPruningInterval);
+                _preparedStatementPruningTimer = new Timer(PruneIdlePersistentStatements, null, _preparedStatementPruningInterval, _preparedStatementPruningInterval);
+            }
         }
 
         #endregion
@@ -297,6 +314,9 @@ namespace Npgsql
         int ConnectionTimeout => _settings.Timeout;
         int KeepAlive => _settings.KeepAlive;
         bool IsKeepAliveEnabled => KeepAlive > 0;
+        int PersistPreparedIdleLifetime => _settings.PersistPreparedIdleLifetime;
+        int PersistPreparedPruningInterval => _settings.PersistPreparedPruningInterval;
+        bool IsPersistentStatementPruningEnabled => PersistPreparedIdleLifetime > 0;
         bool IntegratedSecurity => _settings.IntegratedSecurity;
         internal bool ConvertInfinityDateTime => _settings.ConvertInfinityDateTime;
 
@@ -1439,6 +1459,11 @@ namespace Npgsql
                     _keepAliveLock.Release();
                 _keepAliveLock.Dispose();
             }
+
+            if (IsPersistentStatementPruningEnabled)
+            {
+                _preparedStatementPruningTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            }
         }
 
         /// <summary>
@@ -1498,7 +1523,17 @@ namespace Npgsql
 
             if (!_settings.NoResetOnClose)
             {
-                if (PersistentPreparedStatements.Any())
+                bool hasPersistentStatements = false;
+
+                lock (PreparedStatementsLock)
+                {
+                    hasPersistentStatements = PersistentPreparedStatements.Count > 0;
+
+                    if (!hasPersistentStatements)
+                        PreparedStatements.Clear(); // Simple DISCARD ALL is used to free all the statements
+                }
+
+                if (hasPersistentStatements)
                 {
                     // We have persistent prepared statements, so we can't reset the connection state with DISCARD ALL
                     // Note: the send buffer has been cleared above, and we assume all this will fit in it.
@@ -1524,7 +1559,6 @@ namespace Npgsql
                     // There are no persistent prepared statements.
                     // We simply send DISCARD ALL which is more efficient than sending the above messages separately
                     PrependInternalMessage(PregeneratedMessage.DiscardAll);
-                    PreparedStatements.Clear();
                 }
             }
         }
@@ -1541,13 +1575,24 @@ namespace Npgsql
         void ClosePreparedStatements()
         {
             _preparedStatementIndex = 0;
-            if (PreparedStatements.Count == 0)
-                return;
 
-            var flushing = false;
-            foreach (var statement in PreparedStatements)
+            lock (PreparedStatementsLock)
             {
-                CloseMessage.Populate(StatementOrPortal.Statement, statement);
+                if (PreparedStatements.Count == 0)
+                    return;
+
+                foreach (string statementName in PreparedStatements)
+                {
+                    _closedStatements.Add(statementName);
+                }
+
+                PreparedStatements.Clear();
+            }
+
+            bool flushing = false;
+            foreach (string statementName in _closedStatements)
+            {
+                CloseMessage.Populate(StatementOrPortal.Statement, statementName);
                 if (!CloseMessage.Write(WriteBuffer))
                 {
                     WriteBuffer.Flush();
@@ -1557,6 +1602,9 @@ namespace Npgsql
                 }
                 _pendingPrependedResponses += CloseMessage.ResponseMessageCount;
             }
+
+            _closedStatements.Clear();
+
             if (!SyncMessage.Instance.Write(WriteBuffer))
             {
                 WriteBuffer.Flush();
@@ -1572,7 +1620,37 @@ namespace Npgsql
             }
 
             _pendingPrependedResponses += SyncMessage.Instance.ResponseMessageCount;
-            PreparedStatements.Clear();
+        }
+
+        void PruneIdlePersistentStatements(object state)
+        {
+            if (!Monitor.TryEnter(_prunedStatements))
+                return;
+
+            try
+            {
+                lock (PreparedStatementsLock)
+                {
+                    while (PersistentPreparedStatements.Count > 0 &&
+                        (DateTime.UtcNow - PersistentPreparedStatements.Last.UsageTimestamp).TotalSeconds > PersistPreparedIdleLifetime)
+                    {
+                        _prunedStatements.Add(PersistentPreparedStatements.Last.Name);
+                        PersistentPreparedStatements.RemoveLast();
+                    }
+
+                    foreach (string statementName in _prunedStatements)
+                    {
+                        // Pruned statement is deallocated on next Reset()
+                        PreparedStatements.Add(statementName);
+                    }
+
+                    _prunedStatements.Clear();
+                }
+            }
+            finally
+            {
+                Monitor.Exit(_prunedStatements);
+            }
         }
 
         #endregion Close
@@ -1876,11 +1954,86 @@ namespace Npgsql
         Skip
     }
 
-    struct PreparedStatementInfo
+    #endregion
+
+    class PreparedStatementInfo
     {
-        internal string Name;
-        internal RowDescriptionMessage Description;
+        internal readonly string Name;
+        internal readonly string SQL;
+        internal readonly RowDescriptionMessage Description;
+        internal DateTime UsageTimestamp = DateTime.UtcNow;
+
+        public PreparedStatementInfo(string statementName, string sql, RowDescriptionMessage rowDescription)
+        {
+            Name = statementName;
+            SQL = sql;
+            Description = rowDescription;
+        }
     }
 
-    #endregion
+    class PreparedStatementCollection
+    {
+        private readonly Dictionary<string, LinkedListNode<PreparedStatementInfo>> _statementDict
+            = new Dictionary<string, LinkedListNode<PreparedStatementInfo>>();
+
+        private readonly LinkedList<PreparedStatementInfo> _statements
+            = new LinkedList<PreparedStatementInfo>();
+
+        internal int Count
+        {
+            get { return _statements.Count; }
+        }
+
+        internal PreparedStatementInfo Last
+        {
+            get { return _statements.Last.Value; }
+        }
+
+        internal void Add(PreparedStatementInfo statementInfo)
+        {
+            var node = new LinkedListNode<PreparedStatementInfo>(statementInfo);
+
+            _statementDict.Add(statementInfo.SQL, node);
+            _statements.AddFirst(node);
+        }
+
+        internal bool TryGet(string statementSQL, out PreparedStatementInfo statementInfo)
+        {
+            LinkedListNode<PreparedStatementInfo> node;
+            if (_statementDict.TryGetValue(statementSQL, out node))
+            {
+                statementInfo = node.Value;
+                statementInfo.UsageTimestamp = DateTime.UtcNow;
+
+                // Move the latest accessed node to the head of the linked list
+                _statements.Remove(node);
+                _statements.AddFirst(node);
+
+                return true;
+            }
+
+            statementInfo = default(PreparedStatementInfo);
+            return false;
+        }
+
+        internal bool Remove(string statementSQL)
+        {
+            LinkedListNode<PreparedStatementInfo> node;
+            if (_statementDict.TryGetValue(statementSQL, out node))
+            {
+                _statements.Remove(node);
+                _statementDict.Remove(statementSQL);
+                return true;
+            }
+
+            return false;
+        }
+
+        internal void RemoveLast()
+        {
+            PreparedStatementInfo statementInfo = _statements.Last.Value;
+            _statements.RemoveLast();
+            _statementDict.Remove(statementInfo.SQL);
+        }
+    }
 }


### PR DESCRIPTION
I added 2 more connection string parameters for defining resource management related to the persisted prepared statements (PR #1204).

- Added and implemented a connection string parameter for defining how long idle persistent prepared statements are kept alive: PersistPreparedIdleLifetime
- Also added PersistPreparedPruningInterval parameter for defining how often idling statements are checked
- Added tests for these

This makes it safer to enable the connection wide statement persisting by setting PersistPrepared to true. User can now define how long the idling persistent statements are kept alive. This way resource leaks can be avoided, especially, in applications that might use dynamic SQL queries. This also allows the user to safely enable statement persisting feature without any modifications to the existing codebase. Current statement persisting API does not offer easy way to implement such resource management eventhough there exists Unpersist() method for NpgsqlCommand.

About current implementation and some notes:
- By default persistent statement pruning is disabled (PersistPreparedIdleLifetime=0)
- Pruning interval is 10 seconds by default which is the same as pool pruning interval (PersistPreparedPruningInterval=10)
- Statement data locking between pruning thread and user thread is managed by PreparedStatementsLock in NpgsqlConnector. This lock is not heavily contested and therefore the locking is very light.
- Persistent prepared statements are managed by a collection backed by a dictionary and a linked list. Collection keeps the latest accessed statement at the head of the linked list while keeping the access to the statements O(1) through dictionary. Pruning timer just checks the tail of the linked list without enumerating to whole collection (keeps the contention on the lock always very low).
- Statement pruning timer is active eventhough the connector does not contain any persisted statements (but of course not when pruning is disable).

What do you @roji think?

I would also like to know if there is possibly some other way to manage the long idling persisted statements by removing them in user code (though Unpersist()).

BR
Markus