### PR TITLE
Fixed auto prepared statement is wrongfully replaced by other statement.

### DIFF
--- a/src/Npgsql/PreparedStatementManager.cs
+++ b/src/Npgsql/PreparedStatementManager.cs
@@ -140,6 +140,7 @@ namespace Npgsql
             {
                 case PreparedState.Prepared:
                 case PreparedState.ToBePrepared:
+                case PreparedState.BeingPrepared:
                 // The statement has already been prepared (explicitly or automatically), or has been selected
                 // for preparation (earlier identical statement in the same command).
                 // We just need to check that the parameter types correspond, since prepared statements are


### PR DESCRIPTION
Fixes #2178 

Faulty statement stays in "BeingPrepared" state and replaces another prepared statement.