### PR TITLE
Optimized ArrayHandler

### DIFF
--- a/src/Npgsql/PGUtil.cs
+++ b/src/Npgsql/PGUtil.cs
@@ -138,6 +138,17 @@ namespace Npgsql
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
         internal static readonly Task<bool> FalseTask = Task.FromResult(false);
 
+        internal static Task TaskFromException(Exception exception)
+        {
+#if NET45 || NET451
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.SetException(exception);
+            return tcs.Task;
+#else
+            return Task.FromException(exception);
+#endif
+        }
+
         internal static StringComparer InvariantCaseIgnoringStringComparer => StringComparer.InvariantCultureIgnoreCase;
 
         internal static bool IsWindows =>

--- a/src/Npgsql/PGUtil.cs
+++ b/src/Npgsql/PGUtil.cs
@@ -138,17 +138,6 @@ namespace Npgsql
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
         internal static readonly Task<bool> FalseTask = Task.FromResult(false);
 
-        internal static Task TaskFromException(Exception exception)
-        {
-#if NET45 || NET451
-            var tcs = new TaskCompletionSource<bool>();
-            tcs.SetException(exception);
-            return tcs.Task;
-#else
-            return Task.FromException(exception);
-#endif
-        }
-
         internal static StringComparer InvariantCaseIgnoringStringComparer => StringComparer.InvariantCultureIgnoreCase;
 
         internal static bool IsWindows =>

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -21,15 +21,14 @@
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endregion
 
+using JetBrains.Annotations;
+using Npgsql.BackendMessages;
+using Npgsql.TypeHandling;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Npgsql.BackendMessages;
-using Npgsql.TypeHandling;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -37,12 +36,12 @@ namespace Npgsql.TypeHandlers
 {
     public abstract class ArrayHandler : NpgsqlTypeHandler<Array>
     {
-        internal abstract Type GetElementFieldType(FieldDescription fieldDescription = null);
-        internal abstract Type GetElementPsvType(FieldDescription fieldDescription = null);
+        internal static class IsArrayOf<TArray, TElement>
+        {
+            public static readonly bool Value = typeof(TArray).IsArray && typeof(TArray).GetElementType() == typeof(TElement);
+        }
     }
-
-#pragma warning disable CA1061 // Do not hide base class methods
-#pragma warning disable CA1801 // Review unused parameters
+    
     /// <summary>
     /// Base class for all type handlers which handle PostgreSQL arrays.
     /// </summary>
@@ -61,18 +60,6 @@ namespace Npgsql.TypeHandlers
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null) => typeof(Array);
 
         /// <summary>
-        /// The type of the elements contained within this array
-        /// </summary>
-        /// <param name="fieldDescription"></param>
-        internal override Type GetElementFieldType(FieldDescription fieldDescription = null) => typeof(TElement);
-
-        /// <summary>
-        /// The provider-specific type of the elements contained within this array,
-        /// </summary>
-        /// <param name="fieldDescription"></param>
-        internal override Type GetElementPsvType(FieldDescription fieldDescription = null) => typeof(TElement);
-
-        /// <summary>
         /// The type handler for the element that this array type holds
         /// </summary>
         protected internal NpgsqlTypeHandler ElementHandler { get; protected set; }
@@ -83,85 +70,37 @@ namespace Npgsql.TypeHandlers
             ElementHandler = elementHandler;
         }
 
-        public ArrayHandler([CanBeNull] NpgsqlTypeHandler elementHandler) : this(elementHandler, 1) {}
+        public ArrayHandler([CanBeNull] NpgsqlTypeHandler elementHandler)
+            : this(elementHandler, 1) { }
 
         #region Read
 
-        // Note that unlike most type handlers, we have to override Read<T2> and not Read, since we
-        // must do array-specific checking etc.
-        protected internal override async ValueTask<TArray> Read<TArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
-        {
-            // TODO: Throw SafeReadExceptions
-            var t = typeof(TArray);
-
-            // Getting an array
-            if (t.IsArray)
-            {
-                var elementType = t.GetElementType();
-                // We need to treat this as an actual array type, these need special treatment because of
-                // typing/generics reasons (there is no way to express "array of X" with generics
-                if (elementType == GetElementFieldType())
-                    return (TArray)await ReadAsObject(buf, len, async, fieldDescription);
-                if (elementType == GetElementPsvType())
-                    return (TArray)await ReadPsvAsObject(buf, len, async, fieldDescription);
-            }
-
-            if (t == typeof(List<TElement>))
-                return (TArray)await ReadAsList<TElement>(buf, async);
-
-            if (t.IsGenericType
-                && t.GetGenericTypeDefinition() == typeof(List<>)
-                && t.GenericTypeArguments[0] == GetElementPsvType())
-            {
-                return (TArray)await ReadPsvAsList(buf, async);
-            }
-
-            throw new InvalidCastException($"Can't cast database type {PgDisplayName} to {typeof(TArray).Name}");
-        }
-
-        protected async ValueTask<object> ReadAsList<TElement2>(NpgsqlReadBuffer buf, bool async)
-        {
-            await buf.Ensure(12, async);
-            var dimensions = buf.ReadInt32();
-
-            if (dimensions == 0)
-                return new List<TElement2>();
-            if (dimensions > 1)
-                throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TElement2).Name}>");
-
-            buf.ReadInt32();  // Has nulls. Not populated by PG?
-            buf.ReadUInt32(); // Element OID. Ignored.
-
-            await buf.Ensure(8, async);
-            var length = buf.ReadInt32();
-            buf.ReadInt32(); // We don't care about the lower bounds
-
-            var list = new List<TElement2>(length);
-            for (var i = 0; i < length; i++)
-                list.Add(await ElementHandler.ReadWithLength<TElement2>(buf, async));
-            return list;
-        }
-
-        protected internal virtual ValueTask<object> ReadPsvAsList(NpgsqlReadBuffer buf, bool async)
-            => ReadAsList<TElement>(buf, async);
-
-        internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
-            => ReadAsObject(buf, len, false, fieldDescription).Result;
-
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription)
-            => await Read<TElement>(buf, async);
-
         public override ValueTask<Array> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
-            => Read<TElement>(buf, async);
+            => ReadArray<TElement>(buf, async);
 
-        protected async ValueTask<Array> Read<TElement2>(NpgsqlReadBuffer buf, bool async)
+        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        {
+            if (typeof(TAny) == typeof(List<TElement>))
+                return ReadListImpl<TAny>(buf, async);
+
+            if (IsArrayOf<TAny, TElement>.Value)
+                return ReadArrayImpl<TAny>(buf, async);
+
+            return base.Read<TAny>(buf, len, async, fieldDescription);
+        }
+
+        async ValueTask<TArray> ReadArrayImpl<TArray>(NpgsqlReadBuffer buf, bool async)
+            => (TArray)(object)await ReadArray<TElement>(buf, async);
+
+        async ValueTask<TArray> ReadListImpl<TArray>(NpgsqlReadBuffer buf, bool async)
+            => (TArray)(object)await ReadList<TElement>(buf, async);
+
+        protected async ValueTask<Array> ReadArray<T>(NpgsqlReadBuffer buf, bool async)
         {
             await buf.Ensure(12, async);
             var dimensions = buf.ReadInt32();
             buf.ReadInt32();        // Has nulls. Not populated by PG?
             var elementOID = buf.ReadUInt32();
-            // The following should hold but fails in test CopyTests.ReadBitString
-            //Debug.Assert(elementOID == ElementHandler.BackendType.OID);
 
             var dimLengths = new int[dimensions];
 
@@ -173,15 +112,15 @@ namespace Npgsql.TypeHandlers
             }
 
             if (dimensions == 0)
-                return new TElement2[0];   // TODO: static instance
+                return new T[0];   // TODO: static instance
 
-            var result = Array.CreateInstance(typeof(TElement2), dimLengths);
+            var result = Array.CreateInstance(typeof(T), dimLengths);
 
             if (dimensions == 1)
             {
-                var oneDimensional = (TElement2[])result;
+                var oneDimensional = (T[])result;
                 for (var i = 0; i < oneDimensional.Length; i++)
-                    oneDimensional[i] = await ElementHandler.ReadWithLength<TElement2>(buf, async);
+                    oneDimensional[i] = await ElementHandler.ReadWithLength<T>(buf, async);
                 return oneDimensional;
             }
 
@@ -189,7 +128,7 @@ namespace Npgsql.TypeHandlers
             var indices = new int[dimensions];
             while (true)
             {
-                var element = await ElementHandler.ReadWithLength<TElement2>(buf, async);
+                var element = await ElementHandler.ReadWithLength<T>(buf, async);
                 result.SetValue(element, indices);
 
                 // TODO: Overly complicated/inefficient...
@@ -209,75 +148,99 @@ namespace Npgsql.TypeHandlers
             }
         }
 
+        protected async ValueTask<List<T>> ReadList<T>(NpgsqlReadBuffer buf, bool async)
+        {
+            await buf.Ensure(12, async);
+            var dimensions = buf.ReadInt32();
+
+            if (dimensions == 0)
+                return new List<T>();
+            if (dimensions > 1)
+                throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(T).Name}>");
+
+            buf.ReadInt32();  // Has nulls. Not populated by PG?
+            buf.ReadUInt32(); // Element OID. Ignored.
+
+            await buf.Ensure(8, async);
+            var length = buf.ReadInt32();
+            buf.ReadInt32(); // We don't care about the lower bounds
+
+            var list = new List<T>(length);
+            for (var i = 0; i < length; i++)
+                list.Add(await ElementHandler.ReadWithLength<T>(buf, async));
+            return list;
+        }
+
         #endregion
 
         #region Write
 
-        public override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
-            => ValidateAndGetLength<TElement>(value, ref lengthCache, parameter);
+        static Exception MixedTypesOrJaggedArray(Exception innerException)
+            => new Exception("While trying to write an array, one of its elements failed validation. " +
+                             "You may be trying to mix types in a non-generic IList, or to write a jagged array.", innerException);
 
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter = null)
-            => ValidateAndGetLength<TElement>(value, ref lengthCache, parameter);
+        static Exception CantWriteType(Type type)
+            => new InvalidCastException($"Can't write type {type} as an array of {typeof(TElement)}");
 
         // We're required to override this but it will never be called
         public override int ValidateAndGetLength(Array value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
-            => throw new NotSupportedException();
-
-        public int ValidateAndGetLength<TElement2>(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter = null)
         {
             if (lengthCache == null)
                 lengthCache = new NpgsqlLengthCache(1);
             if (lengthCache.IsPopulated)
                 return lengthCache.Get();
-
-            switch (value)
-            {
-            case IList<TElement2> asGeneric:
-                return ValidateAndGetLengthGeneric(asGeneric, ref lengthCache);
-            case IList asNonGeneric:
-                return ValidateAndGetLengthNonGeneric(asNonGeneric, ref lengthCache);
-            default:
-                throw new InvalidCastException($"Can't write type {value.GetType()} as an array of {typeof(TElement2)}");
-            }
+            return ValidateAndGetLengthNonGeneric(value, ref lengthCache);
         }
 
-        /// <summary>
-        /// Handle single-dimensional arrays and generic IList
-        /// </summary>
-        int ValidateAndGetLengthGeneric<TElement2>(IList<TElement2> value, ref NpgsqlLengthCache lengthCache)
+        public override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+            => ValidateAndGetLength(value, ref lengthCache);
+
+        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter = null)
+            => ValidateAndGetLength(value, ref lengthCache);
+
+        int ValidateAndGetLength(object value, ref NpgsqlLengthCache lengthCache)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get();
+            if (value is ICollection<TElement> generic)
+                return ValidateAndGetLengthGeneric(generic, ref lengthCache);
+            if (value is ICollection nonGeneric)
+                return ValidateAndGetLengthNonGeneric(nonGeneric, ref lengthCache);
+            throw CantWriteType(value.GetType());
+        }
+
+        // Handle single-dimensional arrays and generic IList<T>
+        int ValidateAndGetLengthGeneric(ICollection<TElement> value, ref NpgsqlLengthCache lengthCache)
         {
             // Leave empty slot for the entire array length, and go ahead an populate the element slots
             var pos = lengthCache.Position;
             lengthCache.Set(0);
-            var lengthCache2 = lengthCache;
+            var elemLengthCache = lengthCache;
             var len =
-                4 +       // dimensions
-                4 +       // has_nulls (unused)
-                4 +       // type OID
-                1 * 8 +   // number of dimensions (1) * (length + lower bound)
-                value.Sum(e => 4 + GetSingleElementLength(e, ref lengthCache2));
-            lengthCache = lengthCache2;
-            return lengthCache.Lengths[pos] = len;
+                4 +              // dimensions
+                4 +              // has_nulls (unused)
+                4 +              // type OID
+                1 * 8 +          // number of dimensions (1) * (length + lower bound)
+                4 * value.Count; // sum of element lengths
+            foreach (var element in value)
+                if (element != null && typeof(TElement) != typeof(DBNull))
+                    try
+                    {
+                        len += ElementHandler.ValidateAndGetLength(element, ref lengthCache, null);
+                    }
+                    catch (Exception e)
+                    {
+                        throw MixedTypesOrJaggedArray(e);
+                    }
+            lengthCache = elemLengthCache;
+            lengthCache.Lengths[pos] = len;
+            return len;
         }
 
-        int GetSingleElementLength<T2>([CanBeNull] T2 element, ref NpgsqlLengthCache lengthCache)
-        {
-            if (element == null || typeof(T2) == typeof(DBNull))
-                return 0;
-            try
-            {
-                return ElementHandler.ValidateAndGetLength(element, ref lengthCache, null);
-            }
-            catch (Exception e)
-            {
-                throw new Exception("While trying to write an array, one of its elements failed validation. You may be trying to mix types in a non-generic IList, or to write a jagged array.", e);
-            }
-        }
-
-        /// <summary>
-        /// Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
-        /// </summary>
-        int ValidateAndGetLengthNonGeneric(IList value, ref NpgsqlLengthCache lengthCache)
+        // Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
+        int ValidateAndGetLengthNonGeneric(ICollection value, ref NpgsqlLengthCache lengthCache)
         {
             var asMultidimensional = value as Array;
             var dimensions = asMultidimensional?.Rank ?? 1;
@@ -285,40 +248,42 @@ namespace Npgsql.TypeHandlers
             // Leave empty slot for the entire array length, and go ahead an populate the element slots
             var pos = lengthCache.Position;
             lengthCache.Set(0);
-            var lengthCache2 = lengthCache;
+            var elemLengthCache = lengthCache;
             var len =
-                4 +       // dimensions
-                4 +       // has_nulls (unused)
-                4 +       // type OID
-                dimensions * 8 +  // number of dimensions * (length + lower bound)
-                value.Cast<object>().Sum(element => 4 + GetSingleElementObjectLength(element, ref lengthCache2));
-            lengthCache = lengthCache2;
+                4 +              // dimensions
+                4 +              // has_nulls (unused)
+                4 +              // type OID
+                dimensions * 8 + // number of dimensions * (length + lower bound)
+                4 * value.Count; // sum of element lengths
+            foreach (var element in value)
+                if (element != null && element != DBNull.Value)
+                    try
+                    {
+                        len += ElementHandler.ValidateObjectAndGetLength(element, ref lengthCache, null);
+                    }
+                    catch (Exception e)
+                    {
+                        throw MixedTypesOrJaggedArray(e);
+                    }
+            lengthCache = elemLengthCache;
             lengthCache.Lengths[pos] = len;
             return len;
         }
 
-        int GetSingleElementObjectLength([CanBeNull] object element, ref NpgsqlLengthCache lengthCache)
-        {
-            if (element == null || element is DBNull)
-                return 0;
-            try
-            {
-                return ElementHandler.ValidateObjectAndGetLength(element, ref lengthCache, null);
-            }
-            catch (Exception e)
-            {
-                throw new Exception("While trying to write an array, one of its elements failed validation. You may be trying to mix types in a non-generic IList, or to write a jagged array.", e);
-            }
-        }
-
-        protected override Task WriteWithLength<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
-        {
-            buf.WriteInt32(ValidateAndGetLength<TElement>(value, ref lengthCache, parameter));
-            return Write(value, buf, lengthCache, async);
-        }
-
         public override Task Write(Array value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
-            => throw new NotSupportedException("ArrayHandler overrides Write<T2> so we shouldn't get here");
+            => value is TElement[] array
+                ? WriteGeneric(array, buf, lengthCache, async)
+                : WriteNonGeneric(value, buf, lengthCache, async);
+
+        protected override Task WriteWithLength<TAny>(TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+        {
+            buf.WriteInt32(ValidateAndGetLength(value, ref lengthCache, parameter));
+            if (value is ICollection<TElement> list)
+                return WriteGeneric(list, buf, lengthCache, async);
+            if (value is ICollection nonGeneric)
+                return WriteNonGeneric(nonGeneric, buf, lengthCache, async);
+            return PGUtil.TaskFromException(CantWriteType(value.GetType()));
+        }
 
         // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
         // us (need to handle many types of T, e.g. int[], int[,]...)
@@ -327,12 +292,33 @@ namespace Npgsql.TypeHandlers
                 ? WriteWithLengthInternal<DBNull>(null, buf, lengthCache, parameter, async)
                 : WriteWithLengthInternal(value, buf, lengthCache, parameter, async);
 
-        // TODO: Implement WriteVector which writes arrays without boxing... (accept IList<T2>)
-        async Task Write(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, bool async)
+        async Task WriteGeneric(ICollection<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, bool async)
+        {
+            var len =
+                4 +    // dimensions
+                4 +    // has_nulls (unused)
+                4 +    // type OID
+                1 * 8; // number of dimensions (1) * (length + lower bound)
+            if (buf.WriteSpaceLeft < len)
+            {
+                await buf.Flush(async);
+                Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
+            }
+
+            buf.WriteInt32(1);
+            buf.WriteInt32(1); // has_nulls = 1. Not actually used by the backend.
+            buf.WriteUInt32(ElementHandler.PostgresType.OID);
+            buf.WriteInt32(value.Count);
+            buf.WriteInt32(LowerBound); // We don't map .NET lower bounds to PG
+
+            foreach (var element in value)
+                await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async);
+        }
+
+        async Task WriteNonGeneric(ICollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, bool async)
         {
             var asArray = value as Array;
             var dimensions = asArray?.Rank ?? 1;
-            var writeValue = (IList)value;
 
             var len =
                 4 +               // ndim
@@ -359,18 +345,16 @@ namespace Npgsql.TypeHandlers
             }
             else
             {
-                buf.WriteInt32(writeValue.Count);
+                buf.WriteInt32(value.Count);
                 buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
             }
 
-            foreach (var element in writeValue)
+            foreach (var element in value)
                 await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async);
         }
 
         #endregion
     }
-#pragma warning restore CA1061 // Do not hide base class methods
-#pragma warning restore CA1801 // Review unused parameters
 
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/arrays.html
@@ -379,23 +363,30 @@ namespace Npgsql.TypeHandlers
     /// <typeparam name="TElementPsv">The .NET provider-specific type contained as an element within this array</typeparam>
     class ArrayHandlerWithPsv<TElement, TElementPsv> : ArrayHandler<TElement>
     {
-        /// <summary>
-        /// The provider-specific type of the elements contained within this array,
-        /// </summary>
-        /// <param name="fieldDescription"></param>
-        internal override Type GetElementPsvType(FieldDescription fieldDescription)
-            => typeof(TElementPsv);
+        public ArrayHandlerWithPsv(NpgsqlTypeHandler elementHandler)
+            : base(elementHandler) { }
 
-        internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
+        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        {
+            if (typeof(TAny) == typeof(List<TElementPsv>))
+                return ReadPvsListImpl<TAny>(buf, async);
+
+            if (IsArrayOf<TAny, TElementPsv>.Value)
+                return ReadPvsArrayImpl<TAny>(buf, async);
+
+            return base.Read<TAny>(buf, len, async, fieldDescription);
+        }
+
+        async ValueTask<TArray> ReadPvsArrayImpl<TArray>(NpgsqlReadBuffer buf, bool async)
+            => (TArray)(object)await ReadArray<TElementPsv>(buf, async);
+
+        async ValueTask<TArray> ReadPvsListImpl<TArray>(NpgsqlReadBuffer buf, bool async)
+            => (TArray)(object)await ReadList<TElementPsv>(buf, async);
+
+        internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
             => ReadPsvAsObject(buf, len, false, fieldDescription).Result;
 
         internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription)
-            => await Read<TElementPsv>(buf, async);
-
-        protected internal override ValueTask<object> ReadPsvAsList(NpgsqlReadBuffer buf, bool async)
-            => ReadAsList<TElementPsv>(buf, async);
-
-        public ArrayHandlerWithPsv(NpgsqlTypeHandler elementHandler)
-            : base(elementHandler) {}
+            => await ReadArray<TElementPsv>(buf, async);
     }
 }

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -278,21 +278,25 @@ namespace Npgsql.TypeHandlers
         protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
         {
             if (IsArrayOf<TAny, BitArray>.Value)
-                return ReadArrayImpl<TAny, BitArray>(buf, async);
+                return ReadArrayImpl<BitArray>();
+
             if (IsArrayOf<TAny, bool>.Value)
-                return ReadArrayImpl<TAny, bool>(buf, async);
+                return ReadArrayImpl<bool>();
+
             if (typeof(TAny) == typeof(List<BitArray>))
-                return ReadListImpl<TAny, BitArray>(buf, async);
+                return ReadListImpl<BitArray>();
+
             if (typeof(TAny) == typeof(List<bool>))
-                return ReadListImpl<TAny, bool>(buf, async);
+                return ReadListImpl<bool>();
+
             return base.Read<TAny>(buf, len, async, fieldDescription);
+
+            async ValueTask<TAny> ReadArrayImpl<TElement>()
+                => (TAny)(object)await ReadArray<TElement>(buf, async);
+
+            async ValueTask<TAny> ReadListImpl<TElement>()
+                => (TAny)(object)await ReadList<TElement>(buf, async);
         }
-
-        async ValueTask<TArray> ReadArrayImpl<TArray, TElement>(NpgsqlReadBuffer buf, bool async)
-            => (TArray)(object)await ReadArray<TElement>(buf, async);
-
-        async ValueTask<TArray> ReadListImpl<TArray, TElement>(NpgsqlReadBuffer buf, bool async)
-            => (TArray)(object)await ReadList<TElement>(buf, async);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
             => ReadAsObject(buf, len, false, fieldDescription).Result;

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -275,27 +275,21 @@ namespace Npgsql.TypeHandlers
         public BitStringArrayHandler(BitStringHandler elementHandler)
             : base(elementHandler) { }
 
-        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
         {
             if (IsArrayOf<TAny, BitArray>.Value)
-                return ReadArrayImpl<BitArray>();
+                return (TAny)(object)await ReadArray<BitArray>(buf, async);
 
             if (IsArrayOf<TAny, bool>.Value)
-                return ReadArrayImpl<bool>();
+                return (TAny)(object)await ReadArray<bool>(buf, async);
 
             if (typeof(TAny) == typeof(List<BitArray>))
-                return ReadListImpl<BitArray>();
+                return (TAny)(object)await ReadList<BitArray>(buf, async);
 
             if (typeof(TAny) == typeof(List<bool>))
-                return ReadListImpl<bool>();
+                return (TAny)(object)await ReadList<bool>(buf, async);
 
-            return base.Read<TAny>(buf, len, async, fieldDescription);
-
-            async ValueTask<TAny> ReadArrayImpl<TElement>()
-                => (TAny)(object)await ReadArray<TElement>(buf, async);
-
-            async ValueTask<TAny> ReadListImpl<TElement>()
-                => (TAny)(object)await ReadList<TElement>(buf, async);
+            return await base.Read<TAny>(buf, len, async, fieldDescription);
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)

--- a/test/Npgsql.Benchmarks/ReadArray.cs
+++ b/test/Npgsql.Benchmarks/ReadArray.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Runtime.CompilerServices;
-using System.Text;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using NpgsqlTypes;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
 
 namespace Npgsql.Benchmarks
 {
-
-
     [Config(typeof(ReadArrayConfig))]
     public class ReadArray
     {


### PR DESCRIPTION
Things which have been done:

- [x] Removed the `GetElementFieldType` and `GetElementPsvType` methods. Therefore, the JITter can elide type equalation expressions in the `Read<Any>` method.
- [x] Implemeted a generic method to write arrays without boxing.
- [x] `BitStringHandler` supports reading `List<bool>` like its base class does.

## Benchmarks

```
BenchmarkDotNet=v0.10.12, OS=Windows 10.0.17134
Intel Xeon CPU E5-2687W 0 3.10GHz, 2 CPU, 32 logical cores and 16 physical cores
.NET Core SDK=2.1.104
  [Host]     : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.6 (Framework 4.6.26212.01), 64bit RyuJIT
```

### Before

|               Method | NumArrayElements |             Mean |           Error |          StdDev |           Median |          Op/s |     Gen 0 |     Gen 1 |    Gen 2 |  Allocated |
|--------------------- |----------------- |-----------------:|----------------:|----------------:|-----------------:|--------------:|----------:|----------:|---------:|-----------:|
|         ReadIntArray |                0 |         766.3 ns |        57.53 ns |        169.6 ns |         865.0 ns | 1,304,955.470 |    0.0067 |         - |        - |       48 B |
|      ReadStringArray |                0 |         718.2 ns |        70.21 ns |        207.0 ns |         677.3 ns | 1,392,447.514 |    0.0067 |         - |        - |       48 B |
|   ReadIPAddressArray |                0 |         769.4 ns |        59.75 ns |        176.2 ns |         866.7 ns | 1,299,780.382 |    0.0067 |         - |        - |       48 B |
|  ReadNpgsqlInetArray |                0 |         797.0 ns |        62.38 ns |        183.9 ns |         881.2 ns | 1,254,725.805 |    0.0067 |         - |        - |       48 B |
|        ReadListOfInt |                0 |         565.2 ns |        55.38 ns |        163.3 ns |         658.9 ns | 1,769,166.901 |    0.0057 |         - |        - |       40 B |
|     ReadListOfString |                0 |         613.3 ns |        57.14 ns |        168.5 ns |         698.8 ns | 1,630,614.516 |    0.0057 |         - |        - |       40 B |
|  ReadListOfIPAddress |                0 |         546.4 ns |        47.95 ns |        141.4 ns |         628.3 ns | 1,830,232.998 |    0.0057 |         - |        - |       40 B |
| ReadListOfNpgsqlInet |                0 |       1,040.0 ns |       103.64 ns |        305.6 ns |       1,165.1 ns |   961,517.629 |    0.0095 |         - |        - |       72 B |
|         ReadIntArray |               10 |       4,158.6 ns |       415.16 ns |      1,224.1 ns |       4,631.6 ns |   240,463.805 |    0.0076 |         - |        - |       96 B |
|      ReadStringArray |               10 |       5,708.6 ns |       590.49 ns |      1,741.1 ns |       4,708.6 ns |   175,175.600 |    0.3433 |         - |        - |     2216 B |
|   ReadIPAddressArray |               10 |       5,235.9 ns |       681.42 ns |      2,009.2 ns |       4,278.1 ns |   190,990.701 |    0.1297 |         - |        - |      856 B |
|  ReadNpgsqlInetArray |               10 |       4,992.0 ns |       632.12 ns |      1,863.8 ns |       4,148.5 ns |   200,321.848 |    0.1373 |         - |        - |      936 B |
|        ReadListOfInt |               10 |       2,818.5 ns |       287.02 ns |        846.3 ns |       2,377.9 ns |   354,803.223 |    0.0114 |         - |        - |      104 B |
|     ReadListOfString |               10 |       6,687.1 ns |       638.11 ns |      1,881.5 ns |       6,519.4 ns |   149,541.173 |    0.3357 |         - |        - |     2224 B |
|  ReadListOfIPAddress |               10 |       7,735.4 ns |       549.75 ns |      1,620.9 ns |       8,525.3 ns |   129,276.405 |    0.1221 |         - |        - |      864 B |
| ReadListOfNpgsqlInet |               10 |       9,473.4 ns |       187.67 ns |        470.8 ns |       9,537.7 ns |   105,558.770 |    0.1373 |         - |        - |      976 B |
|         ReadIntArray |             1000 |     313,502.0 ns |    25,884.45 ns |     76,320.9 ns |     353,607.5 ns |     3,189.773 |         - |         - |        - |     4056 B |
|      ReadStringArray |             1000 |     732,030.7 ns |    14,634.35 ns |     32,731.8 ns |     744,911.4 ns |     1,366.063 |   33.2031 |    8.7891 |        - |   216056 B |
|   ReadIPAddressArray |             1000 |     565,780.6 ns |    51,748.93 ns |    152,582.9 ns |     546,989.5 ns |     1,767.470 |   11.7188 |    0.9766 |        - |    80056 B |
|  ReadNpgsqlInetArray |             1000 |     539,329.6 ns |    47,420.59 ns |    139,820.7 ns |     559,662.9 ns |     1,854.154 |   12.6953 |    0.9766 |        - |    88056 B |
|        ReadListOfInt |             1000 |     392,478.6 ns |     7,791.75 ns |      8,001.6 ns |     395,668.4 ns |     2,547.910 |         - |         - |        - |     4064 B |
|     ReadListOfString |             1000 |     656,937.4 ns |    57,877.71 ns |    170,653.7 ns |     742,134.6 ns |     1,522.215 |   33.2031 |    8.7891 |        - |   216064 B |
|  ReadListOfIPAddress |             1000 |     683,677.4 ns |    42,968.77 ns |    126,694.4 ns |     729,700.0 ns |     1,462.678 |   11.7188 |    0.9766 |        - |    80064 B |
| ReadListOfNpgsqlInet |             1000 |     597,058.9 ns |    44,871.46 ns |    132,304.5 ns |     664,446.4 ns |     1,674.877 |   12.6953 |    0.9766 |        - |    88096 B |
|         ReadIntArray |           100000 |  29,892,614.1 ns | 2,883,639.76 ns |  8,502,476.9 ns |  28,690,053.4 ns |        33.453 |   62.5000 |   62.5000 |  62.5000 |   400056 B |
|      ReadStringArray |           100000 | 182,211,288.7 ns | 3,499,574.41 ns |  3,102,281.3 ns | 182,776,262.8 ns |         5.488 | 3750.0000 | 1562.5000 | 500.0000 | 21600086 B |
|   ReadIPAddressArray |           100000 |  83,660,677.3 ns | 7,107,689.43 ns | 20,957,182.6 ns |  80,245,309.7 ns |        11.953 | 1250.0000 |  562.5000 | 187.5000 |  8000314 B |
|  ReadNpgsqlInetArray |           100000 |  76,796,019.7 ns | 6,185,849.47 ns | 18,239,116.7 ns |  76,269,092.8 ns |        13.022 | 1375.0000 |  812.5000 | 375.0000 |  8801206 B |
|        ReadListOfInt |           100000 |  27,524,540.4 ns | 2,736,325.26 ns |  8,068,116.8 ns |  25,540,985.9 ns |        36.331 |   62.5000 |   62.5000 |  62.5000 |   400064 B |
|     ReadListOfString |           100000 | 186,145,563.1 ns | 3,496,371.10 ns |  3,433,903.6 ns | 186,292,494.4 ns |         5.372 | 3750.0000 | 1562.5000 | 500.0000 | 21600222 B |
|  ReadListOfIPAddress |           100000 |  97,127,709.2 ns | 7,713,357.51 ns | 22,743,008.6 ns | 100,338,121.6 ns |        10.296 | 1250.0000 |  562.5000 | 187.5000 |  8000134 B |
| ReadListOfNpgsqlInet |           100000 |  88,915,034.9 ns | 5,975,026.29 ns | 17,617,499.8 ns |  92,489,081.6 ns |        11.247 | 1375.0000 |  812.5000 | 375.0000 |  8800448 B |


### After

|               Method | NumArrayElements |             Mean |           Error |           StdDev |           Median |          Op/s |     Gen 0 |     Gen 1 |    Gen 2 |  Allocated |
|--------------------- |----------------- |-----------------:|----------------:|-----------------:|-----------------:|--------------:|----------:|----------:|---------:|-----------:|
|         ReadIntArray |                0 |         476.9 ns |        42.48 ns |        125.26 ns |         542.1 ns | 2,096,734.424 |    0.0072 |         - |        - |       48 B |
|      ReadStringArray |                0 |         580.9 ns |        55.20 ns |        162.76 ns |         562.0 ns | 1,721,422.003 |    0.0067 |         - |        - |       48 B |
|   ReadIPAddressArray |                0 |         560.3 ns |        56.70 ns |        167.19 ns |         534.3 ns | 1,784,676.935 |    0.0067 |         - |        - |       48 B |
|  ReadNpgsqlInetArray |                0 |         697.9 ns |        14.06 ns |         32.86 ns |         689.2 ns | 1,432,827.978 |    0.0067 |         - |        - |       48 B |
|        ReadListOfInt |                0 |         402.5 ns |        37.82 ns |        111.50 ns |         367.1 ns | 2,484,398.034 |    0.0057 |         - |        - |       40 B |
|     ReadListOfString |                0 |         543.6 ns |        51.49 ns |        151.83 ns |         527.0 ns | 1,839,472.704 |    0.0057 |         - |        - |       40 B |
|  ReadListOfIPAddress |                0 |         615.7 ns |        45.19 ns |        133.25 ns |         680.8 ns | 1,624,150.181 |    0.0057 |         - |        - |       40 B |
| ReadListOfNpgsqlInet |                0 |         618.2 ns |        12.40 ns |         26.16 ns |         614.1 ns | 1,617,607.317 |    0.0057 |         - |        - |       40 B |
|         ReadIntArray |               10 |       3,821.4 ns |       357.93 ns |      1,055.38 ns |       3,815.8 ns |   261,683.334 |    0.0076 |         - |        - |       96 B |
|      ReadStringArray |               10 |       5,690.8 ns |       604.62 ns |      1,782.75 ns |       5,392.3 ns |   175,723.618 |    0.3433 |         - |        - |     2216 B |
|   ReadIPAddressArray |               10 |       6,138.3 ns |       569.67 ns |      1,679.68 ns |       5,791.4 ns |   162,911.656 |    0.1297 |         - |        - |      856 B |
|  ReadNpgsqlInetArray |               10 |       6,116.5 ns |       532.14 ns |      1,569.04 ns |       6,386.7 ns |   163,492.090 |    0.1373 |         - |        - |      936 B |
|        ReadListOfInt |               10 |       3,309.6 ns |       354.82 ns |      1,046.21 ns |       3,075.1 ns |   302,147.445 |    0.0076 |         - |        - |      104 B |
|     ReadListOfString |               10 |       5,854.8 ns |       612.30 ns |      1,805.39 ns |       5,553.5 ns |   170,800.723 |    0.3433 |         - |        - |     2224 B |
|  ReadListOfIPAddress |               10 |       5,809.3 ns |       645.57 ns |      1,903.47 ns |       5,632.8 ns |   172,138.488 |    0.1297 |         - |        - |      864 B |
| ReadListOfNpgsqlInet |               10 |       5,362.5 ns |       524.23 ns |      1,545.70 ns |       5,215.9 ns |   186,479.011 |    0.1450 |         - |        - |      944 B |
|         ReadIntArray |             1000 |     234,702.0 ns |    28,413.64 ns |     83,778.27 ns |     189,285.8 ns |     4,260.722 |    0.2441 |         - |        - |     4056 B |
|      ReadStringArray |             1000 |     580,782.7 ns |    45,925.51 ns |    135,412.39 ns |     650,896.7 ns |     1,721.814 |   33.2031 |    8.7891 |        - |   216056 B |
|   ReadIPAddressArray |             1000 |     566,896.4 ns |    48,716.20 ns |    143,640.82 ns |     584,707.1 ns |     1,763.991 |   11.7188 |    0.9766 |        - |    80056 B |
|  ReadNpgsqlInetArray |             1000 |     535,121.5 ns |    50,108.32 ns |    147,745.51 ns |     517,672.9 ns |     1,868.735 |   12.6953 |    0.9766 |        - |    88056 B |
|        ReadListOfInt |             1000 |     268,110.6 ns |    27,466.69 ns |     80,986.15 ns |     239,248.8 ns |     3,729.804 |         - |         - |        - |     4064 B |
|     ReadListOfString |             1000 |     735,272.8 ns |    13,774.00 ns |     29,650.00 ns |     730,122.9 ns |     1,360.039 |   33.2031 |    8.7891 |        - |   216064 B |
|  ReadListOfIPAddress |             1000 |     597,955.7 ns |    57,013.66 ns |    168,106.08 ns |     598,666.0 ns |     1,672.365 |   11.7188 |    0.9766 |        - |    80064 B |
| ReadListOfNpgsqlInet |             1000 |     516,120.5 ns |    51,010.52 ns |    150,405.68 ns |     516,455.9 ns |     1,937.532 |   12.6953 |    0.9766 |        - |    88064 B |
|         ReadIntArray |           100000 |  28,426,863.0 ns | 2,733,842.06 ns |  8,060,794.99 ns |  26,926,385.9 ns |        35.178 |   62.5000 |   62.5000 |  62.5000 |   400056 B |
|      ReadStringArray |           100000 | 178,763,060.5 ns | 3,523,216.92 ns |  2,750,695.79 ns | 178,951,083.4 ns |         5.594 | 3750.0000 | 1562.5000 | 500.0000 | 21600548 B |
|   ReadIPAddressArray |           100000 |  86,147,647.1 ns | 7,202,289.03 ns | 21,236,111.71 ns |  91,487,732.2 ns |        11.608 | 1250.0000 |  562.5000 | 187.5000 |  8000324 B |
|  ReadNpgsqlInetArray |           100000 |  95,530,870.4 ns | 4,111,718.52 ns | 11,797,291.20 ns |  97,684,565.0 ns |        10.468 | 1375.0000 |  812.5000 | 375.0000 |  8800346 B |
|        ReadListOfInt |           100000 |  25,259,902.9 ns | 2,914,273.33 ns |  8,592,800.66 ns |  24,075,402.7 ns |        39.588 |   93.7500 |   93.7500 |  93.7500 |   400064 B |
|     ReadListOfString |           100000 | 180,939,126.3 ns | 3,372,289.50 ns |  2,989,446.51 ns | 181,186,458.4 ns |         5.527 | 3750.0000 | 1562.5000 | 500.0000 | 21600404 B |
|  ReadListOfIPAddress |           100000 |  90,849,075.1 ns | 7,055,408.74 ns | 20,803,031.85 ns |  92,547,200.0 ns |        11.007 | 1250.0000 |  562.5000 | 187.5000 |  8000360 B |
| ReadListOfNpgsqlInet |           100000 |  80,247,688.6 ns | 6,183,845.72 ns | 18,233,208.63 ns |  81,155,098.1 ns |        12.461 | 1375.0000 |  812.5000 | 375.0000 |  8800372 B |

---

@Brar Sorry for the delay, but I was very tired yesterday. You're welcome to review this PR too (: