### PR TITLE
timestamptz is mapped to DateTime by default

### DIFF
--- a/doc/types/datetime.md
+++ b/doc/types/datetime.md
@@ -70,8 +70,8 @@ PG type     | .NET value               | Action
 timestamp   | DateTime (default)       | Kind=Unspecified
 timestamp   | DateTimeOffset           | Should throw an exception?
             |                          |
-timestamptz | DateTime                 | Kind=Local (according to system tz)
-timestamptz | DateTimeOffset (default) | **Offset=UTC**
+timestamptz | DateTime (default)       | Kind=Local (according to system tz)
+timestamptz | DateTimeOffset           | **Offset=UTC**
             |                          |
 time        | TimeSpan (default)       | As-is
 time        | DateTime                 | **Use only time component**


### PR DESCRIPTION
Tested on Windows 7 with Npgsql 3.2.6.0.
Test program:
```cs
using (var con = new NpgsqlConnection("Server = localhost; Database = postgres; User Id = postgres; Integrated Security = true"))
{
	con.Open();
	using (var cmd = new NpgsqlCommand("SELECT now()", con))
	using (var r = cmd.ExecuteReader())
		while (r.Read())
			Console.WriteLine($"{r.GetDataTypeName(0)} {r.GetFieldType(0)}"); // timestamptz System.DateTime
}
```