### PR TITLE
Bulk copy return rows in NpgsqlBinaryImporter

### DIFF
--- a/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
+++ b/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
@@ -103,7 +103,7 @@ namespace Npgsql.BackendMessages
                 Rows = ParseNumber(bytes, ref i);
                 return this;
 
-                default:
+            default:
                 StatementType = StatementType.Other;
                 return this;
             }

--- a/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
+++ b/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
@@ -95,7 +95,15 @@ namespace Npgsql.BackendMessages
                 Rows = ParseNumber(bytes, ref i);
                 return this;
 
-            default:
+            case (byte)'C':
+                if (!AreEqual(bytes, i, "COPY "))
+                    goto default;
+                StatementType = StatementType.Copy;
+                i += 5;
+                Rows = ParseNumber(bytes, ref i);
+                return this;
+
+                default:
                 StatementType = StatementType.Other;
                 return this;
             }


### PR DESCRIPTION
See issue #2112 . 
I am requesting that npgsql consider integrating this enhancement to return the number of rows copied in `NpgsqlBinaryImport.Complete()` method.

See bytefish/PostgreSQLCopyHelper#30 for downstream implementation.

In this pull request: one commit with 2 files to implement the minor enhancement in npgsql.

I have tested this commit on the latest dev code in the following way:
- Cloned npgsql/dev. 
- Changed 2 files to implement enhancement
- Compiled npgsql:BulkCopyReturnRows branch
- Implemented downstream enhancement in PostgreSQLCopyHelper (checked out latest there)
- Compiled PostgreSQLCopyHelper referencing new npgsql binaries 
- Tested COPY using new libraries (npgsql and PostgreSQLCopyHelper) dropped into my application to verify that copy works and returns the row counts.

- Have not yet had a chance to add tests as I wanted to push this out for comment.