### PR TITLE
Checked casts in type handlers

### DIFF
--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
@@ -48,10 +48,10 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.ReadInt16();
 
         byte INpgsqlSimpleTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (byte)Read(buf, len, fieldDescription);
+            => checked((byte)Read(buf, len, fieldDescription));
 
         sbyte INpgsqlSimpleTypeHandler<sbyte>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (sbyte)Read(buf, len, fieldDescription);
+            => checked((sbyte)Read(buf, len, fieldDescription));
 
         int INpgsqlSimpleTypeHandler<int>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
@@ -96,9 +96,9 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public override void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt16(value);
         public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt16((short)value);
+            => buf.WriteInt16(checked((short)value));
         public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt16((short)value);
+            => buf.WriteInt16(checked((short)value));
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt16(value);
         public void Write(sbyte value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
@@ -106,9 +106,9 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt16((short)value);
         public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt16((short)value);
+            => buf.WriteInt16(checked((short)value));
         public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt16((short)value);
+            => buf.WriteInt16(checked((short)value));
 
         public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
         {

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
@@ -48,10 +48,10 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.ReadInt32();
 
         byte INpgsqlSimpleTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (byte)Read(buf, len, fieldDescription);
+            => checked((byte)Read(buf, len, fieldDescription));
 
         short INpgsqlSimpleTypeHandler<short>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (short)Read(buf, len, fieldDescription);
+            => checked((short)Read(buf, len, fieldDescription));
 
         long INpgsqlSimpleTypeHandler<long>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
@@ -94,13 +94,13 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt32(value);
         public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt32((int)value);
+            => buf.WriteInt32(checked((int)value));
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt32(value);
         public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt32((int)value);
+            => buf.WriteInt32(checked((int)value));
         public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt32((int)value);
+            => buf.WriteInt32(checked((int)value));
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt32((int)value);
         public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
@@ -48,13 +48,13 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.ReadInt64();
 
         byte INpgsqlSimpleTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (byte)Read(buf, len, fieldDescription);
+            => checked((byte)Read(buf, len, fieldDescription));
 
         short INpgsqlSimpleTypeHandler<short>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (short)Read(buf, len, fieldDescription);
+            => checked((short)Read(buf, len, fieldDescription));
 
         int INpgsqlSimpleTypeHandler<int>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => (int)Read(buf, len, fieldDescription);
+            => checked((int)Read(buf, len, fieldDescription));
 
         float INpgsqlSimpleTypeHandler<float>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
@@ -98,9 +98,9 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt64(value);
         public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt64((long)value);
+            => buf.WriteInt64(checked((long)value));
         public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteInt64((long)value);
+            => buf.WriteInt64(checked((long)value));
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt64((long)value);
         public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)


### PR DESCRIPTION
While working on support for nullable arrays I recognized that there are undetected overflows happening in some TypeHandler casts in my (default) unchecked build environment.

This PR adds some explicit `checked` keywords in the relevant places and a test to ensure the behavior.