### PR TITLE
Changes to DateTime mapping

### DIFF
--- a/doc/release-notes/4.0.md
+++ b/doc/release-notes/4.0.md
@@ -60,6 +60,12 @@ In addition to more documentation, several blog posts are planned to explain the
 ## Breaking changes from 3.2
 
 > [!CAUTION]
+> The date/time behavior has changed in the following ways:
+> 1. `Datetime` is *always* sent as `timestamp` by default, regardless of its kind. You can still specify `NpgsqlDbType.TimestampTz`, in which case local `DateTime` gets converted to UTC before sending.
+> 2. When reading `timestamptz` as a `DateTimeOffset`, the machine local offset will be used. Previously a `DateTimeOffset` in UTC was returned.
+> 2. It is no longer possible to read or write `DateTimeOffset` as `timestamp`, only as `timestamptz`.
+
+> [!CAUTION]
 > The API for binary import (COPY IN) has changed substantially in a breaking way, and code from 3.2 will *not* work as-is on 4.0.
 >
 > You must now call `NpgsqlBinaryImporter.Complete()` to save your imported data; not doing so will roll the operation back. `NpgsqlBinaryImporter.Cancel()` has been removed - simply closing/disposing the importer will implicitly cancel the import. This is similar to how `TransactionScope` works and is necessary to prevent accidental commit of data on exception. See [#1646](https://github.com/npgsql/npgsql/issues/1646).

--- a/doc/types/basic.md
+++ b/doc/types/basic.md
@@ -166,10 +166,8 @@ For information about enums, [see the Enums and Composites page](enums_and_compo
 | NpgsqlTsQuery					| tsquery
 | NpgsqlTsVector				| tsvector
 | NpgsqlDate					| date
-| NpgsqlDateTime(Kind=Local,Unspecified)	| timestamp
-| NpgsqlDateTime(Kind=Utc)			| timestamptz
-| DateTime(Kind=Local,Unspecified)		| timestamp
-| DateTime(Kind=Utc)				| timestamptz
+| NpgsqlDateTime				| timestamp
+| DateTime					| timestamp
 | DateTimeOffset				| timestamptz
 | TimeSpan					| time
 | byte[]					| bytea

--- a/doc/types/datetime.md
+++ b/doc/types/datetime.md
@@ -45,34 +45,29 @@ Accordingly, your DateTime's Kind will determine the the timezone sent to the da
 
 ## Detailed Behavior: Sending values to the database
 
-.NET value                 | PG type               | Action
----------------------------|-----------------------|--------------------------------------------------
-DateTime(Kind=UTC)         | timestamp             | Send as-is
-DateTime(Kind=Local)       | timestamp (default)   | Send as-is
-DateTime(Kind=Unspecified) | timestamp (default)   | Send as-is
-DateTimeOffset             | timestamp             | Strip offset, send as-is
-                           |                       |
-DateTime(Kind=UTC)         | timestamptz (default) | Send as-is
-DateTime(Kind=Local)       | timestamptz           | Convert to UTC locally before sending
-DateTime(Kind=Unspecified) | timestamptz           | Send as-is
-DateTimeOffset             | timestamptz (default) | Convert to UTC locally before sending
-                           |                       |
-TimeSpan                   | time                  | Send as-is
-                           |                       |
-DateTime(Kind=UTC)         | timetz                | Send time and UTC timezone
-DateTime(Kind=Local)       | timetz                | Send time and local system timezone
-DateTime(Kind=Unspecified) | timetz                | Assume local, send time and local system timezone
-DateTimeOffset             | timetz                | Send time and timezone
+.NET value                     | PG type               | Action
+-------------------------------|-----------------------|--------------------------------------------------
+DateTime                       | timestamp (default)   | Send as-is
+                               |                       |
+DateTime(Kind=UTC,Unspecified) | timestamptz           | Send as-is
+DateTime(Kind=Local)           | timestamptz           | Convert to UTC locally before sending
+DateTimeOffset                 | timestamptz (default) | Convert to UTC locally before sending
+                               |                       |
+TimeSpan                       | time                  | Send as-is
+                               |                       |
+DateTime(Kind=UTC)             | timetz                | Send time and UTC timezone
+DateTime(Kind=Local)           | timetz                | Send time and local system timezone
+DateTime(Kind=Unspecified)     | timetz                | Assume local, send time and local system timezone
+DateTimeOffset                 | timetz                | Send time and timezone
 
 ## Detailed Behavior: Reading values from the database
 
 PG type     | .NET value               | Action
 ------------|--------------------------|--------------------------------------------------
 timestamp   | DateTime (default)       | Kind=Unspecified
-timestamp   | DateTimeOffset           | Should throw an exception?
             |                          |
-timestamptz | DateTime (default)       | Kind=Local (according to system tz)
-timestamptz | DateTimeOffset           | **Offset=UTC**
+timestamptz | DateTime (default)       | Kind=Local (according to system timezone)
+timestamptz | DateTimeOffset           | In local timezone offset
             |                          |
 time        | TimeSpan (default)       | As-is
 time        | DateTime                 | **Use only time component**

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -370,14 +370,10 @@ namespace Npgsql
         {
             get
             {
-                if (_npgsqlDbType.HasValue) {
+                if (_npgsqlDbType.HasValue)
                     return _npgsqlDbType.Value;
-                }
-
-                if (_value != null) {   // Infer from value
-                    return GlobalTypeMapper.Instance.ToNpgsqlDbType(_value);
-                }
-
+                if (_value != null)   // Infer from value
+                    return GlobalTypeMapper.Instance.ToNpgsqlDbType(_value.GetType());
                 return NpgsqlDbType.Unknown;
             }
             set
@@ -530,7 +526,7 @@ namespace Npgsql
             else if (_dbType.HasValue)
                 Handler = typeMapper.GetByDbType(_dbType.Value);
             else if (_value != null)
-                Handler = typeMapper.GetByValue(_value);
+                Handler = typeMapper.GetByClrType(_value.GetType());
             else
                 throw new InvalidOperationException($"Parameter '{ParameterName}' must have its value set");
         }
@@ -610,7 +606,7 @@ namespace Npgsql
         }
 
         object ICloneable.Clone() => Clone();
-      
+
         #endregion
     }
 }

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -77,14 +77,7 @@ namespace Npgsql
             else if (_dbType.HasValue)
                 Handler = typeMapper.GetByDbType(_dbType.Value);
             else if (TypedValue != null)
-            {
-                // DateTime/NpgsqlDateTime are mapped to timestamp/timestamptz based on their
-                // Kind, so we need a special hack here
-                if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(NpgsqlDateTime))
-                    Handler = typeMapper.GetByValue(TypedValue);   // Yeah, this boxes
-                else
-                    Handler = typeMapper.GetByClrType(typeof(T));
-            }
+                Handler = typeMapper.GetByClrType(typeof(T));
             else
                 throw new InvalidOperationException($"Parameter '{ParameterName}' must have its value set");
         }

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
@@ -41,7 +41,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-datetime.html
     /// </remarks>
-    class TimestampHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>
+    class TimestampHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>
     {
         internal const uint TypeOID = 1114;
 
@@ -159,15 +159,6 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             }
         }
 
-        protected virtual DateTimeOffset ReadDateTimeOffset(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
-        {
-            buf.Skip(len);
-            throw new NpgsqlSafeReadException(new InvalidCastException("Only writing of DateTimeOffset to PostgreSQL timestamp is supported, not reading."));
-        }
-
-        DateTimeOffset INpgsqlSimpleTypeHandler<DateTimeOffset>.Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
-            => ReadDateTimeOffset(buf, len, fieldDescription);
-
         #endregion Read
 
         #region Write
@@ -176,9 +167,6 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             => 8;
 
         public override int ValidateAndGetLength(NpgsqlDateTime value, NpgsqlParameter parameter)
-            => 8;
-
-        public int ValidateAndGetLength(DateTimeOffset value, NpgsqlParameter parameter)
             => 8;
 
         public override void Write(NpgsqlDateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
@@ -268,9 +256,6 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             }
             Write(new NpgsqlDateTime(value), buf, parameter);
         }
-
-        public virtual void Write(DateTimeOffset value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => Write(new NpgsqlDateTime(value.DateTime), buf, parameter);
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -42,7 +42,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-datetime.html
     /// </remarks>
-    class TimestampTzHandler : TimestampHandler
+    class TimestampTzHandler : TimestampHandler, INpgsqlSimpleTypeHandler<DateTimeOffset>
     {
         public TimestampTzHandler(bool integerFormat, bool convertInfinityDateTime)
             : base(integerFormat, convertInfinityDateTime) {}
@@ -73,11 +73,19 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             return new NpgsqlDateTime(ts.Date, ts.Time, DateTimeKind.Utc).ToLocalTime();
         }
 
-        protected override DateTimeOffset ReadDateTimeOffset(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
+        DateTimeOffset INpgsqlSimpleTypeHandler<DateTimeOffset>.Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
         {
+            // TODO: Convert directly to DateTime without passing through NpgsqlTimeStamp?
+            var ts = ReadTimeStamp(buf, len, fieldDescription);
             try
             {
-                return new DateTimeOffset(ReadTimeStamp(buf, len, fieldDescription).ToDateTime(), TimeSpan.Zero);
+                if (ts.IsFinite)
+                    return ts.ToDateTime().ToLocalTime();
+                if (!ConvertInfinityDateTime)
+                    throw new InvalidCastException("Can't convert infinite timestamptz values to DateTime");
+                if (ts.IsInfinity)
+                    return DateTimeOffset.MaxValue;
+                return DateTimeOffset.MinValue;
             } catch (Exception e) {
                 throw new NpgsqlSafeReadException(e);
             }
@@ -86,6 +94,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         #endregion Read
 
         #region Write
+
+        public int ValidateAndGetLength(DateTimeOffset value, NpgsqlParameter parameter)
+            => 8;
 
         public override void Write(NpgsqlDateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
         {
@@ -119,8 +130,8 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             base.Write(value, buf, parameter);
         }
 
-        public override void Write(DateTimeOffset value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => base.Write(value.ToUniversalTime(), buf, parameter);
+        public void Write(DateTimeOffset value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
+            => base.Write(value.ToUniversalTime().DateTime, buf, parameter);
 
         #endregion Write
     }

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -130,30 +130,7 @@ namespace Npgsql.TypeMapping
             throw new NotSupportedException("Could not find PostgreSQL type " + typeName);
         }
 
-        internal NpgsqlTypeHandler GetByValue(object value)
-        {
-            Debug.Assert(value != null);
-
-            if (value is DateTime)
-            {
-                return ((DateTime)value).Kind == DateTimeKind.Utc
-                    ? GetByNpgsqlDbType(NpgsqlDbType.TimestampTz)
-                    : GetByNpgsqlDbType(NpgsqlDbType.Timestamp);
-            }
-
-            if (value is NpgsqlDateTime)
-            {
-                return ((NpgsqlDateTime)value).Kind == DateTimeKind.Utc
-                    ? GetByNpgsqlDbType(NpgsqlDbType.TimestampTz)
-                    : GetByNpgsqlDbType(NpgsqlDbType.Timestamp);
-            }
-
-            return GetByClrType(value.GetType());
-        }
-
-#pragma warning disable CA1043
         internal NpgsqlTypeHandler GetByClrType(Type type)
-#pragma warning restore CA1043
         {
             if (_byClrType.TryGetValue(type, out var handler))
                 return handler;

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -149,26 +149,7 @@ namespace Npgsql.TypeMapping
         internal DbType ToDbType(Type type)
             => _typeToDbType.TryGetValue(type, out var dbType) ? dbType : DbType.Object;
 
-        internal NpgsqlDbType ToNpgsqlDbType(object value)
-        {
-            if (value is DateTime)
-            {
-                return ((DateTime)value).Kind == DateTimeKind.Utc
-                    ? NpgsqlDbType.TimestampTz
-                    : NpgsqlDbType.Timestamp;
-            }
-
-            if (value is NpgsqlDateTime)
-            {
-                return ((NpgsqlDateTime)value).Kind == DateTimeKind.Utc
-                    ? NpgsqlDbType.TimestampTz
-                    : NpgsqlDbType.Timestamp;
-            }
-
-            return ToNpgsqlDbType(value.GetType());
-        }
-
-        NpgsqlDbType ToNpgsqlDbType(Type type)
+        internal NpgsqlDbType ToNpgsqlDbType(Type type)
         {
             if (_typeToNpgsqlDbType.TryGetValue(type, out var npgsqlDbType))
                 return npgsqlDbType;

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -234,19 +234,16 @@ namespace Npgsql.Tests.Types
         {
             using (var conn = OpenConnection())
             {
-                var npgsqlTimeStamp = new NpgsqlDateTime(dateTime.Ticks);
-                var offset = TimeSpan.FromHours(2);
-                var dateTimeOffset = new DateTimeOffset(dateTime, offset);
+                var npgsqlDateTime = new NpgsqlDateTime(dateTime.Ticks);
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6, @p7", conn))
+                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6", conn))
                 {
                     var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Timestamp);
                     var p2 = new NpgsqlParameter("p2", DbType.DateTime);
                     var p3 = new NpgsqlParameter("p3", DbType.DateTime2);
-                    var p4 = new NpgsqlParameter { ParameterName = "p4", Value = npgsqlTimeStamp };
+                    var p4 = new NpgsqlParameter { ParameterName = "p4", Value = npgsqlDateTime };
                     var p5 = new NpgsqlParameter { ParameterName = "p5", Value = dateTime };
-                    var p6 = new NpgsqlParameter("p6", NpgsqlDbType.Timestamp);
-                    var p7 = new NpgsqlParameter<DateTime> { ParameterName = "p7", TypedValue = dateTime };
+                    var p6 = new NpgsqlParameter<DateTime> { ParameterName = "p6", TypedValue = dateTime };
                     Assert.That(p4.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
                     Assert.That(p4.DbType, Is.EqualTo(DbType.DateTime));
                     Assert.That(p5.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
@@ -257,9 +254,7 @@ namespace Npgsql.Tests.Types
                     cmd.Parameters.Add(p4);
                     cmd.Parameters.Add(p5);
                     cmd.Parameters.Add(p6);
-                    cmd.Parameters.Add(p7);
-                    p1.Value = p2.Value = p3.Value = npgsqlTimeStamp;
-                    p6.Value = dateTimeOffset;
+                    p1.Value = p2.Value = p3.Value = npgsqlDateTime;
                     using (var reader = cmd.ExecuteReader())
                     {
                         reader.Read();
@@ -275,10 +270,10 @@ namespace Npgsql.Tests.Types
                             Assert.That(reader.GetValue(i), Is.EqualTo(dateTime));
 
                             // Provider-specific type (NpgsqlTimeStamp)
-                            Assert.That(reader.GetTimeStamp(i), Is.EqualTo(npgsqlTimeStamp));
+                            Assert.That(reader.GetTimeStamp(i), Is.EqualTo(npgsqlDateTime));
                             Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
-                            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlTimeStamp));
-                            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(npgsqlTimeStamp));
+                            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDateTime));
+                            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(npgsqlDateTime));
 
                             // DateTimeOffset
                             Assert.That(() => reader.GetFieldValue<DateTimeOffset>(i), Throws.Exception.TypeOf<InvalidCastException>());
@@ -353,9 +348,10 @@ namespace Npgsql.Tests.Types
                 var nDateTimeLocal = nDateTimeUtc.ToLocalTime();
                 var nDateTimeUnspecified = new NpgsqlDateTime(nDateTimeUtc.Ticks, DateTimeKind.Unspecified);
 
-                var dateTimeOffset = new DateTimeOffset(dateTimeLocal, dateTimeLocal - dateTimeUtc);
+                //var dateTimeOffset = new DateTimeOffset(dateTimeLocal, dateTimeLocal - dateTimeUtc);
+                var dateTimeOffset = new DateTimeOffset(dateTimeLocal);
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9", conn))
+                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6, @p7", conn))
                 {
                     cmd.Parameters.AddWithValue("p1", NpgsqlDbType.TimestampTz, dateTimeUtc);
                     cmd.Parameters.AddWithValue("p2", NpgsqlDbType.TimestampTz, dateTimeLocal);
@@ -363,12 +359,8 @@ namespace Npgsql.Tests.Types
                     cmd.Parameters.AddWithValue("p4", NpgsqlDbType.TimestampTz, nDateTimeUtc);
                     cmd.Parameters.AddWithValue("p5", NpgsqlDbType.TimestampTz, nDateTimeLocal);
                     cmd.Parameters.AddWithValue("p6", NpgsqlDbType.TimestampTz, nDateTimeUnspecified);
-                    cmd.Parameters.AddWithValue("p7", dateTimeUtc);
+                    cmd.Parameters.AddWithValue("p7", dateTimeOffset);
                     Assert.That(cmd.Parameters["p7"].NpgsqlDbType, Is.EqualTo(NpgsqlDbType.TimestampTz));
-                    cmd.Parameters.AddWithValue("p8", nDateTimeUtc);
-                    Assert.That(cmd.Parameters["p8"].NpgsqlDbType, Is.EqualTo(NpgsqlDbType.TimestampTz));
-                    cmd.Parameters.AddWithValue("p9", dateTimeOffset);
-                    Assert.That(cmd.Parameters["p9"].NpgsqlDbType, Is.EqualTo(NpgsqlDbType.TimestampTz));
 
                     using (var reader = cmd.ExecuteReader())
                     {
@@ -390,7 +382,8 @@ namespace Npgsql.Tests.Types
                             Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(nDateTimeLocal));
 
                             // DateTimeOffset
-                            Assert.That(reader.GetFieldValue<DateTimeOffset>(i), Is.EqualTo(dateTimeOffset.ToUniversalTime()));
+                            Assert.That(reader.GetFieldValue<DateTimeOffset>(i), Is.EqualTo(dateTimeOffset));
+                            var x = reader.GetFieldValue<DateTimeOffset>(i);
                         }
                     }
                 }


### PR DESCRIPTION
1. Datetime is *always* sent as timestamp by default, regardless of its kind. You can still specify `NpgsqlDbType.TimestampTz`, in which case local `DateTime` gets converted to UTC before sending.

2. When reading timestamptz as a DateTimeOffset, the machine local  offset will be used. Previously a DateTimeOffset in UTC was returned.

3. It is no longer possible to read or write DateTimeOffset as timestamp, only as timestamptz.