### PR TITLE
Add separate schema field for mappings

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -30,9 +30,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,13 +42,14 @@ using NpgsqlTypes;
 using System.Transactions;
 using IsolationLevel = System.Data.IsolationLevel;
 
+// ReSharper disable ArrangeStaticMemberQualifier
+// ReSharper disable UnusedMember.Global
 namespace Npgsql
 {
     /// <summary>
     /// This class represents a connection to a PostgreSQL server.
     /// </summary>
-    // ReSharper disable once RedundantNameQualifier
-    [System.ComponentModel.DesignerCategory("")]
+    [DesignerCategory("")]
     public sealed class NpgsqlConnection : DbConnection, ICloneable
     {
         #region Fields
@@ -1038,7 +1037,7 @@ namespace Npgsql
         [Obsolete("Use NpgsqlConnection.TypeMapper.MapEnum() instead")]
         public void MapEnum<TEnum>(string pgName = null, INpgsqlNameTranslator nameTranslator = null)
             where TEnum : struct, Enum
-            => TypeMapper.MapEnum<TEnum>(pgName, nameTranslator);
+            => TypeMapper.MapEnum<TEnum>(pgName, null, nameTranslator);
 
         /// <summary>
         /// Maps a CLR enum to a PostgreSQL enum type for use with all connections created from now on. Existing connections aren't affected.
@@ -1066,7 +1065,7 @@ namespace Npgsql
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.MapEnum() instead")]
         public static void MapEnumGlobally<TEnum>(string pgName = null, INpgsqlNameTranslator nameTranslator = null)
             where TEnum : struct, Enum
-            => NpgsqlConnection.GlobalTypeMapper.MapEnum<TEnum>(pgName, nameTranslator);
+            => NpgsqlConnection.GlobalTypeMapper.MapEnum<TEnum>(pgName, null, nameTranslator);
 
         /// <summary>
         /// Removes a previous global enum mapping.
@@ -1082,7 +1081,7 @@ namespace Npgsql
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.UnmapEnum() instead")]
         public static void UnmapEnumGlobally<TEnum>(string pgName = null, INpgsqlNameTranslator nameTranslator = null)
             where TEnum : struct, Enum
-            => NpgsqlConnection.GlobalTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
+            => NpgsqlConnection.GlobalTypeMapper.UnmapEnum<TEnum>(pgName, null, nameTranslator);
 
         #endregion
 

--- a/src/Npgsql/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/NpgsqlDatabaseInfo.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2018 The Npgsql Development Team
@@ -19,13 +20,12 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Data.Common;
-using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 
@@ -135,17 +135,8 @@ namespace Npgsql
 
         /// <summary>
         /// Indexes backend types by their PostgreSQL name, including namespace (e.g. pg_catalog.int4).
-        /// Only used for enums and composites.
         /// </summary>
-        internal Dictionary<string, PostgresType> ByFullName { get; } = new Dictionary<string, PostgresType>();
-
-        /// <summary>
-        /// Indexes backend types by their PostgreSQL name, not including namespace.
-        /// If more than one type exists with the same name (i.e. in different namespaces) this
-        /// table will contain an entry with a null value.
-        /// Only used for enums and composites.
-        /// </summary>
-        internal Dictionary<string, PostgresType> ByName { get; } = new Dictionary<string, PostgresType>();
+        internal Dictionary<(string Name, string Schema), PostgresType> ByNameSchema { get; } = new Dictionary<(string Name, string Schema), PostgresType>();
 
         internal void ProcessTypes()
         {
@@ -159,12 +150,7 @@ namespace Npgsql
             foreach (var type in GetTypes())
             {
                 ByOID[type.OID] = type;
-                ByFullName[type.FullName] = type;
-                // If more than one type exists with the same partial name, we place a null value.
-                // This allows us to detect this case later and force the user to use full names only.
-                ByName[type.Name] = ByName.ContainsKey(type.Name)
-                    ? null
-                    : type;
+                ByNameSchema[(type.Name, type.Namespace)] = type;
 
                 switch (type)
                 {

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -522,7 +522,7 @@ namespace Npgsql
             if (_npgsqlDbType.HasValue)
                 Handler = typeMapper.GetByNpgsqlDbType(_npgsqlDbType.Value);
             else if (_dataTypeName != null)
-                Handler = typeMapper.GetByDataTypeName(_dataTypeName);
+                Handler = typeMapper.GetByDataTypeName(_dataTypeName, _dataTypeName.IndexOf('.') == -1 ? null : _dataTypeName.Split('.')[0]);
             else if (_dbType.HasValue)
                 Handler = typeMapper.GetByDbType(_dbType.Value);
             else if (_value != null)

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -73,7 +73,7 @@ namespace Npgsql
             if (_npgsqlDbType.HasValue)
                 Handler = typeMapper.GetByNpgsqlDbType(_npgsqlDbType.Value);
             else if (_dataTypeName != null)
-                Handler = typeMapper.GetByDataTypeName(_dataTypeName);
+                Handler = typeMapper.GetByDataTypeName(_dataTypeName, _dataTypeName.IndexOf('.') == -1 ? null : _dataTypeName.Split('.')[0]);
             else if (_dbType.HasValue)
                 Handler = typeMapper.GetByDbType(_dbType.Value);
             else

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -25,7 +25,6 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
-using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 using Npgsql.PostgresTypes;
@@ -605,8 +604,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var baseType in connector.DatabaseInfo.BaseTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(baseType.Name, out var mapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(baseType.FullName, out mapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((baseType.Name, null), out var mapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((baseType.Name, baseType.Namespace), out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -622,8 +621,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var arrayType in connector.DatabaseInfo.ArrayTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(arrayType.Element.Name, out var elementMapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(arrayType.Element.FullName, out elementMapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((arrayType.Element.Name, null), out var elementMapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((arrayType.Element.Name, arrayType.Element.Namespace), out elementMapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -643,8 +642,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var rangeType in connector.DatabaseInfo.RangeTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(rangeType.Subtype.Name, out var elementMapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(rangeType.Subtype.FullName, out elementMapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((rangeType.Subtype.Name, null), out var elementMapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((rangeType.Subtype.Name, rangeType.Subtype.Namespace), out elementMapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -664,8 +663,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var enumType in connector.DatabaseInfo.EnumTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(enumType.Name, out var mapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(enumType.FullName, out mapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((enumType.Name, null), out var mapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((enumType.Name, enumType.Namespace), out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -679,8 +678,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var compositeType in connector.DatabaseInfo.CompositeTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(compositeType.Name, out var mapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(compositeType.FullName, out mapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((compositeType.Name, null), out var mapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((compositeType.Name, compositeType.Namespace), out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -694,8 +693,8 @@ and n.nspname not in ('pg_catalog', 'pg_toast')");
 
             foreach (var domainType in connector.DatabaseInfo.DomainTypes)
             {
-                if (!connector.TypeMapper.Mappings.TryGetValue(domainType.BaseType.Name, out var baseMapping) &&
-                    !connector.TypeMapper.Mappings.TryGetValue(domainType.BaseType.FullName, out baseMapping))
+                if (!connector.TypeMapper.Mappings.TryGetValue((domainType.BaseType.Name, null), out var baseMapping) &&
+                    !connector.TypeMapper.Mappings.TryGetValue((domainType.BaseType.Name, domainType.BaseType.Namespace), out baseMapping))
                     continue;
 
                 var row = table.Rows.Add();

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -1,14 +1,9 @@
 ﻿using System;
-using System.CodeDom;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Data;
-using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using Npgsql.BackendMessages;
-using Npgsql.PostgresTypes;
 using Npgsql.TypeHandlers;
 using System.Transactions;
 
@@ -228,14 +223,9 @@ ORDER BY attnum";
         {
             var typeMapper = _connection.Connector.TypeMapper;
 
-            if (typeMapper.Mappings.TryGetValue(column.PostgresType.Name, out var mapping))
+            if (typeMapper.Mappings.TryGetValue((column.PostgresType.Name, null), out var mapping) ||
+                typeMapper.Mappings.TryGetValue((column.PostgresType.Name, column.PostgresType.Namespace), out mapping))
                 column.NpgsqlDbType = mapping.NpgsqlDbType;
-            else if (
-                column.PostgresType.Name.Contains(".") &&
-                typeMapper.Mappings.TryGetValue(column.PostgresType.Name.Split('.')[1], out mapping)
-            ) {
-                column.NpgsqlDbType = mapping.NpgsqlDbType;
-            }
 
             column.DataType = typeMapper.TryGetByOID(column.TypeOID, out var handler)
                 ? handler.GetFieldType()

--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
@@ -34,7 +34,7 @@ namespace Npgsql.TypeHandlers.InternalTypeHandlers
     class Int2VectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
         internal override NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
-            => new Int2VectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["smallint"])
+            => new Int2VectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByNameSchema[("smallint", null)])
             {
                 PostgresType = pgType
             };

--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
@@ -34,7 +34,7 @@ namespace Npgsql.TypeHandlers.InternalTypeHandlers
     class OIDVectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
         internal override NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
-            => new OIDVectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByName["oid"])
+            => new OIDVectorHandler(conn.Connector.TypeMapper.DatabaseInfo.ByNameSchema[("oid", null)])
             {
                 PostgresType = pgType
             };

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -26,9 +26,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Npgsql.NameTranslation;
 using Npgsql.TypeHandling;
 using NpgsqlTypes;
@@ -59,7 +57,7 @@ namespace Npgsql.TypeMapping
 
         internal GlobalTypeMapper()
         {
-            Mappings = new Dictionary<string, NpgsqlTypeMapping>();
+            Mappings = new Dictionary<(string PgTypeName, string PgTypeSchema), NpgsqlTypeMapping>();
             DefaultNameTranslator = new NpgsqlSnakeCaseNameTranslator();
         }
 
@@ -97,12 +95,12 @@ namespace Npgsql.TypeMapping
             }
         }
 
-        public override bool RemoveMapping(string pgTypeName)
+        public override bool RemoveMapping(string pgTypeName, string pgTypeSchema = null)
         {
             Lock.EnterWriteLock();
             try
             {
-                var result = base.RemoveMapping(pgTypeName);
+                var result = base.RemoveMapping(pgTypeName, pgTypeSchema);
                 RecordChange();
                 return result;
             }
@@ -200,6 +198,7 @@ namespace Npgsql.TypeMapping
                     AddMapping(new NpgsqlTypeMappingBuilder
                     {
                         PgTypeName = m.PgName,
+                        PgTypeSchema = null,
                         NpgsqlDbType = m.NpgsqlDbType,
                         DbTypes = m.DbTypes,
                         ClrTypes = m.ClrTypes,
@@ -225,6 +224,7 @@ namespace Npgsql.TypeMapping
                     AddMapping(new NpgsqlTypeMappingBuilder
                     {
                         PgTypeName = m.PgName,
+                        PgTypeSchema = null,
                         NpgsqlDbType = m.NpgsqlDbType,
                         DbTypes = m.DbTypes,
                         ClrTypes = m.ClrTypes,

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -23,12 +23,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Npgsql.NameTranslation;
 using NpgsqlTypes;
 
+// ReSharper disable UnusedMember.Global
 namespace Npgsql.TypeMapping
 {
     /// <summary>
@@ -49,7 +47,7 @@ namespace Npgsql.TypeMapping
         /// Removes an existing mapping from this mapper. Attempts to read or write this type
         /// after removal will result in an exception.
         /// </summary>
-        bool RemoveMapping(string pgTypeName);
+        bool RemoveMapping(string pgTypeName, string pgTypeSchema = null);
 
         /// <summary>
         /// Enumerates all mappings currently set up on this type mapper.
@@ -71,12 +69,15 @@ namespace Npgsql.TypeMapping
         /// A PostgreSQL type name for the corresponding enum type in the database.
         /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
         /// </param>
+        /// <param name="pgSchema">
+        /// A PostgreSQL schema name for the corresponding enum type in the database.
+        /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
-        INpgsqlTypeMapper MapEnum<TEnum>(string pgName = null, INpgsqlNameTranslator nameTranslator = null)
+        INpgsqlTypeMapper MapEnum<TEnum>(string pgName = null, string pgSchema = null, INpgsqlNameTranslator nameTranslator = null)
             where TEnum : struct, Enum;
 
         /// <summary>
@@ -86,11 +87,14 @@ namespace Npgsql.TypeMapping
         /// A PostgreSQL type name for the corresponding enum type in the database.
         /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
+        /// <param name="pgSchema">
+        /// A PostgreSQL schema name for the corresponding enum type in the database.
+        /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
-        bool UnmapEnum<TEnum>(string pgName = null, INpgsqlNameTranslator nameTranslator = null)
+        bool UnmapEnum<TEnum>(string pgName = null, string pgSchema = null, INpgsqlNameTranslator nameTranslator = null)
             where TEnum : struct, Enum;
 
         /// <summary>

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // The PostgreSQL License
 //
 // Copyright (C) 2018 The Npgsql Development Team
@@ -19,15 +20,12 @@
 // AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS
 // ON AN "AS IS" BASIS, AND THE NPGSQL DEVELOPMENT TEAM HAS NO OBLIGATIONS
 // TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
 #endregion
 
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Text;
-using Npgsql;
 using Npgsql.NameTranslation;
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
@@ -406,7 +404,7 @@ namespace Npgsql.Tests.Types
         }
 
         [Test, Description("Tests that a a C# enum an be written to an enum backend when passed as dbUnknown")]
-        public void WriteEnumAsDbUnknwown()
+        public void WriteEnumAsDbUnknown()
         {
             using (var conn = OpenConnection())
             {
@@ -522,8 +520,8 @@ namespace Npgsql.Tests.Types
                     conn.ExecuteNonQuery("CREATE TYPE b.my_enum AS ENUM ('alpha')");
                     conn.ReloadTypes();
                     conn.TypeMapper
-                        .MapEnum<Enum1>("a.my_enum")
-                        .MapEnum<Enum2>("b.my_enum");
+                        .MapEnum<Enum1>("my_enum", "a")
+                        .MapEnum<Enum2>("my_enum", "b");
                     using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
                     {
                         cmd.Parameters.AddWithValue("p1", Enum1.One);
@@ -540,8 +538,8 @@ namespace Npgsql.Tests.Types
                 }
 
                 // Global mapping
-                NpgsqlConnection.GlobalTypeMapper.MapEnum<Enum1>("a.my_enum");
-                NpgsqlConnection.GlobalTypeMapper.MapEnum<Enum2>("b.my_enum");
+                NpgsqlConnection.GlobalTypeMapper.MapEnum<Enum1>("my_enum", "a");
+                NpgsqlConnection.GlobalTypeMapper.MapEnum<Enum2>("my_enum", "b");
                 using (var conn = OpenConnection())
                 {
                     using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
@@ -561,8 +559,8 @@ namespace Npgsql.Tests.Types
             }
             finally
             {
-                NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Enum1>("a.my_enum");
-                NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Enum2>("b.my_enum");
+                NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Enum1>("my_enum", "a");
+                NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Enum2>("my_enum", "b");
                 using (var conn = OpenConnection())
                     conn.ExecuteNonQuery("DROP SCHEMA IF EXISTS a CASCADE; DROP SCHEMA IF EXISTS b CASCADE");
             }


### PR DESCRIPTION
Currently, we have this:

```c#
GlobalTypeMapper.MapEnum<SomeEnum>("some_schema.some_enum");
```

Which contributes to the issues in the EF Core provider involving default schemas and detecting when to escape user defined type names.

npgsql/Npgsql.EntityFrameworkCore.PostgreSQL#605 attempts to address this from the provider-side, but it would be better if the type mapping treated names and schema's separately:

```c#
GlobalTypeMapper.MapEnum<SomeEnum>(name: "some_enum", schema: "some_schema");
```
## Related
- Closes: #2121
- Supports: https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/605