### PR TITLE
Refactor type handler hierarchy for range/array

### DIFF
--- a/src/Npgsql.GeoJSON/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/GeoJSONHandler.cs
@@ -77,7 +77,7 @@ namespace Npgsql.GeoJSON
         }
     }
 
-    sealed class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
+    sealed class GeoJsonHandler : NpgsqlBaseTypeHandler<GeoJSONObject>,
         INpgsqlTypeHandler<Point>, INpgsqlTypeHandler<MultiPoint>,
         INpgsqlTypeHandler<Polygon>, INpgsqlTypeHandler<MultiPolygon>,
         INpgsqlTypeHandler<LineString>, INpgsqlTypeHandler<MultiLineString>,

--- a/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.LegacyPostgis
             => new LegacyPostgisHandler();
     }
 
-    class LegacyPostgisHandler : NpgsqlTypeHandler<PostgisGeometry>,
+    class LegacyPostgisHandler : NpgsqlBaseTypeHandler<PostgisGeometry>,
         INpgsqlTypeHandler<PostgisPoint>, INpgsqlTypeHandler<PostgisMultiPoint>,
         INpgsqlTypeHandler<PostgisLineString>, INpgsqlTypeHandler<PostgisMultiLineString>,
         INpgsqlTypeHandler<PostgisPolygon>, INpgsqlTypeHandler<PostgisMultiPolygon>,

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -50,7 +50,7 @@ namespace Npgsql.NetTopologySuite
             => new NetTopologySuiteHandler(_reader, _writer);
     }
 
-    class NetTopologySuiteHandler : NpgsqlTypeHandler<IGeometry>, INpgsqlTypeHandler<Geometry>,
+    class NetTopologySuiteHandler : NpgsqlBaseTypeHandler<IGeometry>, INpgsqlTypeHandler<Geometry>,
         INpgsqlTypeHandler<IPoint>, INpgsqlTypeHandler<Point>,
         INpgsqlTypeHandler<ILineString>, INpgsqlTypeHandler<LineString>,
         INpgsqlTypeHandler<IPolygon>, INpgsqlTypeHandler<Polygon>,

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -40,14 +40,8 @@ namespace Npgsql.TypeHandlers
         {
             public static readonly bool Value = typeof(TArray).IsArray && typeof(TArray).GetElementType() == typeof(TElement);
         }
-
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
-            => throw new NotSupportedException();
-
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
-            => throw new NotSupportedException();
     }
-    
+
     /// <summary>
     /// Base class for all type handlers which handle PostgreSQL arrays.
     /// </summary>

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -45,7 +45,7 @@ namespace Npgsql.TypeHandlers
     /// </remarks>
     [TypeMapping("bit varying", NpgsqlDbType.Varbit, new[] { typeof(BitArray), typeof(BitVector32) })]
     [TypeMapping("bit", NpgsqlDbType.Bit)]
-    class BitStringHandler : NpgsqlTypeHandler<BitArray>,
+    class BitStringHandler : NpgsqlBaseTypeHandler<BitArray>,
         INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
     {
         internal override Type GetFieldType(FieldDescription fieldDescription = null)
@@ -55,7 +55,7 @@ namespace Npgsql.TypeHandlers
             => GetFieldType(fieldDescription);
 
         // BitString requires a special array handler which returns bool or BitArray
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType backendType)
+        public override ArrayHandler CreateArrayHandler(PostgresType backendType)
             => new BitStringArrayHandler(this) { PostgresType = backendType };
 
         #region Read

--- a/src/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.TypeHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-binary.html
     /// </remarks>
     [TypeMapping("bytea", NpgsqlDbType.Bytea, DbType.Binary, new[] { typeof(byte[]), typeof(ArraySegment<byte>) })]
-    public class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>
+    public class ByteaHandler : NpgsqlBaseTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>
     {
         /// <inheritdoc />
         public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -40,7 +40,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         typeof(NpgsqlTsQuery), typeof(NpgsqlTsQueryAnd), typeof(NpgsqlTsQueryEmpty), typeof(NpgsqlTsQueryFollowedBy),
         typeof(NpgsqlTsQueryLexeme), typeof(NpgsqlTsQueryNot), typeof(NpgsqlTsQueryOr), typeof(NpgsqlTsQueryBinOp) })
     ]
-    class TsQueryHandler : NpgsqlTypeHandler<NpgsqlTsQuery>,
+    class TsQueryHandler : NpgsqlBaseTypeHandler<NpgsqlTsQuery>,
         INpgsqlTypeHandler<NpgsqlTsQueryEmpty>, INpgsqlTypeHandler<NpgsqlTsQueryLexeme>,
         INpgsqlTypeHandler<NpgsqlTsQueryNot>, INpgsqlTypeHandler<NpgsqlTsQueryAnd>,
         INpgsqlTypeHandler<NpgsqlTsQueryOr>, INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -37,7 +37,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-textsearch.html
     /// </summary>
     [TypeMapping("tsvector", NpgsqlDbType.TsVector, typeof(NpgsqlTsVector))]
-    class TsVectorHandler : NpgsqlTypeHandler<NpgsqlTsVector>
+    class TsVectorHandler : NpgsqlBaseTypeHandler<NpgsqlTsVector>
     {
         // 2561 = 2046 (max length lexeme string) + (1) null terminator +
         // 2 (num_pos) + sizeof(int16) * 256 (max_num_pos (positions/wegihts))

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -39,7 +39,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-geometric.html
     /// </remarks>
     [TypeMapping("path", NpgsqlDbType.Path, typeof(NpgsqlPath))]
-    class PathHandler : NpgsqlTypeHandler<NpgsqlPath>
+    class PathHandler : NpgsqlBaseTypeHandler<NpgsqlPath>
     {
         #region Read
 

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -38,7 +38,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
     /// http://www.postgresql.org/docs/current/static/datatype-geometric.html
     /// </remarks>
     [TypeMapping("polygon", NpgsqlDbType.Polygon, typeof(NpgsqlPolygon))]
-    class PolygonHandler : NpgsqlTypeHandler<NpgsqlPolygon>
+    class PolygonHandler : NpgsqlBaseTypeHandler<NpgsqlPolygon>
     {
         #region Read
 

--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -40,7 +40,7 @@ namespace Npgsql.TypeHandlers
     }
 
 #pragma warning disable CA1061 // Do not hide base class methods
-    class HstoreHandler : NpgsqlTypeHandler<Dictionary<string, string>>, INpgsqlTypeHandler<IDictionary<string, string>>
+    class HstoreHandler : NpgsqlBaseTypeHandler<Dictionary<string, string>>, INpgsqlTypeHandler<IDictionary<string, string>>
     {
         /// <summary>
         /// The text handler to which we delegate encoding/decoding of the actual strings

--- a/src/Npgsql/TypeHandlers/InternalTypesHandlers/Int2VectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypesHandlers/Int2VectorHandler.cs
@@ -46,12 +46,14 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
     /// An int2vector is simply a regular array of shorts, with the sole exception that its lower bound must
     /// be 0 (we send 1 for regular arrays).
     /// </summary>
-    class Int2VectorHandler : ArrayHandler<short>
+    class Int2VectorHandler : ArrayHandler<short>, INpgsqlArrayHandlerFactory
     {
         public Int2VectorHandler(PostgresType postgresShortType)
             : base(new Int16Handler { PostgresType = postgresShortType }, 0) { }
 
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        // Arrays can't be elements of arrays, but int2vector can be an element of an array even if it's internally
+        // implemented as an array itself.
+        public ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<ArrayHandler<short>>(this) { PostgresType = arrayBackendType };
     }
 }

--- a/src/Npgsql/TypeHandlers/InternalTypesHandlers/OIDVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypesHandlers/OIDVectorHandler.cs
@@ -46,12 +46,14 @@ namespace Npgsql.TypeHandlers.InternalTypesHandlers
     /// An OIDVector is simply a regular array of uints, with the sole exception that its lower bound must
     /// be 0 (we send 1 for regular arrays).
     /// </summary>
-    class OIDVectorHandler : ArrayHandler<uint>
+    class OIDVectorHandler : ArrayHandler<uint>, INpgsqlArrayHandlerFactory
     {
         public OIDVectorHandler(PostgresType postgresOIDType)
             : base(new UInt32Handler { PostgresType = postgresOIDType }, 0) { }
 
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        // Arrays can't be elements of arrays, but int2vector can be an element of an array even if it's internally
+        // implemented as an array itself.
+        public ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<ArrayHandler<uint>>(this) { PostgresType = arrayBackendType };
     }
 }

--- a/src/Npgsql/TypeHandlers/MappedCompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/MappedCompositeHandler.cs
@@ -20,7 +20,7 @@ namespace Npgsql.TypeHandlers
         Type CompositeType { get; }
     }
 
-    class MappedCompositeHandler<T> : NpgsqlTypeHandler<T>, IMappedCompositeHandler where T : new()
+    class MappedCompositeHandler<T> : NpgsqlBaseTypeHandler<T>, IMappedCompositeHandler where T : new()
     {
         readonly INpgsqlNameTranslator _nameTranslator;
         readonly NpgsqlConnection _conn;

--- a/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
@@ -20,7 +20,7 @@ namespace Npgsql.TypeHandlers
         Type EnumType { get; }
     }
 
-    class MappedEnumHandler<T> : NpgsqlTypeHandler<T>, IMappedEnumHandler where T : new()
+    class MappedEnumHandler<T> : NpgsqlBaseTypeHandler<T>, IMappedEnumHandler where T : new()
     {
         readonly INpgsqlNameTranslator _nameTranslator;
         readonly NpgsqlConnection _conn;

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -38,7 +38,7 @@ namespace Npgsql.TypeHandlers
     /// http://www.postgresql.org/docs/current/static/rangetypes.html
     /// </remarks>
     /// <typeparam name="TElement">the range subtype</typeparam>
-    class RangeHandler<TElement> : NpgsqlTypeHandler<NpgsqlRange<TElement>>
+    class RangeHandler<TElement> : NpgsqlTypeHandler<NpgsqlRange<TElement>>, INpgsqlArrayHandlerFactory
     {
         /// <summary>
         /// The type handler for the element that this range type holds
@@ -50,10 +50,11 @@ namespace Npgsql.TypeHandlers
             ElementHandler = elementHandler;
         }
 
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType backendType)
-        {
-            throw new Exception("Can't create range handler of range types, this is an Npgsql bug, please report.");
-        }
+        /// <summary>
+        /// Creates a type handler for arrays of this handler's type.
+        /// </summary>
+        public ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+            => new ArrayHandler<NpgsqlRange<TElement>>(this) { PostgresType = arrayBackendType };
 
         #region Read
 

--- a/src/Npgsql/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/TypeHandlers/RecordHandler.cs
@@ -48,7 +48,7 @@ namespace Npgsql.TypeHandlers
     /// * The length of the column(32-bit integer), or -1 if null
     /// * The column data encoded as binary
     /// </remarks>
-    class RecordHandler : NpgsqlTypeHandler<object[]>
+    class RecordHandler : NpgsqlBaseTypeHandler<object[]>
     {
         readonly ConnectorTypeMapper _typeMapper;
 

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -57,7 +57,7 @@ namespace Npgsql.TypeHandlers
             => new TextHandler(conn);
     }
 
-    public class TextHandler : NpgsqlTypeHandler<string>, INpgsqlTypeHandler<char[]>, INpgsqlTypeHandler<ArraySegment<char>>,
+    public class TextHandler : NpgsqlBaseTypeHandler<string>, INpgsqlTypeHandler<char[]>, INpgsqlTypeHandler<ArraySegment<char>>,
         INpgsqlTypeHandler<char>, INpgsqlTypeHandler<byte[]>, ITextReaderHandler
     {
         // Text types are handled a bit more efficiently when sent as text than as binary
@@ -275,7 +275,7 @@ namespace Npgsql.TypeHandlers
             return buf.WriteChars(value, 0, charLen, lengthCache.GetLast(), async);
         }
 
-        public virtual Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async) => 
+        public virtual Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async) =>
             buf.WriteChars(value.Array, value.Offset, value.Count, lengthCache.GetLast(), async);
 
         Task WriteString(string str, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, [CanBeNull] NpgsqlParameter parameter, bool async)

--- a/src/Npgsql/TypeHandlers/UnmappedCompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedCompositeHandler.cs
@@ -53,7 +53,7 @@ namespace Npgsql.TypeHandlers
     /// * The length of the column(32-bit integer), or -1 if null
     /// * The column data encoded as binary
     /// </remarks>
-    class UnmappedCompositeHandler : NpgsqlTypeHandler<object>
+    class UnmappedCompositeHandler : NpgsqlBaseTypeHandler<object>
     {
         readonly ConnectorTypeMapper _typeMapper;
         readonly INpgsqlNameTranslator _nameTranslator;

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -43,7 +43,7 @@ namespace Npgsql.TypeHandling
     /// on a column with this handler will return a value with type <typeparamref name="TDefault"/>.
     /// Type handlers can support additional types by implementing <see cref="INpgsqlTypeHandler{T}"/>.
     /// </typeparam>
-    public abstract class NpgsqlSimpleTypeHandler<TDefault> : NpgsqlTypeHandler<TDefault>, INpgsqlSimpleTypeHandler<TDefault>
+    public abstract class NpgsqlSimpleTypeHandler<TDefault> : NpgsqlBaseTypeHandler<TDefault>, INpgsqlSimpleTypeHandler<TDefault>
     {
         delegate int NonGenericValidateAndGetLength(NpgsqlTypeHandler handler, object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter);
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -52,7 +52,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Reads a value of type <typeparamref name="TPsv"/> with the given length from the provided buffer,
         /// with the assumption that it is entirely present in the provided memory buffer and no I/O will be
-        /// required. 
+        /// required.
         /// </summary>
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
@@ -117,7 +117,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Creates a type handler for arrays of this handler's type.
         /// </summary>
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandlerWithPsv<TDefault, TPsv>(this) { PostgresType = arrayBackendType };
 
         #endregion Misc

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -166,16 +166,6 @@ namespace Npgsql.TypeHandling
         internal virtual bool PreferTextWrite => false;
 
         /// <summary>
-        /// Creates a type handler for arrays of this handler's type.
-        /// </summary>
-        protected internal abstract ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
-
-        /// <summary>
-        /// Creates a type handler for ranges of this handler's type.
-        /// </summary>
-        internal abstract NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType);
-
-        /// <summary>
         /// Used to create an exception when the provided type can be converted and written, but an
         /// instance of <see cref="NpgsqlParameter"/> is required for caching of the converted value
         /// (in <see cref="NpgsqlParameter.ConvertedValue"/>.

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandlerFactory.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandlerFactory.cs
@@ -24,6 +24,7 @@
 using System;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
+using Npgsql.TypeHandlers;
 using Npgsql.TypeMapping;
 
 namespace Npgsql.TypeHandling
@@ -71,5 +72,31 @@ namespace Npgsql.TypeHandling
         /// The default CLR type that handlers produced by this factory will read and write.
         /// </summary>
         internal override Type DefaultValueType => typeof(TDefault);
+    }
+
+    // Ranges and arrays are special - their factories are their elements' type handlers.
+
+    /// <summary>
+    /// Implemented by type handlers representing types that can be elements in PostgreSQL ranges.
+    /// While all base types can be range elements, range types cannot.
+    /// </summary>
+    public interface INpgsqlRangeHandlerFactory
+    {
+        /// <summary>
+        /// Creates a type handler for ranges of this handler's type.
+        /// </summary>
+        NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType);
+    }
+
+    /// <summary>
+    /// Implemented by type handlers representing types that can be elements in PostgreSQL arrays.
+    /// While all base types can be array elements, array types cannot.
+    /// </summary>
+    public interface INpgsqlArrayHandlerFactory
+    {
+        /// <summary>
+        /// Creates a type handler for arrays of this handler's type.
+        /// </summary>
+        ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
     }
 }

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -294,15 +294,30 @@ namespace Npgsql.TypeHandling
         internal override Type GetFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
 
+        #endregion Misc
+    }
+
+    /// <summary>
+    /// Base class for type handlers of PostgreSQL base (or scalar) types, which can be elements of ranges and arrays.
+    /// </summary>
+    /// <typeparam name="TDefault">
+    /// The default CLR type that this handler will read and write. For example, calling <see cref="DbDataReader.GetValue"/>
+    /// on a column with this handler will return a value with type <typeparamref name="TDefault"/>.
+    /// Type handlers can support additional types by implementing <see cref="INpgsqlTypeHandler{T}"/>.
+    /// </typeparam>
+    public abstract class NpgsqlBaseTypeHandler<TDefault> : NpgsqlTypeHandler<TDefault>,
+        INpgsqlRangeHandlerFactory, INpgsqlArrayHandlerFactory
+    {
         /// <summary>
         /// Creates a type handler for arrays of this handler's type.
         /// </summary>
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        public virtual ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<TDefault>(this) { PostgresType = arrayBackendType };
 
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
+        /// <summary>
+        /// Creates a type handler for ranges of this handler's type.
+        /// </summary>
+        public virtual NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => new RangeHandler<TDefault>(this) { PostgresType = rangeBackendType };
-
-        #endregion Misc
     }
 }


### PR DESCRIPTION
Type handlers are factories of range and array handlers over their types. In other words, to create a range handler over int, one calls the CreateRangeHandler() on the int handler.

Previously, all type handlers had CreateRangeHandler() and CreateArrayHandler(), but on RangeHandler and ArrayHandler these threw NotSupportedException, respectively. Aside from being a bit ugly, this created issues for AOT compilers (corert, UWP) which failed on infinite potential type recursion (range of range of range...).

Changed the type handler hierarchy to indicate via interfaces which handlers support ranges and arrays.

Fixes #2040, #1861

---
Note that this changes the plugin API, so all plugins will need to be modified accordingly and released. Aside from this it may be low-risk enough for inclusion in 4.0.2.

@YohDeadfall what do you think?