### PR TITLE
Synchronization for non timed-out rollback. #1611

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -604,9 +604,9 @@ namespace Npgsql
             // Note that even when #1378 is implemented in some way, we should check for mono and go volatile in any case -
             // distributed transactions aren't supported.
 
-            var ressourceManager = new VolatileResourceManager(this, transaction);
-            connector.EnlistedResource = ressourceManager;
-            transaction.EnlistVolatile(ressourceManager, EnlistmentOptions.None);
+            var resourceManager = new VolatileResourceManager(this, transaction);
+            connector.EnlistedResource = resourceManager;
+            transaction.EnlistVolatile(resourceManager, EnlistmentOptions.None);
             Log.Debug($"Enlisted volatile resource manager (localid={transaction.TransactionInformation.LocalIdentifier})", connector.Id);
         }
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -143,7 +143,7 @@ namespace Npgsql
 
 #if !NETSTANDARD1_3
         /// <summary>
-        /// The ressource manager actually using this connector. <see langword="null" /> if the
+        /// The resource manager actually using this connector. <see langword="null" /> if the
         /// connector do not participate in a system transaction.
         /// </summary>
         [CanBeNull]

--- a/test/Npgsql.Tests/DistributedTransactionTests.cs
+++ b/test/Npgsql.Tests/DistributedTransactionTests.cs
@@ -251,7 +251,7 @@ Exception {2}",
             }
         }
 
-        [Test(Description = "Connection reuse race after rollback, bool distributed"), Explicit("Currently failing.")]
+        [Test(Description = "Connection reuse race after rollback, bool distributed"), Explicit]
         public void ConnectionReuseRaceAfterRollback([Values(false, true)] bool distributed)
         {
             for (var i = 1; i <= 100; i++)


### PR DESCRIPTION
Here is a working solution for avoiding the race condition after a distributed rollback. It does not even require the `EnlistTransaction(null)`. But it does not handle the troubles with timeouts.

Note that locally I am unable to compile the new target netstandard 2.0. (Not having preview installed.)

I am going to comment the proposed changes.