### PR TITLE
Fix bug #1306

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -287,17 +287,10 @@ namespace Npgsql
                     return _connectionString;
                 if (!_alreadyOpened)   // If not yet opened, return the full connstring but don't cache
                     return Settings.ToString();
+                if (!_settings.PersistSecurityInfo)
+                    return Settings.ToStringWithoutPassword();
 
-                var passwd = Settings.Password;
-                if (!_settings.PersistSecurityInfo && passwd != null)
-                {
-                    Settings.Password = null;
-                    _connectionString = Settings.ToString();
-                    Settings.Password = passwd;
-                }
-                else
-                    _connectionString = Settings.ToString();
-
+                _connectionString = Settings.ToString();
                 return _connectionString;
             }
             set

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -284,6 +284,11 @@ namespace Npgsql
             } else {
                 base[canonicalKeyword] = value;
             }
+
+            lock (_connectionStringWithoutPasswordLocker)
+            {
+                _connectionStringWithoutPassword = null;
+            }
         }
 
         #endregion
@@ -1041,6 +1046,25 @@ namespace Npgsql
         #endregion
 
         #region Misc
+
+        internal string ToStringWithoutPassword()
+        {
+            lock (_connectionStringWithoutPasswordLocker)
+            {
+                if (_connectionStringWithoutPassword != null)
+                {
+                    return _connectionStringWithoutPassword;
+                }
+
+                var clone = Clone();
+                clone.Password = null;
+                _connectionStringWithoutPassword = clone.ToString();
+                return _connectionStringWithoutPassword;
+            }
+        }
+
+        readonly object _connectionStringWithoutPasswordLocker = new object();
+        string _connectionStringWithoutPassword;
 
         internal NpgsqlConnectionStringBuilder Clone()
         {

--- a/test/Npgsql.Tests/ConnectionStringBuilderTests.cs
+++ b/test/Npgsql.Tests/ConnectionStringBuilderTests.cs
@@ -131,6 +131,20 @@ namespace Npgsql.Tests
                 Throws.Exception.TypeOf<ArgumentException>());
         }
 
+        [Test]
+        public void ToStringWithoutPassword()
+        {
+            Builder.ConnectionString = "Host=host1;Username=user;Password=password";
+            var builderWithoutPassword = new NpgsqlConnectionStringBuilder(Builder.ToStringWithoutPassword());
+            Assert.That(builderWithoutPassword.Host, Is.EqualTo(Builder.Host));
+            Assert.That(builderWithoutPassword.Username, Is.EqualTo(Builder.Username));
+            Assert.That(builderWithoutPassword.Password, Is.Null);
+
+            Builder.Host = "host2";
+            builderWithoutPassword = new NpgsqlConnectionStringBuilder(Builder.ToStringWithoutPassword());
+            Assert.That(builderWithoutPassword.Host, Is.EqualTo(Builder.Host));
+        }
+
         #region Setup
 
         NpgsqlConnectionStringBuilder Builder { get; set; }


### PR DESCRIPTION
This should fix #1306. Instead of mutating the Password property of the shared connection string builder instance, use a newly introduced thread-safe internal method ```NpgsqlConnectionStringBuilder.ToStringWithoutPassword()``` that caches (and clears when a value is changed) the passwordless connection string internally.

I used locks to keep the code simple. It is possible to use combination of ```Interlocked.Exchange``` and ```Volatile.Read``` to write / read the internal ```_connectionStringWithoutPassword``` in a lock-free manner, but I don't think the performance win is worth it here.