### PR TITLE
Update DDEX dependency and Re-set NpgsqlConnection's paramters

### DIFF
--- a/Npgsql.all.sln
+++ b/Npgsql.all.sln
@@ -22,6 +22,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.Benchmarks", "test\Npgsql.Benchmarks\Npgsql.Benchmarks.csproj", "{8B4AE9B6-CDAC-44DD-A5CD-28A470D363B8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSIX", "src\VSIX\VSIX.csproj", "{ECFD8615-DEAD-4498-B262-85A4D0230229}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9D13B739-62B1-4190-B386-7A9547304EB3} = {9D13B739-62B1-4190-B386-7A9547304EB3}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.Json.NET", "src\Npgsql.Json.NET\Npgsql.Json.NET.csproj", "{9CBE603F-6746-411D-A5FD-CB2C948CD7D0}"
 EndProject

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -134,15 +134,17 @@ namespace Npgsql
         /// Initializes a new instance of the
         /// <see cref="NpgsqlConnection">NpgsqlConnection</see> class.
         /// </summary>
-        public NpgsqlConnection()
-            => GC.SuppressFinalize(this);
+        public NpgsqlConnection() : this("") { }
 
         /// <summary>
         /// Initializes a new instance of <see cref="NpgsqlConnection"/> with the given connection string.
         /// </summary>
         /// <param name="connectionString">The connection used to open the PostgreSQL database.</param>
         public NpgsqlConnection(string connectionString)
-            => ConnectionString = connectionString;
+        {
+            GC.SuppressFinalize(this);
+            ConnectionString = connectionString;
+        }
 
         /// <summary>
         /// Opens a database connection with the property settings specified by the

--- a/src/VSIX/VSIX.csproj
+++ b/src/VSIX/VSIX.csproj
@@ -219,6 +219,12 @@
     <Reference Include="Npgsql">
       <HintPath>..\Npgsql\bin\$(Configuration)\net451\Npgsql.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe">
+      <HintPath>..\Npgsql\bin\$(Configuration)\net451\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions">
+      <HintPath>..\Npgsql\bin\$(Configuration)\net451\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -236,9 +242,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Security" />
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -293,4 +296,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-</Project>
+</Project>

--- a/src/VSIX/packages.config
+++ b/src/VSIX/packages.config
@@ -52,7 +52,6 @@
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
-  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" requireReinstallation="true" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
Currently, I could not use DDEX (Server Explorer) on dev branch. 
Some commits do not consider DDEX functionality. 

# Fix 1
Commit cf39925 is to remove setting connection string. 
However, DDEX needs the connection string parameters , so I think we should revert this commit. 

# Fix 2
Some depentent ddl are changed and added by 5ef81c6 and 7e90be4
Then, DDEX needs the same dlls as Npgsql's one, so I fixed some dependencies. 
