### PR TITLE
Fix parsing of "10devel" version string for postgres 10

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1829,6 +1829,8 @@ namespace Npgsql
                     break;
                 }
             }
+            if (!versionString.Contains('.'))
+                versionString += ".0";
             ServerVersion = new Version(versionString);
         }
 


### PR DESCRIPTION
new Version("x.y.z") requires at least one dot (2 numbers) so parse 10 as 10.0