### PR TITLE
Fixed incorrect money writer

### DIFF
--- a/src/Npgsql/TypeHandlers/NumericHandlers/MoneyHandler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/MoneyHandler.cs
@@ -57,12 +57,10 @@ namespace Npgsql.TypeHandlers.NumericHandlers
             if (scaleDifference > 0)
                 DecimalRaw.Multiply(ref raw, DecimalRaw.Powers10[scaleDifference]);
             else
-                while (scaleDifference < 0)
-                {
-                    var scaleChunk = Math.Min(DecimalRaw.MaxUInt32Scale, -scaleDifference);
-                    DecimalRaw.Divide(ref raw, DecimalRaw.Powers10[scaleChunk]);
-                    scaleDifference -= scaleChunk;
-                }
+            {
+                value = Math.Round(value, MoneyScale, MidpointRounding.AwayFromZero);
+                raw = Unsafe.As<decimal, DecimalRaw>(ref value);
+            }
 
             var result = (long)raw.Mid << 32 | (long)raw.Low;
             if (raw.Negative) result = -result;

--- a/test/Npgsql.Tests/Types/MoneyTests.cs
+++ b/test/Npgsql.Tests/Types/MoneyTests.cs
@@ -1,0 +1,77 @@
+﻿using NpgsqlTypes;
+using NUnit.Framework;
+using System;
+using System.Data;
+
+namespace Npgsql.Tests.Types
+{
+    public class MoneyTests : TestBase
+    {
+        static readonly object[] ReadWriteCases = new[]
+        {
+            new object[] { "1.22::money", 1.22M },
+            new object[] { "1000.22::money", 1000.22M },
+            new object[] { "1000000.22::money", 1000000.22M },
+            new object[] { "1000000000.22::money", 1000000000.22M },
+            new object[] { "1000000000000.22::money", 1000000000000.22M },
+            new object[] { "1000000000000000.22::money", 1000000000000000.22M },
+
+            new object[] { "+92233720368547758.07::numeric::money", +92233720368547758.07M },
+            new object[] { "-92233720368547758.08::numeric::money", -92233720368547758.08M },
+        };
+
+        [Test]
+        [TestCaseSource(nameof(ReadWriteCases))]
+        public void Read(string query, decimal expected)
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT " + query, conn))
+            {
+                Assert.That(decimal.GetBits(cmd.ExecuteScalar<decimal>()), Is.EqualTo(decimal.GetBits(expected)));
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ReadWriteCases))]
+        public void Write(string query, decimal expected)
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p, @p = " + query, conn))
+            {
+                cmd.Parameters.Add(new NpgsqlParameter("p", NpgsqlDbType.Money) { Value = expected });
+                using (var rdr = cmd.ExecuteRecord())
+                {
+                    Assert.That(decimal.GetBits(rdr.GetFieldValue<decimal>(0)), Is.EqualTo(decimal.GetBits(expected)));
+                    Assert.That(rdr.GetFieldValue<bool>(1));
+                }
+            }
+        }
+
+        [Test]
+        public void Mapping()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
+            {
+                cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Money) { Value = 8M });
+                cmd.Parameters.Add(new NpgsqlParameter("p2", DbType.Currency) { Value = 8M });
+
+                using (var rdr = cmd.ExecuteRecord())
+                    for (var i = 0; i < cmd.Parameters.Count; i++)
+                    {
+                        Assert.That(rdr.GetFieldType(i), Is.EqualTo(typeof(decimal)));
+                        Assert.That(rdr.GetDataTypeName(i), Is.EqualTo("money"));
+                        Assert.That(rdr.GetValue(i), Is.EqualTo(8M));
+                        Assert.That(rdr.GetProviderSpecificValue(i), Is.EqualTo(8M));
+                        Assert.That(rdr.GetFieldValue<decimal>(i), Is.EqualTo(8M));
+                        Assert.That(() => rdr.GetFieldValue<byte>(i), Throws.InstanceOf<InvalidCastException>());
+                        Assert.That(() => rdr.GetFieldValue<short>(i), Throws.InstanceOf<InvalidCastException>());
+                        Assert.That(() => rdr.GetFieldValue<int>(i), Throws.InstanceOf<InvalidCastException>());
+                        Assert.That(() => rdr.GetFieldValue<long>(i), Throws.InstanceOf<InvalidCastException>());
+                        Assert.That(() => rdr.GetFieldValue<float>(i), Throws.InstanceOf<InvalidCastException>());
+                        Assert.That(() => rdr.GetFieldValue<double>(i), Throws.InstanceOf<InvalidCastException>());
+                    }
+            }
+        }
+    }
+}

--- a/test/Npgsql.Tests/Types/NumericTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTypeTests.cs
@@ -263,32 +263,6 @@ namespace Npgsql.Tests.Types
             }
         }
 
-        /// <summary>
-        /// http://www.postgresql.org/docs/current/static/datatype-money.html
-        /// </summary>
-        [Test]
-        public void Money()
-        {
-            using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
-            {
-                var expected1 = 12345.12m;
-                var expected2 = -10.5m;
-                cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Money, expected1);
-                cmd.Parameters.Add(new NpgsqlParameter("p2", DbType.Currency) { Value = expected2 });
-                using (var reader = cmd.ExecuteReader())
-                {
-                    reader.Read();
-                    Assert.That(reader.GetDecimal(0), Is.EqualTo(12345.12m));
-                    Assert.That(reader.GetValue(0), Is.EqualTo(12345.12m));
-                    Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(12345.12m));
-                    Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(decimal)));
-
-                    Assert.That(reader.GetDecimal(1), Is.EqualTo(-10.5m));
-                }
-            }
-        }
-
         [Test, Description("Tests handling of numeric overflow when writing data")]
         [TestCase(NpgsqlDbType.Smallint, 1 + short.MaxValue)]
         [TestCase(NpgsqlDbType.Smallint, 1L + short.MaxValue)]


### PR DESCRIPTION
The loop was replaced by `Math.Round` for compatibility reasons. Fixes #2082.

/cc @RobSiklos