### PR TITLE
Fix typo in SslMode enum

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1445,7 +1445,7 @@ namespace Npgsql
         /// </summary>
         Prefer,
         /// <summary>
-        /// Fail the connection if the server doesn't suppotr SSL.
+        /// Fail the connection if the server doesn't support SSL.
         /// </summary>
         Require,
     }


### PR DESCRIPTION
Really tiny typo fix in the `SslMode` enum.
I couldn't find a contributing guide so I'm just creating a PR for this directly. Please let me know if this is not the correct channel for fixing issues such as this.
✌️ 