### PR TITLE
Better resetting of sync context

### DIFF
--- a/src/Npgsql/NoSynchronizationContextScope.cs
+++ b/src/Npgsql/NoSynchronizationContextScope.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// This mechanism is used to temporarily set the current synchronization context to null while
+    /// executing Npgsql code, making all await continuations execute on the thread pool. This replaces
+    /// the need to place ConfigureAwait(false) everywhere, and should be used in all surface async methods,
+    /// without exception.
+    /// 
+    /// Warning: do not use this directly in async methods, use it in sync wrappers of async methods
+    /// (see https://github.com/npgsql/npgsql/issues/1593)
+    /// </summary>
+    /// <remarks>
+    /// http://stackoverflow.com/a/28307965/640325
+    /// </remarks>
+    static class NoSynchronizationContextScope
+    {
+        internal static Disposable Enter()
+        {
+            var sc = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            return new Disposable(sc);
+        }
+
+        internal struct Disposable : IDisposable
+        {
+            readonly SynchronizationContext _synchronizationContext;
+
+            internal Disposable(SynchronizationContext synchronizationContext)
+            {
+                _synchronizationContext = synchronizationContext;
+            }
+
+            public void Dispose() => SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
+        }
+    }
+}

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -905,18 +905,18 @@ namespace Npgsql
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation, with the number of rows affected if known; -1 otherwise.</returns>
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
-            => SynchronizationContextSwitcher.NoContext(async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                using (cancellationToken.Register(Cancel))
-                    return await ExecuteNonQuery(true, cancellationToken);
-            });
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (NoSynchronizationContextScope.Enter())
+                return ExecuteNonQuery(true, cancellationToken);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         async Task<int> ExecuteNonQuery(bool async, CancellationToken cancellationToken)
         {
             var connector = CheckReadyAndGetConnector();
             using (connector.StartUserAction(this))
+            using (cancellationToken.Register(cmd => ((NpgsqlCommand)cmd).Cancel(), this))
             using (var reader = await Execute(CommandBehavior.Default, async, cancellationToken))
             {
                 while (async ? await reader.NextResultAsync(cancellationToken) : reader.NextResult()) {}
@@ -946,12 +946,11 @@ namespace Npgsql
         /// first row in the result set, or a null reference if the result set is empty.</returns>
         [ItemCanBeNull]
         public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
-            => SynchronizationContextSwitcher.NoContext(async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested()            ;
-                using (cancellationToken.Register(Cancel))
-                    return await ExecuteScalar(true, cancellationToken);
-            });
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (NoSynchronizationContextScope.Enter())
+                return ExecuteScalar(true, cancellationToken).AsTask();
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ItemCanBeNull]
@@ -962,6 +961,7 @@ namespace Npgsql
             if (!Parameters.HasOutputParameters)
                 behavior |= CommandBehavior.SequentialAccess;
             using (connector.StartUserAction(this))
+            using (cancellationToken.Register(cmd => ((NpgsqlCommand)cmd).Cancel(), this))
             using (var reader = await Execute(behavior, async, cancellationToken))
                 return reader.Read() && reader.FieldCount != 0 ? reader.GetValue(0) : null;
         }
@@ -998,12 +998,11 @@ namespace Npgsql
         /// <param name="cancellationToken">A task representing the operation.</param>
         /// <returns></returns>
         protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-            => SynchronizationContextSwitcher.NoContext(async () =>
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                using (cancellationToken.Register(Cancel))
-                    return await ExecuteDbDataReader(behavior, true, cancellationToken);
-            });
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using (NoSynchronizationContextScope.Enter())
+                return ExecuteDbDataReader(behavior, true, cancellationToken).AsTask();
+        }
 
         /// <summary>
         /// Executes the command text against the connection.
@@ -1018,7 +1017,8 @@ namespace Npgsql
             connector.StartUserAction(this);
             try
             {
-                return await Execute(behavior, async, cancellationToken);
+                using (cancellationToken.Register(cmd => ((NpgsqlCommand)cmd).Cancel(), this))
+                    return await Execute(behavior, async, cancellationToken);
             }
             catch
             {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -172,7 +172,10 @@ namespace Npgsql
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         public override Task OpenAsync(CancellationToken cancellationToken)
-            => SynchronizationContextSwitcher.NoContext(async () => await Open(true, cancellationToken));
+        {
+            using (NoSynchronizationContextScope.Enter())
+                return Open(true, cancellationToken);
+        }
 
         void GetPoolAndSettings()
         {

--- a/src/Npgsql/NpgsqlDefaultDataReader.cs
+++ b/src/Npgsql/NpgsqlDefaultDataReader.cs
@@ -44,7 +44,7 @@ namespace Npgsql
         internal override ValueTask<IBackendMessage> ReadMessage(bool async)
             => Connector.ReadMessage(async);
 
-        internal override Task<bool> NextResult(bool async)
+        protected override Task<bool> NextResult(bool async)
         {
             var task = base.NextResult(async);
 


### PR DESCRIPTION
Stop using the delegate-based SynchronizationContextSwitcher, switching back to NoSynchronizationContextScope but calling it only from sync method wrappers of async methods. This avoids the heap allocation associated with the delegate.

Also switched to using the allocation-free overload of CancellationToken.Register().

Based on #1688 (thanks @anpete) but still avoids #1593.

*This is not ready for merging*. While the critical path methods have been done (command execution, reader methods), I still need to get rid of SynchronizationContextSwitcher in the entire codebase.