### PR TITLE
Fix prepared statements and types with no NpgsqlDbType

### DIFF
--- a/src/Npgsql/FrontendMessages/ParseMessage.cs
+++ b/src/Npgsql/FrontendMessages/ParseMessage.cs
@@ -62,7 +62,7 @@ namespace Npgsql.FrontendMessages
             Populate(sql, statementName);
             foreach (var inputParam in inputParameters)
             {
-                inputParam.ResolveHandler(typeMapper);
+                Debug.Assert(inputParam.Handler != null, "Input parameter doesn't have a resolved handler when populating Parse message");
                 ParameterTypeOIDs.Add(inputParam.Handler.PostgresType.OID);
             }
             return this;

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -594,9 +594,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         {
             var connector = CheckReadyAndGetConnector();
             for (var i = 0; i < Parameters.Count; i++)
-                if (!Parameters[i].IsTypeExplicitlySet)
-                    throw new InvalidOperationException(
-                        "The Prepare method requires all parameters to have an explicitly set type.");
+                Parameters[i].Bind(connector.TypeMapper);
 
             ProcessRawQuery();
             Log.Debug($"Preparing: {CommandText}", connector.Id);

--- a/src/Npgsql/PreparedStatement.cs
+++ b/src/Npgsql/PreparedStatement.cs
@@ -45,13 +45,13 @@ namespace Npgsql
         internal DateTime LastUsed { get; set; }
 
         /// <summary>
-        /// Contains the parameter types for a prepared statement, for overloaded cases (same SQL, different param types)
+        /// Contains the handler types for a prepared statement's parameters, for overloaded cases (same SQL, different param types)
         /// Only populated after the statement has been prepared (i.e. null for candidates).
         /// </summary>
         [CanBeNull]
-        internal NpgsqlDbType[] ParamTypes { get; private set; }
+        internal Type[] HandlerParamTypes { get; private set; }
 
-        static readonly NpgsqlDbType[] EmptyParamTypes = new NpgsqlDbType[0];
+        static readonly Type[] EmptyParamTypes = Type.EmptyTypes;
 
         internal static PreparedStatement CreateExplicit(
             PreparedStatementManager manager,
@@ -82,28 +82,35 @@ namespace Npgsql
 
         internal void SetParamTypes(List<NpgsqlParameter> parameters)
         {
-            Debug.Assert(ParamTypes == null);
+            Debug.Assert(HandlerParamTypes == null);
             if (parameters.Count == 0)
-                ParamTypes = EmptyParamTypes;
-            ParamTypes = new NpgsqlDbType[parameters.Count];
+                HandlerParamTypes = EmptyParamTypes;
+            HandlerParamTypes = new Type[parameters.Count];
             for (var i = 0; i < parameters.Count; i++)
-                ParamTypes[i] = parameters[i].NpgsqlDbType;
+            {
+                Debug.Assert(parameters[i].Handler != null, "Parameter handler type not set when creating prepared statement");
+                HandlerParamTypes[i] = parameters[i].Handler.GetType();
+            }
         }
 
         internal bool DoParametersMatch(List<NpgsqlParameter> parameters)
         {
-            Debug.Assert(ParamTypes != null);
-            if (ParamTypes.Length != parameters.Count)
+            Debug.Assert(HandlerParamTypes != null);
+            if (HandlerParamTypes.Length != parameters.Count)
                 return false;
-            for (var i = 0; i < ParamTypes.Length; i++)
-                if (ParamTypes[i] != parameters[i].NpgsqlDbType)
+            for (var i = 0; i < HandlerParamTypes.Length; i++)
+            {
+                Debug.Assert(parameters[i].Handler != null, "Parameter handler type not set when creating prepared statement");
+                if (HandlerParamTypes[i] != parameters[i].Handler.GetType())
                     return false;
+            }
+
             return true;
         }
 
         internal void CompletePrepare()
         {
-            Debug.Assert(ParamTypes != null);
+            Debug.Assert(HandlerParamTypes != null);
             _manager.BySql[Sql] = this;
             _manager.NumPrepared++;
             State = PreparedState.Prepared;

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -78,7 +78,7 @@ namespace Npgsql.Tests
             using (var command = new NpgsqlCommand("SELECT @a, @b", conn))
             {
                 command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-                command.Parameters.Add(new NpgsqlParameter("b", DbType.Int64));
+                command.Parameters.Add(new NpgsqlParameter("b", 8));
                 command.Prepare();
                 command.Parameters[0].Value = 3;
                 command.Parameters[1].Value = 5;
@@ -124,18 +124,6 @@ namespace Npgsql.Tests
                 cmd.ExecuteNonQuery();
 
                 conn.UnprepareAll();
-            }
-        }
-
-        [Test, Description("Checks that prepares requires all params to have explicitly set types (NpgsqlDbType or DbType)")]
-        public void RequiresParamTypesSet()
-        {
-            using (var conn = OpenConnectionAndUnprepare())
-            using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-            {
-                var p = new NpgsqlParameter("p", 8);
-                cmd.Parameters.Add(p);
-                Assert.That(() => cmd.Prepare(), Throws.InvalidOperationException);
             }
         }
 


### PR DESCRIPTION
Npgsql caches prepared statements by their SQL. However, since PostgreSQL makes use of parameter types when preparing, overloaded SQL can exist: same SQL, different param types. We don't include the param types in the cache key for perf reasons (overloaded SQL is very rare), but we do store them on the prepared statement and make sure types correspond.

In the previous implementation, param types were stored as an array of NpgsqlDbType. However, we have types where there's no NpgsqlDbType: enums, composites, and in theory extension types that can be selected via the new DataTypeName, but have no NpgsqlDbType.

This PR changes the param types to be represented as a list of type handler types.

Fixes #1987

Note that we also have the option to drop storing param types altogether, in which case if the user uses overloaded SQLs they'll start to get PostgreSQL type error (this is especially problematic with auto-prepare). For example, if you execute `SELECT @p` on a string, you may end up with an auto-prepared statement where p is a string. Trying to execute with an int instead will throw an error.