### PR TITLE
Update PostGIS to 2.4.4.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
     NPGSQL_TEST_DB: Host=localhost;Database=postgres;Username=postgres;Password=Password12!
     PGUSER: postgres
     PGPASSWORD: Password12!
-    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.3-1.exe
+    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.4.4-1.exe
     NoPackageAnalysis: true  # Suppresses warning about SemVer 2.0.0 version suffixes when packing
 cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'


### PR DESCRIPTION
2.4.3.1 is no longer available so builds will break with it.