### PR TITLE
Allow external type handlers to use a custom array handler

### DIFF
--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -31,9 +31,11 @@ using JetBrains.Annotations;
 using Npgsql.BackendMessages;
 using Npgsql.TypeHandling;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace Npgsql.TypeHandlers
 {
-    abstract class ArrayHandler : NpgsqlTypeHandler<Array>
+    public abstract class ArrayHandler : NpgsqlTypeHandler<Array>
     {
         internal abstract Type GetElementFieldType(FieldDescription fieldDescription = null);
         internal abstract Type GetElementPsvType(FieldDescription fieldDescription = null);
@@ -47,7 +49,7 @@ namespace Npgsql.TypeHandlers
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/arrays.html
     /// </remarks>
-    class ArrayHandler<TElement> : ArrayHandler
+    public class ArrayHandler<TElement> : ArrayHandler
     {
         /// <summary>
         /// The lower bound value sent to the backend when writing arrays. Normally 1 (the PG default) but

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -54,7 +54,7 @@ namespace Npgsql.TypeHandlers
             => GetFieldType(fieldDescription);
 
         // BitString requires a special array handler which returns bool or BitArray
-        internal override ArrayHandler CreateArrayHandler(PostgresType backendType) =>
+        protected internal override ArrayHandler CreateArrayHandler(PostgresType backendType) =>
             new BitStringArrayHandler(this) { PostgresType = backendType };
 
         #region Read

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -114,7 +114,10 @@ namespace Npgsql.TypeHandling
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null)
             => typeof(TPsv);
 
-        internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        /// <summary>
+        /// Creates a type handler for arrays of this handler's type.
+        /// </summary>
+        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandlerWithPsv<TDefault, TPsv>(this) { PostgresType = arrayBackendType };
 
         #endregion Misc

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -168,7 +168,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Creates a type handler for arrays of this handler's type.
         /// </summary>
-        internal abstract ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
+        protected internal abstract ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
 
         /// <summary>
         /// Creates a type handler for ranges of this handler's type.

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -296,7 +296,10 @@ namespace Npgsql.TypeHandling
         internal override Type GetFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
 
-        internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        /// <summary>
+        /// Creates a type handler for arrays of this handler's type.
+        /// </summary>
+        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<TDefault>(this) { PostgresType = arrayBackendType };
 
         internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)


### PR DESCRIPTION
In our [CrateDbObjectHandler](https://github.com/pircher-software/npgsql-cratedb/blob/dev/src/Npgsql.CrateDb/CrateDbObjectHandler.cs) we would like to [override CreateArrayHandler](https://github.com/pircher-software/npgsql-cratedb/blob/f476e5b8c75b3cdb0357e7a00faf388753be41d8/src/Npgsql.CrateDb/CrateDbObjectHandler.cs#L68) to use a custom [CrateDbObjectArrayHandler](https://github.com/pircher-software/npgsql-cratedb/blob/dev/src/Npgsql.CrateDb/CrateDbObjectArrayHandler.cs).

This enables us to read/write arrays of arbitrary CLR objects from/to CrateDB columns with a data type of json or json array.

@roji what do you think about it?