### PR TITLE
Added GetNpgsqlDbType(int) function to NpgsqlDataReader.

### DIFF
--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -361,6 +361,38 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test]
+        public void GetNpgsqlDbType()
+        {
+            using (var conn = OpenConnection())
+            {
+                NpgsqlTypes.NpgsqlDbType intType;
+                using (var cmd = new NpgsqlCommand(@"SELECT 1::INTEGER AS some_column", conn))
+                using (var reader = cmd.ExecuteReader(Behavior))
+                {
+                    reader.Read();
+                    intType = reader.GetNpgsqlDbType(0);
+                    Assert.That(intType, Is.EqualTo(NpgsqlTypes.NpgsqlDbType.Integer));
+                }
+
+                using (var cmd = new NpgsqlCommand(@"SELECT '{1}'::INTEGER[] AS some_column", conn))
+                using (var reader = cmd.ExecuteReader(Behavior))
+                {
+                    reader.Read();
+                    NpgsqlTypes.NpgsqlDbType intArrayType = reader.GetNpgsqlDbType(0);
+                    Assert.That(intArrayType, Is.EqualTo(NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Integer));
+                }
+
+                using (var cmd = new NpgsqlCommand(@"SELECT int4range(0, 1) AS some_column", conn))
+                using (var reader = cmd.ExecuteReader(Behavior))
+                {
+                    reader.Read();
+                    NpgsqlTypes.NpgsqlDbType intRangeType = reader.GetNpgsqlDbType(0);
+                    Assert.That(intRangeType, Is.EqualTo(NpgsqlTypes.NpgsqlDbType.Range | NpgsqlTypes.NpgsqlDbType.Integer));
+                }
+            }
+        }
+
         /// <seealso cref="ReaderNewSchemaTests.DataTypeName"/>
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/787")]
         [TestCase("integer")]


### PR DESCRIPTION
In the pre-4.0 version of Npgsql, we were able to access the NpgsqlDbType for a column from the NpgsqlDataReader via a return of the column's PostgresType class, e.g. var npgsqlDbType = reader.GetPostgresType(row).NpgsqlDbType; 

Since both the NpgsqlDbType property was removed from the PostgresType class and the connector for the data reader is inaccessible for access to the reader's TypeMapper, I went ahead and added a new Getter to the NpgsqlDataReader for getting the NpgsqlDbType directly from the data reader. 

Is there any reason why this should not be allowed from the context of the data reader? 