### PR TITLE
Buffer left space checks for primitive types

### DIFF
--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -227,18 +227,10 @@ namespace Npgsql
         #region Read Simple
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public sbyte ReadSByte()
-        {
-            Debug.Assert(sizeof(sbyte) <= ReadBytesLeft);
-            return (sbyte)Buffer[ReadPosition++];
-        }
+        public sbyte ReadSByte() => Read<sbyte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte ReadByte()
-        {
-            Debug.Assert(sizeof(byte) <= ReadBytesLeft);
-            return Buffer[ReadPosition++];
-        }
+        public byte ReadByte() => Read<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public short ReadInt16()
@@ -337,11 +329,17 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         T Read<T>()
         {
-            Debug.Assert(Unsafe.SizeOf<T>() <= ReadBytesLeft);
+            if (Unsafe.SizeOf<T>() > ReadBytesLeft)
+                ThrowNotSpaceLeft();
+
             var result = Unsafe.ReadUnaligned<T>(ref Buffer[ReadPosition]);
             ReadPosition += Unsafe.SizeOf<T>();
             return result;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowNotSpaceLeft()
+            => throw new InvalidOperationException("There is not enough space left in the buffer.");
 
         public string ReadString(int byteLen)
         {

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -196,18 +196,10 @@ namespace Npgsql
         #region Write Simple
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteSByte(sbyte value)
-        {
-            Debug.Assert(sizeof(sbyte) <= WriteSpaceLeft);
-            Buffer[WritePosition++] = (byte)value;
-        }
+        public void WriteSByte(sbyte value) => Write(value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteByte(byte value)
-        {
-            Debug.Assert(sizeof(byte) <= WriteSpaceLeft);
-            Buffer[WritePosition++] = value;
-        }
+        public void WriteByte(byte value) => Write(value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteInt16(int value)
@@ -280,10 +272,16 @@ namespace Npgsql
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void Write<T>(T value)
         {
-            Debug.Assert(Unsafe.SizeOf<T>() <= WriteSpaceLeft);
+            if (Unsafe.SizeOf<T>() > WriteSpaceLeft)
+                ThrowNotSpaceLeft();
+
             Unsafe.WriteUnaligned(ref Buffer[WritePosition], value);
             WritePosition += Unsafe.SizeOf<T>();
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowNotSpaceLeft()
+            => throw new InvalidOperationException("There is not enough space left in the buffer.");
 
         public Task WriteString(string s, int byteLen, bool async)
             => WriteString(s, s.Length, byteLen, async);


### PR DESCRIPTION
This change should prevent buffer overflows when reading/writing primitive types. At the same time it allows to have an exception in the right place and not in a socket.