### PR TITLE
Remove string conversions from type handlers and correct documentation

### DIFF
--- a/doc/types/basic.md
+++ b/doc/types/basic.md
@@ -28,21 +28,21 @@ citext				| string			|				| char[]
 json				| string			|				| char[]
 jsonb				| string			|				| char[]
 xml				| string			|				| char[]
-point				| NpgsqlPoint			|				| string
-lseg				| NpgsqlLSeg			|				| string
+point				| NpgsqlPoint			|				|
+lseg				| NpgsqlLSeg			|				|
 path				| NpgsqlPath			|				|
 polygon				| NpgsqlPolygon			|				|
-line				| NpgsqlLine			|				| string
-circle				| NpgsqlCircle			|				| string
-box				| NpgsqlBox			|				| string
+line				| NpgsqlLine			|				|
+circle				| NpgsqlCircle			|				|
+box				| NpgsqlBox			|				|
 bit(1)				| bool				|				| BitArray
 bit(n)				| BitArray			|				|
 bit varying			| BitArray			|				|
 hstore				| IDictionary<string, string>	|				|
-uuid				| Guid				|				| string
-cidr				| ValueTuple<IPAddress, int>	|				| NpgsqlInet, string
-inet				| IPAddress			| ValueTuple<IPAddress, int>	| NpgsqlInet, string
-macaddr				| PhysicalAddress		|				| string
+uuid				| Guid				|				|
+cidr				| ValueTuple<IPAddress, int>	|				| NpgsqlInet
+inet				| IPAddress			| ValueTuple<IPAddress, int>	| NpgsqlInet
+macaddr				| PhysicalAddress		|				|
 tsquery				| NpgsqlTsQuery			|				|
 tsvector			| NpgsqlTsVector		|				|
 date				| DateTime			| NpgsqlDate			|
@@ -109,17 +109,17 @@ Box		|			| box				| NpgsqlBox
 Bit		|			| bit				| BitArray, bool, string
 Varbit		|			| bit varying			| BitArray, bool, string
 Hstore		|			| hstore			| IDictionary<string, string>
-Uuid		|			| uuid				| Guid, string
+Uuid		|			| uuid				| Guid
 Cidr		|			| cidr				| ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
 Inet		|			| inet				| ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
 MacAddr		|			| macaddr			| PhysicalAddress
 TsQuery		|			| tsquery			| NpgsqlTsQuery
 TsVector	|			| tsvector			| NpgsqlTsVector
 Date		| Date			| date				| DateTime, NpgsqlDate
-Interval	|			| interval			| TimeSpan, NpgsqlTimeSpan, string
+Interval	|			| interval			| TimeSpan, NpgsqlTimeSpan
 Timestamp	| DateTime, DateTime2	| timestamp			| DateTime, DateTimeOffset, NpgsqlDateTime
 TimestampTz	| DateTimeOffset	| timestamp with time zone	| DateTime, DateTimeOffset, NpgsqlDateTime
-Time		| Time			| time				| TimeSpan, string
+Time		| Time			| time				| TimeSpan
 TimeTz		|			| time with time zone		| DateTimeOffset, DateTime, TimeSpan
 Bytea		| Binary		| bytea				| byte[], ArraySegment\<byte>
 Oid		|			| oid				| uint

--- a/src/Npgsql/TypeHandlers/InternalTypesHandlers/TidHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypesHandlers/TidHandler.cs
@@ -32,7 +32,7 @@ using NpgsqlTypes;
 namespace Npgsql.TypeHandlers.InternalTypesHandlers
 {
     [TypeMapping("tid", NpgsqlDbType.Tid, typeof(NpgsqlTid))]
-    class TidHandler : NpgsqlSimpleTypeHandler<NpgsqlTid>, INpgsqlSimpleTypeHandler<string>
+    class TidHandler : NpgsqlSimpleTypeHandler<NpgsqlTid>
     {
         #region Read
 
@@ -46,9 +46,6 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
             return new NpgsqlTid(blockNumber, offsetNumber);
         }
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -61,12 +58,6 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
             buf.WriteUInt32(value.BlockNumber);
             buf.WriteUInt16(value.OffsetNumber);
         }
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-            => throw new NotSupportedException("Only reading PostgreSQL tid to string is supported, no writing.");
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => throw new NotSupportedException("Only reading PostgreSQL tid to string is supported, no writing.");
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/CidrHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/CidrHandler.cs
@@ -37,8 +37,7 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
     [TypeMapping("cidr", NpgsqlDbType.Cidr)]
-    class CidrHandler : NpgsqlSimpleTypeHandler<(IPAddress Address, int Subnet)>, INpgsqlSimpleTypeHandler<NpgsqlInet>,
-        INpgsqlSimpleTypeHandler<string>
+    class CidrHandler : NpgsqlSimpleTypeHandler<(IPAddress Address, int Subnet)>, INpgsqlSimpleTypeHandler<NpgsqlInet>
     {
         public override (IPAddress Address, int Subnet) Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
             => InetHandler.DoRead(buf, len, fieldDescription, true);
@@ -49,25 +48,16 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             return new NpgsqlInet(address, subnet);
         }
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => ((INpgsqlSimpleTypeHandler<NpgsqlInet>)this).Read(buf, len, fieldDescription).ToString();
-
         public override int ValidateAndGetLength((IPAddress Address, int Subnet) value, NpgsqlParameter parameter)
             => InetHandler.GetLength(value.Address);
 
         public int ValidateAndGetLength(NpgsqlInet value, NpgsqlParameter parameter)
             => InetHandler.GetLength(value.Address);
 
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-            => InetHandler.GetLength(IPAddress.Parse(value));
-
         public override void Write((IPAddress Address, int Subnet) value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => InetHandler.DoWrite(value.Address, value.Subnet, buf, true);
 
         public void Write(NpgsqlInet value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => InetHandler.DoWrite(value.Address, value.Netmask, buf, true);
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => InetHandler.DoWrite(IPAddress.Parse(value), -1, buf, true);
     }
 }

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -40,7 +40,7 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     /// </remarks>
     [TypeMapping("inet", NpgsqlDbType.Inet, new[] { typeof(IPAddress), typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet) })]
     class InetHandler : NpgsqlSimpleTypeHandlerWithPsv<IPAddress, (IPAddress Address, int Subnet)>,
-        INpgsqlSimpleTypeHandler<NpgsqlInet>, INpgsqlSimpleTypeHandler<string>
+        INpgsqlSimpleTypeHandler<NpgsqlInet>
     {
         // ReSharper disable InconsistentNaming
         const byte IPv4 = 2;
@@ -81,9 +81,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             return new NpgsqlInet(address, subnet);
         }
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => ((INpgsqlSimpleTypeHandler<NpgsqlInet>)this).Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -97,9 +94,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
         public int ValidateAndGetLength(NpgsqlInet value, NpgsqlParameter parameter)
             => GetLength(value.Address);
 
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-            => GetLength(IPAddress.Parse(value));
-
         public override void Write(IPAddress value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => DoWrite(value, -1, buf, false);
 
@@ -108,9 +102,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
 
         public void Write(NpgsqlInet value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => DoWrite(value.Address, value.Netmask, buf, false);
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => DoWrite(IPAddress.Parse(value), -1, buf, false);
 
         internal static void DoWrite(IPAddress ip, int mask, NpgsqlWriteBuffer buf, bool isCidrHandler)
         {

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/Macaddr8Handler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/Macaddr8Handler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
     [TypeMapping("macaddr8", NpgsqlDbType.MacAddr8)]
-    class Macaddr8Handler : NpgsqlSimpleTypeHandler<PhysicalAddress>, INpgsqlSimpleTypeHandler<string>
+    class Macaddr8Handler : NpgsqlSimpleTypeHandler<PhysicalAddress>
     {
         #region Read
 
@@ -49,9 +49,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             buf.ReadBytes(bytes, 0, len);
             return new PhysicalAddress(bytes);
         }
-
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
 
         #endregion Read
 
@@ -70,17 +67,11 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             }
         }
 
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-            => ValidateAndGetLength(PhysicalAddress.Parse(value), parameter);
-
         public override void Write(PhysicalAddress value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
         {
             var bytes = value.GetAddressBytes();
             buf.WriteBytes(bytes, 0, bytes.Length);
         }
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => Write(PhysicalAddress.Parse(value), buf, parameter);
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/MacaddrHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/MacaddrHandler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
     [TypeMapping("macaddr", NpgsqlDbType.MacAddr, typeof(PhysicalAddress))]
-    class MacaddrHandler : NpgsqlSimpleTypeHandler<PhysicalAddress>, INpgsqlSimpleTypeHandler<string>
+    class MacaddrHandler : NpgsqlSimpleTypeHandler<PhysicalAddress>
     {
         #region Read
 
@@ -50,9 +50,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             return new PhysicalAddress(bytes);
         }
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -62,14 +59,8 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
                  ? 6
                  : throw new FormatException("MAC addresses must have length 6 in PostgreSQL");
 
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-            => ValidateAndGetLength(PhysicalAddress.Parse(value), parameter);
-
         public override void Write(PhysicalAddress value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteBytes(value.GetAddressBytes(), 0, 6);
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => Write(PhysicalAddress.Parse(value), buf, parameter);
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
@@ -39,8 +39,7 @@ namespace Npgsql.TypeHandlers.NumericHandlers
     [TypeMapping("smallint", NpgsqlDbType.Smallint, new[] { DbType.Int16, DbType.Byte, DbType.SByte }, new[] { typeof(short), typeof(byte), typeof(sbyte) }, DbType.Int16)]
     class Int16Handler : NpgsqlSimpleTypeHandler<short>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<sbyte>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>,
-        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>,
-        INpgsqlSimpleTypeHandler<string>
+        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {
         #region Read
 
@@ -68,9 +67,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         decimal INpgsqlSimpleTypeHandler<decimal>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -83,15 +79,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public int ValidateAndGetLength(float value, NpgsqlParameter parameter)          => 2;
         public int ValidateAndGetLength(double value, NpgsqlParameter parameter)         => 2;
         public int ValidateAndGetLength(decimal value, NpgsqlParameter parameter)        => 2;
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-        {
-            var converted = Convert.ToInt16(value);
-            if (parameter == null)
-                throw CreateConversionButNoParamException(value.GetType());
-            parameter.ConvertedValue = converted;
-            return 2;
-        }
 
         public override void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt16(value);
@@ -109,12 +96,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.WriteInt16(checked((short)value));
         public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt16(checked((short)value));
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-        {
-            Debug.Assert(parameter != null);
-            buf.WriteInt16((short)parameter.ConvertedValue);
-        }
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
@@ -39,8 +39,7 @@ namespace Npgsql.TypeHandlers.NumericHandlers
     [TypeMapping("integer", NpgsqlDbType.Integer, DbType.Int32, typeof(int))]
     class Int32Handler : NpgsqlSimpleTypeHandler<int>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<long>,
-        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>,
-        INpgsqlSimpleTypeHandler<string>
+        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {
         #region Read
 
@@ -65,9 +64,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         decimal INpgsqlSimpleTypeHandler<decimal>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -79,15 +75,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public int ValidateAndGetLength(double value, NpgsqlParameter parameter)       => 4;
         public int ValidateAndGetLength(decimal value, NpgsqlParameter parameter)      => 4;
         public int ValidateAndGetLength(byte value, NpgsqlParameter parameter)         => 4;
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-        {
-            var converted = Convert.ToInt32(value);
-            if (parameter == null)
-                throw CreateConversionButNoParamException(value.GetType());
-            parameter.ConvertedValue = converted;
-            return 4;
-        }
 
         public override void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt32(value);
@@ -103,11 +90,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.WriteInt32(checked((int)value));
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt32((int)value);
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-        {
-            Debug.Assert(parameter != null);
-            buf.WriteInt32((int)parameter.ConvertedValue);
-        }
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
@@ -39,8 +39,7 @@ namespace Npgsql.TypeHandlers.NumericHandlers
     [TypeMapping("bigint", NpgsqlDbType.Bigint, DbType.Int64, typeof(long))]
     class Int64Handler : NpgsqlSimpleTypeHandler<long>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>,
-        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>,
-        INpgsqlSimpleTypeHandler<string>
+        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {
         #region Read
 
@@ -65,9 +64,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         decimal INpgsqlSimpleTypeHandler<decimal>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => Read(buf, len, fieldDescription);
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -79,15 +75,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         public int ValidateAndGetLength(double value, NpgsqlParameter parameter)        => 8;
         public int ValidateAndGetLength(decimal value, NpgsqlParameter parameter)       => 8;
         public int ValidateAndGetLength(byte value, NpgsqlParameter parameter)          => 8;
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-        {
-            var converted = Convert.ToInt64(value);
-            if (parameter == null)
-                throw CreateConversionButNoParamException(value.GetType());
-            parameter.ConvertedValue = converted;
-            return 8;
-        }
 
         public override void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt64(value);
@@ -103,11 +90,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => buf.WriteInt64(checked((long)value));
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteInt64((long)value);
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-        {
-            Debug.Assert(parameter != null);
-            buf.WriteInt64((long)parameter.ConvertedValue);
-        }
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -65,8 +65,7 @@ namespace Npgsql.TypeHandlers.NumericHandlers
     [TypeMapping("numeric", NpgsqlDbType.Numeric, new[] { DbType.Decimal, DbType.VarNumeric }, typeof(decimal), DbType.Decimal)]
     class NumericHandler : NpgsqlSimpleTypeHandler<decimal>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>,
-        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>,
-        INpgsqlSimpleTypeHandler<string>
+        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>
     {
         #region Read
 
@@ -184,9 +183,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         double INpgsqlSimpleTypeHandler<double>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
             => (double)Read(buf, len, fieldDescription);
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #endregion Read
 
         #region Write
@@ -218,15 +214,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => ValidateAndGetLength((decimal) value, parameter);
         public int ValidateAndGetLength(byte value, NpgsqlParameter parameter)
             => ValidateAndGetLength((decimal) value, parameter);
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-        {
-            var converted = Convert.ToDecimal(value);
-            if (parameter == null)
-                throw CreateConversionButNoParamException(value.GetType());
-            parameter.ConvertedValue = converted;
-            return ValidateAndGetLength(converted, parameter);
-        }
 
         public override void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
         {
@@ -266,11 +253,6 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             => Write((decimal)value, buf, parameter);
         public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => Write((decimal)value, buf, parameter);
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-        {
-            Debug.Assert(parameter != null);
-            Write((decimal)parameter.ConvertedValue, buf, parameter);
-        }
 
         void GetNumericHeader(decimal num, out int numGroups, out int weight, out int fractionDigits)
         {

--- a/src/Npgsql/TypeHandlers/UuidHandler.cs
+++ b/src/Npgsql/TypeHandlers/UuidHandler.cs
@@ -34,7 +34,7 @@ namespace Npgsql.TypeHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-uuid.html
     /// </remarks>
     [TypeMapping("uuid", NpgsqlDbType.Uuid, DbType.Guid, typeof(Guid))]
-    class UuidHandler : NpgsqlSimpleTypeHandler<Guid>, INpgsqlSimpleTypeHandler<string>
+    class UuidHandler : NpgsqlSimpleTypeHandler<Guid>
     {
         public override Guid Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
         {
@@ -46,25 +46,10 @@ namespace Npgsql.TypeHandlers
             return new Guid(a, b, c, d);
         }
 
-        string INpgsqlSimpleTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription)
-            => Read(buf, len, fieldDescription).ToString();
-
         #region Write
 
         public override int ValidateAndGetLength(Guid value, NpgsqlParameter parameter)
             => 16;
-
-        public int ValidateAndGetLength(string value, NpgsqlParameter parameter)
-        {
-            var converted = Guid.Parse(value);
-            if (parameter == null)
-                throw CreateConversionButNoParamException(value.GetType());
-            parameter.ConvertedValue = converted;
-            return 16;
-        }
-
-        public void Write(string value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => Write((Guid)parameter.ConvertedValue, buf, parameter);
 
         public override void Write(Guid value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
         {

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -158,7 +158,6 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetGuid(i), Is.EqualTo(expected));
                         Assert.That(reader.GetFieldValue<Guid>(i), Is.EqualTo(expected));
                         Assert.That(reader.GetValue(i), Is.EqualTo(expected));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expected.ToString()));
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Guid)));
                     }
                 }

--- a/test/Npgsql.Tests/Types/NetworkTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NetworkTypeTests.cs
@@ -77,7 +77,6 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
                         Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo((expectedIp, 32)));
                         Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
                     }
 
                     // Address and subnet
@@ -94,7 +93,6 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
                         Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedTuple));
                         Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedNpgsqlInet));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expectedNpgsqlInet.ToString()));
                     }
                 }
             }
@@ -135,7 +133,6 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
                         Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo((expectedIp, 128)));
                         Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(new NpgsqlInet(expectedIp)));
-                        Assert.That(reader.GetString(i), Is.EqualTo(new NpgsqlInet(expectedIp).ToString()));
                     }
 
                     // Address and subnet
@@ -152,7 +149,6 @@ namespace Npgsql.Tests.Types
                         Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof((IPAddress, int))));
                         Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expectedTuple));
                         Assert.That(reader.GetFieldValue<NpgsqlInet>(i), Is.EqualTo(expectedNpgsqlInet));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expectedNpgsqlInet.ToString()));
                     }
                 }
             }
@@ -175,7 +171,6 @@ namespace Npgsql.Tests.Types
                 Assert.That(reader.GetFieldValue<NpgsqlInet>(0), Is.EqualTo(new NpgsqlInet(expected.Address, expected.Subnet)));
                 Assert.That(reader[0], Is.EqualTo(expected));
                 Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-                Assert.That(reader.GetString(0), Is.EqualTo("192.168.1.0/24"));
             }
         }
 
@@ -198,7 +193,6 @@ namespace Npgsql.Tests.Types
                     {
                         Assert.That(reader.GetFieldValue<PhysicalAddress>(i), Is.EqualTo(expected));
                         Assert.That(reader.GetValue(i), Is.EqualTo(expected));
-                        Assert.That(reader.GetString(i), Is.EqualTo(expected.ToString()));
                         Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(PhysicalAddress)));
                     }
                 }
@@ -226,12 +220,10 @@ namespace Npgsql.Tests.Types
 
                         Assert.That(reader.GetFieldValue<PhysicalAddress>(0), Is.EqualTo(expected6));
                         Assert.That(reader.GetValue(0), Is.EqualTo(expected6));
-                        Assert.That(reader.GetString(0), Is.EqualTo(expected6.ToString()));
                         Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(PhysicalAddress)));
 
                         Assert.That(reader.GetFieldValue<PhysicalAddress>(1), Is.EqualTo(expected8));
                         Assert.That(reader.GetValue(1), Is.EqualTo(expected8));
-                        Assert.That(reader.GetString(1), Is.EqualTo(expected8.ToString()));
                         Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(PhysicalAddress)));
                     }
                 }


### PR DESCRIPTION
Per discussion in #1956 I removed string conversions from all type handlers where the same could be achieved with a simple `ToString()` or `Parse(string)` outside of Npgsql.

This PR takes an overall approach removing all those instances but we can certainly discuss every single type handler separately as the most problematic ones are certainly the ones where boxing of value types is involved (`Convert.To...`).