### PR TITLE
Change inet/cidr to map to address/subnet tuple

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlTypes.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTypes.cs
@@ -553,6 +553,7 @@ namespace NpgsqlTypes
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
+    [Obsolete("Use ValueTuple<IPAddress, int> instead")]
     public struct NpgsqlInet : IEquatable<NpgsqlInet>
     {
         public IPAddress Address { get; set; }
@@ -618,6 +619,12 @@ namespace NpgsqlTypes
             => ReferenceEquals(ip, null) ? default(NpgsqlInet) : new NpgsqlInet(ip);
 
         public static implicit operator NpgsqlInet([CanBeNull] IPAddress ip) => ToNpgsqlInet(ip);
+
+        public void Deconstruct(out IPAddress address, out int netmask)
+        {
+            address = Address;
+            netmask = Netmask;
+        }
 
         public bool Equals(NpgsqlInet other) => Address.Equals(other.Address) && Netmask == other.Netmask;
 

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/CidrHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/CidrHandler.cs
@@ -29,27 +29,42 @@ using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
 
+#pragma warning disable 618
+
 namespace Npgsql.TypeHandlers.NetworkHandlers
 {
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
     [TypeMapping("cidr", NpgsqlDbType.Cidr)]
-    class CidrHandler : NpgsqlSimpleTypeHandler<NpgsqlInet>, INpgsqlSimpleTypeHandler<string>
+    class CidrHandler : NpgsqlSimpleTypeHandler<(IPAddress Address, int Subnet)>, INpgsqlSimpleTypeHandler<NpgsqlInet>,
+        INpgsqlSimpleTypeHandler<string>
     {
-        public override NpgsqlInet Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
-            => InetHandler.DoRead(buf, fieldDescription, len, true);
+        public override (IPAddress Address, int Subnet) Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
+            => InetHandler.DoRead(buf, len, fieldDescription, true);
+
+        NpgsqlInet INpgsqlSimpleTypeHandler<NpgsqlInet>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
+        {
+            var (address, subnet) = Read(buf, len, fieldDescription);
+            return new NpgsqlInet(address, subnet);
+        }
 
         string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
+            => ((INpgsqlSimpleTypeHandler<NpgsqlInet>)this).Read(buf, len, fieldDescription).ToString();
 
-        public override int ValidateAndGetLength(NpgsqlInet value, NpgsqlParameter parameter)
+        public override int ValidateAndGetLength((IPAddress Address, int Subnet) value, NpgsqlParameter parameter)
+            => InetHandler.GetLength(value.Address);
+
+        public int ValidateAndGetLength(NpgsqlInet value, NpgsqlParameter parameter)
             => InetHandler.GetLength(value.Address);
 
         public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
             => InetHandler.GetLength(IPAddress.Parse(value));
 
-        public override void Write(NpgsqlInet value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
+        public override void Write((IPAddress Address, int Subnet) value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
+            => InetHandler.DoWrite(value.Address, value.Subnet, buf, true);
+
+        public void Write(NpgsqlInet value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => InetHandler.DoWrite(value.Address, value.Netmask, buf, true);
 
         public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)

--- a/test/Npgsql.Tests/Types/NetworkTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NetworkTypeTests.cs
@@ -45,22 +45,23 @@ namespace Npgsql.Tests.Types
         public void InetV4()
         {
             using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn))
+            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6", conn))
             {
                 var expectedIp = IPAddress.Parse("192.168.1.1");
-                var expectedInet = new NpgsqlInet(expectedIp, 24);
-                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Inet) { Value = expectedInet };
-                var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expectedInet };
-                var p3 = new NpgsqlParameter("p3", NpgsqlDbType.Inet) { Value = expectedIp };
-                var p4 = new NpgsqlParameter { ParameterName = "p4", Value = expectedIp };
-                cmd.Parameters.Add(p1);
-                cmd.Parameters.Add(p2);
-                cmd.Parameters.Add(p3);
-                cmd.Parameters.Add(p4);
+                var expectedTuple = (Address: expectedIp, Subnet: 24);
+                var expectedNpgsqlInet = new NpgsqlInet(expectedIp, 24);
+                cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Inet) { Value = expectedIp });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p2", Value = expectedIp });
+                cmd.Parameters.Add(new NpgsqlParameter("p3", NpgsqlDbType.Inet) { Value = expectedTuple });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p4", Value = expectedTuple });
+                cmd.Parameters.Add(new NpgsqlParameter("p5", NpgsqlDbType.Inet) { Value = expectedNpgsqlInet });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p6", Value = expectedNpgsqlInet });
+
                 using (var reader = cmd.ExecuteReader())
                 {
                     reader.Read();
 
+                    // Address only, no subnet
                     for (var i = 0; i < 2; i++)
                     {
                         // Regular type (IPAddress)
@@ -70,15 +71,15 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetValue(i), Is.EqualTo(expectedIp));
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
 
-                        // Provider-specific type (NpgsqlInet)
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
-                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedInet));
-                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedInet));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expectedInet.ToString()));
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
+                        // Provider-specific type (ValueTuple<IPAddress, int>)
+                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
+                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo((expectedIp, 32)));
+                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
+                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
                     }
 
-                    for (var i = 2; i < 4; i++)
+                    // Address and subnet
+                    for (var i = 2; i < 6; i++)
                     {
                         // Regular type (IPAddress)
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
@@ -88,11 +89,10 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
 
                         // Provider-specific type (NpgsqlInet)
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
-                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
+                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
+                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedTuple));
+                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedNpgsqlInet));
+                        Assert.That(reader.GetString(i), Is.EqualTo(expectedNpgsqlInet.ToString()));
                     }
                 }
             }
@@ -102,23 +102,24 @@ namespace Npgsql.Tests.Types
         public void InetV6()
         {
             using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn))
+            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6", conn))
             {
                 const string addr = "2001:1db8:85a3:1142:1000:8a2e:1370:7334";
                 var expectedIp = IPAddress.Parse(addr);
-                var expectedInet = new NpgsqlInet(expectedIp, 24);
-                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Inet) { Value = expectedInet };
-                var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expectedInet };
-                var p3 = new NpgsqlParameter("p3", NpgsqlDbType.Inet) { Value = expectedIp };
-                var p4 = new NpgsqlParameter { ParameterName = "p4", Value = expectedIp };
-                cmd.Parameters.Add(p1);
-                cmd.Parameters.Add(p2);
-                cmd.Parameters.Add(p3);
-                cmd.Parameters.Add(p4);
+                var expectedTuple = (Address: expectedIp, Subnet: 24);
+                var expectedNpgsqlInet = new NpgsqlInet(expectedIp, 24);
+                cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Inet) { Value = expectedIp });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p2", Value = expectedIp });
+                cmd.Parameters.Add(new NpgsqlParameter("p3", NpgsqlDbType.Inet) { Value = expectedTuple });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p4", Value = expectedTuple });
+                cmd.Parameters.Add(new NpgsqlParameter("p5", NpgsqlDbType.Inet) { Value = expectedNpgsqlInet });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p6", Value = expectedNpgsqlInet });
+
                 using (var reader = cmd.ExecuteReader())
                 {
                     reader.Read();
 
+                    // Address only, no subnet
                     for (var i = 0; i < 2; i++)
                     {
                         // Regular type (IPAddress)
@@ -126,18 +127,17 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetFieldValue<IPAddress>(i), Is.EqualTo(expectedIp));
                         Assert.That(reader[i], Is.EqualTo(expectedIp));
                         Assert.That(reader.GetValue(i), Is.EqualTo(expectedIp));
-                        Assert.That(reader.GetString(i), Is.EqualTo(addr + "/24"));
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
 
-                        // Provider-specific type (NpgsqlInet)
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
-                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedInet));
-                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedInet));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expectedInet.ToString()));
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
+                        // Provider-specific type (ValueTuple<IPAddress, int>)
+                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
+                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo((expectedIp, 128)));
+                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
+                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
                     }
 
-                    for (var i = 2; i < 4; i++)
+                    // Address and subnet
+                    for (var i = 2; i < 6; i++)
                     {
                         // Regular type (IPAddress)
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
@@ -147,11 +147,10 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(IPAddress)));
 
                         // Provider-specific type (NpgsqlInet)
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
-                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
-                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlInet)));
+                        Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
+                        Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedTuple));
+                        Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedNpgsqlInet));
+                        Assert.That(reader.GetString(i), Is.EqualTo(expectedNpgsqlInet.ToString()));
                     }
                 }
             }
@@ -160,7 +159,8 @@ namespace Npgsql.Tests.Types
         [Test]
         public void Cidr()
         {
-            var expectedInet = new NpgsqlInet("192.168.1.0/24");
+            var expected = (Address: IPAddress.Parse("192.168.1.0"), Subnet: 24);
+            //var expectedInet = new NpgsqlInet("192.168.1.0/24");
             using (var conn = OpenConnection())
             using (var cmd = new NpgsqlCommand("SELECT '192.168.1.0/24'::CIDR", conn))
             using (var reader = cmd.ExecuteReader())
@@ -168,12 +168,12 @@ namespace Npgsql.Tests.Types
                 reader.Read();
 
                 // Regular type (IPAddress)
-                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(NpgsqlInet)));
-                Assert.That(reader.GetFieldValue<NpgsqlInet>(0), Is.EqualTo(expectedInet));
-                Assert.That(reader[0], Is.EqualTo(expectedInet));
-                Assert.That(reader.GetValue(0), Is.EqualTo(expectedInet));
+                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof((IPAddress, int))));
+                Assert.That(reader.GetFieldValue<(IPAddress, int)>(0), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<NpgsqlInet>(0), Is.EqualTo(new NpgsqlInet(expected.Address, expected.Subnet)));
+                Assert.That(reader[0], Is.EqualTo(expected));
+                Assert.That(reader.GetValue(0), Is.EqualTo(expected));
                 Assert.That(reader.GetString(0), Is.EqualTo("192.168.1.0/24"));
-                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(NpgsqlInet)));
             }
         }
 


### PR DESCRIPTION
@austindrenski and @YohDeadfall, can I please have your opinion on this PR? It implements the mapping changes suggested by @austindrenski in #407, obsoleting `NpgsqlInet` and replacing it by `ValueTuple<IPAddress, int>`.

Let me know what you guys think.