### PR TITLE
Fixed floating point value altering

### DIFF
--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -319,9 +319,8 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float ReadSingle(bool littleEndian)
         {
-            var result = Read<float>();
-            return littleEndian == BitConverter.IsLittleEndian
-                ? result : PGUtil.ReverseEndianness(result);
+            var result = ReadInt32(littleEndian);
+            return Unsafe.As<int, float>(ref result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -331,9 +330,8 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public double ReadDouble(bool littleEndian)
         {
-            var result = Read<double>();
-            return littleEndian == BitConverter.IsLittleEndian
-                ? result : PGUtil.ReverseEndianness(result);
+            var result = ReadInt64(littleEndian);
+            return Unsafe.As<long, double>(ref result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -267,7 +267,7 @@ namespace Npgsql
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteSingle(float value, bool littleEndian)
-            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+            => WriteInt32(Unsafe.As<float, int>(ref value), littleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteDouble(double value)
@@ -275,10 +275,10 @@ namespace Npgsql
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteDouble(double value, bool littleEndian)
-            => Write(littleEndian == BitConverter.IsLittleEndian ? value : PGUtil.ReverseEndianness(value));
+            => WriteInt64(Unsafe.As<double, long>(ref value), littleEndian);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Write<T>(T value)
+        void Write<T>(T value)
         {
             Debug.Assert(Unsafe.SizeOf<T>() <= WriteSpaceLeft);
             Unsafe.WriteUnaligned(ref Buffer[WritePosition], value);

--- a/src/Npgsql/PGUtil.cs
+++ b/src/Npgsql/PGUtil.cs
@@ -120,20 +120,6 @@ namespace Npgsql
         internal static ulong ReverseEndianness(ulong value)
             => ((ulong)ReverseEndianness((uint)value) << 32) + ReverseEndianness((uint)(value >> 32));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal unsafe static float ReverseEndianness(float value)
-        {
-            var result = ReverseEndianness(*(int*)(&value));
-            return *(float*)(&result);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal unsafe static double ReverseEndianness(double value)
-        {
-            var result = ReverseEndianness(*(long*)(&value));
-            return *(double*)(&result);
-        }
-
         internal static readonly Task CompletedTask = Task.FromResult(0);
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
         internal static readonly Task<bool> FalseTask = Task.FromResult(false);

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -287,6 +287,23 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test]
+        public void Bug2046()
+        {
+            var expected = 64.27245f;
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p = 64.27245::real, 64.27245::real, @p", conn))
+            {
+                cmd.Parameters.AddWithValue("p", expected);
+                using (var rdr = cmd.ExecuteRecord())
+                {
+                    Assert.That(rdr.GetFieldValue<bool>(0));
+                    Assert.That(rdr.GetFieldValue<float>(1), Is.EqualTo(expected));
+                    Assert.That(rdr.GetFieldValue<float>(2), Is.EqualTo(expected));
+                }
+            }
+        }
+
         #region Bug1285
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1285")]


### PR DESCRIPTION
It was because of the FPU which changes the value. Fixed by reading and writing values as `int` for `float` and as `long` for `double` using `Unsafe`.

Fixes #2046