### PR TITLE
Include length of SRID in sub geometries when calculating buffer length for PostgisGeometryCollection

### DIFF
--- a/src/Npgsql/NpgsqlTypes/PostgisTypes.cs
+++ b/src/Npgsql/NpgsqlTypes/PostgisTypes.cs
@@ -89,13 +89,13 @@ namespace NpgsqlTypes
         protected abstract int GetLenHelper();
         internal abstract WkbIdentifier Identifier { get;}
 
-        internal int GetLen(bool isTopLevel=false)
+        internal int GetLen(bool includeSRID)
         {
             // header =
             //      1 byte for the endianness of the structure
             //    + 4 bytes for the type identifier
-            //   (+ 4 bytes for the SRID if present)
-            return 5 + (SRID == 0 || !isTopLevel ? 0 : 4) + GetLenHelper();
+            //   (+ 4 bytes for the SRID if present and included)
+            return 5 + (SRID == 0 || !includeSRID ? 0 : 4) + GetLenHelper();
         }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace NpgsqlTypes
         {
             var n = 4;
             for (var i = 0; i < _lineStrings.Length; i++)
-                n += _lineStrings[i].GetLen();
+                n += _lineStrings[i].GetLen(false);
             return n;
         }
 
@@ -461,7 +461,7 @@ namespace NpgsqlTypes
         {
             var n = 4;
             for (var i = 0; i < _polygons.Length; i++)
-                n += _polygons[i].GetLen();
+                n += _polygons[i].GetLen(false);
             return n;
         }
 
@@ -524,7 +524,7 @@ namespace NpgsqlTypes
         {
             var n = 4;
             for (var i = 0; i < _geometries.Length; i++)
-                n += _geometries[i].GetLen();
+                n += _geometries[i].GetLen(true);
             return n;
         }
 

--- a/test/Npgsql.Tests/Types/PostgisTests.cs
+++ b/test/Npgsql.Tests/Types/PostgisTests.cs
@@ -393,6 +393,37 @@ namespace Npgsql.Tests.Types
             }
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1557")]
+        public void SubGeometriesWithSRID()
+        {
+            var point = new PostgisPoint(1, 1)
+            {
+                SRID = 4326
+            };
+
+            var lineString = new PostgisLineString(new[] { new Coordinate2D(2, 2), new Coordinate2D(3, 3) })
+            {
+                SRID = 4326
+            };
+
+            var polygon = new PostgisPolygon(new[] { new[] { new Coordinate2D(4, 4), new Coordinate2D(5, 5), new Coordinate2D(6, 6), new Coordinate2D(4, 4) } })
+            {
+                SRID = 4326
+            };
+
+            var collection = new PostgisGeometryCollection(new PostgisGeometry[] { point, lineString, polygon })
+            {
+                SRID = 4326
+            };
+
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT :p", conn))
+            {
+                cmd.Parameters.AddWithValue("p", collection);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
         [OneTimeSetUp]
         public void SetUp()
         {


### PR DESCRIPTION
Fix bug #1557.
I renamed the parameter of PostgisGeometry.GetLen() method to better describe its usage.