### PR TITLE
Add JsonSerializerSettings parameter to UseJsonNet()

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
     NPGSQL_TEST_DB: Host=localhost;Database=postgres;Username=postgres;Password=Password12!
     PGUSER: postgres
     PGPASSWORD: Password12!
-    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.3-1.exe
+    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.4-1.exe
     NoPackageAnalysis: true  # Suppresses warning about SemVer 2.0.0 version suffixes when packing
 cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
     NPGSQL_TEST_DB: Host=localhost;Database=postgres;Username=postgres;Password=Password12!
     PGUSER: postgres
     PGPASSWORD: Password12!
-    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.4-1.exe
+    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.3-1.exe
     NoPackageAnalysis: true  # Suppresses warning about SemVer 2.0.0 version suffixes when packing
 cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -33,14 +33,22 @@ namespace Npgsql.Json.NET
 {
     public class JsonHandlerFactory : NpgsqlTypeHandlerFactory<string>
     {
+        private JsonSerializerSettings _jsonSerializerSettings;
+
+        public JsonHandlerFactory(JsonSerializerSettings jsonSerializerSettings) => _jsonSerializerSettings = jsonSerializerSettings;
+
         protected override NpgsqlTypeHandler<string> Create(NpgsqlConnection conn)
-            => new JsonHandler(conn);
+            => new JsonHandler(conn, _jsonSerializerSettings);
     }
 
     class JsonHandler : Npgsql.TypeHandlers.TextHandler
     {
-        public JsonHandler(NpgsqlConnection connection)
-            : base(connection) {}
+        private JsonSerializerSettings _jsonSerializerSettings;
+
+        public JsonHandler(NpgsqlConnection connection, JsonSerializerSettings jsonSerializerSettings) : base(connection)
+        {
+            _jsonSerializerSettings = jsonSerializerSettings;
+        }
 
         protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
         {
@@ -49,7 +57,7 @@ namespace Npgsql.Json.NET
                 return (T)(object)s;
             try
             {
-                return JsonConvert.DeserializeObject<T>(s);
+                return JsonConvert.DeserializeObject<T>(s, _jsonSerializerSettings);
             }
             catch (Exception e)
             {
@@ -73,7 +81,7 @@ namespace Npgsql.Json.NET
             var s = value as string;
             if (s == null)
             {
-                s = JsonConvert.SerializeObject(value);
+                s = JsonConvert.SerializeObject(value, _jsonSerializerSettings);
                 if (parameter != null)
                     parameter.ConvertedValue = s;
             }
@@ -84,7 +92,7 @@ namespace Npgsql.Json.NET
         {
             if (parameter?.ConvertedValue != null)
                 value = parameter.ConvertedValue;
-            var s = value as string ?? JsonConvert.SerializeObject(value);
+            var s = value as string ?? JsonConvert.SerializeObject(value, _jsonSerializerSettings);
             return base.WriteObjectWithLength(s, buf, lengthCache, parameter, async);
         }
     }

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -33,22 +33,19 @@ namespace Npgsql.Json.NET
 {
     public class JsonHandlerFactory : NpgsqlTypeHandlerFactory<string>
     {
-        private JsonSerializerSettings _jsonSerializerSettings;
+        readonly JsonSerializerSettings _settings;
 
-        public JsonHandlerFactory(JsonSerializerSettings jsonSerializerSettings) => _jsonSerializerSettings = jsonSerializerSettings;
+        public JsonHandlerFactory(JsonSerializerSettings settings) => _settings = settings;
 
         protected override NpgsqlTypeHandler<string> Create(NpgsqlConnection conn)
-            => new JsonHandler(conn, _jsonSerializerSettings);
+            => new JsonHandler(conn, _settings);
     }
 
     class JsonHandler : Npgsql.TypeHandlers.TextHandler
     {
-        private JsonSerializerSettings _jsonSerializerSettings;
+        readonly JsonSerializerSettings _settings;
 
-        public JsonHandler(NpgsqlConnection connection, JsonSerializerSettings jsonSerializerSettings) : base(connection)
-        {
-            _jsonSerializerSettings = jsonSerializerSettings;
-        }
+        public JsonHandler(NpgsqlConnection connection, JsonSerializerSettings settings) : base(connection) => _settings = settings;
 
         protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
         {
@@ -57,7 +54,7 @@ namespace Npgsql.Json.NET
                 return (T)(object)s;
             try
             {
-                return JsonConvert.DeserializeObject<T>(s, _jsonSerializerSettings);
+                return JsonConvert.DeserializeObject<T>(s, _settings);
             }
             catch (Exception e)
             {
@@ -81,7 +78,7 @@ namespace Npgsql.Json.NET
             var s = value as string;
             if (s == null)
             {
-                s = JsonConvert.SerializeObject(value, _jsonSerializerSettings);
+                s = JsonConvert.SerializeObject(value, _settings);
                 if (parameter != null)
                     parameter.ConvertedValue = s;
             }
@@ -92,7 +89,7 @@ namespace Npgsql.Json.NET
         {
             if (parameter?.ConvertedValue != null)
                 value = parameter.ConvertedValue;
-            var s = value as string ?? JsonConvert.SerializeObject(value, _jsonSerializerSettings);
+            var s = value as string ?? JsonConvert.SerializeObject(value, _settings);
             return base.WriteObjectWithLength(s, buf, lengthCache, parameter, async);
         }
     }

--- a/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
+++ b/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
@@ -40,14 +40,20 @@ namespace Npgsql
         /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
         /// <param name="jsonbClrTypes">A list of CLR types to map to PostgreSQL jsonb (no need to specify NpgsqlDbType.Jsonb)</param>
         /// <param name="jsonClrTypes">A list of CLR types to map to PostgreSQL json (no need to specify NpgsqlDbType.Json)</param>
-        public static INpgsqlTypeMapper UseJsonNet(this INpgsqlTypeMapper mapper, Type[] jsonbClrTypes = null, Type[] jsonClrTypes = null)
+        /// <param name="jsonSerializerSettings">Optional settings to customize JSON serialization</param>
+        public static INpgsqlTypeMapper UseJsonNet(
+            this INpgsqlTypeMapper mapper, 
+            Type[] jsonbClrTypes = null, 
+            Type[] jsonClrTypes = null,
+            Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings = null
+        )
         {
             mapper.AddMapping(new NpgsqlTypeMappingBuilder
             {
                 PgTypeName = "jsonb",
                 NpgsqlDbType = NpgsqlDbType.Jsonb,
                 ClrTypes = jsonbClrTypes,
-                TypeHandlerFactory = new JsonbHandlerFactory()
+                TypeHandlerFactory = new JsonbHandlerFactory(jsonSerializerSettings)
             }.Build());
 
             mapper.AddMapping(new NpgsqlTypeMappingBuilder
@@ -55,7 +61,7 @@ namespace Npgsql
                 PgTypeName = "json",
                 NpgsqlDbType = NpgsqlDbType.Json,
                 ClrTypes = jsonClrTypes,
-                TypeHandlerFactory = new JsonHandlerFactory()
+                TypeHandlerFactory = new JsonHandlerFactory(jsonSerializerSettings)
             }.Build());
 
             return mapper;

--- a/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
+++ b/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
@@ -25,6 +25,7 @@ using System;
 using Npgsql.Json.NET;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
 namespace Npgsql
@@ -40,12 +41,12 @@ namespace Npgsql
         /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
         /// <param name="jsonbClrTypes">A list of CLR types to map to PostgreSQL jsonb (no need to specify NpgsqlDbType.Jsonb)</param>
         /// <param name="jsonClrTypes">A list of CLR types to map to PostgreSQL json (no need to specify NpgsqlDbType.Json)</param>
-        /// <param name="jsonSerializerSettings">Optional settings to customize JSON serialization</param>
+        /// <param name="settings">Optional settings to customize JSON serialization</param>
         public static INpgsqlTypeMapper UseJsonNet(
             this INpgsqlTypeMapper mapper, 
             Type[] jsonbClrTypes = null, 
             Type[] jsonClrTypes = null,
-            Newtonsoft.Json.JsonSerializerSettings jsonSerializerSettings = null
+            JsonSerializerSettings settings = null
         )
         {
             mapper.AddMapping(new NpgsqlTypeMappingBuilder
@@ -53,7 +54,7 @@ namespace Npgsql
                 PgTypeName = "jsonb",
                 NpgsqlDbType = NpgsqlDbType.Jsonb,
                 ClrTypes = jsonbClrTypes,
-                TypeHandlerFactory = new JsonbHandlerFactory(jsonSerializerSettings)
+                TypeHandlerFactory = new JsonbHandlerFactory(settings)
             }.Build());
 
             mapper.AddMapping(new NpgsqlTypeMappingBuilder
@@ -61,7 +62,7 @@ namespace Npgsql
                 PgTypeName = "json",
                 NpgsqlDbType = NpgsqlDbType.Json,
                 ClrTypes = jsonClrTypes,
-                TypeHandlerFactory = new JsonHandlerFactory(jsonSerializerSettings)
+                TypeHandlerFactory = new JsonHandlerFactory(settings)
             }.Build());
 
             return mapper;

--- a/test/Npgsql.PluginTests/JsonNetTests.cs
+++ b/test/Npgsql.PluginTests/JsonNetTests.cs
@@ -190,7 +190,7 @@ namespace Npgsql.PluginTests
                     using (var reader = cmd.ExecuteReader())
                     {
                         reader.Read();
-                        var actual = reader.GetFieldValue<System.DateTime>(0);
+                        var actual = reader.GetFieldValue<DateWrapper>(0);
                         var actualString = reader.GetFieldValue<string>(1);
                         Assert.That(actual, Is.EqualTo(expected));
                         Assert.That(actualString, Is.EqualTo(expectedString));

--- a/test/Npgsql.PluginTests/JsonNetTests.cs
+++ b/test/Npgsql.PluginTests/JsonNetTests.cs
@@ -190,6 +190,7 @@ namespace Npgsql.PluginTests
 
             var settings = new JsonSerializerSettings()
             {
+                // "The 20th of April, 2018"
                 DateFormatString = @"T\he d\t\h o\f MMMM, yyyy"
             };
 

--- a/test/Npgsql.PluginTests/JsonNetTests.cs
+++ b/test/Npgsql.PluginTests/JsonNetTests.cs
@@ -185,11 +185,11 @@ namespace Npgsql.PluginTests
             {
                 if (asJsonb)
                 {
-                    conn.TypeMapper.UseJsonNet(jsonbClrTypes : new[] { typeof(DateWrapper) }, jsonSerializerSettings: settings);
+                    conn.TypeMapper.UseJsonNet(jsonbClrTypes : new[] { typeof(DateWrapper) }, settings: settings);
                 }
                 else
                 {
-                    conn.TypeMapper.UseJsonNet(jsonClrTypes : new[] { typeof(DateWrapper) }, jsonSerializerSettings: settings);
+                    conn.TypeMapper.UseJsonNet(jsonClrTypes : new[] { typeof(DateWrapper) }, settings: settings);
                 }
 
                 using (var cmd = new NpgsqlCommand($@"SELECT @p::{_pgTypeName}, @p::text", conn))


### PR DESCRIPTION
A simple PR to allow users to customise how the JSON serialization and deserialization should happen with the Json.NET plugin.

Note: The reason I updated the PostGIS path is because the older version isn't available any more and AppVeyor would fail (unless the file was cached, as in the main branch).