### PR TITLE
 Implement NpgsqlCommandBuilder.ApplyParameterInfo()

### DIFF
--- a/src/Npgsql/NpgsqlCommandBuilder.cs
+++ b/src/Npgsql/NpgsqlCommandBuilder.cs
@@ -355,9 +355,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// <param name="statementType">Type of the statement.</param>
         /// <param name="whereClause">if set to <c>true</c> [where clause].</param>
         protected override void ApplyParameterInfo(DbParameter p, DataRow row, System.Data.StatementType statementType, bool whereClause)
-        {
-            // TODO: We may need to set NpgsqlDbType, as well as other properties, on p
-        }
+            => ((NpgsqlParameter)p).NpgsqlDbType = (NpgsqlDbType)row[SchemaTableColumn.ProviderType];
 
         /// <summary>
         /// Returns the name of the specified parameter in the format of @p#.

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1417,7 +1417,7 @@ namespace Npgsql
             table.Columns.Add("BaseTableName", typeof(string));
             table.Columns.Add("DataType", typeof(Type));
             table.Columns.Add("AllowDBNull", typeof(bool));
-            table.Columns.Add("ProviderType", typeof(Type));
+            table.Columns.Add("ProviderType", typeof(int));
             table.Columns.Add("IsAliased", typeof(bool));
             table.Columns.Add("IsExpression", typeof(bool));
             table.Columns.Add("IsIdentity", typeof(bool));
@@ -1445,8 +1445,9 @@ namespace Npgsql
                 row["BaseColumnName"] = column.BaseColumnName;
                 row["BaseSchemaName"] = column.BaseSchemaName;
                 row["BaseTableName"] = column.BaseTableName;
-                row["DataType"] = row["ProviderType"] = column.DataType; // Non-standard
+                row["DataType"] =  column.DataType;
                 row["AllowDBNull"] = (object)column.AllowDBNull ?? DBNull.Value;
+                row["ProviderType"] = column.NpgsqlDbType ?? NpgsqlDbType.Unknown;
                 row["IsAliased"] = column.IsAliased == true;
                 row["IsExpression"] = column.IsExpression == true;
                 row["IsIdentity"] = column.IsIdentity == true;

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -231,9 +231,16 @@ ORDER BY attnum";
         /// </summary>
         void ColumnPostConfig(NpgsqlDbColumn column, int typeModifier)
         {
-            column.DataType = _connection.Connector.TypeHandlerRegistry.TryGetByOID(column.TypeOID, out var handler)
-                ? handler.GetFieldType()
-                : null;
+            if (_connection.Connector.TypeHandlerRegistry.TryGetByOID(column.TypeOID, out var handler))
+            {
+                column.DataType = handler.GetFieldType();
+                column.NpgsqlDbType = handler.PostgresType.NpgsqlDbType;
+            }
+            else
+            {
+                column.DataType = null;
+                column.NpgsqlDbType = null;
+            }
 
             if (column.DataType != null)
             {

--- a/src/Npgsql/Schema/NpgsqlDbColumn.cs
+++ b/src/Npgsql/Schema/NpgsqlDbColumn.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
 using Npgsql.PostgresTypes;
+using NpgsqlTypes;
 
 #if NETSTANDARD1_3 || NETSTANDARD2_0
 using System.Data.Common;
@@ -161,6 +162,8 @@ namespace Npgsql.Schema
         public short? ColumnAttributeNumber { get; internal set; }
         [PublicAPI]
         public string DefaultValue { get; internal set; }
+        [PublicAPI]
+        public NpgsqlDbType? NpgsqlDbType { get; internal set; }
 
         [CanBeNull]
         public override object this[string propertyName]
@@ -179,6 +182,8 @@ namespace Npgsql.Schema
                     return ColumnAttributeNumber;
                 case nameof(DefaultValue):
                     return DefaultValue;
+                case nameof(NpgsqlDbType):
+                    return NpgsqlDbType;
                 }
 
                 return base[propertyName];


### PR DESCRIPTION
In order to safely update the database with a command that was generated
via NpgsqlCommandBuilder.GetUpdateCommand() we need to have the correct
NpgsqlDbType set for every parameter.
This PR is mostly a backport of the 4.x code that is necessary to
do this in NpgsqlCommandBuilder.ApplyParameterInfo().

Fixes #1591
