### PR TITLE
Fix certificat authentication to postgresql server

### DIFF
--- a/src/Npgsql/Tls/TlsClientStream.cs
+++ b/src/Npgsql/Tls/TlsClientStream.cs
@@ -1449,7 +1449,7 @@ namespace Npgsql.Tls
             var keyDsa = key as DSACryptoServiceProvider;
             var keyRsa = key as RSACryptoServiceProvider;
 #else
-            var keyRsa = new X509Certificate2(_clientCertificates[0].Export(X509ContentType.Cert)).GetRSAPrivateKey();
+            var keyRsa = (_clientCertificates[0] as X509Certificate2).GetRSAPrivateKey();
 #endif
 
             byte[] signature = null, hash = null;
@@ -1543,7 +1543,7 @@ namespace Npgsql.Tls
             }
             else
             {
-                SendAlertFatal(AlertDescription.HandshakeFailure);
+                SendAlertFatal(AlertDescription.HandshakeFailure, "No private key in provided certificate");
             }
             _handshakeData.CertificateVerifyHash_SHA1.Dispose();
             _handshakeData.CertificateVerifyHash_SHA1 = null;

--- a/src/Npgsql/Tls/TlsClientStream.cs
+++ b/src/Npgsql/Tls/TlsClientStream.cs
@@ -1449,7 +1449,7 @@ namespace Npgsql.Tls
             var keyDsa = key as DSACryptoServiceProvider;
             var keyRsa = key as RSACryptoServiceProvider;
 #else
-            var keyRsa = (_clientCertificates[0] as X509Certificate2).GetRSAPrivateKey();
+            var keyRsa = ((X509Certificate2)_clientCertificates[0]).GetRSAPrivateKey();
 #endif
 
             byte[] signature = null, hash = null;


### PR DESCRIPTION
Exporting the certificate only export the public part of if.
Private key is needed for authentication of client.
+
if keyRsa is null the file provided is miss encoded or private key is not inside, try to have less unexplained HandshakeFailure in code.

Tested with 9.6.2 server ( psql string : host:5432/precontrol_data?sslmode=verify-full and hostssl with cert auth in  pg_hba )