### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Npgsql - .NET Data Provider for PostgreSQL
 ![Unstable nuget](https://img.shields.io/myget/npgsql-unstable/v/npgsql.svg?label=unstable%20nuget)
 [![Build Status](https://img.shields.io/teamcity/http/build.npgsql.org/s/npgsql_CompileReleaseAndPush.svg?label=TeamCity)](http://build.npgsql.org/viewType.html?buildTypeId=npgsql_CompileReleaseAndPush&guest=1) [![Join the chat at https://gitter.im/npgsql/npsgl](https://img.shields.io/badge/GITTER-JOIN%20CHAT-brightgreen.svg)](https://gitter.im/npgsql/npgsql)
 
-###What Is Npgsql?
+### What Is Npgsql?
 
 Npgsql is a .NET data provider for PostgreSQL. It allows you to connect and interact with PostgreSQL server using .NET.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
