### PR TITLE
performance.md: Unix sockets is not Linux-only

### DIFF
--- a/doc/performance.md
+++ b/doc/performance.md
@@ -60,5 +60,5 @@ You can also control the socket's receive buffer size (not to be confused with N
 
 ## Unix Domain Socket
 
-If you're on Linux and are connecting to a PostgreSQL server on the same machine, you can boost performance a little by connecting via Unix domain socket rather than via a regular TCP/IP socket. To do this, simply specify the directory of your PostgreSQL sockets in the `Host` connection string parameter - if this parameter starts with a slash, it will be taken to mean a filesystem path.
+If you're on Linux or macOS and are connecting to a PostgreSQL server on the same machine, you can boost performance a little by connecting via Unix domain socket rather than via a regular TCP/IP socket. To do this, simply specify the directory of your PostgreSQL sockets in the `Host` connection string parameter - if this parameter starts with a slash, it will be taken to mean a filesystem path.
 


### PR DESCRIPTION
**Note**: I _presume_ it works on macOS also, since it definitely has Unix domain sockets. I see no reason why this assumption would be wrong, so I suggest we reword this until proven wrong.