### PR TITLE
ProvideAutoLoad for Npgsql.VSIX package.

### DIFF
--- a/src/VSIX/NpgsqlVSPackage.cs
+++ b/src/VSIX/NpgsqlVSPackage.cs
@@ -40,6 +40,7 @@ namespace Npgsql.VSIX
     [NpgsqlProviderRegistration]
     [Guid(NpgsqlVSPackage.PackageGuidString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
+    [ProvideAutoLoad(Microsoft.VisualStudio.Shell.Interop.UIContextGuids80.NoSolution)]
     public sealed class NpgsqlVSPackage : Package
     {
         /// <summary>


### PR DESCRIPTION
- It may fix `Entity Data model wizard crashes silently when generating a new EF model from database` #1480
- Npgsql.VSIX is loaded and `Npgsql ADO.NET provider` works even if no solution opens.