### PR TITLE
Changes to NpgsqlRange<T> equality and hashing

### DIFF
--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -180,6 +180,36 @@ namespace Npgsql.Tests.Types
             Assert.IsFalse(r3 == r4);
         }
 
+        [Test]
+        public void RangeHashCode_ValueTypes()
+        {
+            NpgsqlRange<int> a = default;
+            NpgsqlRange<int> b = NpgsqlRange<int>.Empty;
+            NpgsqlRange<int> c = NpgsqlRange<int>.Parse("(,)");
+
+            Assert.IsFalse(a.Equals(b));
+            Assert.IsFalse(a.Equals(c));
+            Assert.IsFalse(b.Equals(c));
+            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), c.GetHashCode());
+            Assert.AreNotEqual(b.GetHashCode(), c.GetHashCode());
+        }
+
+        [Test]
+        public void RangeHashCode_ReferenceTypes()
+        {
+            NpgsqlRange<string> a= default;
+            NpgsqlRange<string> b = NpgsqlRange<string>.Empty;
+            NpgsqlRange<string> c = NpgsqlRange<string>.Parse("(,)");
+
+            Assert.IsFalse(a.Equals(b));
+            Assert.IsFalse(a.Equals(c));
+            Assert.IsFalse(b.Equals(c));
+            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
+            Assert.AreNotEqual(a.GetHashCode(), c.GetHashCode());
+            Assert.AreNotEqual(b.GetHashCode(), c.GetHashCode());
+        }
+
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {


### PR DESCRIPTION
This PR addresses the [post-merge review](https://github.com/npgsql/npgsql/pull/1939#pullrequestreview-122852053) from #1939.

- Simplifies the equality logic:
  - Null checks should be elided by the JIT when T is a struct.
  - This also applies to the logic in IsEmptyRange().

- Modifies the hashing logic:
  - The hash code of a default struct should be zero.
  - RangeFlags.Empty is not the default flag (i.e. RangeFlags.Empty == 1).
  - The default initialized NpgsqlRange<T> is definite-exclusive, not empty.
  - Added tests to verify.

Here's the output of the [updated](https://github.com/npgsql/npgsql/pull/1939#issuecomment-391596412) benchmarks:

```c#
[MemoryDiagnoser]
public class NpgsqlRangeEquality
{
    static readonly NpgsqlRange<int> EmptyIntRange = NpgsqlRange<int>.Empty;
    static readonly NpgsqlRange<int> IntRange1 = NpgsqlRange<int>.Parse("(0,1)");
    static readonly NpgsqlRange<int> IntRange2 = IntRange1;

    static readonly NpgsqlRange<string> EmptyStringRange = NpgsqlRange<string>.Empty;
    static readonly NpgsqlRange<string> StringRange1 = NpgsqlRange<string>.Parse("(a,b)");
    static readonly NpgsqlRange<string> StringRange2 = StringRange1;

    [Benchmark(Baseline = true)]
    public bool Equals1() => EmptyIntRange == IntRange1;

    [Benchmark]
    public bool Equals2() => IntRange1 == IntRange2;

    [Benchmark]
    public bool Equals3() => EmptyStringRange == StringRange1;

    [Benchmark]
    public bool Equals4() => StringRange1 == StringRange2;
}
```
```
.NET Core SDK=2.1.300-rc1-008673
  [Host]     : .NET Core 2.1.0-rc1 (CoreCLR 4.6.26426.02, CoreFX 4.6.26426.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rc1 (CoreCLR 4.6.26426.02, CoreFX 4.6.26426.04), 64bit RyuJIT

  Method |      Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
-------- |----------:|----------:|----------:|-------:|---------:|-------:|----------:|
 Equals1 |  3.863 ns | 0.1180 ns | 0.3424 ns |   1.00 |     0.00 |      - |       0 B |
 Equals2 | 18.480 ns | 0.4019 ns | 0.4935 ns |   4.82 |     0.43 | 0.0229 |      48 B |
 Equals3 | 14.366 ns | 0.1114 ns | 0.0870 ns |   3.75 |     0.32 |      - |       0 B |
 Equals4 | 34.971 ns | 0.1556 ns | 0.1299 ns |   9.12 |     0.77 |      - |       0 B |
```

> For the benchmarks, the most important part for us here is the fact that there are zero allocations. A few nanos here or there make very little difference - especially in a code-path which can be considered non-hot - but allocations quickly add up and have a perf impact on the application as a whole by creating more GC pressure.

Based on `Equals2()`, it looks like the bounds (when `T` is `ValueType`) are being boxed on the cast to `IEquatable<T>`. But since we don't constrain `T`  to `IEquatable<T>`, wouldn't boxing be [unavoidable](https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.constrained.aspx)?

@roji I'm not sure how to approach this. Any advice?