### PR TITLE
Support for the tsquery 'FOLLOWED BY' operator introduced in pg 9.6+

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
@@ -32,7 +32,8 @@ using JetBrains.Annotations;
 namespace NpgsqlTypes
 {
     /// <summary>
-    /// Represents a PostgreSQL tsquery. This is the base class for lexeme, not, and and or nodes.
+    /// Represents a PostgreSQL tsquery. This is the base class for the
+    /// lexeme, not, or, and, and "followed by" nodes.
     /// </summary>
     public abstract class NpgsqlTsQuery
     {
@@ -47,25 +48,29 @@ namespace NpgsqlTypes
         public enum NodeKind
         {
             /// <summary>
+            /// Represents the empty tsquery. Should only be used at top level.
+            /// </summary>
+            Empty = -1,
+            /// <summary>
             /// Lexeme
             /// </summary>
-            Lexeme,
+            Lexeme = 0,
             /// <summary>
             /// Not operator
             /// </summary>
-            Not,
+            Not = 1,
             /// <summary>
             /// And operator
             /// </summary>
-            And,
+            And = 2,
             /// <summary>
             /// Or operator
             /// </summary>
-            Or,
+            Or = 3,
             /// <summary>
-            /// Represents the empty tsquery. Should only be used at top level.
+            /// "Followed by" operator
             /// </summary>
-            Empty
+            Phrase = 4
         }
 
         internal abstract void Write(StringBuilder sb, bool first = false);
@@ -92,11 +97,13 @@ namespace NpgsqlTypes
                 throw new ArgumentNullException(nameof(value));
 
             var valStack = new Stack<NpgsqlTsQuery>();
-            var opStack = new Stack<char>();
+            var opStack = new Stack<NpgsqlTsQueryOperator>();
 
             var sb = new StringBuilder();
             var pos = 0;
             var expectingBinOp = false;
+
+            var lastFollowedByOpDistance = -1;
 
             NextToken:
             if (pos >= value.Length)
@@ -106,12 +113,49 @@ namespace NpgsqlTypes
                 goto WaitEndComplex;
             if ((ch == ')' || ch == '|' || ch == '&') && !expectingBinOp || (ch == '(' || ch == '!') && expectingBinOp)
                 throw new FormatException("Syntax error in tsquery. Unexpected token.");
-            if (ch == '(' || ch == '!' || ch == '&')
+
+            if (ch == '<')
             {
-                opStack.Push(ch);
+                var endOfOperatorConsumed = false;
+                var sbCurrentLength = sb.Length;
+
+                while (pos < value.Length)
+                {
+                    var c = value[pos++];
+                    if (c == '>')
+                    {
+                        endOfOperatorConsumed = true;
+                        break;
+                    }
+
+                    sb.Append(c);
+                }
+
+                if (sb.Length == sbCurrentLength || !endOfOperatorConsumed)
+                    throw new FormatException("Syntax error in tsquery. Malformed 'followed by' operator.");
+
+                var followedByOpDistanceString = sb.ToString(sbCurrentLength, sb.Length - sbCurrentLength);
+                if (followedByOpDistanceString == "-")
+                {
+                    lastFollowedByOpDistance = 1;
+                }
+                else if (!int.TryParse(followedByOpDistanceString, out lastFollowedByOpDistance)
+                         || lastFollowedByOpDistance < 0)
+                {
+                    throw new FormatException("Syntax error in tsquery. Malformed distance in 'followed by' operator.");
+                }
+
+                sb.Length -= followedByOpDistanceString.Length;
+            }
+
+            if (ch == '(' || ch == '!' || ch == '&' || ch == '<')
+            {
+                opStack.Push(new NpgsqlTsQueryOperator(ch, lastFollowedByOpDistance));
                 expectingBinOp = false;
+                lastFollowedByOpDistance = 0;
                 goto NextToken;
             }
+
             if (ch == '|')
             {
                 if (opStack.Count > 0 && opStack.Peek() == '|')
@@ -128,25 +172,48 @@ namespace NpgsqlTypes
                 expectingBinOp = false;
                 goto NextToken;
             }
+
             if (ch == ')')
             {
                 while (opStack.Count > 0 && opStack.Peek() != '(')
                 {
                     if (valStack.Count < 2 || opStack.Peek() == '!')
                         throw new FormatException("Syntax error in tsquery");
+
                     var right = valStack.Pop();
                     var left = valStack.Pop();
-                    valStack.Push(opStack.Pop() == '&' ? (NpgsqlTsQuery)new NpgsqlTsQueryAnd(left, right) : new NpgsqlTsQueryOr(left, right));
+
+                    var tsOp = opStack.Pop();
+                    switch (tsOp)
+                    {
+                    case '&':
+                        valStack.Push(new NpgsqlTsQueryAnd(left, right));
+                        break;
+
+                    case '|':
+                        valStack.Push(new NpgsqlTsQueryOr(left, right));
+                        break;
+
+                    case '<':
+                        valStack.Push(new NpgsqlTsQueryFollowedBy(left, tsOp.FollowedByDistance, right));
+                        break;
+
+                    default:
+                        throw new FormatException("Syntax error in tsquery");
+                    }
                 }
                 if (opStack.Count == 0)
                     throw new FormatException("Syntax error in tsquery: closing parenthesis without an opening parenthesis");
                 opStack.Pop();
                 goto PushedVal;
             }
+
             if (ch == ':')
                 throw new FormatException("Unexpected : while parsing tsquery");
+
             if (char.IsWhiteSpace(ch))
                 goto NextToken;
+
             pos--;
             if (expectingBinOp)
                 throw new FormatException("Unexpected lexeme while parsing tsquery");
@@ -227,23 +294,45 @@ namespace NpgsqlTypes
 
             PushedVal:
             sb.Clear();
-            while (opStack.Count > 0 && (opStack.Peek() == '&' || opStack.Peek() == '!'))
+            var processTightBindingOperator = true;
+            while (opStack.Count > 0 && processTightBindingOperator)
             {
-                if (opStack.Peek() == '&')
+                var tsOp = opStack.Peek();
+                switch (tsOp)
                 {
+                case '&':
                     if (valStack.Count < 2)
                         throw new FormatException("Syntax error in tsquery");
-                    var right = valStack.Pop();
-                    var left = valStack.Pop();
-                    valStack.Push(new NpgsqlTsQueryAnd(left, right));
-                }
-                else if (opStack.Peek() == '!')
-                {
+                    var andRight = valStack.Pop();
+                    var andLeft = valStack.Pop();
+                    valStack.Push(new NpgsqlTsQueryAnd(andLeft, andRight));
+                    opStack.Pop();
+                    break;
+
+                case '!':
                     if (valStack.Count == 0)
                         throw new FormatException("Syntax error in tsquery");
                     valStack.Push(new NpgsqlTsQueryNot(valStack.Pop()));
+                    opStack.Pop();
+                    break;
+
+                case '<':
+                    if (valStack.Count < 2)
+                        throw new FormatException("Syntax error in tsquery");
+                    var followedByRight = valStack.Pop();
+                    var followedByLeft = valStack.Pop();
+                    valStack.Push(
+                        new NpgsqlTsQueryFollowedBy(
+                            followedByLeft,
+                            tsOp.FollowedByDistance,
+                            followedByRight));
+                    opStack.Pop();
+                    break;
+
+                default:
+                    processTightBindingOperator = false;
+                    break;
                 }
-                opStack.Pop();
             }
             expectingBinOp = true;
             goto NextToken;
@@ -251,16 +340,53 @@ namespace NpgsqlTypes
             Finish:
             while (opStack.Count > 0)
             {
-                if (valStack.Count < 2 || (opStack.Peek() != '|' && opStack.Peek() != '&'))
+                if (valStack.Count < 2)
                     throw new FormatException("Syntax error in tsquery");
+
                 var right = valStack.Pop();
                 var left = valStack.Pop();
-                valStack.Push(opStack.Pop() == '&' ? (NpgsqlTsQuery)new NpgsqlTsQueryAnd(left, right) : new NpgsqlTsQueryOr(left, right));
+
+                NpgsqlTsQuery query;
+                var tsOp = opStack.Pop();
+                switch (tsOp)
+                {
+                case '&':
+                    query = new NpgsqlTsQueryAnd(left, right);
+                    break;
+
+                case '|':
+                    query = new NpgsqlTsQueryOr(left, right);
+                    break;
+
+                case '<':
+                    query = new NpgsqlTsQueryFollowedBy(left, tsOp.FollowedByDistance, right);
+                    break;
+
+                default:
+                    throw new FormatException("Syntax error in tsquery");
+                }
+
+                valStack.Push(query);
             }
             if (valStack.Count != 1)
                 throw new FormatException("Syntax error in tsquery");
             return valStack.Pop();
         }
+    }
+
+    readonly struct NpgsqlTsQueryOperator
+    {
+        public readonly char Char;
+        public readonly int FollowedByDistance;
+
+        public NpgsqlTsQueryOperator(char character, int followedByDistance)
+        {
+            Char = character;
+            FollowedByDistance = followedByDistance;
+        }
+
+        public static implicit operator NpgsqlTsQueryOperator(char c) => new NpgsqlTsQueryOperator(c, 0);
+        public static implicit operator char(NpgsqlTsQueryOperator o) => o.Char;
     }
 
     /// <summary>
@@ -485,6 +611,56 @@ namespace NpgsqlTypes
 
             Left.Write(sb);
             sb.Append(" | ");
+            Right.Write(sb);
+
+            if (!first)
+                sb.Append(" )");
+        }
+    }
+
+    /// <summary>
+    /// TsQuery "Followed by" Node.
+    /// </summary>
+    public sealed class NpgsqlTsQueryFollowedBy : NpgsqlTsQueryBinOp
+    {
+        /// <summary>
+        /// The distance between the 2 nodes, in lexemes.
+        /// </summary>
+        public int Distance { get; set; }
+
+        /// <summary>
+        /// Creates a "followed by" operator, specifying 2 child nodes and the 
+        /// distance between them in lexemes.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="distance"></param>
+        /// <param name="right"></param>
+        public NpgsqlTsQueryFollowedBy(
+            [CanBeNull] NpgsqlTsQuery left,
+            int distance,
+            [CanBeNull] NpgsqlTsQuery right)
+        {
+            if (distance < 0)
+                throw new ArgumentOutOfRangeException(nameof(distance));
+
+            Left = left;
+            Distance = distance;
+            Right = right;
+            Kind = NodeKind.Phrase;
+        }
+
+        internal override void Write(StringBuilder sb, bool first = false)
+        {
+            if (!first)
+                sb.Append("( ");
+
+            Left.Write(sb);
+
+            sb.Append(" <");
+            if (Distance == 1) sb.Append("-");
+            else sb.Append(Distance);
+            sb.Append("> ");
+
             Right.Write(sb);
 
             if (!first)

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -37,13 +37,13 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-textsearch.html
     /// </summary>
     [TypeMapping("tsquery", NpgsqlDbType.TsQuery, new[] {
-        typeof(NpgsqlTsQuery), typeof(NpgsqlTsQueryAnd), typeof(NpgsqlTsQueryEmpty),
+        typeof(NpgsqlTsQuery), typeof(NpgsqlTsQueryAnd), typeof(NpgsqlTsQueryEmpty), typeof(NpgsqlTsQueryFollowedBy),
         typeof(NpgsqlTsQueryLexeme), typeof(NpgsqlTsQueryNot), typeof(NpgsqlTsQueryOr), typeof(NpgsqlTsQueryBinOp) })
     ]
     class TsQueryHandler : NpgsqlTypeHandler<NpgsqlTsQuery>,
         INpgsqlTypeHandler<NpgsqlTsQueryEmpty>, INpgsqlTypeHandler<NpgsqlTsQueryLexeme>,
         INpgsqlTypeHandler<NpgsqlTsQueryNot>, INpgsqlTypeHandler<NpgsqlTsQueryAnd>,
-        INpgsqlTypeHandler<NpgsqlTsQueryOr>
+        INpgsqlTypeHandler<NpgsqlTsQueryOr>, INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>
     {
         // 1 (type) + 1 (weight) + 1 (is prefix search) + 2046 (max str len) + 1 (null terminator)
         const int MaxSingleTokenBytes = 2050;
@@ -83,7 +83,6 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
                     else
                     {
                         NpgsqlTsQuery node;
-
                         switch (operKind)
                         {
                         case NpgsqlTsQuery.NodeKind.And:
@@ -91,6 +90,10 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
                             break;
                         case NpgsqlTsQuery.NodeKind.Or:
                             node = new NpgsqlTsQueryOr(null, null);
+                            break;
+                        case NpgsqlTsQuery.NodeKind.Phrase:
+                            var distance = buf.ReadInt16();
+                            node = new NpgsqlTsQueryFollowedBy(null, distance, null);
                             break;
                         default:
                             throw new InvalidOperationException($"Internal Npgsql bug: unexpected value {operKind} of enum {nameof(NpgsqlTsQuery.NodeKind)}. Please file a bug.");
@@ -134,6 +137,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription)
             => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription);
 
+        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription)
+            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription);
+
         #endregion Read
 
         #region Write
@@ -171,6 +177,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
             case NpgsqlTsQuery.NodeKind.And:
             case NpgsqlTsQuery.NodeKind.Or:
                 return 2 + GetNodeLength(((NpgsqlTsQueryBinOp)node).Left) + GetNodeLength(((NpgsqlTsQueryBinOp)node).Right);
+            case NpgsqlTsQuery.NodeKind.Phrase:
+                // 2 additional bytes for uint16 phrase operator "distance" field.
+                return 4 + GetNodeLength(((NpgsqlTsQueryBinOp)node).Left) + GetNodeLength(((NpgsqlTsQueryBinOp)node).Right);
             case NpgsqlTsQuery.NodeKind.Not:
                 return 2 + GetNodeLength(((NpgsqlTsQueryNot)node).Child);
             case NpgsqlTsQuery.NodeKind.Empty:
@@ -210,6 +219,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
                         _stack.Push(((NpgsqlTsQueryNot)node).Child);
                     else
                     {
+                        if (node.Kind == NpgsqlTsQuery.NodeKind.Phrase)
+                            buf.WriteInt16(((NpgsqlTsQueryFollowedBy)node).Distance);
+
                         _stack.Push(((NpgsqlTsQueryBinOp)node).Right);
                         _stack.Push(((NpgsqlTsQueryBinOp)node).Left);
                     }
@@ -235,6 +247,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
                 return 1;
             case NpgsqlTsQuery.NodeKind.And:
             case NpgsqlTsQuery.NodeKind.Or:
+            case NpgsqlTsQuery.NodeKind.Phrase:
                 return 1 + GetTokenCount(((NpgsqlTsQueryBinOp)node).Left) + GetTokenCount(((NpgsqlTsQueryBinOp)node).Right);
             case NpgsqlTsQuery.NodeKind.Not:
                 return 1 + GetTokenCount(((NpgsqlTsQueryNot)node).Child);
@@ -259,6 +272,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         public int ValidateAndGetLength(NpgsqlTsQueryEmpty value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => ValidateAndGetLength((NpgsqlTsQuery)value, ref lengthCache, parameter);
 
+        public int ValidateAndGetLength(NpgsqlTsQueryFollowedBy value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+            => ValidateAndGetLength((NpgsqlTsQuery)value, ref lengthCache, parameter);
+
         public Task Write(NpgsqlTsQueryOr value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
             => Write((NpgsqlTsQuery)value, buf, lengthCache, parameter, async);
 
@@ -272,6 +288,14 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
             => Write((NpgsqlTsQuery)value, buf, lengthCache, parameter, async);
 
         public Task Write(NpgsqlTsQueryEmpty value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+            => Write((NpgsqlTsQuery)value, buf, lengthCache, parameter, async);
+
+        public Task Write(
+            NpgsqlTsQueryFollowedBy value,
+            NpgsqlWriteBuffer buf,
+            NpgsqlLengthCache lengthCache,
+            NpgsqlParameter parameter,
+            bool async)
             => Write((NpgsqlTsQuery)value, buf, lengthCache, parameter, async);
 
         #endregion Write

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -732,7 +732,7 @@ namespace Npgsql.Tests.Types
             using (var conn = OpenConnection())
             using (var cmd = conn.CreateCommand())
             {
-                var query = NpgsqlTsQuery.Parse("(a & !(c | d)) & (!!a&b) | ä | d | e");
+                var query = NpgsqlTsQuery.Parse("(a & !(c | d)) & (!!a&b) | ä | x <-> y | x <10> y | d <0> e | f");
 
                 cmd.CommandText = "Select :p";
                 cmd.Parameters.AddWithValue("p", query);

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -458,6 +458,12 @@ namespace Npgsql.Tests
             Assert.AreEqual(@"a\b'cde", ((NpgsqlTsQueryLexeme)query).Text);
             Assert.AreEqual(@"'a\\b''cde'", query.ToString());
 
+            query = NpgsqlTsQuery.Parse(@"a <-> b");
+            Assert.AreEqual("'a' <-> 'b'", query.ToString());
+
+            query = NpgsqlTsQuery.Parse("((a & b) <5> c) <-> !d <0> e");
+            Assert.AreEqual("( ( 'a' & 'b' <5> 'c' ) <-> !'d' ) <0> 'e'", query.ToString());
+
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("a b c & &"));
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("&"));
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("|"));
@@ -465,6 +471,21 @@ namespace Npgsql.Tests
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("("));
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse(")"));
             Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("()"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("<"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("<-"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("<->"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("a <->"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("<>"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("a <a> b"));
+            Assert.Throws(typeof(FormatException), () => NpgsqlTsQuery.Parse("a <-1> b"));
+        }
+
+        [Test]
+        public void TsQueryOperatorPrecedence()
+        {
+            var query = NpgsqlTsQuery.Parse("!a <-> b & c | d & e");
+            var expectedGrouping = NpgsqlTsQuery.Parse("((!(a) <-> b) & c) | (d & e)");
+            Assert.AreEqual(expectedGrouping.ToString(), query.ToString());
         }
 
         [Test]


### PR DESCRIPTION
Hello,
This adds support for the ```<->``` / ```<n>``` operator in tsquery objects to the ```NpgsqlTsQuery``` type (parse, send and receive through the binary protocol).

About operator precedence, the [documentation](https://www.postgresql.org/docs/current/static/datatype-textsearch.html#DATATYPE-TSQUERY) says: 
> In the absence of parentheses, ! (NOT) binds most tightly, <-> (FOLLOWED BY) next most tightly, then & (AND), with | (OR) binding the least tightly.

I am not sure if as implemented in the ```NpgsqlTsQuery.Parse``` method my logic is correct there, I would appreciate a review to confirm that.

The information about the binary protocol is not really documented, but I made some guesses from looking at the code at:
https://github.com/postgres/postgres/blob/REL_10_2/src/backend/utils/adt/tsquery.c (tsquerysend / tsqueryrecv functions) and https://github.com/postgres/postgres/blob/REL_10_2/src/include/tsearch/ts_type.h

The page at http://www.npgsql.org/dev/types.html needs to be updated like this:
> For each token:
>            UInt8 type (1 = val, 2 = oper)
>            UInt8 weight + UInt8 prefix (1/0) + null-terminated string, or UInt8 oper (1 = not, 2 = and, 3 = or)

should become
> For each token:
>            UInt8 type (1 = val, 2 = oper)
>            For val: UInt8 weight + UInt8 prefix (1/0) + null-terminated string, 
>            For oper: UInt8 oper (1 = not, 2 = and, 3 = or, 4 = phrase). In case of phrase oper code, an additional int16 field is sent (distance value of operator). Default is 1 for ```<->```, otherwise the n value in ```<n>```.

@roji @Emill 