### PR TITLE
Read and Write arrays of nullable value types

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -404,11 +404,11 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 if (rdr.Read())
                 {
                     if (!rdr.IsDBNull(0))
-                        names = rdr.GetValue(0) as string[];
+                        names = rdr.GetFieldValue<string[]>(0);
                     if (!rdr.IsDBNull(2))
-                        types = rdr.GetValue(2) as uint[];
+                        types = rdr.GetFieldValue<uint[]>(2);
                     if (!rdr.IsDBNull(3))
-                        modes = rdr.GetValue(3) as char[];
+                        modes = rdr.GetFieldValue<char[]>(3);
                     if (types == null)
                     {
                         if (rdr.IsDBNull(1) || rdr.GetFieldValue<uint[]>(1).Length == 0)

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -280,17 +280,23 @@ namespace Npgsql.TypeHandlers
         /// <inheritdoc />
         protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            if (IsArrayOf<TAny, BitArray>.Value)
+            if (RequestedType<TAny>.IsArrayOf<BitArray>.Value)
                 return (TAny)(object)await ReadArray<BitArray>(buf, async);
 
-            if (IsArrayOf<TAny, bool>.Value)
+            if (RequestedType<TAny>.IsArrayOf<bool>.Value)
+                return (TAny)(object)await ReadArray<bool>(buf, async, false);
+
+            if (RequestedType<TAny>.IsNullableArrayOf<bool>.Value)
                 return (TAny)(object)await ReadArray<bool>(buf, async);
 
-            if (typeof(TAny) == typeof(List<BitArray>))
+            if (RequestedType<TAny>.IsListOf<BitArray>.Value)
                 return (TAny)(object)await ReadList<BitArray>(buf, async);
 
-            if (typeof(TAny) == typeof(List<bool>))
+            if (RequestedType<TAny>.IsListOf<bool>.Value)
                 return (TAny)(object)await ReadList<bool>(buf, async);
+
+            if (RequestedType<TAny>.IsNullableListOf<bool>.Value)
+                return (TAny)await ReadNullableList<bool>(buf, async);
 
             return await base.Read<TAny>(buf, len, async, fieldDescription);
         }

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -278,27 +278,27 @@ namespace Npgsql.TypeHandlers
             : base(postgresType, elementHandler) {}
 
         /// <inheritdoc />
-        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            if (RequestedType<TAny>.IsArrayOf<BitArray>.Value)
-                return (TAny)(object)await ReadArray<BitArray>(buf, async);
+            if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
+            {
+                if (ArrayTypeInfo<TRequestedArray>.IsArray)
+                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async);
 
-            if (RequestedType<TAny>.IsArrayOf<bool>.Value)
-                return (TAny)(object)await ReadArray<bool>(buf, async, false);
+                if (ArrayTypeInfo<TRequestedArray>.IsList)
+                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async);
+            }
 
-            if (RequestedType<TAny>.IsNullableArrayOf<bool>.Value)
-                return (TAny)(object)await ReadArray<bool>(buf, async);
+            if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
+            {
+                if (ArrayTypeInfo<TRequestedArray>.IsArray)
+                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async);
 
-            if (RequestedType<TAny>.IsListOf<BitArray>.Value)
-                return (TAny)(object)await ReadList<BitArray>(buf, async);
+                if (ArrayTypeInfo<TRequestedArray>.IsList)
+                    return (TRequestedArray)(object)await ReadList<bool>(buf, async);
+            }
 
-            if (RequestedType<TAny>.IsListOf<bool>.Value)
-                return (TAny)(object)await ReadList<bool>(buf, async);
-
-            if (RequestedType<TAny>.IsNullableListOf<bool>.Value)
-                return (TAny)await ReadNullableList<bool>(buf, async);
-
-            return await base.Read<TAny>(buf, len, async, fieldDescription);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription);
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -81,9 +81,10 @@ namespace Npgsql.TypeHandling
             => ReadAsObject(buf, len, async, fieldDescription);
 
 // The following function is used by array and range to read their elements, including their length - which means null
-// handling. Only arrays can actually get nulls here (in ranges infinite bounds are indicated via header flags).
-// We can't mix generics and nullability, hence the warning suppression - but we have an effort to support
-// nullable arrays which may take care of this.
+// handling. Only arrays of reference types can actually get nulls here (arrays of value types are read via
+// ReadNullableWithLength and in ranges infinite bounds are indicated via header flags).
+// We currently can't mix unconstrained generics and nullability, hence the warning suppression.
+// This problem can possibly be solved if https://github.com/dotnet/csharplang/issues/2194 gets resolved in the future.
         /// <summary>
         /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
         /// If the length is -1 (null), this method will return the default value.
@@ -94,6 +95,19 @@ namespace Npgsql.TypeHandling
             var len = buf.ReadInt32();
             if (len == -1)
                 return default!;
+            return await Read<TAny>(buf, len, async, fieldDescription);
+        }
+
+        /// <summary>
+        /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
+        /// If the length is -1 (null), this method will return null.
+        /// </summary>
+        internal async ValueTask<object?> ReadNullableWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription? fieldDescription = null)
+        {
+            await buf.Ensure(4, async);
+            var len = buf.ReadInt32();
+            if (len == -1)
+                return null;
             return await Read<TAny>(buf, len, async, fieldDescription);
         }
 

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -129,16 +129,19 @@ namespace Npgsql.TypeMapping
         {
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsArray)
-                return type.GetElementType();
+                return GetUnderlyingType(type.GetElementType()!); // The use of bang operator is justified here as Type.GetElementType() only returns null for the Array base class which can't be mapped in a useful way.
 
             var ilist = typeInfo.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
             if (ilist != null)
-                return ilist.GetGenericArguments()[0];
+                return GetUnderlyingType(ilist.GetGenericArguments()[0]);
 
             if (typeof(IList).IsAssignableFrom(type))
                 throw new NotSupportedException("Non-generic IList is a supported parameter, but the NpgsqlDbType parameter must be set on the parameter");
 
             return null;
+
+            Type GetUnderlyingType(Type t)
+                => Nullable.GetUnderlyingType(t) ?? t;
         }
 
         #endregion Type handler lookup

--- a/test/Npgsql.Benchmarks/ReadArray.cs
+++ b/test/Npgsql.Benchmarks/ReadArray.cs
@@ -8,221 +8,82 @@ using System.Runtime.CompilerServices;
 
 namespace Npgsql.Benchmarks
 {
-    public abstract class ReadNullableArrayBase
+    public class ReadArrays
     {
-        public readonly struct ConfigStruct
+        [Params(true, false)]
+        public bool AllNulls;
+
+        [Params(1, 10, 1000, 100000)]
+        public int NumElements;
+
+        NpgsqlConnection _intConn = default!;
+        NpgsqlCommand _intCmd = default!;
+        NpgsqlDataReader _intReader = default!;
+
+        NpgsqlConnection _nullableIntConn = default!;
+        NpgsqlCommand _nullableIntCmd = default!;
+        NpgsqlDataReader _nullableIntReader = default!;
+
+        NpgsqlConnection _stringConn = default!;
+        NpgsqlCommand _stringCmd = default!;
+        NpgsqlDataReader _stringReader = default!;
+
+        [GlobalSetup]
+        public void Setup()
         {
-            public readonly int NumArrayElements;
-            public readonly double? Ratio;
+            var intArray = new int[NumElements];
+            for (var i = 0; i < NumElements; i++)
+                intArray[i] = 666;
+            _intConn = BenchmarkEnvironment.OpenConnection();
+            _intCmd = new NpgsqlCommand("SELECT @p1", _intConn);
+            _intCmd.Parameters.AddWithValue("p1", intArray);
+            _intReader = _intCmd.ExecuteReader();
+            _intReader.Read();
 
-            public ConfigStruct(int numElements, double? ratio)
-            {
-                NumArrayElements = numElements;
-                Ratio = ratio;
-            }
+            var nullableIntArray = new int?[NumElements];
+            for (var i = 0; i < NumElements; i++)
+                nullableIntArray[i] = AllNulls ? (int?)null : 666;
+            _nullableIntConn = BenchmarkEnvironment.OpenConnection();
+            _nullableIntCmd = new NpgsqlCommand("SELECT @p1", _nullableIntConn);
+            _nullableIntCmd.Parameters.AddWithValue("p1", nullableIntArray);
+            _nullableIntReader = _nullableIntCmd.ExecuteReader();
+            _nullableIntReader.Read();
 
-            public override string ToString()
-            {
-                var writer = new StringWriter();
-                writer.Write($"{NumArrayElements}");
-                if (Ratio.HasValue)
-                {
-                    writer.Write($",{(int)Math.Truncate(100 / (1 + Ratio.Value))}%");
-                }
-                return writer.ToString();
-            }
-        }
-
-        NpgsqlConnection _conn = default!;
-        NpgsqlCommand _cmd = default!;
-        NpgsqlDataReader _reader = default!;
-
-        public IEnumerable<ConfigStruct> GetConfigValuesForNullable()
-        {
-            var numArrayElementsList = new[] { 0, 1, 10, 1000, 100000 };
-            foreach (var numArrayElements in numArrayElementsList)
-            {
-                switch (numArrayElements)
-                {
-                    case 0:
-                        yield return new ConfigStruct(numArrayElements, null);
-                        break;
-                    case 1:
-                        yield return new ConfigStruct(numArrayElements, 0D);
-                        yield return new ConfigStruct(numArrayElements, double.MaxValue);
-                        break;
-                    case 10:
-                        yield return new ConfigStruct(numArrayElements, 0D);
-                        yield return new ConfigStruct(numArrayElements, 0.5D);
-                        yield return new ConfigStruct(numArrayElements, 1D);
-                        yield return new ConfigStruct(numArrayElements, 2D);
-                        yield return new ConfigStruct(numArrayElements, double.MaxValue);
-                        break;
-                    default:
-                        yield return new ConfigStruct(numArrayElements, 0D);
-                        yield return new ConfigStruct(numArrayElements, 0.125D);
-                        yield return new ConfigStruct(numArrayElements, 0.5D);
-                        yield return new ConfigStruct(numArrayElements, 1D);
-                        yield return new ConfigStruct(numArrayElements, 2D);
-                        yield return new ConfigStruct(numArrayElements, 8D);
-                        yield return new ConfigStruct(numArrayElements, double.MaxValue);
-                        break;
-                }
-            }
-        }
-
-        [ParamsSource(nameof(GetConfigValuesForNullable))]
-        public virtual ConfigStruct Config { get; set; }
-
-        protected void Setup<T>(T initializationValue)
-        {
-            _conn = BenchmarkEnvironment.OpenConnection();
-            _cmd = new NpgsqlCommand("SELECT @p1;", _conn);
-            _cmd.Parameters.AddWithValue("@p1", CreateArray(initializationValue));
-            _reader = _cmd.ExecuteReader();
-            _reader.Read();
-        }
-
-        protected virtual object CreateArray<T>(T initializationValue)
-        {
-            return Create(initializationValue).ToArray();
-
-            IEnumerable<T> Create(T init)
-            {
-                for (var i = 0; i < Config.NumArrayElements; i++)
-                {
-                    Debug.Assert(Config.Ratio.HasValue);
-                    if (0 == (int)Math.Truncate((i + 1) % (1 + Config.Ratio!.Value)))
-// Unconstrained generics and nullable reference types currently don't interoperate
-// if the return value might be null so we have to disable the warning here
-#pragma warning disable CS8653
-                        yield return default;
-#pragma warning restore CS8653
-                    else
-                        yield return init;
-                }
-            }
+            var stringArray = new string?[NumElements];
+            for (var i = 0; i < NumElements; i++)
+                stringArray[i] = AllNulls ? null : "666";
+            _stringConn = BenchmarkEnvironment.OpenConnection();
+            _stringCmd = new NpgsqlCommand("SELECT @p1", _stringConn);
+            _stringCmd.Parameters.AddWithValue("p1", stringArray);
+            _stringReader = _stringCmd.ExecuteReader();
+            _stringReader.Read();
         }
 
         protected void Cleanup()
         {
-            _reader.Dispose();
-            _cmd.Dispose();
-            _conn.Dispose();
+            _intReader.Dispose();
+            _nullableIntReader.Dispose();
+            _stringReader.Dispose();
+
+            _intCmd.Dispose();
+            _nullableIntCmd.Dispose();
+            _stringCmd.Dispose();
+
+            _intConn.Dispose();
+            _nullableIntConn.Dispose();
+            _stringConn.Dispose();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected T GetFieldValue<T>()
-            => _reader.GetFieldValue<T>(0);
-    }
-
-    public abstract class ReadArrayBase : ReadNullableArrayBase
-    {
-        protected override object CreateArray<T>(T initializationValue)
-            => Enumerable.Repeat(initializationValue, Config.NumArrayElements).ToArray();
-
-        public IEnumerable<ConfigStruct> GetConfigValues()
-        {
-            var numArrayElementsList = new[] { 0, 1, 10, 1000, 100000 };
-            foreach (var numArrayElements in numArrayElementsList)
-            {
-                yield return new ConfigStruct(numArrayElements, null);
-            }
-        }
-
-        [ParamsSource(nameof(GetConfigValues))]
-        public override ConfigStruct Config { get; set; }
-    }
-
-    public class ReadArray : ReadArrayBase
-    {
-        [GlobalSetup(Target = nameof(ReadIntArray))]
-        public void GlobalSetupForNullableInt()
-            => Setup(42);
-
-        [GlobalSetup(Target = nameof(ReadStringArray))]
-        public void GlobalSetupForString()
-            => Setup("The Answer to the Ultimate Question of Life, The Universe, and Everything.");
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-            => Cleanup();
+        [Benchmark]
+        public int ReadIntArray()
+            => _intReader.GetFieldValue<int[]>(0).Length;
 
         [Benchmark]
-        public void ReadIntArray()
-            => GetFieldValue<int[]>();
+        public int ReadNullableIntArray()
+            => _nullableIntReader.GetFieldValue<int?[]>(0).Length;
 
         [Benchmark]
-        public void ReadStringArray()
-            => GetFieldValue<string[]>();
-    }
-
-    public class ReadList : ReadArrayBase
-    {
-        [GlobalSetup(Target = nameof(ReadListOfInt))]
-        public void GlobalSetupForNullableInt()
-            => Setup(42);
-
-        [GlobalSetup(Target = nameof(ReadListOfString))]
-        public void GlobalSetupForString()
-            => Setup("The Answer to the Ultimate Question of Life, The Universe, and Everything.");
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-            => Cleanup();
-
-        [Benchmark]
-        public void ReadListOfInt()
-            => GetFieldValue<List<int>>();
-
-        [Benchmark]
-        public void ReadListOfString()
-            => GetFieldValue<List<string>>();
-    }
-
-    public class ReadArrayWithNulls: ReadNullableArrayBase
-    {
-        [GlobalSetup(Target = nameof(ReadNullableIntArray))]
-        public void GlobalSetupForNullableInt()
-            => Setup<int?>(42);
-
-        [GlobalSetup(Target = nameof(ReadStringArray))]
-        public void GlobalSetupForString()
-            => Setup("The Answer to the Ultimate Question of Life, The Universe, and Everything.");
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-            => Cleanup();
-
-        [Benchmark]
-        public void ReadNullableIntArray()
-            => GetFieldValue<int?[]>();
-
-        [Benchmark]
-        public void ReadStringArray()
-            => GetFieldValue<string[]>();
-    }
-
-    public class ReadListWithNulls : ReadNullableArrayBase
-    {
-        [GlobalSetup(Target = nameof(ReadListOfNullableInt))]
-        public void GlobalSetupForNullableInt()
-            => Setup<int?>(42);
-
-        [GlobalSetup(Target = nameof(ReadListOfString))]
-        public void GlobalSetupForString()
-            => Setup("The Answer to the Ultimate Question of Life, The Universe, and Everything.");
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-            => Cleanup();
-
-        [Benchmark]
-        public void ReadListOfNullableInt()
-            => GetFieldValue<List<int?>>();
-
-        [Benchmark]
-        public void ReadListOfString()
-            => GetFieldValue<List<string>>();
+        public int ReadStringArray()
+            => _stringReader.GetFieldValue<string[]>(0).Length;
     }
 }

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -93,32 +93,43 @@ namespace Npgsql.Tests.Types
         [Test, Description("Roundtrips a simple, one-dimensional array of int? values")]
         public void NullableInts()
         {
-            using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn))
-            {
-                var expected = new int?[] { 1, 5, null, 9 };
-                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
-                var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-                var p3 = new NpgsqlParameter<int?[]>("p3", expected);
-                cmd.Parameters.Add(p1);
-                cmd.Parameters.Add(p2);
-                cmd.Parameters.Add(p3);
-                p1.Value = expected;
-                var reader = cmd.ExecuteReader();
-                reader.Read();
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn);
 
-                for (var i = 0; i < cmd.Parameters.Count; i++)
-                {
-                    Assert.That(reader.GetValue(i), Is.EqualTo(expected));
-                    Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expected));
-                    Assert.That(reader.GetFieldValue<int?[]>(i), Is.EqualTo(expected));
-                    Assert.That(reader.GetFieldValue<List<int?>>(i), Is.EqualTo(expected.ToList()));
-                    Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Array)));
-                    Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(Array)));
-                }
+            var expected = new int?[] { 1, 5, null, 9 };
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
+            var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
+            var p3 = new NpgsqlParameter<int?[]>("p3", expected);
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            cmd.Parameters.Add(p3);
+            p1.Value = expected;
+            var reader = cmd.ExecuteReader();
+            reader.Read();
+
+            for (var i = 0; i < cmd.Parameters.Count; i++)
+            {
+                Assert.That(reader.GetValue(i), Is.EqualTo(expected));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<int?[]>(i), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<List<int?>>(i), Is.EqualTo(expected.ToList()));
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Array)));
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(Array)));
             }
         }
 
+        [Test]
+        public void EmptyArray()
+        {
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT @p", conn);
+
+            cmd.Parameters.Add(new NpgsqlParameter("p", NpgsqlDbType.Array | NpgsqlDbType.Integer) { Value = new int[0] });
+            var reader = cmd.ExecuteReader();
+            reader.Read();
+
+            Assert.That(reader.GetFieldValue<int[]>(0), Is.SameAs(Array.Empty<int>()));
+        }
 
         [Test, Description("Verifies that the array type returned from NpgsqlDataReader.GetValue() is always compatible with null values.")]
         public void GetValueArrayTypeForValueTypesDependsOnActualValue()

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -90,6 +90,102 @@ namespace Npgsql.Tests.Types
             }
         }
 
+        [Test, Description("Roundtrips a simple, one-dimensional array of int? values")]
+        public void NullableInts()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn))
+            {
+                var expected = new int?[] { 1, 5, null, 9 };
+                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
+                var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
+                var p3 = new NpgsqlParameter<int?[]>("p3", expected);
+                cmd.Parameters.Add(p1);
+                cmd.Parameters.Add(p2);
+                cmd.Parameters.Add(p3);
+                p1.Value = expected;
+                var reader = cmd.ExecuteReader();
+                reader.Read();
+
+                for (var i = 0; i < cmd.Parameters.Count; i++)
+                {
+                    Assert.That(reader.GetValue(i), Is.EqualTo(expected));
+                    Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expected));
+                    Assert.That(reader.GetFieldValue<int?[]>(i), Is.EqualTo(expected));
+                    Assert.That(reader.GetFieldValue<List<int?>>(i), Is.EqualTo(expected.ToList()));
+                    Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Array)));
+                    Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(Array)));
+                }
+            }
+        }
+
+
+        [Test, Description("Verifies that the array type returned from NpgsqlDataReader.GetValue() is always compatible with null values.")]
+        public void GetValueArrayTypeForValueTypesDependsOnActualValue()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand(@"
+                CREATE TEMP TABLE GetValueArrayTypeForValueTypesDependsOnActualValue
+                (
+	                col1 integer[4] NOT NULL
+                );
+                INSERT into GetValueArrayTypeForValueTypesDependsOnActualValue VALUES
+                (ARRAY[1, 2, 3, 4]),
+                (ARRAY[null, 1, 2, 3]);
+                SELECT * FROM GetValueArrayTypeForValueTypesDependsOnActualValue;
+                ", conn))
+            {
+                var reader = cmd.ExecuteReader();
+                reader.Read();
+                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(Array)));
+                Assert.That(reader.GetValue(0), Is.TypeOf<int?[]>());
+
+                reader.Read();
+                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(Array)));
+                Assert.That(reader.GetValue(0), Is.TypeOf<int?[]>());
+            }
+        }
+
+
+        [Test, Description("Verifies that an attempt to read an Array of value types that contains null values as array of a non-nullable type fails.")]
+        public void GetFieldValueNonNullableValueTypeArrayFailsOnArrayContainingNull()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p1", conn))
+            {
+                var expected = new int?[] { 1, 5, null, 9 };
+                cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer, expected);
+
+                var reader = cmd.ExecuteReader();
+                reader.Read();
+
+                Assert.That(
+                    () => reader.GetFieldValue<int[]>(0),
+                    Throws.Exception.TypeOf<InvalidOperationException>()
+                        .With.Message.EqualTo("Can't read a non-nullable array of 'Int32' if the database array field contains null values."));
+            }
+        }
+
+
+        [Test, Description("Verifies that an attempt to read an Array of value types that contains null values as List of a non-nullable type fails.")]
+        public void GetFieldValueNonNullableValueTypeListFailsOnArrayContainingNull()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p1", conn))
+            {
+                var expected = new int?[] { 1, 5, null, 9 };
+                cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer, expected);
+
+                var reader = cmd.ExecuteReader();
+                reader.Read();
+
+                Assert.That(
+                    () => reader.GetFieldValue<List<int>>(0),
+                    Throws.Exception.TypeOf<InvalidOperationException>()
+                        .With.Message.EqualTo("Can't read a non-nullable List<Int32> if the database array field contains null values. Use List<Int32?> instead."));
+            }
+        }
+
         [Test, Description("Roundtrips a large, one-dimensional array of ints that will be chunked")]
         public void LongOneDimensional()
         {

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -173,7 +173,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(
                     () => reader.GetFieldValue<int[]>(0),
                     Throws.Exception.TypeOf<InvalidOperationException>()
-                        .With.Message.EqualTo("Can't read a non-nullable array of 'Int32' if the database array field contains null values."));
+                        .With.Message.EqualTo("Cannot read a non-nullable collection of elements because the returned array contains nulls"));
             }
         }
 
@@ -193,7 +193,7 @@ namespace Npgsql.Tests.Types
                 Assert.That(
                     () => reader.GetFieldValue<List<int>>(0),
                     Throws.Exception.TypeOf<InvalidOperationException>()
-                        .With.Message.EqualTo("Can't read a non-nullable List<Int32> if the database array field contains null values. Use List<Int32?> instead."));
+                        .With.Message.EqualTo("Cannot read a non-nullable collection of elements because the returned array contains nulls"));
             }
         }
 

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -591,8 +591,8 @@ namespace Npgsql.Tests.Types
                 using (var rdr = cmd.ExecuteReader())
                 {
                     rdr.Read();
-                    Assert.AreEqual(typeof(uint[]), rdr.GetValue(0).GetType());
-                    Assert.AreEqual(typeof(uint[]), rdr.GetValue(1).GetType());
+                    Assert.AreEqual(typeof(uint?[]), rdr.GetValue(0).GetType());
+                    Assert.AreEqual(typeof(uint?[]), rdr.GetValue(1).GetType());
                     Assert.IsTrue(rdr.GetFieldValue<uint[]>(0).SequenceEqual(new uint[] { 1, 2, 3 }));
                     Assert.IsTrue(rdr.GetFieldValue<uint[]>(1).SequenceEqual(new uint[] { 4, 5, 6 }));
                 }

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -127,7 +127,7 @@ namespace Npgsql.Tests.Types
                 cmd.CommandText = "select array['[2,10)'::int4range, '[3,9)'::int4range]";
                 cmd.Prepare();
                 obj = cmd.ExecuteScalar();
-                Assert.AreEqual(new NpgsqlRange<int>(3, true, false, 9, false, false), ((NpgsqlRange<int>[])obj)[1]);
+                Assert.AreEqual(new NpgsqlRange<int>(3, true, false, 9, false, false), ((NpgsqlRange<int>?[])obj)[1]!.Value);
             }
         }
 

--- a/test/Npgsql.Tests/Types/TextTests.cs
+++ b/test/Npgsql.Tests/Types/TextTests.cs
@@ -195,8 +195,8 @@ namespace Npgsql.Tests.Types
                     {
                         Assert.AreEqual(expected[i], reader.GetChar(i));
                     }
-                    var arr = (char[])reader.GetValue(5);
-                    var arr2 = (char[])reader.GetValue(6);
+                    var arr = (char?[])reader.GetValue(5);
+                    var arr2 = (char?[])reader.GetValue(6);
                     Assert.AreEqual(testArr.Length, arr.Length);
                     for (var i = 0; i < arr.Length; i++)
                     {


### PR DESCRIPTION
After deciding that my extended testing project should not hold this one up forever, I'm finally submitting this one that fixes #443 

I've explicitly broken backwards compatibility for `NpgsqlDataReader.GetFieldValue<T>()` where reading an array containing null values resulted in an array where the null values were replaced with the value types default value.

Another thing to note is that `NpgsqlDataReader.GetValue()` now returns an array of the value type or an array of its nullable counterpart on a row to row base, depending on the question whether the actual array returned by the backend contains null values or not.