### PR TITLE
Return 0 or something for ConnectionLifeTime getter

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -954,7 +954,7 @@ namespace Npgsql
         [Obsolete("The ConnectionLifeTime parameter is no longer supported")]
         public int ConnectionLifeTime
         {
-            get { throw new NotSupportedException("The ConnectionLifeTime parameter is no longer supported. Please see http://www.npgsql.org/doc/3.1/migration.html"); }
+            get { return 0; }
             set { throw new NotSupportedException("The ConnectionLifeTime parameter is no longer supported. Please see http://www.npgsql.org/doc/3.1/migration.html"); }
         }
 


### PR DESCRIPTION
I'm working on recovery of ddex support.

`throw NotSupportedException` in `ConnectionLifeTime` getter causes error message on clicking [OK] of Connection Dialog. Can I modify it to return 0 or something?

Thrown exception captured by another instance of Visual Studio:
```
-		$exception	{"The ContinuousProcessing parameter is no longer supported. Please see http://www.npgsql.org/doc/3.1/migration.html"}	System.Exception {System.NotSupportedException}
```

Some stacktrace:
```
>	Npgsql.dll!Npgsql.NpgsqlConnectionStringBuilder.ConnectionLifeTime.get() + 0x2f バイト	
 	[ネイティブからマネージへの移行]	
 	Npgsql.dll!Npgsql.NpgsqlConnectionStringBuilder.TryGetValue(string keyword, out object value) + 0x83 バイト	
 	System.Data.dll!System.Data.Common.DbConnectionStringBuilderDescriptor.GetValue(object component) + 0x37 バイト	
 	System.Windows.Forms.dll!System.Windows.Forms.PropertyGridInternal.GridEntry.GetPropEntries(System.Windows.Forms.PropertyGridInternal.GridEntry peParent, object obj, System.Type objType) + 0x3c2 バイト	

 	...
```