### PR TITLE
Fix ArgumentOutOfRangeException when parsing "time with time zone"

### DIFF
--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -711,5 +711,18 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
   CONSTRAINT ""pk_OrganisatieQmo_Organisatie_QueryModelObjects_Imp"" PRIMARY KEY (""Id"")
 )";
         #endregion Bug1285
+
+        [Test]
+        public void TimeWithTimeZoneBeforeUtcZero()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT TIME WITH TIME ZONE '01:00:00+02'", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+                var record = reader.GetFieldValue<DateTimeOffset>(0);
+                Assert.That(record, Is.EqualTo(new DateTimeOffset(1, 1, 2, 1, 0, 0, new TimeSpan(0, 2, 0, 0))));
+            }
+        }
     }
 }


### PR DESCRIPTION
Loading the "time with time zone" value `01:00:00+02` from the database previously caused an ArgumentOutOfRangeException to be thrown:

> The UTC time represented when the offset is applied must be between year 0 and 10,000.

I solved this issue by adding an extra day in those cases to keep the UTC time in the acceptable range. This _should theoretically_ be safe as the date part is discarded anyways.