### PR TITLE
Implement DataTypes schema collection

### DIFF
--- a/test/Npgsql.Tests/SchemaTests.cs
+++ b/test/Npgsql.Tests/SchemaTests.cs
@@ -31,6 +31,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Npgsql;
 using Npgsql.Tests;
+using NpgsqlTypes;
 using NUnit.Framework;
 
 namespace Npgsql.Tests
@@ -125,7 +126,7 @@ namespace Npgsql.Tests
             {
                 var metadata = conn.GetSchema(DbMetaDataCollectionNames.MetaDataCollections).Rows
                     .Cast<DataRow>()
-                    .Single(r => (string)r["CollectionName"] == "DataSourceInformation");
+                    .Single(r => r["CollectionName"].Equals("DataSourceInformation"));
                 Assert.That(metadata["NumberOfRestrictions"], Is.Zero);
                 Assert.That(metadata["NumberOfIdentifierParts"], Is.Zero);
 
@@ -144,6 +145,80 @@ namespace Npgsql.Tests
                     Is.EqualTo("some_identifier"));
             }
         }
+
+        [Test]
+        public void DataTypes()
+        {
+            using (var conn = OpenConnection())
+            {
+                conn.ExecuteNonQuery("CREATE TYPE pg_temp.test_enum AS ENUM ('a', 'b')");
+                conn.ExecuteNonQuery("CREATE TYPE pg_temp.test_composite AS (a INTEGER)");
+                conn.ExecuteNonQuery("CREATE DOMAIN pg_temp.us_postal_code AS TEXT");
+                conn.ReloadTypes();
+                conn.TypeMapper.MapEnum<TestEnum>();
+                conn.TypeMapper.MapComposite<TestComposite>();
+
+                var metadata = conn.GetSchema(DbMetaDataCollectionNames.MetaDataCollections).Rows
+                    .Cast<DataRow>()
+                    .Single(r => r["CollectionName"].Equals("DataTypes"));
+                Assert.That(metadata["NumberOfRestrictions"], Is.Zero);
+                Assert.That(metadata["NumberOfIdentifierParts"], Is.Zero);
+
+                var dataTypes = conn.GetSchema(DbMetaDataCollectionNames.DataTypes);
+
+                var intRow = dataTypes.Rows.Cast<DataRow>().Single(r => r["TypeName"].Equals("integer"));
+                Assert.That(intRow["DataType"], Is.EqualTo("System.Int32"));
+                Assert.That(intRow["ProviderDbType"], Is.EqualTo((int)NpgsqlDbType.Integer));
+                Assert.That(intRow["IsUnsigned"], Is.False);
+                Assert.That(intRow["OID"], Is.EqualTo(23));
+
+                var textRow = dataTypes.Rows.Cast<DataRow>().Single(r => r["TypeName"].Equals("text"));
+                Assert.That(textRow["DataType"], Is.EqualTo("System.String"));
+                Assert.That(textRow["ProviderDbType"], Is.EqualTo((int)NpgsqlDbType.Text));
+                Assert.That(textRow["IsUnsigned"], Is.SameAs(DBNull.Value));
+                Assert.That(textRow["OID"], Is.EqualTo(25));
+
+                var numericRow = dataTypes.Rows.Cast<DataRow>().Single(r => r["TypeName"].Equals("numeric"));
+                Assert.That(numericRow["DataType"], Is.EqualTo("System.Decimal"));
+                Assert.That(numericRow["ProviderDbType"], Is.EqualTo((int)NpgsqlDbType.Numeric));
+                Assert.That(numericRow["IsUnsigned"], Is.False);
+                Assert.That(numericRow["OID"], Is.EqualTo(1700));
+                Assert.That(numericRow["CreateFormat"], Is.EqualTo("NUMERIC({0},{1})"));
+                Assert.That(numericRow["CreateParameters"], Is.EqualTo("precision, scale"));
+
+                var intArrayRow = dataTypes.Rows.Cast<DataRow>().Single(r => r["TypeName"].Equals("integer[]"));
+                Assert.That(intArrayRow["DataType"], Is.EqualTo("System.Int32[]"));
+                Assert.That(intArrayRow["ProviderDbType"], Is.EqualTo((int)(NpgsqlDbType.Integer | NpgsqlDbType.Array)));
+                Assert.That(intArrayRow["OID"], Is.EqualTo(1007));
+                Assert.That(intArrayRow["CreateFormat"], Is.EqualTo("INTEGER[]"));
+
+                var numericArrayRow = dataTypes.Rows.Cast<DataRow>().Single(r => r["TypeName"].Equals("numeric[]"));
+                Assert.That(numericArrayRow["CreateFormat"], Is.EqualTo("NUMERIC({0},{1})[]"));
+                Assert.That(numericArrayRow["CreateParameters"], Is.EqualTo("precision, scale"));
+
+                var intRangeRow = dataTypes.Rows.Cast<DataRow>().Single(r => ((string)r["TypeName"]).EndsWith("int4range"));
+                Assert.That(intRangeRow["DataType"], Does.StartWith("NpgsqlTypes.NpgsqlRange`1[[System.Int32"));
+                Assert.That(intRangeRow["ProviderDbType"], Is.EqualTo((int)(NpgsqlDbType.Integer | NpgsqlDbType.Range)));
+                Assert.That(intRangeRow["OID"], Is.EqualTo(3904));
+
+                var enumRow = dataTypes.Rows.Cast<DataRow>().Single(r => ((string)r["TypeName"]).EndsWith(".test_enum"));
+                Assert.That(enumRow["DataType"], Is.EqualTo("Npgsql.Tests.SchemaTests+TestEnum"));
+                Assert.That(enumRow["ProviderDbType"], Is.SameAs(DBNull.Value));
+
+                var compositeRow = dataTypes.Rows.Cast<DataRow>().Single(r => ((string)r["TypeName"]).EndsWith(".test_composite"));
+                Assert.That(compositeRow["DataType"], Is.EqualTo("Npgsql.Tests.SchemaTests+TestComposite"));
+                Assert.That(compositeRow["ProviderDbType"], Is.SameAs(DBNull.Value));
+
+                var domainRow = dataTypes.Rows.Cast<DataRow>().Single(r => ((string)r["TypeName"]).EndsWith(".us_postal_code"));
+                Assert.That(domainRow["DataType"], Is.EqualTo("System.String"));
+                Assert.That(domainRow["ProviderDbType"], Is.EqualTo((int)NpgsqlDbType.Text));
+                Assert.That(domainRow["IsBestMatch"], Is.False);
+            }
+        }
+
+        enum TestEnum { A, B };
+
+        class TestComposite { int A { get; set; } }
 
         [Test]
         public void Restrictions()


### PR DESCRIPTION
Expose PostgreSQL type and mapping information via the standard DataType schema collection. All type types are supported (base, array, range, enum, composite, domain), and most metadata values are populated properly.

Fixes #1762

Reviewers, note that this PR doesn't aim to be completely exhaustive - there are surely some extra features we could add, extra values we could populate, etc. The idea is to present at the very least a minimal working implementation for DataTypes.

@Brar, you may be interested in taking a look, this intersects a little bit with your parameter derivation work.