### PR TITLE
Fixes #1496 - Parameter 'collectionName' of method 'GetSchema' should…

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1285,41 +1285,46 @@ namespace Npgsql
         /// <returns>The collection specified.</returns>
         public override DataTable GetSchema([CanBeNull] string collectionName, [CanBeNull] string[] restrictions)
         {
-            switch (collectionName)
+            if (String.IsNullOrEmpty(collectionName))
             {
-                case "MetaDataCollections":
+                throw new ArgumentException("Collection name cannot be null or empty", nameof(collectionName));
+            }
+
+            switch (collectionName.ToUpperInvariant())
+            {
+                case "METADATACOLLECTIONS":
                     return NpgsqlSchema.GetMetaDataCollections();
-                case "Restrictions":
+                case "RESTRICTIONS":
                     return NpgsqlSchema.GetRestrictions();
-                case "DataSourceInformation":
+                case "DATASOURCEINFORMATION":
                     return NpgsqlSchema.GetDataSourceInformation();
-                case "DataTypes":
+                case "DATATYPES":
                     throw new NotSupportedException();
-                case "ReservedWords":
+                case "RESERVEDWORDS":
                     return NpgsqlSchema.GetReservedWords();
-                    // custom collections for npgsql
-                case "Databases":
+                // custom collections for npgsql
+                case "DATABASES":
                     return NpgsqlSchema.GetDatabases(this, restrictions);
-                case "Schemata":
+                case "SCHEMATA":
                     return NpgsqlSchema.GetSchemata(this, restrictions);
-                case "Tables":
+                case "TABLES":
                     return NpgsqlSchema.GetTables(this, restrictions);
-                case "Columns":
+                case "COLUMNS":
                     return NpgsqlSchema.GetColumns(this, restrictions);
-                case "Views":
+                case "VIEWS":
                     return NpgsqlSchema.GetViews(this, restrictions);
-                case "Users":
+                case "USERS":
                     return NpgsqlSchema.GetUsers(this, restrictions);
-                case "Indexes":
+                case "INDEXES":
                     return NpgsqlSchema.GetIndexes(this, restrictions);
-                case "IndexColumns":
+                case "INDEXCOLUMNS":
                     return NpgsqlSchema.GetIndexColumns(this, restrictions);
-                case "Constraints":
-                case "PrimaryKey":
-                case "UniqueKeys":
-                case "ForeignKeys":
+                case "CONSTRAINTS":
+                case "PRIMARYKEY":
+                case "UNIQUEKEYS":
+                case "FOREIGNKEYS":
                     return NpgsqlSchema.GetConstraints(this, restrictions, collectionName);
-                case "ConstraintColumns":
+                case "CONSTRAINTCOLUMNS":
                     return NpgsqlSchema.GetConstraintColumns(this, restrictions);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(collectionName), collectionName, "Invalid collection name");

--- a/test/Npgsql.Tests/SchemaTests.cs
+++ b/test/Npgsql.Tests/SchemaTests.cs
@@ -70,6 +70,55 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test, Description("Calling GetSchema(collectionName [, restrictions]) case insensive collectionName can be used")]
+        public void CaseInsensitiveCollectionName()
+        {
+            using (var conn = OpenConnection())
+            {
+                var collections1 = conn.GetSchema(DbMetaDataCollectionNames.MetaDataCollections).Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections2 = conn.GetSchema("METADATACOLLECTIONS").Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections3 = conn.GetSchema("metadatacollections").Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections4 = conn.GetSchema("MetaDataCollections").Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections5 = conn.GetSchema("METADATACOLLECTIONS", null).Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections6 = conn.GetSchema("metadatacollections", null).Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                var collections7 = conn.GetSchema("MetaDataCollections", null).Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["CollectionName"])
+                    .ToList();
+
+                Assert.That(collections1, Is.EquivalentTo(collections2));
+                Assert.That(collections1, Is.EquivalentTo(collections3));
+                Assert.That(collections1, Is.EquivalentTo(collections4));
+                Assert.That(collections1, Is.EquivalentTo(collections5));
+                Assert.That(collections1, Is.EquivalentTo(collections6));
+                Assert.That(collections1, Is.EquivalentTo(collections7));
+            }
+        }
+
         [Test]
         public void Restrictions()
         {


### PR DESCRIPTION
… be case insensitive

test snipped. 
```
DbConnection conn = new NpgsqlConnection("Server=192.168.2.19;User Id=uyum;Password=12345;Database=db1497;");
conn.Open();
DataTable dt = conn.GetSchema("metadatacollections");
```