### PR TITLE
Add initializing Setting variable in NpgsqlConnection constructor for VSIX

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -135,7 +135,10 @@ namespace Npgsql
         /// <see cref="NpgsqlConnection">NpgsqlConnection</see> class.
         /// </summary>
         public NpgsqlConnection()
-            => GC.SuppressFinalize(this);
+        {
+            GC.SuppressFinalize(this);
+            Settings = new NpgsqlConnectionStringBuilder();
+        }
 
         /// <summary>
         /// Initializes a new instance of <see cref="NpgsqlConnection"/> with the given connection string.


### PR DESCRIPTION
Hi, this PR is a part of #1844. 

Even if #1855 is committed, DDEX(Server Exproler) does not work. 
When trying to add connection, firstly calling NpgsqlConnection(), then CommandTimeout paramter is set before setting ConnectionString. 
In this case, `Setting` variable is not initialized, so following getter throws exception: 

        NpgsqlCommand.cs
        /// <summary>
        /// Gets the time to wait while trying to execute a command
        /// before terminating the attempt and generating an error.
        /// </summary>
        /// <value>The time (in seconds) to wait for a command to complete. The default value is 20 seconds.</value>
        public int CommandTimeout => Settings.CommandTimeout;

### How to reproduce
I also attach screenshot. 
Firstly, I try to add connection in Server Explorer: 
![01_add_connection](https://user-images.githubusercontent.com/20634318/37864129-ddc59ee2-2fad-11e8-81cd-cf890aa3ee1d.png)

Error is occurred like following: 
![02_error](https://user-images.githubusercontent.com/20634318/37864149-126236f6-2fae-11e8-8be1-90ddfe8abbdb.png)

### How to fix this problem
I think there are two ways for solving this problem. 

1. Initializing `Setting` variable at first like this PR. 
2. Modifying this getter to check `Setting` variable is null or not. 

These solutions does not cal ConnectionString setter twice, so I think what @roji care about will not happen. 
In order to simplify the source code, I select first solution. 
However, I hear other opinions... 
