### PR TITLE
Allow NpgsqlDatabaseInfo derived classes to adapt type mappings 

### DIFF
--- a/src/Npgsql/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/NpgsqlDatabaseInfo.cs
@@ -28,6 +28,7 @@ using System.Data.Common;
 using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
+using Npgsql.TypeMapping;
 
 namespace Npgsql
 {
@@ -204,6 +205,12 @@ namespace Npgsql
         /// </summary>
         /// <returns></returns>
         protected abstract IEnumerable<PostgresType> GetTypes();
+
+        /// <summary>
+        /// Adapts the type mappings for this database.
+        /// </summary>
+        /// <param name="mappings">The mappings that are about the be bound.</param>
+        protected internal virtual void AdaptTypeMappings(IDictionary<string, NpgsqlTypeMapping> mappings) { }
 
         #endregion Types
 

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -246,6 +246,9 @@ namespace Npgsql.TypeMapping
 
         void BindTypes()
         {
+            // Prepare the registered type mappings for the DBMS currently in use.
+            DatabaseInfo?.AdaptTypeMappings(Mappings);
+
             foreach (var mapping in Mappings.Values)
                 BindType(mapping, _connector, false);
 


### PR DESCRIPTION
When using npgsql to connect to CrateDB, some type mappings always have to be adapted. Therefore we have to tell users to call the `CrateDbDatabaseInfo.AddCrateDbSpecificTypeMappings`-method either on the global type mapper or on the type mapper of the connection.

We think, that this is not optimal. Calling this method on the global type mapper could mess things up for connections to PostgreSQL and calling it on the connection´s type mapper is something that is easily forgotten.

We would rather like to fix the mappings in our `CrateDbDatabaseInfo`-class right before the types are bound and this PR would allow us to do so. 

It also allows us to remove unsupported mappings from the dictionary what prevents thousands of ArgumentExceptions and log entries that are otherwise thrown and created when binding types.

What do you think about it?