### PR TITLE
Fix race condition in PreparedStatementManager.TryGetAutoPrepared()

### DIFF
--- a/src/Npgsql/PreparedStatement.cs
+++ b/src/Npgsql/PreparedStatement.cs
@@ -132,14 +132,13 @@ namespace Npgsql
         /// <summary>
         /// The statement has been selected for preparation, but the preparation hasn't started yet.
         /// This is a temporary state that only occurs during preparation.
-        /// Specifically, no protocol message (Parse) has been sent yet. Specifically, it means that
-        /// a Parse message for the statement has already been written to the write buffer.
+        /// Specifically, it means that no protocol message (Parse/Describe) has been written to the write buffer yet.
         /// </summary>
         ToBePrepared,
 
         /// <summary>
         /// The statement is in the process of being prepared. This is a temporary state that only occurs during
-        /// preparation. Specifically, it means that a Parse message for the statement has already been written
+        /// preparation. Specifically, it means that a Describe message for the statement has already been written
         /// to the write buffer.
         /// </summary>
         BeingPrepared,

--- a/src/Npgsql/PreparedStatement.cs
+++ b/src/Npgsql/PreparedStatement.cs
@@ -83,8 +83,6 @@ namespace Npgsql
         internal void SetParamTypes(List<NpgsqlParameter> parameters)
         {
             Debug.Assert(ParamTypes == null);
-            if (parameters.Count == 0)
-                ParamTypes = EmptyParamTypes;
             ParamTypes = new NpgsqlDbType[parameters.Count];
             for (var i = 0; i < parameters.Count; i++)
                 ParamTypes[i] = parameters[i].NpgsqlDbType;

--- a/src/Npgsql/PreparedStatementManager.cs
+++ b/src/Npgsql/PreparedStatementManager.cs
@@ -138,13 +138,14 @@ namespace Npgsql
 
             switch (pStatement.State)
             {
-                case PreparedState.Prepared:
                 case PreparedState.ToBePrepared:
-                // The statement has already been prepared (explicitly or automatically), or has been selected
-                // for preparation (earlier identical statement in the same command).
-                // We just need to check that the parameter types correspond, since prepared statements are
-                // only keyed by SQL (to prevent pointless allocations). If we have a mismatch, simply run unprepared.
-                return pStatement.DoParametersMatch(statement.InputParameters)
+                case PreparedState.BeingPrepared:
+                case PreparedState.Prepared:
+                    // The statement has already been prepared (explicitly or automatically), or has been selected
+                    // for preparation (earlier identical statement in the same command).
+                    // We just need to check that the parameter types correspond, since prepared statements are
+                    // only keyed by SQL (to prevent pointless allocations). If we have a mismatch, simply run unprepared.
+                    return pStatement.DoParametersMatch(statement.InputParameters)
                     ? pStatement
                     : null;
             }
@@ -200,8 +201,7 @@ namespace Npgsql
         void RemoveCandidate(PreparedStatement candidate)
         {
             Debug.Assert(_candidates != null);
-            var i = 0;
-            for (; i < _candidates.Length; i++)
+            for (var i = 0; i < _candidates.Length; i++)
             {
                 if (_candidates[i] == candidate)
                 {
@@ -209,7 +209,8 @@ namespace Npgsql
                     return;
                 }
             }
-            Debug.Assert(i < _candidates.Length);
+            Debug.Fail("Prepared statement candidate not found.",
+                "PreparedStatementManager.RemoveCandidate() is expected to be called in a state where its _candidates array contains the PreparedStatement candidate to be removed.");
         }
 
         internal void ClearAll()


### PR DESCRIPTION
While working on #1698 I was lucky to stumble into a race condition, which - for some reason - I was even able able to debug, that caused two assertion failures (the second assertion in PreparedStatementManager.RemoveCandidate() and the only assertion in PreparedStatement.SetParamTypes()).
It turned out that PreparedStatementManager.TryGetAutoPrepared() preliminarily returned on pStatement.State beeing PreparedState.ToBePrepared and PreparedState.Prepared but not on PreparedState.BeingPrepared which caused duplicate entries in _autoPrepared and a call to PreparedStatement.SetParamTypes() in an unexpected state.
I'm no longer able to reproduce the race condition but from my interpretation of the code and the message flow, the fix seems to be safe and correct.

Please feel free to comment or refuse it if it doesn't solve an actual problem.