### PR TITLE
Added support to specify byte order

### DIFF
--- a/src/Npgsql/Common.cs
+++ b/src/Npgsql/Common.cs
@@ -144,21 +144,4 @@ namespace Npgsql
         Other
 #pragma warning restore 1591
     }
-
-    /// <summary>
-    /// The way how to order bytes.
-    /// </summary>
-    enum ByteOrder
-    {
-        // ReSharper disable once InconsistentNaming
-        /// <summary>
-        /// Most significant byte first (XDR)
-        /// </summary>
-        MSB = 0,
-        // ReSharper disable once InconsistentNaming
-        /// <summary>
-        /// Less significant byte first (NDR)
-        /// </summary>
-        LSB = 1
-    }
 }

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
 <!-- Causes issues in Appveyor and Travis

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -213,151 +213,112 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public sbyte ReadSByte()
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(sbyte));
+            Debug.Assert(sizeof(sbyte) <= ReadBytesLeft);
             return (sbyte)Buffer[ReadPosition++];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte ReadByte()
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(byte));
+            Debug.Assert(sizeof(byte) <= ReadBytesLeft);
             return Buffer[ReadPosition++];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public short ReadInt16() => ReadInt16(BitConverter.IsLittleEndian);
+        public short ReadInt16()
+            => ReadInt16(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe short ReadInt16(bool littleEndian)
+        public short ReadInt16(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(short));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((short*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(short);
-                return result;
-            }
+            var result = Read<short>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ushort ReadUInt16() => ReadUInt16(BitConverter.IsLittleEndian);
+        public ushort ReadUInt16()
+            => ReadUInt16(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ushort ReadUInt16(bool littleEndian)
+        public ushort ReadUInt16(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(ushort));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((ushort*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(ushort);
-                return result;
-            }
+            var result = Read<ushort>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ReadInt32() => ReadInt32(BitConverter.IsLittleEndian);
+        public int ReadInt32()
+            => ReadInt32(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe int ReadInt32(bool littleEndian)
+        public int ReadInt32(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(int));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((int*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(int);
-                return result;
-            }
+            var result = Read<int>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public uint ReadUInt32() => ReadUInt32(BitConverter.IsLittleEndian);
+        public uint ReadUInt32()
+            => ReadUInt32(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe uint ReadUInt32(bool littleEndian)
+        public uint ReadUInt32(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(uint));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((uint*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(uint);
-                return result;
-            }
+            var result = Read<uint>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long ReadInt64() => ReadInt64(BitConverter.IsLittleEndian);
+        public long ReadInt64()
+            => ReadInt64(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe long ReadInt64(bool littleEndian)
+        public long ReadInt64(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(long));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((long*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(long);
-                return result;
-            }
+            var result = Read<long>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong ReadUInt64() => ReadUInt64(BitConverter.IsLittleEndian);
+        public ulong ReadUInt64()
+            => ReadUInt64(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ulong ReadUInt64(bool littleEndian)
+        public ulong ReadUInt64(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(ulong));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((ulong*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(ulong);
-                return result;
-            }
+            var result = Read<ulong>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public float ReadSingle() => ReadSingle(BitConverter.IsLittleEndian);
+        public float ReadSingle()
+            => ReadSingle(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe float ReadSingle(bool littleEndian)
+        public float ReadSingle(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(float));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((float*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(float);
-                return result;
-            }
+            var result = Read<float>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double ReadDouble() => ReadDouble(BitConverter.IsLittleEndian);
+        public double ReadDouble()
+            => ReadDouble(BitConverter.IsLittleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe double ReadDouble(bool littleEndian)
+        public double ReadDouble(bool littleEndian)
         {
-            Debug.Assert(ReadBytesLeft >= sizeof(double));
-            fixed (byte* buf = Buffer)
-            {
-                var result = *((double*)(buf + ReadPosition));
-                if (littleEndian)
-                    result = PGUtil.ReverseEndianness(result);
-                ReadPosition += sizeof(double);
-                return result;
-            }
+            var result = Read<double>();
+            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T Read<T>()
+        {
+            Debug.Assert(Unsafe.SizeOf<T>() <= ReadBytesLeft);
+            var result = Unsafe.ReadUnaligned<T>(ref Buffer[ReadPosition]);
+            ReadPosition += Unsafe.SizeOf<T>();
+            return result;
         }
 
         public string ReadString(int byteLen)

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -226,90 +226,98 @@ namespace Npgsql
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public short ReadInt16()
-            => ReadInt16(BitConverter.IsLittleEndian);
+            => ReadInt16(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public short ReadInt16(bool littleEndian)
         {
             var result = Read<short>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ushort ReadUInt16()
-            => ReadUInt16(BitConverter.IsLittleEndian);
+            => ReadUInt16(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ushort ReadUInt16(bool littleEndian)
         {
             var result = Read<ushort>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ReadInt32()
-            => ReadInt32(BitConverter.IsLittleEndian);
+            => ReadInt32(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ReadInt32(bool littleEndian)
         {
             var result = Read<int>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint ReadUInt32()
-            => ReadUInt32(BitConverter.IsLittleEndian);
+            => ReadUInt32(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint ReadUInt32(bool littleEndian)
         {
             var result = Read<uint>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long ReadInt64()
-            => ReadInt64(BitConverter.IsLittleEndian);
+            => ReadInt64(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long ReadInt64(bool littleEndian)
         {
             var result = Read<long>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong ReadUInt64()
-            => ReadUInt64(BitConverter.IsLittleEndian);
+            => ReadUInt64(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong ReadUInt64(bool littleEndian)
         {
             var result = Read<ulong>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float ReadSingle()
-            => ReadSingle(BitConverter.IsLittleEndian);
+            => ReadSingle(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float ReadSingle(bool littleEndian)
         {
             var result = Read<float>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double ReadDouble()
-            => ReadDouble(BitConverter.IsLittleEndian);
+            => ReadDouble(false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double ReadDouble(bool littleEndian)
         {
             var result = Read<double>();
-            return littleEndian ? PGUtil.ReverseEndianness(result) : result;
+            return littleEndian == BitConverter.IsLittleEndian
+                ? result : PGUtil.ReverseEndianness(result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -185,146 +185,91 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteSByte(sbyte value)
         {
-            Debug.Assert(WriteSpaceLeft >= sizeof(byte));
+            Debug.Assert(sizeof(sbyte) <= WriteSpaceLeft);
             _buf[_writePosition++] = (byte)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteByte(byte value)
         {
-            Debug.Assert(WriteSpaceLeft >= sizeof(byte));
+            Debug.Assert(sizeof(byte) <= WriteSpaceLeft);
             _buf[_writePosition++] = value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void WriteInt16(int value) => WriteInt16((short)value, false);
+        internal void WriteInt16(int value)
+            => WriteInt16((short)value, false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteInt16(short value) => WriteInt16(value, false);
+        public void WriteInt16(short value)
+            => WriteInt16(value, false);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteInt16(short value, bool littleEndian)
+        public void WriteInt16(short value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt16(ushort value)
+            => WriteUInt16(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt16(ushort value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt32(int value)
+            => WriteInt32(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt32(int value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt32(uint value)
+            => WriteUInt32(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt32(uint value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt64(long value)
+            => WriteInt64(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt64(long value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt64(ulong value)
+            => WriteUInt64(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt64(ulong value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteSingle(float value)
+            => WriteSingle(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteSingle(float value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteDouble(double value)
+            => WriteDouble(value, false);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteDouble(double value, bool littleEndian)
+            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Write<T>(T value)
         {
-            Debug.Assert(WriteSpaceLeft >= sizeof(short));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (short*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(short);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteUInt16(ushort value) => WriteUInt16(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteUInt16(ushort value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(ushort));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (ushort*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(ushort);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteInt32(int value) => WriteInt32(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteInt32(int value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(int));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (int*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(int);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteUInt32(uint value) => WriteUInt32(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteUInt32(uint value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(uint));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (uint*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(uint);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteInt64(long value) => WriteInt64(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteInt64(long value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(long));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (long*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(long);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteUInt64(ulong value) => WriteUInt64(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteUInt64(ulong value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(ulong));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (ulong*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(ulong);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteSingle(float value) => WriteSingle(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteSingle(float value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(float));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (float*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(float);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteDouble(double value) => WriteDouble(value, false);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void WriteDouble(double value, bool littleEndian)
-        {
-            Debug.Assert(WriteSpaceLeft >= sizeof(double));
-            fixed (byte* buf = _buf)
-            {
-                var ptr = (double*)(buf + _writePosition);
-                *ptr = littleEndian == BitConverter.IsLittleEndian
-                    ? value : PGUtil.ReverseEndianness(value);
-            }
-            _writePosition += sizeof(double);
+            Debug.Assert(Unsafe.SizeOf<T>() <= WriteSpaceLeft);
+            Unsafe.WriteUnaligned(ref _buf[_writePosition], value);
+            _writePosition += Unsafe.SizeOf<T>();
         }
 
         public Task WriteString(string s, int byteLen, bool async)

--- a/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
+++ b/src/Npgsql/TypeHandlers/PostgisGeometryHandler.cs
@@ -66,37 +66,37 @@ namespace Npgsql.TypeHandlers
         public override async ValueTask<PostgisGeometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
         {
             await buf.Ensure(5, async);
-            var bo = (ByteOrder)buf.ReadByte();
-            var id = buf.ReadUInt32(bo);
+            var le = buf.ReadByte() != 0;
+            var id = buf.ReadUInt32(le);
 
             var srid = 0u;
             if ((id & (uint)EwkbModifiers.HasSRID) != 0)
             {
                 await buf.Ensure(4, async);
-                srid = buf.ReadUInt32(bo);
+                srid = buf.ReadUInt32(le);
             }
 
-            var geom = await DoRead(buf, (WkbIdentifier)(id & 7), bo, async);
+            var geom = await DoRead(buf, (WkbIdentifier)(id & 7), le, async);
             geom.SRID = srid;
             return geom;
         }
 
-        async ValueTask<PostgisGeometry> DoRead(NpgsqlReadBuffer buf, WkbIdentifier id, ByteOrder bo, bool async)
+        async ValueTask<PostgisGeometry> DoRead(NpgsqlReadBuffer buf, WkbIdentifier id, bool le, bool async)
         {
             switch (id)
             {
             case WkbIdentifier.Point:
                 await buf.Ensure(16, async);
-                return new PostgisPoint(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                return new PostgisPoint(buf.ReadDouble(le), buf.ReadDouble(le));
 
             case WkbIdentifier.LineString:
             {
                 await buf.Ensure(4, async);
-                var points = new Coordinate2D[buf.ReadInt32(bo)];
+                var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
                     await buf.Ensure(16, async);
-                    points[ipts] = new Coordinate2D(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                    points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisLineString(points);
             }
@@ -104,16 +104,16 @@ namespace Npgsql.TypeHandlers
             case WkbIdentifier.Polygon:
             {
                 await buf.Ensure(4, async);
-                var rings = new Coordinate2D[buf.ReadInt32(bo)][];
+                var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
                     await buf.Ensure(4, async);
-                    rings[irng] = new Coordinate2D[buf.ReadInt32(bo)];
+                    rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
                         await buf.Ensure(16, async);
-                        rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                        rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
                 return new PostgisPolygon(rings);
@@ -122,12 +122,12 @@ namespace Npgsql.TypeHandlers
             case WkbIdentifier.MultiPoint:
             {
                 await buf.Ensure(4, async);
-                var points = new Coordinate2D[buf.ReadInt32(bo)];
+                var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
                     await buf.Ensure(21, async);
                     await buf.Skip(5, async);
-                    points[ipts] = new Coordinate2D(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                    points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisMultiPoint(points);
             }
@@ -135,17 +135,17 @@ namespace Npgsql.TypeHandlers
             case WkbIdentifier.MultiLineString:
             {
                 await buf.Ensure(4, async);
-                var rings = new Coordinate2D[buf.ReadInt32(bo)][];
+                var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
                     await buf.Ensure(9, async);
                     await buf.Skip(5, async);
-                    rings[irng] = new Coordinate2D[buf.ReadInt32(bo)];
+                    rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
                         await buf.Ensure(16, async);
-                        rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                        rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
                 return new PostgisMultiLineString(rings);
@@ -154,21 +154,21 @@ namespace Npgsql.TypeHandlers
             case WkbIdentifier.MultiPolygon:
             {
                 await buf.Ensure(4, async);
-                var pols = new Coordinate2D[buf.ReadInt32(bo)][][];
+                var pols = new Coordinate2D[buf.ReadInt32(le)][][];
 
                 for (var ipol = 0; ipol < pols.Length; ipol++)
                 {
                     await buf.Ensure(9, async);
                     await buf.Skip(5, async);
-                    pols[ipol] = new Coordinate2D[buf.ReadInt32(bo)][];
+                    pols[ipol] = new Coordinate2D[buf.ReadInt32(le)][];
                     for (var irng = 0; irng < pols[ipol].Length; irng++)
                     {
                         await buf.Ensure(4, async);
-                        pols[ipol][irng] = new Coordinate2D[buf.ReadInt32(bo)];
+                        pols[ipol][irng] = new Coordinate2D[buf.ReadInt32(le)];
                         for (var ipts = 0; ipts < pols[ipol][irng].Length; ipts++)
                         {
                             await buf.Ensure(16, async);
-                            pols[ipol][irng][ipts] = new Coordinate2D(buf.ReadDouble(bo), buf.ReadDouble(bo));
+                            pols[ipol][irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                         }
                     }
                 }
@@ -178,15 +178,15 @@ namespace Npgsql.TypeHandlers
             case WkbIdentifier.GeometryCollection:
             {
                 await buf.Ensure(4, async);
-                var g = new PostgisGeometry[buf.ReadInt32(bo)];
+                var g = new PostgisGeometry[buf.ReadInt32(le)];
 
                 for (var i = 0; i < g.Length; i++)
                 {
                     await buf.Ensure(5, async);
-                    var elemBo = (ByteOrder)buf.ReadByte();
-                    var elemId = (WkbIdentifier)(buf.ReadUInt32(bo) & 7);
+                    var elemLe = buf.ReadByte() != 0;
+                    var elemId = (WkbIdentifier)(buf.ReadUInt32(le) & 7);
 
-                    g[i] = await DoRead(buf, elemId, elemBo, async);
+                    g[i] = await DoRead(buf, elemId, elemLe, async);
                 }
                 return new PostgisGeometryCollection(g);
             }


### PR DESCRIPTION
I've added support to specify endianness while reading and writing in #1787. The new implementation also takes into account `BitConverter.IsLittleEndian` and swaps bytes if needed. It uses the `Unsafe` class to read memory directly without byte shifts (like via reinterpret_cast), but not by accessing memory by pointers. Therefore it's safe.

Please review it ASAP because I need it to finish my GeoJSON support.