### PR TITLE
Fix ArgumentOutOfRangeException when handling PostgresException in NextResult()

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -318,7 +318,10 @@ namespace Npgsql
             catch (PostgresException e)
             {
                 _state = ReaderState.Consumed;
-                e.Statement = _statements[_statementIndex];
+                if ((_statementIndex >= 0) && (_statementIndex < _statements.Count))
+                { 
+                    e.Statement = _statements[_statementIndex];
+                }
                 throw;
             }
         }


### PR DESCRIPTION
This change adds a bounds check before indexing into the `_statements` list, to ensure that `_statementIndex` points to a valid position within the list. This ArgumentOutOfRangeException hides the underlying PostgresException that was raised by the database, obscuring the actual problem.

(In our case, the underlying fault was a field value that didn't match a foreign key constraint).

    System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
    Parameter name: index
      at System.ThrowHelper.ThrowArgumentOutOfRangeException (ExceptionArgument argument, ExceptionResource resource) <0x7f4d5f894c50 + 0x0003a> in <filename unknown>:0 
      at System.ThrowHelper.ThrowArgumentOutOfRangeException () <0x7f4d5f8949e0 + 0x00012> in <filename unknown>:0 
      at System.Collections.Generic.List`1[T].get_Item (Int32 index) <0x7f4d5f713ac0 + 0x0001e> in <filename unknown>:0 
      at Npgsql.NpgsqlDataReader.NextResult () <0x4131c5a0 + 0x0008d> in <filename unknown>:0 
      at Npgsql.NpgsqlCommand.ExecuteNonQueryInternal () <0x41326ea0 + 0x000b3> in <filename unknown>:0 
      at Npgsql.NpgsqlCommand.ExecuteNonQuery () <0x41326e70 + 0x00014> in <filename unknown>:0 