### PR TITLE
Change UseNodatime to UseNodaTime as documented

### DIFF
--- a/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
@@ -33,7 +33,7 @@ namespace Npgsql
     /// <summary>
     /// Extension adding the NodaTime plugin to an Npgsql type mapper.
     /// </summary>
-    public static class NpgsqlNodatimeExtensions
+    public static class NpgsqlNodaTimeExtensions
     {
         /// <summary>
         /// Sets up NodaTime mappings for the PostgreSQL date/time types.

--- a/src/Npgsql.NodaTime/NpgsqlNodatimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodatimeExtensions.cs
@@ -39,7 +39,7 @@ namespace Npgsql
         /// Sets up NodaTime mappings for the PostgreSQL date/time types.
         /// </summary>
         /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
-        public static INpgsqlTypeMapper UseNodatime(this INpgsqlTypeMapper mapper)
+        public static INpgsqlTypeMapper UseNodaTime(this INpgsqlTypeMapper mapper)
             => mapper
                 .AddMapping(new NpgsqlTypeMappingBuilder
                 {

--- a/test/Npgsql.PluginTests/NodaTimeTests.cs
+++ b/test/Npgsql.PluginTests/NodaTimeTests.cs
@@ -370,7 +370,7 @@ namespace Npgsql.PluginTests
         {
             var conn = new NpgsqlConnection(connectionString ?? ConnectionString);
             conn.Open();
-            conn.TypeMapper.UseNodatime();
+            conn.TypeMapper.UseNodaTime();
             return conn;
         }
 


### PR DESCRIPTION
It's unfortunate that this shipped as `UseNodatime`, but I hope it's not too late to change it. This would make it consistent with the documentation and the EF extension method.