### PR TITLE
Fixed memory leak when async is used

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1445,6 +1445,12 @@ namespace Npgsql
                 CurrentReader = null;
             }
 
+            if (!IsSecure)
+            {
+                ReadBuffer.AwaitableSocket.Dispose();
+                WriteBuffer.AwaitableSocket.Dispose();
+            }
+
             ClearTransaction();
             _stream = null;
             _baseStream = null;

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1445,16 +1445,12 @@ namespace Npgsql
                 CurrentReader = null;
             }
 
-            if (!IsSecure)
-            {
-                ReadBuffer.AwaitableSocket.Dispose();
-                WriteBuffer.AwaitableSocket.Dispose();
-            }
-
             ClearTransaction();
             _stream = null;
             _baseStream = null;
+            ReadBuffer?.AwaitableSocket?.Dispose();
             ReadBuffer = null;
+            WriteBuffer?.AwaitableSocket?.Dispose();
             WriteBuffer = null;
             Connection = null;
             PostgresParameters.Clear();

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -52,7 +52,7 @@ namespace Npgsql
         /// Wraps SocketAsyncEventArgs for better async I/O as long as we're not doing SSL.
         /// </summary>
         [CanBeNull]
-        internal AwaitableSocket AwaitableSocket { private get; set; }
+        internal AwaitableSocket AwaitableSocket { get; set; }
 
         /// <summary>
         /// The total byte length of the buffer.

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -50,7 +50,7 @@ namespace Npgsql
         /// Wraps SocketAsyncEventArgs for better async I/O as long as we're not doing SSL.
         /// </summary>
         [CanBeNull]
-        internal AwaitableSocket AwaitableSocket { private get; set; }
+        internal AwaitableSocket AwaitableSocket { get; set; }
 
         /// <summary>
         /// The total byte length of the buffer.


### PR DESCRIPTION
The issue was caused by not disposing instances of the `AwaitableSocket` class which internally hold `Overlapped`s.

Fixes #2038