### PR TITLE
Add support for arrays of domains

### DIFF
--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -258,7 +258,11 @@ namespace Npgsql.TypeMapping
             // for reading domain fields of composites
             foreach (var domain in DatabaseInfo.DomainTypes)
                 if (_byOID.TryGetValue(domain.BaseType.OID, out var baseTypeHandler))
+                {
                     _byOID[domain.OID] = baseTypeHandler;
+                    if (domain.Array != null)
+                        BindType(baseTypeHandler.CreateArrayHandler(domain.Array), domain.Array);
+                }
 
             // Composites
             var dynamicCompositeFactory = new UnmappedCompositeTypeHandlerFactory(DefaultNameTranslator);

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -403,6 +403,69 @@ namespace Npgsql.Tests.Types
             Assert.That(p.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Array | NpgsqlDbType.Integer));
         }
 
+        [Test, Description("Roundtrips one-dimensional and two-dimensional arrays of a PostgreSQL domain.")]
+        public void ArrayOfDomain()
+        {
+            using (var conn = OpenConnection())
+            {
+                TestUtil.MinimumPgVersion(conn, "11.0", "Arrays of domains were introduced in PostgreSQL 11");
+                conn.ExecuteNonQuery("CREATE DOMAIN pg_temp.posint AS integer CHECK (VALUE > 0);");
+                conn.ReloadTypes();
+                using (var cmd = new NpgsqlCommand("SELECT @p1::posint[], @p2::posint[][]", conn))
+                {
+                    var oneDim = new[] { 1, 3, 5, 9 };
+                    var twoDim = new[,] { { 1, 3 }, { 5, 9 } };
+                    cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Integer | NpgsqlDbType.Array, oneDim);
+                    cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Integer | NpgsqlDbType.Array, twoDim);
+                    var reader = cmd.ExecuteRecord();
+
+                    Assert.That(reader.GetValue(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetFieldValue<int[]>(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(Array)));
+                    Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(Array)));
+
+                    Assert.That(reader.GetValue(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetProviderSpecificValue(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetFieldValue<int[,]>(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(Array)));
+                    Assert.That(reader.GetProviderSpecificFieldType(1), Is.EqualTo(typeof(Array)));
+                }
+            }
+        }
+
+        [Test, Description("Roundtrips a PostgreSQL domain over a one-dimensional and a two-dimensional array.")]
+        public void DomainOfArray()
+        {
+            using (var conn = OpenConnection())
+            {
+                TestUtil.MinimumPgVersion(conn, "11.0", "Domains over arrays were introduced in PostgreSQL 11");
+                conn.ExecuteNonQuery("CREATE DOMAIN pg_temp.int_array_1d  AS int[] CHECK(array_length(VALUE, 1) = 4);" +
+                                     "CREATE DOMAIN pg_temp.int_array_2d  AS int[][] CHECK(array_length(VALUE, 2) = 2);");
+                conn.ReloadTypes();
+                using (var cmd = new NpgsqlCommand("SELECT @p1::int_array_1d, @p2::int_array_2d", conn))
+                {
+                    var oneDim = new[] { 1, 3, 5, 9 };
+                    var twoDim = new[,] { { 1, 3 }, { 5, 9 } };
+                    cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Integer | NpgsqlDbType.Array, oneDim);
+                    cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Integer | NpgsqlDbType.Array, twoDim);
+                    var reader = cmd.ExecuteRecord();
+
+                    Assert.That(reader.GetValue(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetFieldValue<int[]>(0), Is.EqualTo(oneDim));
+                    Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(Array)));
+                    Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(Array)));
+
+                    Assert.That(reader.GetValue(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetProviderSpecificValue(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetFieldValue<int[,]>(1), Is.EqualTo(twoDim));
+                    Assert.That(reader.GetFieldType(1), Is.EqualTo(typeof(Array)));
+                    Assert.That(reader.GetProviderSpecificFieldType(1), Is.EqualTo(typeof(Array)));
+                }
+            }
+        }
+
         void AssertIListRoundtrips<TElement>(NpgsqlConnection conn, IEnumerable<TElement> value)
         {
             using (var cmd = new NpgsqlCommand("SELECT @p", conn))


### PR DESCRIPTION
This pull request adds support for arrays of domains which are supported as of PostgreSQL 11.

See also #1942 