### PR TITLE
Update enums_and_composites.md

### DIFF
--- a/doc/types/enums_and_composites.md
+++ b/doc/types/enums_and_composites.md
@@ -56,7 +56,7 @@ Note that your PostgreSQL enum and composites types (`pg_enum_type` and `pg_comp
 
 # Name Translation
 
-CLR type and field names are usually camelcase (e.g. `SomeType`), whereas in PostgreSQL they are snake_case (e.g. `some_type`). To help make the mapping for enums and composites seamless, pluggable name translators are used translate all names. The default translation scheme is `NpgsqlSnakeCaseNameTranslator`, which maps names like `SomeType` to `some_type`, but you can specify others. The default name translator can be set for all your connections via `NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator`, or for a specific connection for `NpgsqlConnection.TypeMapper.DefaultNameTranslator`. You also have the option of specifyin a name translator when setting up a mapping:
+CLR type and field names are usually camelcase (e.g. `SomeType`), whereas in PostgreSQL they are snake_case (e.g. `some_type`). To help make the mapping for enums and composites seamless, pluggable name translators are used translate all names. The default translation scheme is `NpgsqlSnakeCaseNameTranslator`, which maps names like `SomeType` to `some_type`, but you can specify others. The default name translator can be set for all your connections via `NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator`, or for a specific connection for `NpgsqlConnection.TypeMapper.DefaultNameTranslator`. You also have the option to specify a name translator when setting up a mapping:
 
 ```c#
 NpgsqlConnection.GlobalTypeMapper.MapComposite<SomeType>("some_type", new NpgsqlNullNameTranslator());


### PR DESCRIPTION
Typo fix

Before:
> You also have the option __of specifyin__ a name translator when setting up a mapping:

After:
> You also have the option __to specify__ a name translator when setting up a mapping:
