### PR TITLE
added basic connection string builder support for PgSQL client SSL certificates

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -535,6 +535,24 @@ namespace Npgsql
         SslMode _sslmode;
 
         /// <summary>
+        /// Specifies the file name of the client SSL certificate.
+        /// </summary>
+        [Category("Security")]
+        [Description("Specifies the file name of the client SSL certificate.")]
+        [DisplayName("SSL Cert")]
+        [NpgsqlConnectionStringProperty]
+        public string SslCert
+        {
+            get => _sslCert;
+            set
+            {
+                _sslCert = value;
+                SetValue(nameof(SslCert), value);
+            }
+        }
+        string _sslCert;
+
+        /// <summary>
         /// Whether to trust the server certificate without validating it.
         /// </summary>
         [Category("Security")]


### PR DESCRIPTION
added basic support for client SSL certificates, naming based on:
https://www.postgresql.org/docs/9.6/static/libpq-envars.html
The certificate can be used like in this example: https://cloud.google.com/appengine/docs/flexible/dotnet/using-cloud-sql-postgres#setting_the_connection_string_and_adding_a_library