### PR TITLE
Draft: Update types to parse with ReadOnlySpan<char>

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.0" />
 <!-- Causes issues in Appveyor and Travis
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.0-beta2" PrivateAssets="All" />
 -->

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -166,7 +166,7 @@ namespace NpgsqlTypes
         /// <param name="lowerBound">The lower bound of the range.</param>
         /// <param name="upperBound">The upper bound of the range.</param>
         public NpgsqlRange(T lowerBound, T upperBound)
-            : this(lowerBound, true, false, upperBound, true, false) { }
+            : this(lowerBound, true, false, upperBound, true, false) {}
 
         /// <summary>
         /// Constructs an <see cref="NpgsqlRange{T}"/> with definite bounds.
@@ -176,7 +176,7 @@ namespace NpgsqlTypes
         /// <param name="upperBound">The upper bound of the range.</param>
         /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
         public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, T upperBound, bool upperBoundIsInclusive)
-            : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) { }
+            : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) {}
 
         /// <summary>
         /// Constructs an <see cref="NpgsqlRange{T}"/>.
@@ -196,7 +196,7 @@ namespace NpgsqlTypes
                     lowerBoundIsInclusive,
                     upperBoundIsInclusive,
                     lowerBoundInfinite,
-                    upperBoundInfinite)) { }
+                    upperBoundInfinite)) {}
 
         /// <summary>
         /// Constructs an <see cref="NpgsqlRange{T}"/>.
@@ -366,13 +366,12 @@ namespace NpgsqlTypes
             return sb.ToString();
         }
 
-        // TODO: rewrite this to use ReadOnlySpan<char> for the 4.1 release
         /// <summary>
         /// Parses the well-known text representation of a PostgreSQL range type into a <see cref="NpgsqlRange{T}"/>.
         /// </summary>
-        /// <param name="value">A PosgreSQL range type in a well-known text format.</param>
+        /// <param name="input">A PosgreSQL range type in a well-known text format.</param>
         /// <returns>
-        /// The <see cref="NpgsqlRange{T}"/> represented by the <paramref name="value"/>.
+        /// The <see cref="NpgsqlRange{T}"/> represented by the <paramref name="input"/>.
         /// </returns>
         /// <exception cref="FormatException">
         /// Malformed range literal.
@@ -389,64 +388,60 @@ namespace NpgsqlTypes
         /// <remarks>
         /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
         /// </remarks>
-        public static NpgsqlRange<T> Parse([NotNull] string value)
+        public static NpgsqlRange<T> Parse([NotNull] string input)
         {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            if (input is null)
+                throw new ArgumentNullException(nameof(input));
 
-            value = value.Trim();
+            var value = input.AsSpan().Trim();
 
             if (value.Length < 3)
-                throw new FormatException("Malformed range literal.");
+                throw new FormatException($"Malformed range literal: {value.ToString()}");
 
-            if (string.Equals(value, EmptyLiteral, StringComparison.OrdinalIgnoreCase))
+            if (value.SequenceEqual(EmptyLiteral.AsSpan()))
                 return Empty;
 
             var lowerInclusive = value[0] == LowerInclusiveBound;
             var lowerExclusive = value[0] == LowerExclusiveBound;
 
             if (!lowerInclusive && !lowerExclusive)
-                throw new FormatException("Malformed range literal. Missing left parenthesis or bracket.");
+                throw new FormatException($"Malformed range literal. Missing left parenthesis or bracket: {value.ToString()}");
 
             var upperInclusive = value[value.Length - 1] == UpperInclusiveBound;
             var upperExclusive = value[value.Length - 1] == UpperExclusiveBound;
 
             if (!upperInclusive && !upperExclusive)
-                throw new FormatException("Malformed range literal. Missing right parenthesis or bracket.");
+                throw new FormatException($"Malformed range literal. Missing right parenthesis or bracket: {value.ToString()}");
 
             int separator = value.IndexOf(BoundSeparator);
 
             if (separator == -1)
-                throw new FormatException("Malformed range literal. Missing comma after lower bound.");
+                throw new FormatException($"Malformed range literal. Missing comma after lower bound: {value.ToString()}");
 
             if (separator != value.LastIndexOf(BoundSeparator))
                 // TODO: this should be replaced to handle quoted commas.
-                throw new NotSupportedException("Ranges with embedded commas are not currently supported.");
+                throw new NotSupportedException($"Ranges with embedded commas are not currently supported: {value.ToString()}");
 
-            // Skip the opening bracket and stop short of the separator.
-            var lowerSegment = value.Substring(1, separator - 1).Trim();
+            // Skip the opening bracket and stop short of the separator, then trim whitespace.
+            var lowerSegment = value.Slice(1, separator - 1).Trim();
 
-            // Skip past the separator and stop short of the closing bracket.
-            var upperSegment = value.Substring(separator + 1, value.Length - separator - 2).Trim();
+            // Skip past the separator and stop short of the closing bracket, then trim whitespace.
+            var upperSegment = value.Slice(separator + 1, value.Length - separator - 2).Trim();
 
             // TODO: infinity literals have special meaning to some types (e.g. daterange), we should consider a flag to track them.
 
             var lowerInfinite =
-                lowerSegment.Length == 0 ||
-                string.Equals(lowerSegment, string.Empty, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(lowerSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(lowerSegment, LowerInfinityLiteral, StringComparison.OrdinalIgnoreCase);
+                lowerSegment.IsEmpty ||
+                lowerSegment.SequenceEqual(NullLiteral.AsSpan()) ||
+                lowerSegment.SequenceEqual(LowerInfinityLiteral.AsSpan());
 
             var upperInfinite =
-                upperSegment.Length == 0 ||
-                string.Equals(upperSegment, string.Empty, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(upperSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(upperSegment, UpperInfinityLiteral, StringComparison.OrdinalIgnoreCase);
+                upperSegment.IsEmpty ||
+                upperSegment.SequenceEqual(NullLiteral.AsSpan()) ||
+                upperSegment.SequenceEqual(UpperInfinityLiteral.AsSpan());
 
-            T lower = lowerInfinite ? default : (T)BoundConverter.ConvertFromString(lowerSegment);
-            T upper = upperInfinite ? default : (T)BoundConverter.ConvertFromString(upperSegment);
+            T lower = lowerInfinite ? default : (T)BoundConverter.ConvertFromString(lowerSegment.ToString());
+            T upper = upperInfinite ? default : (T)BoundConverter.ConvertFromString(upperSegment.ToString());
 
             return new NpgsqlRange<T>(lower, lowerInclusive, lowerInfinite, upper, upperInclusive, upperInfinite);
         }

--- a/test/Npgsql.Benchmarks/Parsing/NpgsqlDateParsing.cs
+++ b/test/Npgsql.Benchmarks/Parsing/NpgsqlDateParsing.cs
@@ -1,0 +1,22 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using NpgsqlTypes;
+
+namespace Npgsql.Benchmarks.Parsing
+{
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    public class NpgsqlDateParsing
+    {
+        const string Infinity = "infinity";
+        const string Date = "2018-06-03";
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory(nameof(Date))]
+        public NpgsqlDate ParseInfiniteDate() => NpgsqlDate.Parse(Infinity);
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(Date))]
+        public NpgsqlDate ParseDate() => NpgsqlDate.Parse(Date);
+    }
+}

--- a/test/Npgsql.Benchmarks/Parsing/NpgsqlRangeParsing.cs
+++ b/test/Npgsql.Benchmarks/Parsing/NpgsqlRangeParsing.cs
@@ -3,11 +3,11 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using NpgsqlTypes;
 
-namespace Npgsql.Benchmarks
+namespace Npgsql.Benchmarks.Parsing
 {
     [MemoryDiagnoser]
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
-    public class ReadOnlySpan
+    public class NpgsqlRangeParsing
     {
         const string Empty = "empty";
         const string IntRange = "[0,1]";
@@ -15,27 +15,27 @@ namespace Npgsql.Benchmarks
         const string DateRange = "[2018-06-03,2018-06-04]";
 
         [Benchmark(Baseline = true)]
-        [BenchmarkCategory(nameof(Int32))]
+        [BenchmarkCategory(nameof(IntRange))]
         public NpgsqlRange<int> ParseEmptyIntRange() => NpgsqlRange<int>.Parse(Empty);
 
         [Benchmark]
-        [BenchmarkCategory(nameof(Int32))]
+        [BenchmarkCategory(nameof(IntRange))]
         public NpgsqlRange<int> ParseIntRange() => NpgsqlRange<int>.Parse(IntRange);
 
         [Benchmark(Baseline = true)]
-        [BenchmarkCategory(nameof(Double))]
+        [BenchmarkCategory(nameof(DoubleRange))]
         public NpgsqlRange<double> ParseEmptyDoubleRange() => NpgsqlRange<double>.Parse(Empty);
 
         [Benchmark]
-        [BenchmarkCategory(nameof(Double))]
+        [BenchmarkCategory(nameof(DoubleRange))]
         public NpgsqlRange<double> ParseDoubleRange() => NpgsqlRange<double>.Parse(DoubleRange);
 
         [Benchmark(Baseline = true)]
-        [BenchmarkCategory(nameof(DateTime))]
+        [BenchmarkCategory(nameof(DateRange))]
         public NpgsqlRange<DateTime> ParseEmptyDateRange() => NpgsqlRange<DateTime>.Parse(Empty);
 
         [Benchmark]
-        [BenchmarkCategory(nameof(DateTime))]
+        [BenchmarkCategory(nameof(DateRange))]
         public NpgsqlRange<DateTime> ParseDateRange() => NpgsqlRange<DateTime>.Parse(DateRange);
     }
 }

--- a/test/Npgsql.Benchmarks/ReadOnlySpan.cs
+++ b/test/Npgsql.Benchmarks/ReadOnlySpan.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using NpgsqlTypes;
+
+namespace Npgsql.Benchmarks
+{
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    public class ReadOnlySpan
+    {
+        const string Empty = "empty";
+        const string IntRange = "[0,1]";
+        const string DoubleRange = "[0.0,1.1]";
+        const string DateRange = "[2018-06-03,2018-06-04]";
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory(nameof(Int32))]
+        public NpgsqlRange<int> ParseEmptyIntRange() => NpgsqlRange<int>.Parse(Empty);
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(Int32))]
+        public NpgsqlRange<int> ParseIntRange() => NpgsqlRange<int>.Parse(IntRange);
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory(nameof(Double))]
+        public NpgsqlRange<double> ParseEmptyDoubleRange() => NpgsqlRange<double>.Parse(Empty);
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(Double))]
+        public NpgsqlRange<double> ParseDoubleRange() => NpgsqlRange<double>.Parse(DoubleRange);
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory(nameof(DateTime))]
+        public NpgsqlRange<DateTime> ParseEmptyDateRange() => NpgsqlRange<DateTime>.Parse(Empty);
+
+        [Benchmark]
+        [BenchmarkCategory(nameof(DateTime))]
+        public NpgsqlRange<DateTime> ParseDateRange() => NpgsqlRange<DateTime>.Parse(DateRange);
+    }
+}

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2018 The Npgsql Development Team
@@ -19,6 +20,7 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
@@ -54,8 +56,8 @@ namespace Npgsql.Tests.Types
 
                 using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
                 {
-                    var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Date) {Value = npgsqlDate};
-                    var p2 = new NpgsqlParameter {ParameterName = "p2", Value = npgsqlDate};
+                    var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Date) { Value = npgsqlDate };
+                    var p2 = new NpgsqlParameter { ParameterName = "p2", Value = npgsqlDate };
                     Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Date));
                     Assert.That(p2.DbType, Is.EqualTo(DbType.Date));
                     cmd.Parameters.Add(p1);
@@ -84,23 +86,27 @@ namespace Npgsql.Tests.Types
             }
         }
 
-        static readonly TestCaseData[] DateSpecialCases = {
+        static readonly TestCaseData[] DateSpecialCases =
+        {
             new TestCaseData(NpgsqlDate.Infinity).SetName(nameof(DateSpecial) + "Infinity"),
             new TestCaseData(NpgsqlDate.NegativeInfinity).SetName(nameof(DateSpecial) + "NegativeInfinity"),
-            new TestCaseData(new NpgsqlDate(-5, 3, 3)).SetName(nameof(DateSpecial) +"BC"),
+            new TestCaseData(new NpgsqlDate(-5, 3, 3)).SetName(nameof(DateSpecial) + "BC"),
         };
 
         [Test, TestCaseSource(nameof(DateSpecialCases))]
         public void DateSpecial(NpgsqlDate value)
         {
             using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p", conn)) {
+            using (var cmd = new NpgsqlCommand("SELECT @p", conn))
+            {
                 cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
-                using (var reader = cmd.ExecuteReader()) {
+                using (var reader = cmd.ExecuteReader())
+                {
                     reader.Read();
                     Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(value));
                     Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
                 }
+
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
             }
         }
@@ -112,10 +118,12 @@ namespace Npgsql.Tests.Types
             {
                 conn.Open();
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn)) {
+                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
+                {
                     cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Date, DateTime.MaxValue);
                     cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Date, DateTime.MinValue);
-                    using (var reader = cmd.ExecuteReader()) {
+                    using (var reader = cmd.ExecuteReader())
+                    {
                         reader.Read();
                         Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(NpgsqlDate.Infinity));
                         Assert.That(reader.GetFieldValue<NpgsqlDate>(1), Is.EqualTo(NpgsqlDate.NegativeInfinity));
@@ -124,6 +132,17 @@ namespace Npgsql.Tests.Types
                     }
                 }
             }
+        }
+
+        [Test]
+        [TestCase("2018-06-03", 2018, 06, 03)]
+        [TestCase("2018-6-3", 2018, 6, 3)]
+        [TestCase("2018-06-03 AD", 2018, 06, 03)]
+        [TestCase("2018-06-03 BC", -2018, 06, 03)]
+        public void DateParse(string date, int year, int month, int day)
+        {
+            var test = NpgsqlDate.Parse(date);
+            Assert.AreEqual(new NpgsqlDate(year, month, day), test);
         }
 
         #endregion
@@ -139,8 +158,8 @@ namespace Npgsql.Tests.Types
 
                 using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
                 {
-                    cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Time) {Value = expected});
-                    cmd.Parameters.Add(new NpgsqlParameter("p2", DbType.Time) {Value = expected});
+                    cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Time) { Value = expected });
+                    cmd.Parameters.Add(new NpgsqlParameter("p2", DbType.Time) { Value = expected });
                     using (var reader = cmd.ExecuteReader())
                     {
                         reader.Read();
@@ -223,7 +242,8 @@ namespace Npgsql.Tests.Types
 
         #region Timestamp
 
-        static readonly TestCaseData[] TimeStampCases = {
+        static readonly TestCaseData[] TimeStampCases =
+        {
             new TestCaseData(new DateTime(1998, 4, 12, 13, 26, 38)).SetName(nameof(Timestamp) + "Pre2000"),
             new TestCaseData(new DateTime(2015, 1, 27, 8, 45, 12, 345)).SetName(nameof(Timestamp) + "Post2000"),
             new TestCaseData(new DateTime(2013, 7, 25)).SetName(nameof(Timestamp) + "DateOnly"),
@@ -283,7 +303,8 @@ namespace Npgsql.Tests.Types
             }
         }
 
-        static readonly TestCaseData[] TimeStampSpecialCases = {
+        static readonly TestCaseData[] TimeStampSpecialCases =
+        {
             new TestCaseData(NpgsqlDateTime.Infinity).SetName(nameof(TimeStampSpecial) + "Infinity"),
             new TestCaseData(NpgsqlDateTime.NegativeInfinity).SetName(nameof(TimeStampSpecial) + "NegativeInfinity"),
             new TestCaseData(new NpgsqlDateTime(-5, 3, 3, 1, 0, 0)).SetName(nameof(TimeStampSpecial) + "BC"),
@@ -293,13 +314,16 @@ namespace Npgsql.Tests.Types
         public void TimeStampSpecial(NpgsqlDateTime value)
         {
             using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p", conn)) {
+            using (var cmd = new NpgsqlCommand("SELECT @p", conn))
+            {
                 cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
-                using (var reader = cmd.ExecuteReader()) {
+                using (var reader = cmd.ExecuteReader())
+                {
                     reader.Read();
                     Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(value));
                     Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
                 }
+
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
             }
         }


### PR DESCRIPTION
_Work in progress:_

## `NpgsqlRange<T>`

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-6650U CPU 2.20GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2156252 Hz, Resolution=463.7677 ns, Timer=TSC
.NET Core SDK=2.1.300
  [Host]     : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT


               Method |        Mean |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
--------------------- |------------:|-----------:|-------:|---------:|-------:|----------:|
   ParseEmptyIntRange |    43.67 ns |   2.481 ns |   1.00 |     0.00 |      - |       0 B |
        ParseIntRange |   689.76 ns |  45.454 ns |  15.85 |     1.36 | 0.0525 |     112 B |
                      |             |            |        |          |        |           |
ParseEmptyDoubleRange |    45.12 ns |   4.063 ns |   1.00 |     0.00 |      - |       0 B |
     ParseDoubleRange |   815.08 ns |  53.029 ns |  18.21 |     2.03 | 0.0525 |     112 B |
                      |             |            |        |          |        |           |
  ParseEmptyDateRange |    58.74 ns |   9.547 ns |   1.00 |     0.00 |      - |       0 B |
       ParseDateRange | 1,558.95 ns | 278.341 ns |  27.34 |     7.00 | 0.0687 |     144 B |
```

## `NpgsqlDate`

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-6650U CPU 2.20GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2156252 Hz, Resolution=463.7677 ns, Timer=TSC
.NET Core SDK=2.1.300
  [Host]     : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT


            Method |      Mean |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
------------------ |----------:|----------:|-------:|---------:|-------:|----------:|
 ParseInfiniteDate |  12.90 ns | 0.1784 ns |   1.00 |     0.00 |      - |       0 B |
         ParseDate | 370.42 ns | 4.7614 ns |  28.72 |     0.52 | 0.0491 |     104 B |
```

Related:
- #1939
- #1943 