### PR TITLE
Refactored range type handler

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -256,8 +256,8 @@ namespace NpgsqlTypes
             if (!HasEquatableBounds)
                 return lowerBound?.Equals(upperBound) ?? false;
 
-            IEquatable<T> lower = (IEquatable<T>)lowerBound;
-            IEquatable<T> upper = (IEquatable<T>)upperBound;
+            var lower = (IEquatable<T>)lowerBound;
+            var upper = (IEquatable<T>)upperBound;
 
             return
                 !(lower?.Equals(default) ?? true) &&

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -41,10 +41,12 @@ namespace Npgsql.TypeHandlers
             public static readonly bool Value = typeof(TArray).IsArray && typeof(TArray).GetElementType() == typeof(TElement);
         }
 
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        /// <inheritdoc />
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => throw new NotSupportedException();
 
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
+        /// <inheritdoc />
+        public override RangeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => throw new NotSupportedException();
     }
     

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -55,7 +55,7 @@ namespace Npgsql.TypeHandlers
             => GetFieldType(fieldDescription);
 
         // BitString requires a special array handler which returns bool or BitArray
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType backendType)
+        public override ArrayHandler CreateArrayHandler(PostgresType backendType)
             => new BitStringArrayHandler(this) { PostgresType = backendType };
 
         #region Read

--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeHandlers.InternalTypeHandlers
         public Int2VectorHandler(PostgresType postgresShortType)
             : base(new Int16Handler { PostgresType = postgresShortType }, 0) { }
 
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<ArrayHandler<short>>(this) { PostgresType = arrayBackendType };
     }
 }

--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeHandlers.InternalTypeHandlers
         public OIDVectorHandler(PostgresType postgresOIDType)
             : base(new UInt32Handler { PostgresType = postgresOIDType }, 0) { }
 
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<ArrayHandler<uint>>(this) { PostgresType = arrayBackendType };
     }
 }

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -21,15 +21,23 @@
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #endregion
 
-using Npgsql.BackendMessages;
 using System;
 using System.Threading.Tasks;
-using NpgsqlTypes;
+using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
+using NpgsqlTypes;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Npgsql.TypeHandlers
 {
+    public abstract class RangeHandler : NpgsqlTypeHandler
+    {
+        public override RangeHandler CreateRangeHandler(PostgresType rangeBackendType)
+            => throw new NotSupportedException();
+    }
+
     /// <summary>
     /// Type handler for PostgreSQL range types
     /// </summary>
@@ -38,37 +46,63 @@ namespace Npgsql.TypeHandlers
     /// http://www.postgresql.org/docs/current/static/rangetypes.html
     /// </remarks>
     /// <typeparam name="TElement">the range subtype</typeparam>
-    class RangeHandler<TElement> : NpgsqlTypeHandler<NpgsqlRange<TElement>>
+    public class RangeHandler<TElement> : RangeHandler, INpgsqlTypeHandler<NpgsqlRange<TElement>>
     {
         /// <summary>
         /// The type handler for the element that this range type holds
         /// </summary>
-        public NpgsqlTypeHandler ElementHandler { get; }
+        readonly NpgsqlTypeHandler _elementHandler;
 
-        public RangeHandler(NpgsqlTypeHandler<TElement> elementHandler)
-        {
-            ElementHandler = elementHandler;
-        }
+        public RangeHandler(NpgsqlTypeHandler elementHandler)
+            => _elementHandler = elementHandler;
 
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType backendType)
-        {
-            throw new Exception("Can't create range handler of range types, this is an Npgsql bug, please report.");
-        }
+        /// <inheritdoc />
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+            => new ArrayHandler<NpgsqlRange<TElement>>(this) { PostgresType = arrayBackendType };
+
+        internal override Type GetFieldType(FieldDescription fieldDescription = null) => typeof(NpgsqlRange<TElement>);
+        internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null) => typeof(NpgsqlRange<TElement>);
 
         #region Read
 
-        public override async ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        internal override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
+            => Read<TAny>(buf, len, false, fieldDescription).Result;
+
+        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        {
+            if (this is INpgsqlTypeHandler<TAny> typedHandler)
+                return typedHandler.Read(buf, len, async, fieldDescription);
+
+            buf.Skip(len); // Perform this in sync for performance
+            throw new NpgsqlSafeReadException(new InvalidCastException(fieldDescription == null
+                ? $"Can't cast database type to {typeof(TAny).Name}"
+                : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TAny).Name}"
+            ));
+        }
+
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+            => await Read(buf, len, async, fieldDescription);
+
+        internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
+            => Read(buf, len, false, fieldDescription).Result;
+
+        public async ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription)
         {
             await buf.Ensure(1, async);
+
             var flags = (RangeFlags)buf.ReadByte();
             if ((flags & RangeFlags.Empty) != 0)
                 return NpgsqlRange<TElement>.Empty;
 
-            TElement lowerBound = default(TElement), upperBound = default(TElement);
+            var lowerBound = default(TElement);
+            var upperBound = default(TElement);
+
             if ((flags & RangeFlags.LowerBoundInfinite) == 0)
-                lowerBound = await ElementHandler.ReadWithLength<TElement>(buf, async);
+                lowerBound = await _elementHandler.ReadWithLength<TElement>(buf, async);
+
             if ((flags & RangeFlags.UpperBoundInfinite) == 0)
-                upperBound = await ElementHandler.ReadWithLength<TElement>(buf, async);
+                upperBound = await _elementHandler.ReadWithLength<TElement>(buf, async);
+
             return new NpgsqlRange<TElement>(lowerBound, upperBound, flags);
         }
 
@@ -76,17 +110,25 @@ namespace Npgsql.TypeHandlers
 
         #region Write
 
-        public override int ValidateAndGetLength(NpgsqlRange<TElement> value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        protected internal override int ValidateAndGetLength<TAny>(TAny value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+            => this is INpgsqlTypeHandler<TAny> typedHandler
+                ? typedHandler.ValidateAndGetLength(value, ref lengthCache, parameter)
+                : throw new InvalidCastException($"Can't write CLR type {typeof(TAny)} to database type {PgDisplayName}");
+
+        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter = null)
+            => ValidateAndGetLength((NpgsqlRange<TElement>)value, ref lengthCache, parameter);
+
+        public int ValidateAndGetLength(NpgsqlRange<TElement> value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
         {
             var totalLen = 1;
-
             var lengthCachePos = lengthCache?.Position ?? 0;
             if (!value.IsEmpty)
             {
                 if (!value.LowerBoundInfinite)
-                    totalLen += 4 + ElementHandler.ValidateAndGetLength(value.LowerBound, ref lengthCache, null);
+                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.LowerBound, ref lengthCache, null);
+
                 if (!value.UpperBoundInfinite)
-                    totalLen += 4 + ElementHandler.ValidateAndGetLength(value.UpperBound, ref lengthCache, null);
+                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.UpperBound, ref lengthCache, null);
             }
 
             // If we're traversing an already-populated length cache, rewind to first element slot so that
@@ -97,17 +139,67 @@ namespace Npgsql.TypeHandlers
             return totalLen;
         }
 
-        public override async Task Write(NpgsqlRange<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+        internal override Task WriteWithLengthInternal<TAny>(TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 4)
+                return WriteWithLengthLong();
+
+            if (value == null || typeof(TAny) == typeof(DBNull))
+            {
+                buf.WriteInt32(-1);
+                return PGUtil.CompletedTask;
+            }
+
+            return WriteWithLengthCore();
+
+            async Task WriteWithLengthLong()
+            {
+                if (buf.WriteSpaceLeft < 4)
+                    await buf.Flush(async);
+
+                if (value == null || typeof(TAny) == typeof(DBNull))
+                {
+                    buf.WriteInt32(-1);
+                    return;
+                }
+
+                await WriteWithLengthCore();
+            }
+
+            Task WriteWithLengthCore()
+            {
+                if (this is INpgsqlTypeHandler<TAny> typedHandler)
+                {
+                    buf.WriteInt32(typedHandler.ValidateAndGetLength(value, ref lengthCache, parameter));
+                    return typedHandler.Write(value, buf, lengthCache, parameter, async);
+                }
+                else
+                    throw new InvalidCastException($"Can't write CLR type {typeof(TAny)} to database type {PgDisplayName}");
+            }
+        }
+
+        // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
+        // us (need to handle many types of T, e.g. int[], int[,]...)
+        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+            => value == null || value is DBNull
+                ? WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async)
+                : WriteWithLengthInternal((NpgsqlRange<TElement>)value, buf, lengthCache, parameter, async);
+
+        public async Task Write(NpgsqlRange<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
         {
             if (buf.WriteSpaceLeft < 1)
                 await buf.Flush(async);
+
             buf.WriteByte((byte)value.Flags);
+
             if (value.IsEmpty)
                 return;
+
             if (!value.LowerBoundInfinite)
-                await ElementHandler.WriteWithLengthInternal(value.LowerBound, buf, lengthCache, null, async);
+                await _elementHandler.WriteWithLengthInternal(value.LowerBound, buf, lengthCache, null, async);
+
             if (!value.UpperBoundInfinite)
-                await ElementHandler.WriteWithLengthInternal(value.UpperBound, buf, lengthCache, null, async);
+                await _elementHandler.WriteWithLengthInternal(value.UpperBound, buf, lengthCache, null, async);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -114,10 +114,8 @@ namespace Npgsql.TypeHandling
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null)
             => typeof(TPsv);
 
-        /// <summary>
-        /// Creates a type handler for arrays of this handler's type.
-        /// </summary>
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        /// <inheeritdoc />
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandlerWithPsv<TDefault, TPsv>(this) { PostgresType = arrayBackendType };
 
         #endregion Misc

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -168,12 +168,12 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Creates a type handler for arrays of this handler's type.
         /// </summary>
-        protected internal abstract ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
+        public abstract ArrayHandler CreateArrayHandler(PostgresType arrayBackendType);
 
         /// <summary>
         /// Creates a type handler for ranges of this handler's type.
         /// </summary>
-        internal abstract NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType);
+        public abstract RangeHandler CreateRangeHandler(PostgresType rangeBackendType);
 
         /// <summary>
         /// Used to create an exception when the provided type can be converted and written, but an

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -294,13 +294,12 @@ namespace Npgsql.TypeHandling
         internal override Type GetFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
         internal override Type GetProviderSpecificFieldType(FieldDescription fieldDescription = null) => typeof(TDefault);
 
-        /// <summary>
-        /// Creates a type handler for arrays of this handler's type.
-        /// </summary>
-        protected internal override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
+        /// <inheritdoc />
+        public override ArrayHandler CreateArrayHandler(PostgresType arrayBackendType)
             => new ArrayHandler<TDefault>(this) { PostgresType = arrayBackendType };
 
-        internal override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
+        /// <inheritdoc />
+        public override RangeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => new RangeHandler<TDefault>(this) { PostgresType = rangeBackendType };
 
         #endregion Misc


### PR DESCRIPTION
This is my idea how the range handler should be refactored to fix #2040. The only one error I encountered is shown below. Will investigate this tomorrow.

```
\.nuget\packages\microsoft.dotnet.ilcompiler\1.0.0-alpha-26714-01\build\Microsoft.NETCore.Native.Windows.props(95,43): error MSB4184: The expression ""System.String[]".GetValue(1)" cannot be evaluated. Index was outside the bounds of the array.
```