### PR TITLE
Fix DDEX losing password on getting a connection

### DIFF
--- a/src/VSIX/NpgsqlConnectionEquivalencyComparer.cs
+++ b/src/VSIX/NpgsqlConnectionEquivalencyComparer.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.Data.Framework;
+using Microsoft.VisualStudio.Data.Services.SupportEntities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Npgsql.VSIX
+{
+    class NpgsqlConnectionEquivalencyComparer : DataConnectionEquivalencyComparer
+    {
+        protected override bool AreEquivalent(IVsDataConnectionProperties connectionProperties1, IVsDataConnectionProperties connectionProperties2)
+            => connectionProperties1["Host"].ToString() == connectionProperties2["Host"].ToString()
+            && connectionProperties1["Port"].ToString() == connectionProperties2["Port"].ToString()
+            && connectionProperties1["Database"].ToString() == connectionProperties2["Database"].ToString()
+            && connectionProperties1["Username"].ToString() == connectionProperties2["Username"].ToString()
+            ;
+    }
+}

--- a/src/VSIX/NpgsqlProviderObjectFactory.cs
+++ b/src/VSIX/NpgsqlProviderObjectFactory.cs
@@ -26,6 +26,8 @@ namespace Npgsql.VSIX
                 return new DataObjectSupport($"{GetType().Namespace}.NpgsqlDataObjectSupport", Assembly.GetExecutingAssembly());
             if (objType == typeof(IVsDataViewSupport))
                 return new DataViewSupport($"{GetType().Namespace}.NpgsqlDataViewSupport", Assembly.GetExecutingAssembly());
+            if (objType == typeof(IVsDataConnectionEquivalencyComparer))
+                return new NpgsqlConnectionEquivalencyComparer();
             return null;
         }
     }

--- a/src/VSIX/NpgsqlProviderRegistration.cs
+++ b/src/VSIX/NpgsqlProviderRegistration.cs
@@ -29,6 +29,7 @@ namespace Npgsql.VSIX
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataConnectionSupport));
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataConnectionUIControl));
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataConnectionProperties));
+                supportedObjectsKey.CreateSubkey(nameof(IVsDataConnectionEquivalencyComparer));
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataSourceInformation));
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataObjectSupport));
                 supportedObjectsKey.CreateSubkey(nameof(IVsDataViewSupport));

--- a/src/VSIX/VSIX.csproj
+++ b/src/VSIX/VSIX.csproj
@@ -71,6 +71,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
+    <Compile Include="NpgsqlConnectionEquivalencyComparer.cs" />
     <Compile Include="NpgsqlConnectionProperties.cs" />
     <Compile Include="NpgsqlConnectionUIControl.cs">
       <SubType>UserControl</SubType>


### PR DESCRIPTION
- When we drag a table from Server Explorer into DataSet designer,
  it says connecting to server without password.

- When we implement `IVsDataConnectionEquivalencyComparer`,
  `Microsoft.VisualStudio.Data.Package.DataConnectionManager.GetConnection()`
  can find and reuse existing connection already opened for the table.
  Without it, try to create new connection with `ConnectionString` with
  no Password set. This may be bug of VS.