### PR TITLE
fix: Allows to receive the geometry as byte array

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -844,6 +844,12 @@ namespace Npgsql
             var fieldDescription = RowDescription[ordinal];
             var handler = fieldDescription.Handler as ByteaHandler;
             if (handler == null)
+            {
+                var geomHandler = fieldDescription.Handler as PostgisGeometryHandler;
+                if (geomHandler != null)
+                    handler = geomHandler.ByteaHandler;
+            }
+            if (handler == null)
                 throw new InvalidCastException("GetBytes() not supported for type " + fieldDescription.Name);
 
             SeekToColumn(ordinal, false).GetAwaiter().GetResult();

--- a/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
+++ b/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
@@ -53,6 +53,8 @@ namespace Npgsql.TypeHandlers
         INpgsqlTypeHandler<PostgisGeometryCollection>,
         INpgsqlTypeHandler<byte[]>
     {
+        internal ByteaHandler ByteaHandler => _byteaHandler;
+
         [CanBeNull]
         readonly ByteaHandler _byteaHandler;
 


### PR DESCRIPTION
This fix allows to receive the byte representation of the geometry instead of receiving an exception.
This enables geometry processing via NetTopologySuite in e.g. NHibernate.Spatial.