### PR TITLE
Revisiting NpgsqlRange<T> boundaries and support for range literals

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -30,10 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0-rc1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0-rc1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0-rc1" />
-<!-- Causes issues in Appveyor and Travis
+    <!-- Causes issues in Appveyor and Travis
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.0-beta2" PrivateAssets="All" />
 -->
   </ItemGroup>

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -30,11 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0-rc1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0-rc1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0-rc1" />
-    <!-- Causes issues in Appveyor and Travis
+<!-- Causes issues in Appveyor and Travis
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.0-beta2" PrivateAssets="All" />
 -->
   </ItemGroup>

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2018 The Npgsql Development Team
@@ -19,109 +20,176 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
+using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
-
-#pragma warning disable 1591
+using Microsoft.Extensions.Primitives;
 
 // ReSharper disable once CheckNamespace
 namespace NpgsqlTypes
 {
-    public struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
+    /// <summary>
+    /// Represents a PostgreSQL range type.
+    /// </summary>
+    /// <typeparam name="T">The element type of the values in the range.</typeparam>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
+    /// </remarks>
+    [TypeConverter(typeof(NpgsqlRange<>.RangeTypeConverter))]
+    public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     {
-#pragma warning disable CA1000
+        /// <summary>
+        /// Represents the empty range.
+        /// </summary>
         public static NpgsqlRange<T> Empty { get; } = new NpgsqlRange<T>(default, default, RangeFlags.Empty);
-#pragma warning restore CA1000
 
+        /// <summary>
+        /// The lower bound of the range. Only valid when <see cref="LowerBoundInfinite"/> is false.
+        /// </summary>
+        [CanBeNull]
         public T LowerBound { get; }
+
+        /// <summary>
+        /// The upper bound of the range. Only valid when <see cref="UpperBoundInfinite"/> is false.
+        /// </summary>
+        [CanBeNull]
         public T UpperBound { get; }
 
-        internal RangeFlags Flags { get; set; }
+        /// <summary>
+        /// The characteristics of the boundaries.
+        /// </summary>
+        internal readonly RangeFlags Flags;
 
-        public bool LowerBoundIsInclusive
-        {
-            get => (Flags & RangeFlags.LowerBoundInclusive) != 0;
-            private set
-            {
-                if (value)
-                    Flags |= RangeFlags.LowerBoundInclusive;
-                else
-                    Flags &= ~RangeFlags.LowerBoundInclusive;
-            }
-        }
+        /// <summary>
+        /// True if the lower bound is part of the range (i.e. inclusive); otherwise, false.
+        /// </summary>
+        public bool LowerBoundIsInclusive => Flags.HasFlag(RangeFlags.LowerBoundInclusive);
 
-        public bool UpperBoundIsInclusive
-        {
-            get => (Flags & RangeFlags.UpperBoundInclusive) != 0;
-            private set
-            {
-                if (value)
-                    Flags |= RangeFlags.UpperBoundInclusive;
-                else
-                    Flags &= ~RangeFlags.UpperBoundInclusive;
-            }
-        }
+        /// <summary>
+        /// True if the upper bound is part of the range (i.e. inclusive); otherwise, false.
+        /// </summary>
+        public bool UpperBoundIsInclusive => Flags.HasFlag(RangeFlags.UpperBoundInclusive);
 
-        public bool LowerBoundInfinite
-        {
-            get => (Flags & RangeFlags.LowerBoundInfinite) != 0;
-            private set
-            {
-                if (value)
-                    Flags |= RangeFlags.LowerBoundInfinite;
-                else
-                    Flags &= ~RangeFlags.LowerBoundInfinite;
-            }
-        }
+        /// <summary>
+        /// True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.
+        /// </summary>
+        public bool LowerBoundInfinite => Flags.HasFlag(RangeFlags.LowerBoundInfinite);
 
-        public bool UpperBoundInfinite
-        {
-            get => (Flags & RangeFlags.UpperBoundInfinite) != 0;
-            private set
-            {
-                if (value)
-                    Flags |= RangeFlags.UpperBoundInfinite;
-                else
-                    Flags &= ~RangeFlags.UpperBoundInfinite;
-            }
-        }
+        /// <summary>
+        /// True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.
+        /// </summary>
+        public bool UpperBoundInfinite => Flags.HasFlag(RangeFlags.UpperBoundInfinite);
 
-        public bool IsEmpty => (Flags & RangeFlags.Empty) != 0;
+        /// <summary>
+        /// True if the range is empty; otherwise, false.
+        /// </summary>
+        public bool IsEmpty => Flags.HasFlag(RangeFlags.Empty);
 
+        /// <summary>
+        /// Constructs an <see cref="NpgsqlRange{T}"/> with inclusive and definite bounds.
+        /// </summary>
+        /// <param name="lowerBound">The lower bound of the range.</param>
+        /// <param name="upperBound">The upper bound of the range.</param>
         public NpgsqlRange(T lowerBound, T upperBound)
-            : this(lowerBound, true, false, upperBound, true, false) {}
+            : this(lowerBound, true, false, upperBound, true, false) { }
 
+        /// <summary>
+        /// Constructs an <see cref="NpgsqlRange{T}"/> with definite bounds.
+        /// </summary>
+        /// <param name="lowerBound">The lower bound of the range.</param>
+        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
+        /// <param name="upperBound">The upper bound of the range.</param>
+        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
         public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, T upperBound, bool upperBoundIsInclusive)
             : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) { }
 
+        /// <summary>
+        /// Constructs an <see cref="NpgsqlRange{T}"/>.
+        /// </summary>
+        /// <param name="lowerBound">The lower bound of the range.</param>
+        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
+        /// <param name="lowerBoundInfinite">True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
+        /// <param name="upperBound">The upper bound of the range.</param>
+        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
+        /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
         public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite,
-                           T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite) : this()
-        {
-            if (lowerBoundInfinite && lowerBoundIsInclusive)
-                throw new ArgumentException("Infinite bound can't be inclusive", nameof(lowerBoundIsInclusive));
-            if (upperBoundInfinite && upperBoundIsInclusive)
-                throw new ArgumentException("Infinite bound can't be inclusive", nameof(upperBoundIsInclusive));
+                           T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
+            : this(
+                lowerBound,
+                upperBound,
+                EvaluateBoundaryFlags(
+                    lowerBoundIsInclusive,
+                    upperBoundIsInclusive,
+                    lowerBoundInfinite,
+                    upperBoundInfinite)) { }
 
-            LowerBound = lowerBound;
-            UpperBound = upperBound;
-
-            LowerBoundIsInclusive = lowerBoundIsInclusive;
-            UpperBoundIsInclusive = upperBoundIsInclusive;
-
-            LowerBoundInfinite = lowerBoundInfinite;
-            UpperBoundInfinite = upperBoundInfinite;
-        }
-
+        /// <summary>
+        /// Constructs an <see cref="NpgsqlRange{T}"/>.
+        /// </summary>
+        /// <param name="lowerBound">The lower bound of the range.</param>
+        /// <param name="upperBound">The upper bound of the range.</param>
+        /// <param name="flags">The characteristics of the range boundaries.</param>
         internal NpgsqlRange([CanBeNull] T lowerBound, [CanBeNull] T upperBound, RangeFlags flags) : this()
         {
-            LowerBound = lowerBound;
-            UpperBound = upperBound;
+            if (flags == RangeFlags.None)
+                throw new ArgumentException("An error occured while constructing the range. Boundary characteristics were not set.");
+
+            // TODO: We need to check if the bounds are implicitly empty. E.g. '(1,1)' or '(0,0]'.
+            // TODO: This will require introducing the concept of continuous and discrete ranges.
+
+            LowerBound = flags.HasFlag(RangeFlags.LowerBoundInfinite) ? default : lowerBound;
+            UpperBound = flags.HasFlag(RangeFlags.UpperBoundInfinite) ? default : upperBound;
             Flags = flags;
         }
 
+        /// <summary>
+        /// Evaluates the boundary flags.
+        /// </summary>
+        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
+        /// <param name="lowerBoundInfinite">True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
+        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
+        /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
+        /// <returns>
+        /// The boundary characteristics.
+        /// </returns>
+        private static RangeFlags EvaluateBoundaryFlags(bool lowerBoundIsInclusive, bool upperBoundIsInclusive, bool lowerBoundInfinite, bool upperBoundInfinite)
+        {
+            RangeFlags result = RangeFlags.None;
+
+            // This is the only place flags are calculated, so no bitwise removal needed.
+            if (lowerBoundIsInclusive)
+                result |= RangeFlags.LowerBoundInclusive;
+            if (upperBoundIsInclusive)
+                result |= RangeFlags.UpperBoundInclusive;
+            if (lowerBoundInfinite)
+                result |= RangeFlags.LowerBoundInfinite;
+            if (upperBoundInfinite)
+                result |= RangeFlags.UpperBoundInfinite;
+
+            // PostgreSQL automatically converts inclusive-infinities, so no throw.
+            // See: https://www.postgresql.org/docs/current/static/rangetypes.html#RANGETYPES-INFINITE
+            if (result.HasFlag(RangeFlags.LowerBoundInclusive & RangeFlags.LowerBoundInfinite))
+                result &= ~RangeFlags.LowerBoundInclusive;
+
+            if (result.HasFlag(RangeFlags.UpperBoundInclusive & RangeFlags.UpperBoundInfinite))
+                result &= ~RangeFlags.UpperBoundInclusive;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Indicates whether the <see cref="NpgsqlRange{T}"/> on the left is equal to the <see cref="NpgsqlRange{T}"/> on the right.
+        /// </summary>
+        /// <param name="x">The <see cref="NpgsqlRange{T}"/> on the left.</param>
+        /// <param name="y">The <see cref="NpgsqlRange{T}"/> on the right.</param>
+        /// <returns>
+        /// True if the <see cref="NpgsqlRange{T}"/> on the left is equal to the <see cref="NpgsqlRange{T}"/> on the right; otherwise, false.
+        /// </returns>
         public static bool operator ==(NpgsqlRange<T> x, NpgsqlRange<T> y)
             => x.IsEmpty == y.IsEmpty &&
                (x.LowerBoundInfinite || y.LowerBoundInfinite || x.LowerBound.Equals(y.LowerBound)) &&
@@ -131,49 +199,215 @@ namespace NpgsqlTypes
                x.LowerBoundInfinite == y.LowerBoundInfinite &&
                x.UpperBoundInfinite == y.UpperBoundInfinite;
 
+        /// <summary>
+        /// Indicates whether the <see cref="NpgsqlRange{T}"/> on the left is not equal to the <see cref="NpgsqlRange{T}"/> on the right.
+        /// </summary>
+        /// <param name="x">The <see cref="NpgsqlRange{T}"/> on the left.</param>
+        /// <param name="y">The <see cref="NpgsqlRange{T}"/> on the right.</param>
+        /// <returns>
+        /// True if the <see cref="NpgsqlRange{T}"/> on the left is not equal to the <see cref="NpgsqlRange{T}"/> on the right; otherwise, false.
+        /// </returns>
         public static bool operator !=(NpgsqlRange<T> x, NpgsqlRange<T> y) => !(x == y);
 
-        public override bool Equals([CanBeNull] object o) => o is NpgsqlRange<T> && this == (NpgsqlRange<T>)o;
+        /// <inheritdoc />
+        public override bool Equals(object o) => o is NpgsqlRange<T> range && this == range;
 
+        /// <inheritdoc />
         public bool Equals(NpgsqlRange<T> other) => this == other;
 
+        /// <inheritdoc />
         public override int GetHashCode()
-            => IsEmpty ? 0 :
-                (LowerBoundInfinite ? 0 : LowerBound.GetHashCode()) +
-                (UpperBoundInfinite ? 0 : UpperBound.GetHashCode());
+            => IsEmpty
+                ? 0
+                : (LowerBoundInfinite ? 0 : LowerBound.GetHashCode()) +
+                  (UpperBoundInfinite ? 0 : UpperBound.GetHashCode());
 
+        /// <inheritdoc />
         public override string ToString()
         {
             if (IsEmpty)
                 return "empty";
+
             var sb = new StringBuilder();
-            if (LowerBoundInfinite)
-                sb.Append('(');
-            else
-            {
-                sb.Append(LowerBoundIsInclusive ? '[' : '(');
+
+            sb.Append(LowerBoundIsInclusive ? '[' : '(');
+
+            if (!LowerBoundInfinite)
                 sb.Append(LowerBound);
-            }
 
             sb.Append(',');
 
-            if (UpperBoundInfinite)
-                sb.Append(')');
-            else {
+            if (!UpperBoundInfinite)
                 sb.Append(UpperBound);
-                sb.Append(UpperBoundIsInclusive ? ']' : ')');
-            }
+
+            sb.Append(UpperBoundIsInclusive ? ']' : ')');
+
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Parses the well-known text representation of a PostgreSQL range type into a <see cref="NpgsqlRange{T}"/>.
+        /// </summary>
+        /// <param name="value">A PosgreSQL range type in a well-known text format.</param>
+        /// <returns>
+        /// The <see cref="NpgsqlRange{T}"/> represented by the <paramref name="value"/>.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// Invalid format for PostgreSQL range type.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Invalid format for PostgreSQL range type. Ranges must start with '(' or '['.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Invalid format for PostgreSQL range type. Ranges must start with '(' or '['.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Invalid format for PostgreSQL range type. Ranges must contain ','.
+        /// </exception>
+        /// <remarks>
+        /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
+        /// </remarks>
+        public static NpgsqlRange<T> Parse(in StringSegment value)
+        {
+            if (value.Length < 3)
+                throw new FormatException("Invalid format for PostgreSQL range type.");
+
+            if (value.Equals("empty", StringComparison.OrdinalIgnoreCase))
+                return Empty;
+
+            bool lowerInclusive = value[0] == '[';
+            bool lowerExclusive = value[0] == '(';
+
+            if (!lowerInclusive && !lowerExclusive)
+                throw new FormatException("Invalid format for PostgreSQL range type. Ranges must start with '(' or '['.");
+
+            bool upperInclusive = value[value.Length - 1] == ']';
+            bool upperExclusive = value[value.Length - 1] == ')';
+
+            if (!upperInclusive && !upperExclusive)
+                throw new FormatException("Invalid format for PostgreSQL range type. Ranges must end with ')' or ']'.");
+
+            int separator = value.IndexOf(',');
+
+            if (separator == -1)
+                throw new FormatException("Invalid format for PostgreSQL range type. Ranges must contain ','.");
+
+            if (separator != value.LastIndexOf(','))
+                // TODO: this should be replaced to handle quoted commas.
+                throw new NotSupportedException("Ranges with embedded commas are not currently supported.");
+
+            // Skip the opening bracket and stop short of the separator.
+            StringSegment lowerSegment = value.Subsegment(1, separator - 1);
+
+            // Skip past the separator and stop short of the closing bracket.
+            StringSegment upperSegment = value.Subsegment(separator + 1, value.Length - separator - 2);
+
+            bool lowerInfinite =
+                !lowerSegment.HasValue ||
+                lowerSegment.Equals(string.Empty, StringComparison.OrdinalIgnoreCase) ||
+                lowerSegment.Equals("null", StringComparison.OrdinalIgnoreCase) ||
+                lowerSegment.Equals("-infinity", StringComparison.OrdinalIgnoreCase);
+
+            bool upperInfinite =
+                !upperSegment.HasValue ||
+                upperSegment.Equals(string.Empty, StringComparison.OrdinalIgnoreCase) ||
+                upperSegment.Equals("null", StringComparison.OrdinalIgnoreCase) ||
+                upperSegment.Equals("infinity", StringComparison.OrdinalIgnoreCase);
+
+            TypeConverter typeConverter = TypeDescriptor.GetConverter(typeof(T));
+
+            T lower = lowerInfinite ? default : (T)typeConverter.ConvertFromString(lowerSegment.Value);
+            T upper = upperInfinite ? default : (T)typeConverter.ConvertFromString(upperSegment.Value);
+
+            if (lowerInclusive && lowerInfinite)
+                // PostgreSQL automatically converts '[-infinity,tody]' to '(-infinity,tody]'.
+                lowerInclusive = false;
+
+            if (upperInclusive && upperInfinite)
+                // PostgreSQL automatically converts '[tody,infinity]' to '[today,infinity)'.
+                upperInclusive = false;
+
+            return new NpgsqlRange<T>(lower, lowerInclusive, lowerInfinite, upper, upperInclusive, upperInfinite);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Represents a type converter for <see cref="NpgsqlRange{T}" />.
+        /// </summary>
+        [PublicAPI]
+        internal class RangeTypeConverter : TypeConverter
+        {
+            /// <inheritdoc />
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            {
+                return sourceType == typeof(string) || sourceType == typeof(StringSegment) || base.CanConvertFrom(context, sourceType);
+            }
+
+            /// <inheritdoc />
+            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            {
+                switch (value)
+                {
+                case string s:
+                {
+                    return Parse(s);
+                }
+                case StringSegment s:
+                {
+                    return Parse(s);
+                }
+                default:
+                {
+                    return base.ConvertFrom(context, culture, value);
+                }
+                }
+            }
+
+            /// <inheritdoc />
+            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+            {
+                return value.ToString();
+            }
         }
     }
 
+    /// <summary>
+    /// Represents characteristics of range type boundaries.
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
+    /// </remarks>
     [Flags]
     enum RangeFlags : byte
     {
+        /// <summary>
+        /// The default flag. This represents an error.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The range is empty. E.g. '(0,0)', 'empty'.
+        /// </summary>
         Empty = 1,
+
+        /// <summary>
+        /// The lower bound is inclusive. E.g. '[0,5]', '[0,5)', '[0,)'.
+        /// </summary>
         LowerBoundInclusive = 2,
+
+        /// <summary>
+        /// The upper bound is inclusive. E.g. '[0,5]', '(0,5]', '(,5]'.
+        /// </summary>
         UpperBoundInclusive = 4,
+
+        /// <summary>
+        /// The lower bound is infinite or indefinite. E.g. '(null,5]', '(-infinity,5]', '(,5]'.
+        /// </summary>
         LowerBoundInfinite = 8,
+
+        /// <summary>
+        /// The upper bound is infinite or indefinite. E.g. '[0,null)', '[0,infinity)', '[0,)'.
+        /// </summary>
         UpperBoundInfinite = 16
     }
 }

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -28,5 +28,5 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
   <PropertyGroup>
     <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyOriginatorKeyFile>../../Npgsql.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="../../src/Npgsql/Npgsql.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NLog" Version="4.5.4" />
@@ -16,10 +20,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Transactions" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  
 </Project>

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Npgsql;
-using Npgsql.Tests;
 using NpgsqlTypes;
 using NUnit.Framework;
 
@@ -190,5 +185,109 @@ namespace Npgsql.Tests.Types
             using (var conn = OpenConnection())
                 TestUtil.MinimumPgVersion(conn, "9.2.0");
         }
+
+        #region ParseTests
+
+        [Theory]
+        [TestCase("empty")]
+        [TestCase("EMPTY")]
+        public void GivenEmptyString_WhenConverted_ThenReturnsEmptyRange(string value)
+        {
+            // Act
+            NpgsqlRange<DateTime> result = NpgsqlRange<DateTime>.Parse(value);
+
+            // Assert
+            Assert.AreEqual(NpgsqlRange<DateTime>.Empty, result );
+        }
+
+        [Theory]
+        [TestCaseSource(nameof(DateTimeRangeTheoryData))]
+        public void GivenDateRangeString_WhenConverted_ThenReturnsDateRange(NpgsqlRange<DateTime> input)
+        {
+            // Arrange
+            string wellKnownText = input.ToString();
+
+            // Act
+            NpgsqlRange<DateTime> result = NpgsqlRange<DateTime>.Parse(wellKnownText);
+
+            // Assert
+            Assert.AreEqual(input, result);
+        }
+
+        #endregion
+
+        #region TheoryData
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly DateTime May_17_2018 = DateTime.Parse("2018-05-17");
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly DateTime May_18_2018 = DateTime.Parse("2018-05-18");
+
+        /// <summary>
+        /// Provides theory data for <see cref="NpgsqlRange{T}"/> of <see cref="DateTime"/>.
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        public static IEnumerable<object[]> DateTimeRangeTheoryData =>
+            new List<object[]>
+            {
+                // (2018-05-17, 2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, false) },
+
+                // [2018-05-17, 2018-05-18]
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, true, false) },
+
+                // [2018-05-17, 2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, false, false) },
+
+                // (2018-05-17, 2018-05-18]
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, true, false) },
+
+                // (,)
+                new object[] { new NpgsqlRange<DateTime>(default, false, true, default, false, true) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, true) },
+
+                // (2018-05-17,)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, default, false, true) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, true) },
+
+                // (,2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(default, false, true, May_18_2018, false, false) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, false) }
+            };
+
+        /// <summary>
+        /// Provides theory data for ranges.
+        /// </summary>
+        // ReSharper disable once MemberCanBePrivate.Global
+        public static IEnumerable<object[]> IntRangeTheoryData =>
+            new List<object[]>
+            {
+                // (2018-05-17, 2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, false) },
+
+                // [2018-05-17, 2018-05-18]
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, true, false) },
+
+                // [2018-05-17, 2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, false, false) },
+
+                // (2018-05-17, 2018-05-18]
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, true, false) },
+
+                // (,)
+                new object[] { new NpgsqlRange<DateTime>(default, false, true, default, false, true) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, true) },
+
+                // (2018-05-17,)
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, default, false, true) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, true) },
+
+                // (,2018-05-18)
+                new object[] { new NpgsqlRange<DateTime>(default, false, true, May_18_2018, false, false) },
+                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, false) }
+            };
+
+        #endregion
     }
 }

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -219,10 +219,10 @@ namespace Npgsql.Tests.Types
         #region TheoryData
 
         // ReSharper disable once InconsistentNaming
-        private static readonly DateTime May_17_2018 = DateTime.Parse("2018-05-17");
+        static readonly DateTime May_17_2018 = DateTime.Parse("2018-05-17");
 
         // ReSharper disable once InconsistentNaming
-        private static readonly DateTime May_18_2018 = DateTime.Parse("2018-05-18");
+        static readonly DateTime May_18_2018 = DateTime.Parse("2018-05-18");
 
         /// <summary>
         /// Provides theory data for <see cref="NpgsqlRange{T}"/> of <see cref="DateTime"/>.


### PR DESCRIPTION
# Overview

Range types in PostgreSQL are a breeze, but `NpgsqlRange<T>` can be complicated to work with. 

This PR is focused on improving `NpgsqlRange<T>` by:

 1. Simplifying construction
 2. Preventing bad states 
 3. Adding XML documentation
 4. Including a `TypeConverter`
 
## Simplifying construction

Currently, the fully specified constructor takes 6 arguments:

```c#
NpgsqlRange<int> range = new NpgsqlRange<int>(0, true, false, 5, true, false);
```

Contrast that with the range literal format in PostgreSQL:

```sql
SELECT '[0,5]'::int4range;
```

I've added a static method in https://github.com/npgsql/npgsql/commit/abbfe29174010e4ec36f0878c453ab7711ed3cd9 to parse the PostgreSQL range literal format:

```c#
NpgsqlRange<int> range = NpgsqlRange<int>.Parse("[0,5]");
```

I initially wrote `Parse` for a project that included `Microsoft.Extensions.Primitives.StringSegment`. I would prefer to keep using `StringSegment` here (nice API, reduce allocations), but it could be rewritten with low level `string`/`char[]` methods, if the added dependency is untenable...

## Preventing bad states

Currently, `NpgsqlRange<T>` uses private property setters via the constructors:
```c#
public bool LowerBoundIsInclusive
{
    get => (Flags & RangeFlags.LowerBoundInclusive) != 0;
    private set
    {
        if (value)
            Flags |= RangeFlags.LowerBoundInclusive;
       else
           Flags &= ~RangeFlags.LowerBoundInclusive;
    }
}
```

Given the arrival of `readonly struct`, I've attempted to rework the initialization logic to:
 1. Pass the initialization down to the `internal` constructor for consistency.
 2. Move the bitwise logic out of the setters and into a dedicated method.
 3. Add logic to guard against known bad states.
 4. Add recovery code for bad states that PostgreSQL would correct automatically (e.g. inclusive + infinite).
 5. Replaced the bitwise _checks_ with calls to `bool Enum.HasFlag(Enum)`.

Results:
```c#
/// <summary>
/// True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.
/// </summary>
public bool LowerBoundInfinite => Flags.HasFlag(RangeFlags.LowerBoundInfinite);
```

## Adding XML documentation

I've add some basic documentation to `NpgsqlRange<T>` and `RangeFlags`.

## Including a `TypeConverter`

I've added a `TypeConverter` as an internal nested class that calls up to the static `Parse(string)` method.

## Related items
https://github.com/npgsql/npgsql/issues/126#issue-24215665
https://github.com/npgsql/npgsql/issues/1418#issuecomment-280265251
https://github.com/npgsql/npgsql/pull/1493
