### PR TITLE
Reimplement connection pool as lock-free

### DIFF
--- a/doc/migration/3.3.md
+++ b/doc/migration/3.3.md
@@ -12,6 +12,7 @@ Npgsql 3.3 is out and available on nuget.org. This is a major release with subst
 
 ## Major Changes
 
+* The connection pool has been rewritten to be lock-free, since in highly concurrent scenarios with short connection lifespans lock contention started be a significant issue. Such application should experience a significant performance boost.
 
 ## Breaking Changes from 3.2
 
@@ -28,3 +29,4 @@ Npgsql 3.3 is out and available on nuget.org. This is a major release with subst
 * The following APIs "connection capability" APIs have been removed from NpgsqlConnection: `UseConformantStrings`, `SupportsEStringPrefix`, `UseSslStream`.
 * The default name translator, `NpgsqlSnakeCaseNameTranslator`, has been changed to handle acronyms better. Given the property name `IsJSON`, the old translator algorithm would output `is_j_s_o_n`, while the new outputs `is_json`. To revert back to the old algorithm, create a `NpgsqlSnakeCaseNameTranslator` instance with `legacyMode: true` and pass it when calling the `MapComposite` and `MapEnum` methods.
 * If you are reading tables as composites ([#990](https://github.com/npgsql/npgsql/issues/990)), you will have to add the new `Load Table Composites` to your connection string.
+* The `Min Pool Size` parameter will no longer make the pool create new connections internally - it will only have an effect on how many connections are pruned. Previously, in various points the pool would check if the current number of connections was below `Min Pool Size`, and if so, automatically created new ones - this no longer happens.

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -261,8 +261,6 @@ namespace Npgsql
                     else  // No enlist
                         Connector = await _pool.Allocate(this, timeout, async, cancellationToken);
 
-                    Counters.SoftConnectsPerSecond.Increment();
-
                     // Since this pooled connector was opened, global mappings may have
                     // changed. Bring this up to date if needed.
                     var mapper = Connector.TypeMapper;

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -739,7 +739,7 @@ namespace Npgsql
         /// </summary>
         /// <value>The time (in seconds) to wait. The default value is 300.</value>
         [Category("Pooling")]
-        [Description("The time to wait before closing unused connections in the pool if the count of all connections exeeds MinPoolSize.")]
+        [Description("The time to wait before closing unused connections in the pool if the count of all connections exceeds MinPoolSize.")]
         [DisplayName("Connection Idle Lifetime")]
         [NpgsqlConnectionStringProperty]
         [DefaultValue(300)]

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -426,6 +426,7 @@ namespace Npgsql
 
                 if (Settings.Pooling && SupportsDiscard)
                     GenerateResetMessage();
+                Counters.NumberOfNonPooledConnections.Increment();
                 Counters.HardConnectsPerSecond.Increment();
                 Log.Trace($"Opened connection to {Host}:{Port}");
             }
@@ -1487,6 +1488,11 @@ namespace Npgsql
         /// (e.g. prepared statements), resetting parameters to their defaults, and resetting client-side
         /// state
         /// </summary>
+        /// <remarks>
+        /// It's important that this method be idempotent, since some race conditions in the pool
+        /// can cause it to be called twice (and also the user may close the connection right after
+        /// allocating it, without doing anything).
+        /// </remarks>
         internal void Reset()
         {
             Debug.Assert(State == ConnectorState.Ready);

--- a/test/Npgsql.Tests/SystemTransactionTests.cs
+++ b/test/Npgsql.Tests/SystemTransactionTests.cs
@@ -514,7 +514,7 @@ Exception {2}",
             }
             AssertNumberOfRows(1);
             var pool = PoolManager.Pools[connString];
-            Assert.That(pool.Idle, Has.Count.EqualTo(1));
+            Assert.That(pool.IdleCount, Is.EqualTo(1));
 
             using (var conn = new NpgsqlConnection(connString))
                 NpgsqlConnection.ClearPool(conn);


### PR DESCRIPTION
@anpete, @damageboy, would you care to review as this is a tricky and sensitive piece of code?

It basically reimplements all the standard ADO.NET functionality without taking any locks:

* The fast path for allocation only scans the array and does `Interlocked.Exchange` to get a connector out, as in the minimal implementation @anpete provided. Releasing is similar except for some very minor added overhead.
* MaxPoolSize is respected. Trying to allocate more will block your open attempt, by enqueuing a TaskCompletionSort in a ConcurrentQueue. This queue is checked first when releasing, effectively "handing off" the connection from the releaser to the opener without passing through the idle array.
* A pruning thread runs periodically, scanning the idle list to see if any have been there for too long, and closes them if so (without going under MinPoolSize).
* Performance counter updating is still there, although if they're disabled they're supposed to add very little performance.

I'll benchmark this tomorrow to see how it behaves. I'd also really appreciate a review, because:

![one-does-not-simply](https://user-images.githubusercontent.com/1862641/35788897-25d53670-09ed-11e8-82fe-ac665c159fcd.jpg)
