### PR TITLE
SafeWrite method for NpgsqlBinaryImporter

### DIFF
--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -152,6 +152,23 @@ namespace Npgsql
         }
 
         /// <summary>
+        /// Writes a single column in the current row. This overloaded method writes nullable types using WriteNull() when they are null.
+        /// </summary>
+        /// <param name="value">The value to be written</param>
+        /// <typeparam name="T">
+        /// The type of the column to be written. This must correspond to the actual type or data
+        /// corruption will occur. If in doubt, use <see cref="Write{T}(T, NpgsqlDbType)"/> to manually
+        /// specify the type.
+        /// </typeparam>
+        public void SafeWrite<T>(T value)
+        {
+            if (value == null)
+                WriteNull();
+            else
+                Write(value);
+        }
+
+        /// <summary>
         /// Writes a single column in the current row as type <paramref name="type"/>.
         /// </summary>
         /// <param name="value">The value to be written</param>


### PR DESCRIPTION
allow easier syntax such as

```csharp
foreach (var contact in contacts)
{
  wr.StartRow();
  wr.SafeWrite(contact.firstname);
  wr.SafeWrite(contact.lastname);
  wr.SafeWrite(contact.phone);
  wr.SafeWrite(contact.birth_date);
}
```

instead of the following

```csharp
foreach (var contact in contacts)
{
  wr.StartRow();
  wr.Write(contact.firstname);
  wr.Write(contact.lastname);
  if (contact.phone != null) wr.Write(contact.phone); else wr.WriteNull();
  if (contact.birth_date.HasValue) wr.Write(contact.birth_date); else wr.WriteNull();
}
```