### PR TITLE
properly detect type of host string in some cultures

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -621,7 +621,7 @@ namespace Npgsql
         void Connect(NpgsqlTimeout timeout)
         {
             EndPoint[] endpoints;
-            if (Host.StartsWith("/", StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(Host) && Host[0] == '/')
             {
                 endpoints = new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) };
             }
@@ -712,7 +712,7 @@ namespace Npgsql
         async Task ConnectAsync(NpgsqlTimeout timeout, CancellationToken cancellationToken)
         {
             EndPoint[] endpoints;
-            if (Host.StartsWith("/", StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(Host) && Host[0] == '/')
             {
                 endpoints = new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) };
             }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -621,7 +621,7 @@ namespace Npgsql
         void Connect(NpgsqlTimeout timeout)
         {
             EndPoint[] endpoints;
-            if (Host.StartsWith("/"))
+            if (Host.StartsWith("/", StringComparison.Ordinal))
             {
                 endpoints = new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) };
             }
@@ -712,7 +712,7 @@ namespace Npgsql
         async Task ConnectAsync(NpgsqlTimeout timeout, CancellationToken cancellationToken)
         {
             EndPoint[] endpoints;
-            if (Host.StartsWith("/"))
+            if (Host.StartsWith("/", StringComparison.Ordinal))
             {
                 endpoints = new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) };
             }


### PR DESCRIPTION
In some cultures on Linux function `StartsWith('/')` works odd. 

For example in th_TH.UTF-8 `"127.0.0.1".StartsWith('/')` returns true and thus type of endpoint will be incorrectly determined and connection to db can't be established.
