### PR TITLE
Return an empty Dictionary for an empty hstore

### DIFF
--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -189,6 +189,7 @@ namespace Npgsql.TypeHandlers
                 _value = new Dictionary<string, string>(_numElements);
                 if (_numElements == 0)
                 {
+                    result = (Dictionary<string, string>)_value;
                     CleanupState();
                     return true;
                 }

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -277,19 +277,30 @@ namespace Npgsql.Tests.Types
                     {"cd", "hello"}
                 };
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
+                var expected2 = new Dictionary<string, string> {};
+
+                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn))
                 {
                     cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Hstore, expected);
                     cmd.Parameters.AddWithValue("p2", expected);
+                    cmd.Parameters.AddWithValue("p3", NpgsqlDbType.Hstore, expected2);
+                    cmd.Parameters.AddWithValue("p4", expected2);
                     using (var reader = cmd.ExecuteReader())
                     {
                         reader.Read();
-                        for (var i = 0; i < cmd.Parameters.Count; i++)
+                        for (var i = 0; i < 2; i++)
                         {
                             Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Dictionary<string, string>)));
                             Assert.That(reader.GetFieldValue<Dictionary<string, string>>(i), Is.EqualTo(expected));
                             Assert.That(reader.GetFieldValue<IDictionary<string, string>>(i), Is.EqualTo(expected));
                             Assert.That(reader.GetString(i), Is.EqualTo(@"""a""=>""3"",""b""=>NULL,""cd""=>""hello"""));
+                        }
+                        for (var i = 2; i < 4; i++)
+                        {
+                            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Dictionary<string, string>)));
+                            Assert.That(reader.GetFieldValue<Dictionary<string, string>>(i), Is.EqualTo(expected2));
+                            Assert.That(reader.GetFieldValue<IDictionary<string, string>>(i), Is.EqualTo(expected2));
+                            Assert.That(reader.GetString(i), Is.EqualTo(""));
                         }
                     }
                 }


### PR DESCRIPTION
An empty hstore value (0 keys) used to return null. An empty Dictionary seems better.

Also add a test.