### PR TITLE
Support reading arrays as List<T>

### DIFF
--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -113,7 +113,8 @@ namespace Npgsql.TypeHandlers
             {
                 return (TArray)await ReadPsvAsList(buf, async);
             }
-                throw new InvalidCastException($"Can't cast database type {PgDisplayName} to {typeof(TArray).Name}");
+
+            throw new InvalidCastException($"Can't cast database type {PgDisplayName} to {typeof(TArray).Name}");
         }
 
         protected async ValueTask<object> ReadAsList<TElement2>(NpgsqlReadBuffer buf, bool async)
@@ -126,10 +127,8 @@ namespace Npgsql.TypeHandlers
             if (dimensions > 1)
                 throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TElement2).Name}>");
 
-            buf.ReadInt32();        // Has nulls. Not populated by PG?
-            var elementOID = buf.ReadUInt32();
-            // The following should hold but fails in test CopyTests.ReadBitString
-            //Debug.Assert(elementOID == ElementHandler.BackendType.OID);
+            buf.ReadInt32();  // Has nulls. Not populated by PG?
+            buf.ReadUInt32(); // Element OID. Ignored.
 
             await buf.Ensure(8, async);
             var length = buf.ReadInt32();
@@ -142,7 +141,7 @@ namespace Npgsql.TypeHandlers
         }
 
         protected internal virtual ValueTask<object> ReadPsvAsList(NpgsqlReadBuffer buf, bool async)
-            => throw new NotSupportedException();
+            => ReadAsList<TElement>(buf, async);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
             => ReadAsObject(buf, len, false, fieldDescription).Result;

--- a/test/Npgsql.Benchmarks/ReadArray.cs
+++ b/test/Npgsql.Benchmarks/ReadArray.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Npgsql.Benchmarks
+{
+    class ReadArrayConfig : ManualConfig
+    {
+        public ReadArrayConfig()
+        {
+            Add(StatisticColumn.OperationsPerSecond);
+            Add(MemoryDiagnoser.Default);
+        }
+    }
+
+
+    public abstract class ReadArray<T>
+    {
+        readonly T _initializationValue;
+        NpgsqlConnection _conn;
+        NpgsqlCommand _cmd;
+        NpgsqlDataReader _reader;
+
+        [Params(0, 10, 1000, 100000)]
+        public int NumArrayElements { get; set; }
+
+        protected ReadArray(T initializationValue)
+        {
+            _initializationValue = initializationValue;
+        }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _conn = BenchmarkEnvironment.OpenConnection();
+            _cmd = new NpgsqlCommand("SELECT @p1;", _conn);
+            _cmd.Parameters.AddWithValue("@p1", GetArray());
+            _reader = _cmd.ExecuteReader();
+            _reader.Read();
+        }
+
+        T[] GetArray()
+            => Enumerable.Repeat(_initializationValue, NumArrayElements).ToArray();
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _reader.Dispose();
+            _cmd.Dispose();
+            _conn.Dispose();
+        }
+
+        [Benchmark]
+        public void AsArray() => _reader.GetFieldValue<T[]>(0);
+
+        [Benchmark]
+        public object AsListOfT() => _reader.GetFieldValue<List<T>>(0);
+    }
+
+    [Config(typeof(ReadArrayConfig))]
+    public class ReadArrayOfStrings : ReadArray<string>
+    {
+        public ReadArrayOfStrings() : base("FooBar") { }
+    }
+
+    [Config(typeof(ReadArrayConfig))]
+    public class ReadArrayOfIntegers : ReadArray<int>
+    {
+        public ReadArrayOfIntegers() : base(42) { }
+    }
+}

--- a/test/Npgsql.Benchmarks/ReadArray.cs
+++ b/test/Npgsql.Benchmarks/ReadArray.cs
@@ -1,51 +1,52 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using NpgsqlTypes;
 
 namespace Npgsql.Benchmarks
 {
-    class ReadArrayConfig : ManualConfig
-    {
-        public ReadArrayConfig()
-        {
-            Add(StatisticColumn.OperationsPerSecond);
-            Add(MemoryDiagnoser.Default);
-        }
-    }
 
 
-    public abstract class ReadArray<T>
+    [Config(typeof(ReadArrayConfig))]
+    public class ReadArray
     {
-        readonly T _initializationValue;
         NpgsqlConnection _conn;
         NpgsqlCommand _cmd;
         NpgsqlDataReader _reader;
 
-        [Params(0, 10, 1000, 100000)]
-        public int NumArrayElements { get; set; }
+        [GlobalSetup(Target = nameof(ReadIntArray) + "," + nameof(ReadListOfInt))]
+        public void GlobalSetupForInt()
+            => GlobalSetupImpl(42);
 
-        protected ReadArray(T initializationValue)
-        {
-            _initializationValue = initializationValue;
-        }
+        [GlobalSetup(Target = nameof(ReadStringArray) + "," + nameof(ReadListOfString))]
+        public void GlobalSetupForString()
+            => GlobalSetupImpl("The Answer to the Ultimate Question of Life, The Universe, and Everything.");
 
-        [GlobalSetup]
-        public void GlobalSetup()
+        [GlobalSetup(Target = nameof(ReadIPAddressArray)
+                              + "," + nameof(ReadNpgsqlInetArray)
+                              + "," + nameof(ReadListOfIPAddress)
+                              + "," + nameof(ReadListOfNpgsqlInet))]
+        public void GlobalSetupForInet()
+            => GlobalSetupImpl(IPAddress.Loopback);
+
+        void GlobalSetupImpl<T>(T initializationValue)
         {
             _conn = BenchmarkEnvironment.OpenConnection();
             _cmd = new NpgsqlCommand("SELECT @p1;", _conn);
-            _cmd.Parameters.AddWithValue("@p1", GetArray());
+            _cmd.Parameters.AddWithValue("@p1", Enumerable.Repeat(initializationValue, NumArrayElements).ToArray());
             _reader = _cmd.ExecuteReader();
             _reader.Read();
         }
 
-        T[] GetArray()
-            => Enumerable.Repeat(_initializationValue, NumArrayElements).ToArray();
+        [Params(0, 10, 1000, 100000)]
+        public int NumArrayElements { get; set; }
 
         [GlobalCleanup]
         public void Cleanup()
@@ -56,21 +57,54 @@ namespace Npgsql.Benchmarks
         }
 
         [Benchmark]
-        public void AsArray() => _reader.GetFieldValue<T[]>(0);
+        public void ReadIntArray()
+            => ReadArrayImpl<int>();
 
         [Benchmark]
-        public object AsListOfT() => _reader.GetFieldValue<List<T>>(0);
-    }
+        public void ReadStringArray()
+            => ReadArrayImpl<string>();
 
-    [Config(typeof(ReadArrayConfig))]
-    public class ReadArrayOfStrings : ReadArray<string>
-    {
-        public ReadArrayOfStrings() : base("FooBar") { }
-    }
+        [Benchmark]
+        // ReSharper disable once InconsistentNaming
+        public void ReadIPAddressArray()
+            => ReadArrayImpl<IPAddress>();
 
-    [Config(typeof(ReadArrayConfig))]
-    public class ReadArrayOfIntegers : ReadArray<int>
-    {
-        public ReadArrayOfIntegers() : base(42) { }
+        [Benchmark]
+        public void ReadNpgsqlInetArray() // PSV for IPAddress
+            => ReadArrayImpl<NpgsqlInet>();
+
+        [Benchmark]
+        public void ReadListOfInt()
+            => ReadListImpl<int>();
+
+        [Benchmark]
+        public void ReadListOfString()
+            => ReadListImpl<string>();
+
+        [Benchmark]
+        // ReSharper disable once InconsistentNaming
+        public void ReadListOfIPAddress()
+            => ReadListImpl<IPAddress>();
+
+        [Benchmark]
+        public void ReadListOfNpgsqlInet() // PSV for IPAddress
+            => ReadListImpl<NpgsqlInet>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void ReadArrayImpl<T>()
+            => _reader.GetFieldValue<T[]>(0);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void ReadListImpl<T>()
+            => _reader.GetFieldValue<List<T>>(0);
+
+        class ReadArrayConfig : ManualConfig
+        {
+            public ReadArrayConfig()
+            {
+                Add(StatisticColumn.OperationsPerSecond);
+                Add(MemoryDiagnoser.Default);
+            }
+        }
     }
 }

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -303,16 +303,16 @@ namespace Npgsql.Tests.Types
             using (var conn = OpenConnection())
             using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
             {
-                var expected = new[] {1, 2, 3};
-                var p1 = new NpgsqlParameter {ParameterName = "p1", Value = expected.ToList()};
-                var p2 = new NpgsqlParameter {ParameterName = "p2", Value = expected.ToList()};
+                var expected = new[] {1, 2, 3}.ToList();
+                var p1 = new NpgsqlParameter {ParameterName = "p1", Value = expected};
+                var p2 = new NpgsqlParameter {ParameterName = "p2", Value = expected};
                 cmd.Parameters.Add(p1);
                 cmd.Parameters.Add(p2);
                 using (var reader = cmd.ExecuteReader())
                 {
                     reader.Read();
-                    Assert.That(reader[0], Is.EqualTo(expected.ToArray()));
-                    Assert.That(reader[1], Is.EqualTo(expected.ToArray()));
+                    Assert.That(reader.GetValue(0), Is.EqualTo(expected));
+                    Assert.That(reader.GetFieldValue<List<int>>(1), Is.EqualTo(expected));
                 }
             }
         }

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -331,11 +331,11 @@ namespace Npgsql.Tests.Types
                 {
                     reader.Read();
                     Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-                    var exception = Assert.Throws<InvalidCastException>(() =>
+                    var exception = Assert.Throws<NotSupportedException>(() =>
                     {
                         reader.GetFieldValue<List<int>>(0);
                     });
-                    Assert.That(exception.Message, Is.EqualTo("Can't cast multidimensional array Int32[,] to List`1"));
+                    Assert.That(exception.Message, Is.EqualTo("Can't read multidimensional array as List<Int32>"));
                 }
             }
         }


### PR DESCRIPTION
This is an initial PR to implement #1821 
It is mostly for discussion now as I intentionally didn't optimize anything yet.
The List\<T> is created via reflection and initialized with the array that has been read from the database.

IMO there are two options for optimization but I'm not sure if this rare case justifies additional code complexity:

1. Use delegates to create the List\<T>
2. Read the values from the buffer directly into the List\<T>

No 1 would certainly be faster but make the code ways more complicated ([example](https://codeblog.jonskeet.uk/2008/08/09/making-reflection-fly-and-exploring-delegates/)).
No 2 would save the allocation of one copy of the array to return but would lead to a separate implementation of `ArrayHandler.Read<TElement2>` just for this case.

@roji what do you think?