### PR TITLE
DeriveParameters for domain types

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -93,7 +93,8 @@ CASE
   ELSE 0
 END AS elemoid,
 CASE
-  WHEN pg_proc.proname IN ('array_recv','oidvectorrecv') THEN 3    /* Arrays last */
+  WHEN a.typtype='d' AND a.typcategory='A' THEN 4                  /* Domains over arrays last */
+  WHEN pg_proc.proname IN ('array_recv','oidvectorrecv') THEN 3    /* Arrays before */
   WHEN a.typtype='r' THEN 2                                        /* Ranges before */
   WHEN a.typtype='d' THEN 1                                        /* Domains before */
   ELSE 0                                                           /* Base types first */


### PR DESCRIPTION
This pull request prepares `NpgsqlCommandBuilder.DeriveParameters()` for PostgreSQL 11 with arrays of domains and domains over arrays.

It also sets the NpgsqlDbType according to the domains' base type for all domains.

It adresses the following comment from https://github.com/npgsql/npgsql/issues/1942#issuecomment-399745861:

> Also let's not forget `NpgsqlCommandBuilder.DeriveParameters()` for this.