### PR TITLE
Fix some special cases of CommandBuilder.DeriveParameters

### DIFF
--- a/src/Npgsql/NpgsqlCommandBuilder.cs
+++ b/src/Npgsql/NpgsqlCommandBuilder.cs
@@ -137,50 +137,31 @@ namespace Npgsql
         {
             // See http://www.postgresql.org/docs/current/static/catalog-pg-proc.html
             command.Parameters.Clear();
-            // Updated after 0.99.3 to support the optional existence of a name qualifying schema and case insensitivity when the schema ror procedure name do not contain a quote.
-            // This fixed an incompatibility with NpgsqlCommand.CheckFunctionReturn(String ReturnType)
-            var serverVersion = command.Connection.Connector.ServerVersion;
-            string query;
-            string procedureName;
-            string schemaName = null;
-            var fullName = command.CommandText.Split('.');
-            if (fullName.Length > 1 && fullName[0].Length > 0)
-            {
-                // proargsmodes is supported for Postgresql 8.1 and above
-                query = serverVersion >= new Version(8, 1, 0)
-                    ? "select proargnames, proargtypes, proallargtypes, proargmodes from pg_proc p left join pg_namespace n on p.pronamespace = n.oid where proname=:proname and n.nspname=:nspname"
-                    : "select proargnames, proargtypes from pg_proc p left join pg_namespace n on p.pronamespace = n.oid where proname=:proname and n.nspname=:nspname";
-                schemaName = (fullName[0].IndexOf("\"") != -1) ? fullName[0] : fullName[0].ToLower();
-                procedureName = (fullName[1].IndexOf("\"") != -1) ? fullName[1] : fullName[1].ToLower();
-
-                // The pg_temp pseudo-schema is special - it's an alias to a real schema name (e.g. pg_temp_2).
-                // We get the real name with pg_my_temp_schema().
-                if (schemaName == "pg_temp")
-                {
-                    using (var c = new NpgsqlCommand("SELECT nspname FROM pg_namespace WHERE oid=pg_my_temp_schema()", command.Connection))
-                    {
-                        schemaName = (string)c.ExecuteScalar();
-                    }
-                }
-            }
-            else
-            {
-                // proargsmodes is supported for Postgresql 8.1 and above
-                query = serverVersion >= new Version(8, 1, 0)
-                    ? "select proargnames, proargtypes, proallargtypes, proargmodes from pg_proc where proname = :proname"
-                    : "select proargnames, proargtypes from pg_proc where proname = :proname";
-                procedureName = (fullName[0].IndexOf("\"") != -1) ? fullName[0] : fullName[0].ToLower();
-            }
-
+            string query = @"
+SELECT
+CASE
+	WHEN pg_proc.proargnames IS NULL THEN array_cat(array_fill(''::name,ARRAY[pg_proc.pronargs]),array_agg(pg_attribute.attname ORDER BY pg_attribute.attnum))
+	ELSE pg_proc.proargnames
+END AS proargnames,
+pg_proc.proargtypes,
+CASE
+	WHEN pg_proc.proallargtypes IS NULL AND (array_agg(pg_attribute.atttypid))[1] IS NOT NULL THEN array_cat(string_to_array(pg_proc.proargtypes::text,' ')::oid[],array_agg(pg_attribute.atttypid ORDER BY pg_attribute.attnum))
+	ELSE pg_proc.proallargtypes
+END AS proallargtypes,
+CASE
+	WHEN pg_proc.proargmodes IS NULL AND (array_agg(pg_attribute.atttypid))[1] IS NOT NULL THEN array_cat(array_fill('i'::""char"",ARRAY[pg_proc.pronargs]),array_fill('o'::""char"",ARRAY[array_length(array_agg(pg_attribute.atttypid), 1)]))
+    ELSE pg_proc.proargmodes
+END AS proargmodes
+FROM pg_proc
+LEFT JOIN pg_type ON pg_proc.prorettype = pg_type.oid
+LEFT JOIN pg_attribute ON pg_type.typrelid = pg_attribute.attrelid AND pg_attribute.attnum >= 1
+WHERE pg_proc.oid = :proname::regproc::oid
+GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_proc.proargmodes, pg_proc.pronargs;
+";
             using (var c = new NpgsqlCommand(query, command.Connection))
             {
                 c.Parameters.Add(new NpgsqlParameter("proname", NpgsqlDbType.Text));
-                c.Parameters[0].Value = procedureName.Replace("\"", "").Trim();
-                if (fullName.Length > 1 && !string.IsNullOrEmpty(schemaName))
-                {
-                    var prm = c.Parameters.Add(new NpgsqlParameter("nspname", NpgsqlDbType.Text));
-                    prm.Value = schemaName.Replace("\"", "").Trim();
-                }
+                c.Parameters[0].Value = command.CommandText;
 
                 string[] names = null;
                 uint[] types = null;
@@ -192,13 +173,10 @@ namespace Npgsql
                     {
                         if (!rdr.IsDBNull(0))
                             names = rdr.GetValue(0) as string[];
-                        if (serverVersion >= new Version("8.1.0"))
-                        {
-                            if (!rdr.IsDBNull(2))
-                                types = rdr.GetValue(2) as uint[];
-                            if (!rdr.IsDBNull(3))
-                                modes = rdr.GetValue(3) as char[];
-                        }
+                        if (!rdr.IsDBNull(2))
+                            types = rdr.GetValue(2) as uint[];
+                        if (!rdr.IsDBNull(3))
+                            modes = rdr.GetValue(3) as char[];
                         if (types == null)
                         {
                             if (rdr.IsDBNull(1) || rdr.GetFieldValue<uint[]>(1).Length == 0)

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -150,8 +150,8 @@ namespace Npgsql.Tests
             {
                 var invalidCommandName = new NpgsqlCommand("invalidfunctionname", conn);
                 Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(invalidCommandName),
-                    Throws.Exception.TypeOf<InvalidOperationException>()
-                                    .With.Message.Contains("does not exist"));
+                    Throws.Exception.TypeOf<PostgresException>()
+                        .With.Property("SqlState").EqualTo("42883"));
             }
         }
 
@@ -287,8 +287,8 @@ RESET search_path;
 ");
                     var command = new NpgsqlCommand("schema1func", conn) { CommandType = CommandType.StoredProcedure };
                     Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
-                        Throws.Exception.TypeOf<NpgsqlException>()
-                        .With.Property("Code").EqualTo("42883"));
+                        Throws.Exception.TypeOf<PostgresException>()
+                        .With.Property("SqlState").EqualTo("42883"));
                 }
                 finally
                 {
@@ -327,10 +327,9 @@ LANGUAGE 'plpgsql';
 SET search_path TO schema1, schema2;
 ");
                     var command = new NpgsqlCommand("redundantfunc", conn) { CommandType = CommandType.StoredProcedure };
-                    NpgsqlCommandBuilder.DeriveParameters(command);
                     Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
-                        Throws.Exception.TypeOf<NpgsqlException>()
-                        .With.Property("Code").EqualTo("42725"));
+                        Throws.Exception.TypeOf<PostgresException>()
+                        .With.Property("SqlState").EqualTo("42725"));
                 }
                 finally
                 {

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -151,7 +151,7 @@ namespace Npgsql.Tests
                 var invalidCommandName = new NpgsqlCommand("invalidfunctionname", conn);
                 Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(invalidCommandName),
                     Throws.Exception.TypeOf<PostgresException>()
-                        .With.Property("SqlState").EqualTo("42883"));
+                        .With.Property(nameof(PostgresException.SqlState)).EqualTo("42883"));
             }
         }
 
@@ -288,7 +288,7 @@ RESET search_path;
                     var command = new NpgsqlCommand("schema1func", conn) { CommandType = CommandType.StoredProcedure };
                     Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
                         Throws.Exception.TypeOf<PostgresException>()
-                        .With.Property("SqlState").EqualTo("42883"));
+                        .With.Property(nameof(PostgresException.SqlState)).EqualTo("42883"));
                 }
                 finally
                 {
@@ -329,7 +329,7 @@ SET search_path TO schema1, schema2;
                     var command = new NpgsqlCommand("redundantfunc", conn) { CommandType = CommandType.StoredProcedure };
                     Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
                         Throws.Exception.TypeOf<PostgresException>()
-                        .With.Property("SqlState").EqualTo("42725"));
+                        .With.Property(nameof(PostgresException.SqlState)).EqualTo("42725"));
                 }
                 finally
                 {

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -180,6 +180,271 @@ namespace Npgsql.Tests
                 Assert.That(cmd.Parameters[2].Value, Is.EqualTo(6));
             }
         }
+
+        [Test, Description("Tests function parameter derivation for quoted functions with double quotes in the name works")]
+        public void FunctionQuoteCharactersInNameDeriveParameters()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery(
+                    @"CREATE OR REPLACE FUNCTION pg_temp.""""""FunctionQuote""""CharactersInName""""""(int4, text) returns int4 as
+                              $BODY$
+                              begin
+                                return 0;
+                              end
+                              $BODY$
+                              language 'plpgsql';");
+                var command = new NpgsqlCommand("pg_temp.\"\"\"FunctionQuote\"\"CharactersInName\"\"\"", conn) { CommandType = CommandType.StoredProcedure };
+                NpgsqlCommandBuilder.DeriveParameters(command);
+                Assert.AreEqual(NpgsqlDbType.Integer, command.Parameters[0].NpgsqlDbType);
+                Assert.AreEqual(NpgsqlDbType.Text, command.Parameters[1].NpgsqlDbType);
+            }
+        }
+
+        [Test, Description("Tests function parameter derivation for quoted functions with dots in the name works")]
+        public void FunctionDotCharacterInNameDeriveParameters()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery(
+                    @"CREATE OR REPLACE FUNCTION pg_temp.""My.Dotted.Function""(int4, text) returns int4 as
+                              $BODY$
+                              begin
+                                return 0;
+                              end
+                              $BODY$
+                              language 'plpgsql';");
+                var command = new NpgsqlCommand("pg_temp.\"My.Dotted.Function\"", conn) { CommandType = CommandType.StoredProcedure };
+                NpgsqlCommandBuilder.DeriveParameters(command);
+                Assert.AreEqual(NpgsqlDbType.Integer, command.Parameters[0].NpgsqlDbType);
+                Assert.AreEqual(NpgsqlDbType.Text, command.Parameters[1].NpgsqlDbType);
+            }
+        }
+
+        [Test, Description("Tests if the right function according to search_path is used in function parameter derivation")]
+        public void DeriveParametersWithCorrectSchemaResolution()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1, schema2 CASCADE; CREATE SCHEMA schema1; CREATE SCHEMA schema2;");
+                try
+                {
+                    conn.ExecuteNonQuery(
+                        @"
+CREATE OR REPLACE FUNCTION schema1.redundantfunc() RETURNS int AS
+$BODY$
+BEGIN
+    RETURN 1;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION schema2.redundantfunc(IN param1 INT, IN param2 INT) RETURNS int AS
+$BODY$
+BEGIN
+RETURN param1 + param2;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+SET search_path TO schema2;
+");
+                    var command = new NpgsqlCommand("redundantfunc", conn) { CommandType = CommandType.StoredProcedure };
+                    NpgsqlCommandBuilder.DeriveParameters(command);
+                    Assert.That(command.Parameters, Has.Count.EqualTo(2));
+                    Assert.That(command.Parameters[0].Direction, Is.EqualTo(ParameterDirection.Input));
+                    Assert.That(command.Parameters[1].Direction, Is.EqualTo(ParameterDirection.Input));
+                    command.Parameters[0].Value = 5;
+                    command.Parameters[1].Value = 4;
+                    Assert.That(command.ExecuteScalar(), Is.EqualTo(9));
+                }
+                finally
+                {
+                    if (conn.State == ConnectionState.Open)
+                        conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1, schema2 CASCADE");
+                }
+            }
+        }
+
+        [Test, Description("Tests if function parameter derivation throws an exception if the specified function is not in the search_path")]
+        public void DeriveThrowsForExistingFunctionThatIsNotInSearchPath()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1 CASCADE; CREATE SCHEMA schema1;");
+                try
+                {
+                    conn.ExecuteNonQuery(@"
+CREATE OR REPLACE FUNCTION schema1.schema1func() RETURNS int AS
+$BODY$
+BEGIN
+    RETURN 1;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+RESET search_path;
+");
+                    var command = new NpgsqlCommand("schema1func", conn) { CommandType = CommandType.StoredProcedure };
+                    Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
+                        Throws.Exception.TypeOf<NpgsqlException>()
+                        .With.Property("Code").EqualTo("42883"));
+                }
+                finally
+                {
+                    if (conn.State == ConnectionState.Open)
+                        conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1 CASCADE");
+                }
+            }
+        }
+
+        [Test, Description("Tests if an exception is thrown if multiple functions with the specified name are in the search_path")]
+        public void DeriveThrowsForMultipleFunctionNameHitsInSearchPath()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1, schema2 CASCADE; CREATE SCHEMA schema1; CREATE SCHEMA schema2;");
+                try
+                {
+                    conn.ExecuteNonQuery(
+                        @"
+CREATE OR REPLACE FUNCTION schema1.redundantfunc() RETURNS int AS
+$BODY$
+BEGIN
+    RETURN 1;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION schema2.redundantfunc(IN param1 INT, IN param2 INT) RETURNS int AS
+$BODY$
+BEGIN
+RETURN param1 + param2;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+SET search_path TO schema1, schema2;
+");
+                    var command = new NpgsqlCommand("redundantfunc", conn) { CommandType = CommandType.StoredProcedure };
+                    NpgsqlCommandBuilder.DeriveParameters(command);
+                    Assert.That(() => NpgsqlCommandBuilder.DeriveParameters(command),
+                        Throws.Exception.TypeOf<NpgsqlException>()
+                        .With.Property("Code").EqualTo("42725"));
+                }
+                finally
+                {
+                    if (conn.State == ConnectionState.Open)
+                        conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS schema1, schema2 CASCADE");
+                }
+            }
+        }
+
+        #region Set returning functions
+
+        [Test, Description("Tests parameter derivation for a function that returns SETOF sometype")]
+        public void DeriveParametersFunctionReturningSetofType()
+        {
+            using (var conn = OpenConnection())
+            {
+                TestUtil.MinimumPgVersion(conn, "9.2.0");
+
+                // This function returns record because of the two Out (InOut & Out) parameters
+                conn.ExecuteNonQuery(@"
+CREATE TABLE pg_temp.foo (fooid int, foosubid int, fooname text);
+
+INSERT INTO pg_temp.foo VALUES
+(1, 1, 'Joe'),
+(1, 2, 'Ed'),
+(2, 1, 'Mary');
+
+CREATE FUNCTION pg_temp.getfoo(int) RETURNS SETOF foo AS $$
+    SELECT * FROM pg_temp.foo WHERE pg_temp.foo.fooid = $1 ORDER BY pg_temp.foo.foosubid;
+$$ LANGUAGE SQL;
+                ");
+
+                var cmd = new NpgsqlCommand("pg_temp.getfoo", conn) { CommandType = CommandType.StoredProcedure };
+                NpgsqlCommandBuilder.DeriveParameters(cmd);
+                Assert.That(cmd.Parameters, Has.Count.EqualTo(4));
+                Assert.That(cmd.Parameters[0].Direction, Is.EqualTo(ParameterDirection.Input));
+                Assert.That(cmd.Parameters[1].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[2].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[3].Direction, Is.EqualTo(ParameterDirection.Output));
+                cmd.Parameters[0].Value = 1;
+                cmd.ExecuteNonQuery();
+                Assert.That(cmd.Parameters[0].Value, Is.EqualTo(1));
+            }
+        }
+
+        [Test, Description("Tests parameter derivation for a function that returns TABLE")]
+        public void DeriveParametersFunctionReturningTable()
+        {
+            using (var conn = OpenConnection())
+            {
+                TestUtil.MinimumPgVersion(conn, "9.2.0");
+
+                // This function returns record because of the two Out (InOut & Out) parameters
+                conn.ExecuteNonQuery(@"
+CREATE TABLE pg_temp.foo (fooid int, foosubid int, fooname text);
+
+INSERT INTO pg_temp.foo VALUES
+(1, 1, 'Joe'),
+(1, 2, 'Ed'),
+(2, 1, 'Mary');
+
+CREATE FUNCTION pg_temp.getfoo(int) RETURNS TABLE(fooid int, foosubid int, fooname text) AS $$
+    SELECT * FROM pg_temp.foo WHERE pg_temp.foo.fooid = $1 ORDER BY pg_temp.foo.foosubid;
+$$ LANGUAGE SQL;
+                ");
+
+                var cmd = new NpgsqlCommand("pg_temp.getfoo", conn) { CommandType = CommandType.StoredProcedure };
+                NpgsqlCommandBuilder.DeriveParameters(cmd);
+                Assert.That(cmd.Parameters, Has.Count.EqualTo(4));
+                Assert.That(cmd.Parameters[0].Direction, Is.EqualTo(ParameterDirection.Input));
+                Assert.That(cmd.Parameters[1].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[2].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[3].Direction, Is.EqualTo(ParameterDirection.Output));
+                cmd.Parameters[0].Value = 1;
+                cmd.ExecuteNonQuery();
+                Assert.That(cmd.Parameters[0].Value, Is.EqualTo(1));
+            }
+        }
+
+        [Test, Description("Tests parameter derivation for a function that returns SETOF record")]
+        public void DeriveParametersFunctionReturningSetofRecord()
+        {
+            using (var conn = OpenConnection())
+            {
+                TestUtil.MinimumPgVersion(conn, "9.2.0");
+
+                // This function returns record because of the two Out (InOut & Out) parameters
+                conn.ExecuteNonQuery(@"
+CREATE TABLE pg_temp.foo (fooid int, foosubid int, fooname text);
+
+INSERT INTO pg_temp.foo VALUES
+(1, 1, 'Joe'),
+(1, 2, 'Ed'),
+(2, 1, 'Mary');
+
+CREATE FUNCTION pg_temp.getfoo(int, OUT fooid int, OUT foosubid int, OUT fooname text) RETURNS SETOF record AS $$
+    SELECT * FROM pg_temp.foo WHERE pg_temp.foo.fooid = $1 ORDER BY pg_temp.foo.foosubid;
+$$ LANGUAGE SQL;
+                ");
+
+                var cmd = new NpgsqlCommand("pg_temp.getfoo", conn) { CommandType = CommandType.StoredProcedure };
+                NpgsqlCommandBuilder.DeriveParameters(cmd);
+                Assert.That(cmd.Parameters, Has.Count.EqualTo(4));
+                Assert.That(cmd.Parameters[0].Direction, Is.EqualTo(ParameterDirection.Input));
+                Assert.That(cmd.Parameters[1].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[2].Direction, Is.EqualTo(ParameterDirection.Output));
+                Assert.That(cmd.Parameters[3].Direction, Is.EqualTo(ParameterDirection.Output));
+                cmd.Parameters[0].Value = 1;
+                cmd.ExecuteNonQuery();
+                Assert.That(cmd.Parameters[0].Value, Is.EqualTo(1));
+            }
+        }
+
+        #endregion
     }
 }
 


### PR DESCRIPTION
There are some special cases of PostgreSQL functions that currently aren't supported by Npgsql's CommandBuilder.DeriveParameters.

CommandBuilder.DeriveParameters should correctly derive function
parameters in the following cases:

- functions with double quotes in the name

- functions with dots in the name

Also it should respect search_path and derive parameters for a function that returns
a set of some user defined type.

This is a greatly simplified version of #912 with some modifications to maintain compatibiliy with the changes introduced in the context of #1212 

It also doesn't bother with overloaded functions.
While this is possible in principle, it is ways more complex than this pretty straightforward PR.

**This PR removes compatibility with PostgreSQL versions < 8.1**
The latest minor release of 8.0 was 8.0.26 on 2010-10-04 which is about seven years ago.
As of today all PostgreSQL versions < 9.2 are officially unsupported.
