### PR TITLE
ReloadTypes() takes effect on other connections

### DIFF
--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -71,7 +71,7 @@ namespace Npgsql.TypeMapping
             try
             {
                 base.AddMapping(mapping);
-                _changeCounter++;
+                RecordChange();
 
                 if (mapping.NpgsqlDbType.HasValue)
                 {
@@ -103,7 +103,7 @@ namespace Npgsql.TypeMapping
             try
             {
                 var result = base.RemoveMapping(pgTypeName);
-                _changeCounter++;
+                RecordChange();
                 return result;
             }
             finally
@@ -119,13 +119,15 @@ namespace Npgsql.TypeMapping
             {
                 Mappings.Clear();
                 SetupGlobalTypeMapper();
-                _changeCounter++;
+                RecordChange();
             }
             finally
             {
                 Lock.ExitWriteLock();
             }
         }
+
+        internal void RecordChange() => Interlocked.Increment(ref _changeCounter);
 
         #endregion Mapping management
 


### PR DESCRIPTION
Calling `ReloadTypes()` previously only affected the connection on which it was called, and new physical connections. Other pooled connections were not affected and `ReloadTypes()` had to be called manually on them.

when `ReloadTypes()` is called, the global type mapper's change counter is now incremented, and when a new connection is opened from the pool, if a such a change is detected the new DatabaseInfo is taken into account.