### PR TITLE
Issue #1260 Fails to copy in/out geocoll

### DIFF
--- a/test/Npgsql.Tests/Types/PostgisTests.cs
+++ b/test/Npgsql.Tests/Types/PostgisTests.cs
@@ -22,7 +22,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Diagnostics;
 using NpgsqlTypes;
 using NUnit.Framework;
@@ -263,6 +263,79 @@ namespace Npgsql.Tests.Types
 
                 Assert.That(conn.ExecuteScalar("SELECT foo FROM data"), Is.EqualTo(point));
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(Tests)), IssueLink("https://github.com/npgsql/npgsql/issues/1260")]
+        public void CopyBinary(TestAtt a)
+        {
+            using (var c = OpenConnection())
+            {
+                using (var cmd = new NpgsqlCommand("CREATE TEMPORARY TABLE testcopybin (g geometry)", c))
+                    cmd.ExecuteNonQuery();
+
+                try
+                {
+                    using (var writer = c.BeginBinaryImport($"COPY testcopybin (g) FROM STDIN (FORMAT BINARY)"))
+                        for (int i = 0; i < 1000; i++)
+                            writer.WriteRow(a.Geom);
+                }
+                catch(Exception e)
+                {
+                    Assert.Fail($"Copy from stdin failed with {e} at geometry {a.Geom}.");
+                }
+
+                try
+                {
+                    using (var rdr = c.BeginBinaryExport($"COPY testcopybin (g) TO STDOUT (FORMAT BINARY) "))
+                    {
+                        for (int i =0; i < 1000; i++)
+                        {
+                            rdr.StartRow();
+                            Assert.IsTrue(a.Geom.Equals(rdr.Read<PostgisGeometry>()));
+                        }
+                    }
+                }
+                catch(Exception e)
+                {
+                    Assert.Fail($"Copy from stdout failed with {e} at geometry {a.Geom}.");
+                }
+            }
+        }
+
+        [Test, TestCaseSource(nameof(Tests)), IssueLink("https://github.com/npgsql/npgsql/issues/1260")]
+        public void CopyBinaryArray(TestAtt a)
+        {
+            using (var c = OpenConnection())
+            {
+                using (var cmd = new NpgsqlCommand("CREATE TEMPORARY TABLE testcopybinarray (g geometry[3])", c))
+                    cmd.ExecuteNonQuery();
+
+                var t = new PostgisGeometry[3] { a.Geom, a.Geom, a.Geom };
+                try
+                {
+                    using (var writer = c.BeginBinaryImport("COPY testcopybinarray (g) FROM STDIN (FORMAT BINARY)"))
+                        for (int i = 0; i < 1000; i++)
+                            writer.WriteRow(new[] {t});
+                }
+                catch(Exception e)
+                {
+                    Assert.Fail($"Copy from stdin failed with {e} at geometry {a.Geom}.");
+                }
+
+                try
+                {
+                    using (var rdr = c.BeginBinaryExport("COPY testcopybinarray (g) TO STDOUT (FORMAT BINARY)"))
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            rdr.StartRow();
+                            Assert.IsTrue(t.SequenceEqual(rdr.Read<PostgisGeometry[]>()));
+                        }
+                }
+                catch(Exception e)
+                {
+                    Assert.Fail($"Copy to stdout failed with {e} at geometry {a.Geom}.");
+                }
             }
         }
 


### PR DESCRIPTION
Corrected handling of reading/writing geometrycollection with insufficient buffer space scenario.

I was unable to restore nuget packages for Npgsql.Benchmark on my machine, so I didn't run the tests I've written. I will dig the test fail ASAP.