### PR TITLE
Filter out system tables from GetSchema() views

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -236,7 +236,11 @@ WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'informat
 
             var getViews = new StringBuilder();
 
-            getViews.Append("SELECT table_catalog, table_schema, table_name, check_option, is_updatable FROM information_schema.views");
+            //getViews.Append("SELECT table_catalog, table_schema, table_name, check_option, is_updatable FROM information_schema.views WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
+            getViews.Append(@"
+SELECT table_catalog, table_schema, table_name, check_option, is_updatable
+FROM information_schema.views
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
 
             using (var command = BuildCommand(conn, getViews, restrictions, "table_catalog", "table_schema", "table_name"))
             using (var adapter = new NpgsqlDataAdapter(command))

--- a/test/Npgsql.Tests/SchemaTests.cs
+++ b/test/Npgsql.Tests/SchemaTests.cs
@@ -215,6 +215,16 @@ namespace Npgsql.Tests
                 Assert.That(tables, Does.Not.Contain("pg_type"));  // schema pg_catalog
                 Assert.That(tables, Does.Not.Contain("tables"));   // schema information_schema
             }
+
+            using (var conn = OpenConnection())
+            {
+                var views = conn.GetSchema("Views").Rows
+                    .Cast<DataRow>()
+                    .Select(r => (string)r["TABLE_NAME"])
+                    .ToList();
+                Assert.That(views, Does.Not.Contain("pg_user"));  // schema pg_catalog
+                Assert.That(views, Does.Not.Contain("views"));    // schema information_schema
+            }
         }
     }
 }


### PR DESCRIPTION
Hi, 
I see the commit id 3a0a467 ( issue #1831 ), I think the same fix should be applied for views. 
This PR filters out pg_catalog and information_schema when returning views from GetSchema. 