### PR TITLE
Prefix jsonb with version when using ArraySegment

### DIFF
--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -367,8 +367,9 @@ namespace Npgsql
 
         internal void WriteChars(char[] chars, int offset, int len)
         {
-            Debug.Assert(TextEncoding.GetByteCount(chars) <= WriteSpaceLeft);
-            WritePosition += TextEncoding.GetBytes(chars, offset, len == 0 ? chars.Length : len, Buffer, WritePosition);
+            var charCount = len == 0 ? chars.Length : len;
+            Debug.Assert(TextEncoding.GetByteCount(chars, 0, charCount) <= WriteSpaceLeft);
+            WritePosition += TextEncoding.GetBytes(chars, offset, charCount, Buffer, WritePosition);
         }
 
         public void WriteBytes(byte[] buf) => WriteBytes(buf, 0, buf.Length);

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -242,7 +242,7 @@ namespace Npgsql.TypeHandlers
             );
         }
 
-        public int ValidateAndGetLength(ArraySegment<char> value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        public virtual int ValidateAndGetLength(ArraySegment<char> value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
         {
             if (lengthCache == null)
                 lengthCache = new NpgsqlLengthCache(1);
@@ -275,8 +275,8 @@ namespace Npgsql.TypeHandlers
             return buf.WriteChars(value, 0, charLen, lengthCache.GetLast(), async);
         }
 
-        public Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
-            => buf.WriteChars(value.Array, value.Offset, value.Count, lengthCache.GetLast(), async);
+        public virtual Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async) => 
+            buf.WriteChars(value.Array, value.Offset, value.Count, lengthCache.GetLast(), async);
 
         Task WriteString(string str, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, [CanBeNull] NpgsqlParameter parameter, bool async)
         {


### PR DESCRIPTION
I've found that jsonb is not correctly prefixed with 0x01 byte when using ArraySegment<char>.  This pr fixes that.  