### PR TITLE
Refactored type handlers

### DIFF
--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -62,12 +62,11 @@ namespace Npgsql.Json.NET
             }
         }
 
-        public override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => typeof(T2) == typeof(string)
                 ? base.ValidateAndGetLength(value, ref lengthCache, parameter)
                 : ValidateObjectAndGetLength(value, ref lengthCache, parameter);
-
-
+        
         protected override Task WriteWithLength<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
             => typeof(T2) == typeof(string)
                 ? base.WriteWithLength(value, buf, lengthCache, parameter, async)

--- a/src/Npgsql.Json.NET/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/JsonbHandler.cs
@@ -62,12 +62,11 @@ namespace Npgsql.Json.NET
             }
         }
 
-        public override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => typeof(T2) == typeof(string)
                 ? base.ValidateAndGetLength(value, ref lengthCache, parameter)
                 : ValidateObjectAndGetLength(value, ref lengthCache, parameter);
-
-
+        
         protected override Task WriteWithLength<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
             => typeof(T2) == typeof(string)
                 ? base.WriteWithLength(value, buf, lengthCache, parameter, async)

--- a/src/Npgsql/TypeHandlers/InternalTypesHandlers/Int2VectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypesHandlers/Int2VectorHandler.cs
@@ -21,20 +21,25 @@
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endregion
 
-using System;
-using NpgsqlTypes;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandlers.NumericHandlers;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
+using NpgsqlTypes;
+using System;
 
 namespace Npgsql.TypeHandlers.InternalTypesHandlers
 {
     [TypeMapping("int2vector", NpgsqlDbType.Int2Vector)]
-    class Int2VectorHandlerFactory : NpgsqlTypeHandlerFactory<Array>
+    class Int2VectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
-        protected override NpgsqlTypeHandler<Array> Create(NpgsqlConnection conn)
-            => new Int2VectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["int2"]);
+        internal override NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
+            => new Int2VectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["int2"])
+            {
+                PostgresType = pgType
+            };
+
+        internal override Type DefaultValueType => null;
     }
 
     /// <summary>
@@ -44,9 +49,6 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
     class Int2VectorHandler : ArrayHandler<short>
     {
         public Int2VectorHandler(PostgresType postgresShortType)
-            : base(null, 0)
-        {
-            ElementHandler = new Int16Handler { PostgresType = postgresShortType };
-        }
+            : base(new Int16Handler { PostgresType = postgresShortType }, 0) { }
     }
 }

--- a/src/Npgsql/TypeHandlers/InternalTypesHandlers/OIDVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypesHandlers/OIDVectorHandler.cs
@@ -21,21 +21,25 @@
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endregion
 
-using System;
-using Npgsql.Logging;
-using NpgsqlTypes;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandlers.NumericHandlers;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
+using NpgsqlTypes;
+using System;
 
 namespace Npgsql.TypeHandlers.InternalTypesHandlers
 {
     [TypeMapping("oidvector", NpgsqlDbType.Oidvector)]
-    class OIDectorHandlerFactory : NpgsqlTypeHandlerFactory<Array>
+    class OIDVectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
-        protected override NpgsqlTypeHandler<Array> Create(NpgsqlConnection conn)
-            => new OIDVectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["oid"]);
+        internal override NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
+            => new OIDVectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["oid"])
+            {
+                PostgresType = pgType
+            };
+
+        internal override Type DefaultValueType => null;
     }
 
     /// <summary>
@@ -45,9 +49,6 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
     class OIDVectorHandler : ArrayHandler<uint>
     {
         public OIDVectorHandler(PostgresType postgresOIDType)
-            : base(null, 0)
-        {
-            ElementHandler = new UInt32Handler { PostgresType = postgresOIDType };
-        }
+            : base(new UInt32Handler { PostgresType = postgresOIDType }, 0) { }
     }
 }

--- a/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
@@ -75,11 +75,8 @@ namespace Npgsql.TypeHandlers
 
         // Allow writing anything that is a string or can be converted to one via the unknown type handler
 
-        public override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => ValidateObjectAndGetLength(value, ref lengthCache, parameter);
-
-        //protected override Task Write<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
-        //    => WriteObjectWithLength(value, buf, lengthCache, parameter, async);
 
         protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
         {

--- a/src/Npgsql/TypeHandlers/UnmappedCompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedCompositeHandler.cs
@@ -152,7 +152,7 @@ namespace Npgsql.TypeHandlers
                 ? -1
                 : ValidateAndGetLength(value, ref lengthCache, parameter);
 
-        public override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => ValidateAndGetLength(value, ref lengthCache, parameter);
 
         public override int ValidateAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)

--- a/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
@@ -82,7 +82,7 @@ namespace Npgsql.TypeHandlers
                 ? -1
                 : ValidateAndGetLength(value, ref lengthCache, parameter);
 
-        public override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => ValidateAndGetLength(value, ref lengthCache, parameter);
 
         int ValidateAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -21,6 +21,7 @@
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endregion
 
+using Npgsql.BackendMessages;
 using System;
 using System.Collections.Concurrent;
 using System.Data.Common;
@@ -29,8 +30,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Npgsql.BackendMessages;
 
 namespace Npgsql.TypeHandling
 {
@@ -168,7 +167,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// This method is sealed, override <see cref="ValidateAndGetLength(TDefault,NpgsqlParameter)"/>.
         /// </summary>
-        public override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => this is INpgsqlSimpleTypeHandler<TAny> typedHandler
                 ? typedHandler.ValidateAndGetLength(value, parameter)
                 : throw new InvalidCastException($"Can't write CLR type {typeof(TAny)} to database type {PgDisplayName}");

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -49,7 +49,7 @@ namespace Npgsql.TypeHandling
         #region Read
 
         /// <summary>
-        /// Reads a value of type <typeparamref name="T"/> with the given length from the provided buffer,
+        /// Reads a value of type <typeparamref name="TAny"/> with the given length from the provided buffer,
         /// using either sync or async I/O.
         /// </summary>
         /// <param name="buf">The buffer from which to read.</param>
@@ -57,10 +57,10 @@ namespace Npgsql.TypeHandling
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        protected internal abstract ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null);
+        protected internal abstract ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null);
 
         /// <summary>
-        /// Reads a value of type <typeparamref name="T"/> with the given length from the provided buffer,
+        /// Reads a value of type <typeparamref name="TAny"/> with the given length from the provided buffer,
         /// with the assumption that it is entirely present in the provided memory buffer and no I/O will be
         /// required. This can save the overhead of async functions and improves performance.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        internal abstract T Read<T>(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null);
+        internal abstract TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null);
 
         /// <summary>
         /// Reads a column as the type handler's default read type, assuming that it is already entirely
@@ -103,13 +103,13 @@ namespace Npgsql.TypeHandling
         /// If the length is -1 (null), this method will return the default value.
         /// </summary>
         [ItemCanBeNull]
-        internal async ValueTask<T> ReadWithLength<T>(NpgsqlReadBuffer buf, bool async, FieldDescription fieldDescription = null)
+        internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription fieldDescription = null)
         {
             await buf.Ensure(4, async);
             var len = buf.ReadInt32();
             if (len == -1)
-                return default(T);
-            return await Read<T>(buf, len, async, fieldDescription);
+                return default(TAny);
+            return await Read<TAny>(buf, len, async, fieldDescription);
         }
 
         #endregion
@@ -119,7 +119,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Called to validate and get the length of a value of a generic <see cref="NpgsqlParameter{T}"/>.
         /// </summary>
-        public abstract int ValidateAndGetLength<TAny>([CanBeNull] TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter);
+        protected internal abstract int ValidateAndGetLength<TAny>([CanBeNull] TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter);
 
         /// <summary>
         /// Called to write the value of a generic <see cref="NpgsqlParameter{T}"/>.

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -137,7 +137,7 @@ namespace Npgsql.TypeHandling
         /// Called to validate and get the length of a value of an arbitrary type.
         /// Checks that the current handler supports that type and throws an exception otherwise.
         /// </summary>
-        public override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
             => this is INpgsqlTypeHandler<TAny> typedHandler
                 ? typedHandler.ValidateAndGetLength(value, ref lengthCache, parameter)
                 : throw new InvalidCastException($"Can't write CLR type {typeof(TAny)} to database type {PgDisplayName}");


### PR DESCRIPTION
* `Read` methods of non-generic `NpgsqlTypeHandler` use the `TAny` generic parameter instead of `T` for name consistency.
* `ValidateAndGetLength<TAny>` is `protected internal` (previously `public`).
* `ArrayHandler` inherits from non-generic `NpgsqlTypeHandler `.
* `ElementHandler` and `LowerBound` are readonly fields.

---

Should `ArrayHandler` have an internal constructor? Or should it check the `elementHandler` parameter?