### PR TITLE
Support timestamp values stored as floating point numbers.

### DIFF
--- a/src/Npgsql.NodaTime/IntervalHandler.cs
+++ b/src/Npgsql.NodaTime/IntervalHandler.cs
@@ -34,18 +34,26 @@ namespace Npgsql.NodaTime
     {
         // Check for the legacy floating point timestamps feature
         protected override NpgsqlTypeHandler<Period> Create(NpgsqlConnection conn)
-            => new IntervalHandler();
+            => new IntervalHandler(conn.HasIntegerDateTimes);
     }
 
     class IntervalHandler : NpgsqlSimpleTypeHandler<Period>
     {
-        public IntervalHandler()
+        /// <summary>
+        /// A deprecated compile-time option of PostgreSQL switches to a floating-point representation of some date/time
+        /// fields. Some PostgreSQL-like databases (e.g. CrateDB) use floating-point representation by default and do not 
+        /// provide the option of switching to integer format.
+        /// </summary>
+        readonly bool _integerFormat;
+
+        public IntervalHandler(bool integerFormat)
         {
+            _integerFormat = integerFormat;
         }
 
         public override Period Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
         {
-            var microsecondsInDay = buf.ReadInt64();
+            var microsecondsInDay = _integerFormat ? buf.ReadInt64() : (long)(buf.ReadDouble() * 1000000);
             var days = buf.ReadInt32();
             var totalMonths = buf.ReadInt32();
 
@@ -73,7 +81,12 @@ namespace Npgsql.NodaTime
             var microsecondsInDay =
                 (((value.Hours * NodaConstants.MinutesPerHour + value.Minutes) * NodaConstants.SecondsPerMinute + value.Seconds) * NodaConstants.MillisecondsPerSecond + value.Milliseconds) * 1000 +
                 value.Nanoseconds / 1000;  // Take the microseconds, discard the nanosecond remainder
-            buf.WriteInt64(microsecondsInDay);
+
+            if (_integerFormat)
+                buf.WriteInt64(microsecondsInDay);
+            else
+                buf.WriteDouble(microsecondsInDay / 1000000d);
+
             buf.WriteInt32(value.Weeks * 7 + value.Days);     // days
             buf.WriteInt32(value.Years * 12 + value.Months);  // months
         }

--- a/src/Npgsql.NodaTime/TimeHandler.cs
+++ b/src/Npgsql.NodaTime/TimeHandler.cs
@@ -34,19 +34,30 @@ namespace Npgsql.NodaTime
     {
         // Check for the legacy floating point timestamps feature
         protected override NpgsqlTypeHandler<LocalTime> Create(NpgsqlConnection conn)
-            => new TimeHandler();
+            => new TimeHandler(conn.HasIntegerDateTimes);
     }
 
     class TimeHandler : NpgsqlSimpleTypeHandler<LocalTime>
     {
-        public TimeHandler()
+        /// <summary>
+        /// A deprecated compile-time option of PostgreSQL switches to a floating-point representation of some date/time
+        /// fields. Some PostgreSQL-like databases (e.g. CrateDB) use floating-point representation by default and do not 
+        /// provide the option of switching to integer format.
+        /// </summary>
+        readonly bool _integerFormat;
+
+        public TimeHandler(bool integerFormat)
         {
+            _integerFormat = integerFormat;
         }
 
         public override LocalTime Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
         {
-            // PostgreSQL time resolution == 1 microsecond == 10 ticks
-            return LocalTime.FromTicksSinceMidnight(buf.ReadInt64() * 10);
+            if (_integerFormat)
+                // PostgreSQL time resolution == 1 microsecond == 10 ticks
+                return LocalTime.FromTicksSinceMidnight(buf.ReadInt64() * 10);
+            else
+                return LocalTime.FromTicksSinceMidnight((long)(buf.ReadDouble() * NodaConstants.TicksPerSecond));
         }
 
         public override int ValidateAndGetLength(LocalTime value, NpgsqlParameter parameter)
@@ -55,6 +66,11 @@ namespace Npgsql.NodaTime
         }
 
         public override void Write(LocalTime value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt64(value.TickOfDay / 10);
+        {
+            if (_integerFormat)
+                buf.WriteInt64(value.TickOfDay / 10);
+            else
+                buf.WriteDouble((double)value.TickOfDay / NodaConstants.TicksPerSecond);
+        }
     }
 }


### PR DESCRIPTION
This enables support for postgresql instances built using the --disable-integer-datetimes compile time option. The time and interval datatypes seem to be not affected by this option.