### PR TITLE
Fix silent overflows in InternalCharHandler via checked keyword

### DIFF
--- a/src/Npgsql/TypeHandlers/InternalCharHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalCharHandler.cs
@@ -68,19 +68,19 @@ namespace Npgsql.TypeHandlers
         public int ValidateAndGetLength(long value, NpgsqlParameter parameter)          => 1;
 
         public override void Write(char value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteByte((byte)value);
+            => buf.WriteByte(checked((byte)value));
 
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
             => buf.WriteByte(value);
 
         public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteByte((byte)value);
+            => buf.WriteByte(checked((byte)value));
 
         public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteByte((byte)value);
+            => buf.WriteByte(checked((byte)value));
 
         public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter parameter)
-            => buf.WriteByte((byte)value);
+            => buf.WriteByte(checked((byte)value));
 
         #endregion
     }


### PR DESCRIPTION
I just realized that InternalCharHandler still has some casts that would be better off with a checked keyword as we recently did it for some numeric handlers.