### PR TITLE
Introducing asynchronous GetTextReader and GetStream for data reader

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -989,6 +989,26 @@ namespace Npgsql
             return row.GetStream();
         }
 
+        /// <summary>
+        /// Retrieves data as a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <returns>The returned object.</returns>
+        public async Task<Stream> GetStreamAsync(int ordinal)
+        {
+            CheckRowAndOrdinal(ordinal);
+
+            var fieldDescription = _rowDescription[ordinal];
+            var handler = fieldDescription.Handler as ByteaHandler;
+            if (handler == null)
+                throw new InvalidCastException("GetStream() not supported for type " + fieldDescription.Handler.PgDisplayName);
+
+            var row = Row;
+            await row.SeekToColumnStart(ordinal, false);
+            row.CheckNotNull();
+            return row.GetStream();
+        }
+
         #endregion
 
         #region Special text getters

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1044,6 +1044,27 @@ namespace Npgsql
             return handler.GetTextReader(row.GetStream());
         }
 
+        /// <summary>
+        /// Retrieves data as a <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <returns>The returned object.</returns>
+        public async Task<TextReader> GetTextReaderAsync(int ordinal)
+        {
+            CheckRowAndOrdinal(ordinal);
+
+            var fieldDescription = _rowDescription[ordinal];
+            var handler = fieldDescription.Handler as ITextReaderHandler;
+            if (handler == null)
+                throw new InvalidCastException("GetTextReader() not supported for type " + fieldDescription.Handler.PgDisplayName);
+
+            var row = Row;
+            await row.SeekToColumnStart(ordinal, false);
+            row.CheckNotNull();
+
+            return handler.GetTextReader(row.GetStream());
+        }
+
         #endregion
 
         #region IsDBNull


### PR DESCRIPTION
This PR introduces an asynchronous version of following `NpgsqlDataReader` methods:
- `GetTextReader`
- `GetStream`