### PR TITLE
Snapshot isolation level equals to PostgreSQL Repeatable Read

### DIFF
--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -103,11 +103,11 @@ namespace Npgsql
 
             switch (isolationLevel) {
                 case IsolationLevel.RepeatableRead:
+                case IsolationLevel.Snapshot:
                     _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
                     _connector.PrependInternalMessage(PregeneratedMessage.SetTransRepeatableRead);
                     break;
                 case IsolationLevel.Serializable:
-                case IsolationLevel.Snapshot:
                     _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
                     _connector.PrependInternalMessage(PregeneratedMessage.SetTransSerializable);
                     break;


### PR DESCRIPTION
Before version 9.1 Postgresql had only two isolation levels:
- Read Committed
- Serializable which acted as Snapshot isolation level.
Repeatable Read were promoted to Serializable, so it also acted
as Snapshot.

Since 9.1 Snaphot isolation level were renamed from Serializable to
Repeatable Read, and Serializable becomes true Serializable.

Using true Serializable instead of Snapshot introduces encountable
overhead. So, if user wants Snaphost isolation level it is better to
give real Snapshot (PostgreSQL's Repeatabl Read).

fixes #1521