### PR TITLE
Start transactions with a single simple message

### DIFF
--- a/src/Npgsql/FrontendMessages/PregeneratedMessage.cs
+++ b/src/Npgsql/FrontendMessages/PregeneratedMessage.cs
@@ -71,16 +71,14 @@ namespace Npgsql.FrontendMessages
             var buf = new NpgsqlWriteBuffer(null, new MemoryStream(), NpgsqlWriteBuffer.MinimumSize, Encoding.ASCII);
             var message = new QueryMessage(PGUtil.UTF8Encoding);
 
-            BeginTrans                = Generate(buf, message, "BEGIN");
-            SetTransRepeatableRead    = Generate(buf, message, "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
-            SetTransSerializable      = Generate(buf, message, "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE");
-            SetTransReadCommitted     = Generate(buf, message, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED");
-            SetTransReadUncommitted   = Generate(buf, message, "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
-            CommitTransaction         = Generate(buf, message, "COMMIT");
-            RollbackTransaction       = Generate(buf, message, "ROLLBACK");
-            KeepAlive                 = Generate(buf, message, "SELECT NULL");
-
-            DiscardAll                = Generate(buf, message, "DISCARD ALL");
+            BeginTransRepeatableRead    = Generate(buf, message, "BEGIN ISOLATION LEVEL REPEATABLE READ");
+            BeginTransSerializable      = Generate(buf, message, "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE");
+            BeginTransReadCommitted     = Generate(buf, message, "BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED");
+            BeginTransReadUncommitted   = Generate(buf, message, "BEGIN TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
+            CommitTransaction           = Generate(buf, message, "COMMIT");
+            RollbackTransaction         = Generate(buf, message, "ROLLBACK");
+            KeepAlive                   = Generate(buf, message, "SELECT NULL");
+            DiscardAll                  = Generate(buf, message, "DISCARD ALL");
         }
 
         internal static PregeneratedMessage Generate(NpgsqlWriteBuffer buf, QueryMessage queryMessage, string query, int responseMessageCount=2)
@@ -94,11 +92,10 @@ namespace Npgsql.FrontendMessages
             return new PregeneratedMessage(bytes, description, responseMessageCount);
         }
 
-        internal static readonly PregeneratedMessage BeginTrans;
-        internal static readonly PregeneratedMessage SetTransRepeatableRead;
-        internal static readonly PregeneratedMessage SetTransSerializable;
-        internal static readonly PregeneratedMessage SetTransReadCommitted;
-        internal static readonly PregeneratedMessage SetTransReadUncommitted;
+        internal static readonly PregeneratedMessage BeginTransRepeatableRead;
+        internal static readonly PregeneratedMessage BeginTransSerializable;
+        internal static readonly PregeneratedMessage BeginTransReadCommitted;
+        internal static readonly PregeneratedMessage BeginTransReadUncommitted;
         internal static readonly PregeneratedMessage CommitTransaction;
         internal static readonly PregeneratedMessage RollbackTransaction;
         internal static readonly PregeneratedMessage KeepAlive;

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -107,22 +107,18 @@ namespace Npgsql
             switch (isolationLevel) {
                 case IsolationLevel.RepeatableRead:
                 case IsolationLevel.Snapshot:
-                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
-                    _connector.PrependInternalMessage(PregeneratedMessage.SetTransRepeatableRead);
+                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTransRepeatableRead);
                     break;
                 case IsolationLevel.Serializable:
-                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
-                    _connector.PrependInternalMessage(PregeneratedMessage.SetTransSerializable);
+                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTransSerializable);
                     break;
                 case IsolationLevel.ReadUncommitted:
                     // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still
                     // send as if.
-                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
-                    _connector.PrependInternalMessage(PregeneratedMessage.SetTransReadUncommitted);
+                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTransReadUncommitted);
                     break;
                 case IsolationLevel.ReadCommitted:
-                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTrans);
-                    _connector.PrependInternalMessage(PregeneratedMessage.SetTransReadCommitted);
+                    _connector.PrependInternalMessage(PregeneratedMessage.BeginTransReadCommitted);
                     break;
                 case IsolationLevel.Unspecified:
                     isolationLevel = DefaultIsolationLevel;

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -163,7 +163,7 @@ namespace Npgsql.Tests
 
         [Test, Description("Tests that the isolation levels are properly supported")]
         [TestCase(IsolationLevel.ReadCommitted,   "read committed")]
-        [TestCase(IsolationLevel.ReadUncommitted, "read uncommitted")]  // Not actually supported in PostgreSQL
+        [TestCase(IsolationLevel.ReadUncommitted, "read uncommitted")]
         [TestCase(IsolationLevel.RepeatableRead,  "repeatable read")]
         [TestCase(IsolationLevel.Serializable,    "serializable")]
         [TestCase(IsolationLevel.Snapshot,        "repeatable read")]

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -162,33 +162,27 @@ namespace Npgsql.Tests
         }
 
         [Test, Description("Tests that the isolation levels are properly supported")]
-        public void IsolationLevels()
+        [TestCase(IsolationLevel.ReadCommitted,   "read committed")]
+        [TestCase(IsolationLevel.ReadUncommitted, "read uncommitted")]  // Not actually supported in PostgreSQL
+        [TestCase(IsolationLevel.RepeatableRead,  "repeatable read")]
+        [TestCase(IsolationLevel.Serializable,    "serializable")]
+        [TestCase(IsolationLevel.Snapshot,        "repeatable read")]
+        [TestCase(IsolationLevel.Unspecified,     "read committed")]
+        public void IsolationLevels(IsolationLevel level, string expectedName)
         {
             using (var conn = OpenConnection())
             {
-                foreach (var level in new[]
-                {
-                    IsolationLevel.Unspecified,
-                    IsolationLevel.ReadCommitted,
-                    IsolationLevel.ReadUncommitted,
-                    IsolationLevel.RepeatableRead,
-                    IsolationLevel.Serializable,
-                    IsolationLevel.Snapshot,
-                })
-                {
-                    var tx = conn.BeginTransaction(level);
-                    tx.Commit();
-                }
-
-                foreach (var level in new[]
-                {
-                    IsolationLevel.Chaos,
-                })
-                {
-                    var level2 = level;
-                    Assert.That(() => conn.BeginTransaction(level2), Throws.Exception.TypeOf<NotSupportedException>());
-                }
+                var tx = conn.BeginTransaction(level);
+                Assert.That(conn.ExecuteScalar("SHOW TRANSACTION ISOLATION LEVEL"), Is.EqualTo(expectedName));
+                tx.Commit();
             }
+        }
+
+        [Test]
+        public void IsolationLevelChaosUnsupported()
+        {
+            using (var conn = OpenConnection())
+                Assert.That(() => conn.BeginTransaction(IsolationLevel.Chaos), Throws.Exception.TypeOf<NotSupportedException>());
         }
 
         [Test, Description("Rollback of an already rolled back transaction")]


### PR DESCRIPTION
For some reason, we used to send one message for BEGIN, and another for
setting the isolation level.

Fixes #2247