### PR TITLE
Corner case test fixes

### DIFF
--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -779,7 +779,7 @@ namespace Npgsql.Tests
             using (var conn = OpenConnection())
             {
                 // Make sure messages are in English
-                conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF8'");
+                conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF-8'");
                 conn.ExecuteNonQuery(@"
                         CREATE OR REPLACE FUNCTION pg_temp.emit_notice() RETURNS VOID AS
                         'BEGIN RAISE NOTICE ''testnotice''; END;'

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -38,7 +38,7 @@ namespace Npgsql.Tests
             using (var conn = OpenConnection())
             {
                 // Make sure messages are in English
-                conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF8'");
+                conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF-8'");
                 conn.ExecuteNonQuery(@"
                      CREATE OR REPLACE FUNCTION pg_temp.emit_exception() RETURNS VOID AS
                         'BEGIN RAISE EXCEPTION ''testexception'' USING ERRCODE = ''12345''; END;'

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -679,9 +679,7 @@ namespace Npgsql.Tests
         {
             using (var conn = OpenConnection())
             {
-                TestUtil.MinimumPgVersion(conn, "9.1.0", "HSTORE data type not yet introduced");
-                conn.ExecuteNonQuery(@"CREATE EXTENSION IF NOT EXISTS hstore");
-                conn.ReloadTypes();
+                TestUtil.EnsureExtension(conn, "hstore", "9.1");
 
                 using (var cmd = new NpgsqlCommand("SELECT NULL::HSTORE", conn))
                 using (var reader = cmd.ExecuteReader(CommandBehavior.SchemaOnly))

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -54,7 +54,7 @@ namespace Npgsql.Tests
         public static void IgnoreExceptOnBuildServer(string message, params object[] args)
             => IgnoreExceptOnBuildServer(string.Format(message, args));
 
-        public static void MinimumPgVersion(NpgsqlConnection conn, string minVersion, string ignoreText=null)
+        public static void MinimumPgVersion(NpgsqlConnection conn, string minVersion, string ignoreText = null)
         {
             var min = new Version(minVersion);
             if (conn.PostgreSqlVersion < min)
@@ -64,6 +64,20 @@ namespace Npgsql.Tests
                     msg += ": " + ignoreText;
                 Assert.Ignore(msg);
             }
+        }
+
+        static readonly Version MinCreateExtensionVersion = new Version(9, 1);
+        public static void EnsureExtension(NpgsqlConnection conn, string extension, string minVersion = null)
+        {
+            if (minVersion != null)
+                MinimumPgVersion(conn, minVersion,
+                    $"The extension '{extension}' only works for PostgreSQL {minVersion} and higher.");
+
+            if (conn.PostgreSqlVersion < MinCreateExtensionVersion)
+                Assert.Ignore($"The 'CREATE EXTENSION' command only works for PostgreSQL {MinCreateExtensionVersion} and higher.");
+
+            conn.ExecuteNonQuery($"CREATE EXTENSION IF NOT EXISTS {extension}");
+            conn.ReloadTypes();
         }
 
         public static string GetUniqueIdentifier(string prefix)

--- a/test/Npgsql.Tests/TypeMapperTests.cs
+++ b/test/Npgsql.Tests/TypeMapperTests.cs
@@ -161,6 +161,8 @@ CHECK
         {
             using (var conn = OpenLocalConnection())
             {
+                TestUtil.EnsureExtension(conn, "citext");
+
                 conn.TypeMapper.RemoveMapping("text");
                 conn.TypeMapper.AddMapping(new NpgsqlTypeMappingBuilder
                 {

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -266,9 +266,7 @@ namespace Npgsql.Tests.Types
         {
             using (var conn = OpenConnection())
             {
-                TestUtil.MinimumPgVersion(conn, "9.1.0", "HSTORE data type not yet introduced");
-                conn.ExecuteNonQuery(@"CREATE EXTENSION IF NOT EXISTS hstore");
-                conn.ReloadTypes();
+                TestUtil.EnsureExtension(conn, "hstore", "9.1");
 
                 var expected = new Dictionary<string, string> {
                     {"a", "3"},

--- a/test/Npgsql.Tests/Types/TextTests.cs
+++ b/test/Npgsql.Tests/Types/TextTests.cs
@@ -253,11 +253,7 @@ namespace Npgsql.Tests.Types
         {
             using (var conn = OpenConnection())
             {
-                if (conn.PostgreSqlVersion >= new Version(9, 1, 0))
-                {
-                    conn.ExecuteNonQuery("CREATE EXTENSION IF NOT EXISTS citext");
-                    conn.ReloadTypes();
-                }
+                TestUtil.EnsureExtension(conn, "citext");
 
                 var value = "Foo";
                 using (var cmd = new NpgsqlCommand("SELECT @p::CITEXT", conn))


### PR DESCRIPTION
Today I've installed PostgreSQL on a Mac (MacOS High Sierra 10.13) to get an idea of the work needed to implement #685 (IMO we'd need to test at least Linux, Windows and MacOS backends).

When running the Npgsql test suite on a newly created test database I got three failing tests which fall into two categories:

1. The MacOS server doesn't like the locale `en_US.UTF8` but wants it to be `en_US.UTF-8`. I've tried both variants on Windows 10 (1803) and Ubuntu (18.04) and they don't seem to care, so I think the 'UTF-8' variant is the most portable one.

2. There was an oversight in `TypeMapperTests.StringToCitext()` where `citext` was used without ensuring that the extension is actually installed. This test variably fails only once after creating a new test database because `TextTests.Citext()` installs the extension, which prevents the problem in subsequent runs.

Instead of copy-pasting code to fix case 2 I went ahead and created `TestUtil.EnsureExtension()` which reduces the redundancy needed to ensure the presence of a certain extension.