### PR TITLE
Fix GetSchema problems occurred by #1831 and #1834

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -179,7 +179,7 @@ SELECT table_catalog, table_schema, table_name, table_type
 FROM information_schema.tables
 WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'information_schema')");
 
-            using (var command = BuildCommand(conn, getTables, restrictions, "table_catalog", "table_schema", "table_name", "table_type"))
+            using (var command = BuildCommand(conn, getTables, restrictions, false, "table_catalog", "table_schema", "table_name", "table_type"))
             using (var adapter = new NpgsqlDataAdapter(command))
                 adapter.Fill(tables);
 
@@ -242,7 +242,7 @@ SELECT table_catalog, table_schema, table_name, check_option, is_updatable
 FROM information_schema.views
 WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
 
-            using (var command = BuildCommand(conn, getViews, restrictions, "table_catalog", "table_schema", "table_name"))
+            using (var command = BuildCommand(conn, getViews, restrictions, false, "table_catalog", "table_schema", "table_name"))
             using (var adapter = new NpgsqlDataAdapter(command))
                 adapter.Fill(views);
 

--- a/test/Npgsql.Tests/SchemaTests.cs
+++ b/test/Npgsql.Tests/SchemaTests.cs
@@ -226,5 +226,53 @@ namespace Npgsql.Tests
                 Assert.That(views, Does.Not.Contain("views"));    // schema information_schema
             }
         }
+
+        [Test]
+        public void GetSchemaWithRestrictions()
+        {
+            // We can't use temporary tables because GetSchema filters out that in WHERE clause.
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("DROP TABLE IF EXISTS data");
+                conn.ExecuteNonQuery("CREATE TABLE data (bar INTEGER)");
+
+                try
+                {
+                    string[] restrictions = { null, null, "data" };
+                    var dt = conn.GetSchema("Tables", restrictions);
+                    foreach (DataRow row in dt.Rows)
+                    {
+                        var d = row["table_name"];
+                        Assert.That(row["table_name"], Is.EqualTo("data"));
+                    }
+                }
+                finally
+                {
+                    conn.ExecuteNonQuery("DROP TABLE IF EXISTS data");
+                }
+            }
+
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("DROP VIEW IF EXISTS view");
+                conn.ExecuteNonQuery("CREATE VIEW view AS SELECT 8 AS foo");
+
+                try
+                {
+                    string[] restrictions = { null, null, "view" };
+                    var dt = conn.GetSchema("Views", restrictions);
+                    foreach (DataRow row in dt.Rows)
+                    {
+                        var d = row["table_name"];
+                        Assert.That(row["table_name"], Is.EqualTo("view"));
+                    }
+                }
+                finally
+                {
+                    conn.ExecuteNonQuery("DROP VIEW IF EXISTS view");
+                }
+            }
+
+        }
     }
 }


### PR DESCRIPTION
Hi @roji ,
I just submitted PR a while ago, but it seems there was a problem... 
If GetSchema() has the restriction argument, SQL building is not done properly. 

### Steps to reproduce
The problem occurs in basic usage as follows : 

            using (var conn = new NpgsqlConnection(constr))
            {
                conn.Open();
                string[] restrictions = { "postgres", "public", null };
                DataTable dt = conn.GetSchema("Tables", restrictions);
            }

This application throw away exception because building SQL command is failed. 

### The issue
By #1831 and #1834, SQL command is built like following: 
  _SELECT table_catalog, table_schema, table_name, table_type
  FROM information_schema.tables
  WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'information_schema')")
  WHERE table_catalog = :table_catalog AND table_schema = :table_schema;_

WHERE clause is written twice, so this PR changes second WHERE clause into "AND". 
This behavior is the same as GetSchema("Indexes",restrictions)'s one. 

Regards,
Daisuke, Higuchi