### PR TITLE
Correct metadata size for char(1) and bit(1)

### DIFF
--- a/src/Npgsql/PostgresTypes/PostgresBaseType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresBaseType.cs
@@ -69,7 +69,7 @@ namespace Npgsql.PostgresTypes
             switch (Name)
             {
             case "character":
-                return typeModifier - 4 == 1 ? PostgresFacets.None : new PostgresFacets(typeModifier - 4, null, null);
+                return new PostgresFacets(typeModifier - 4, null, null);
             case "character varying":
                 return new PostgresFacets(typeModifier - 4, null, null);  // Max length
             case "numeric":
@@ -90,7 +90,6 @@ namespace Npgsql.PostgresTypes
                 precision = typeModifier & 0xFFFF;
                 return new PostgresFacets(null, precision, null);
             case "bit":
-                return new PostgresFacets(typeModifier == 1 ? (int?)null : typeModifier, null, null);
             case "bit varying":
                 return new PostgresFacets(typeModifier, null, null);
             default:

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -553,7 +553,7 @@ namespace Npgsql.Tests
         [TestCase("character varying")]
         [TestCase("character varying(10)[]", 10)]
         [TestCase("character(10)", 10)]
-        [TestCase("character")]
+        [TestCase("character", 1)]
         [TestCase("numeric(1000, 2)", null, 1000, 2)]
         [TestCase("numeric(1000)", null, 1000, null)]
         [TestCase("numeric")]
@@ -565,7 +565,7 @@ namespace Npgsql.Tests
         [TestCase("time(2) with time zone", null, 2)]
         [TestCase("interval")]
         [TestCase("interval(2)", null, 2)]
-        [TestCase("bit")]   // Size is implicitly 1
+        [TestCase("bit", 1)]
         [TestCase("bit(3)", 3)]
         [TestCase("bit varying")]
         [TestCase("bit varying(3)", 3)]

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -386,7 +386,7 @@ namespace Npgsql.Tests
         [TestCase("bit(3)")]
         [TestCase("bit varying")]
         [TestCase("bit varying(3)")]
-        public void GetDataTypeName(string typeName, string normalizedName=null)
+        public void GetDataTypeName(string typeName, string normalizedName = null)
         {
             if (normalizedName == null)
                 normalizedName = typeName;

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -370,7 +370,7 @@ namespace Npgsql.Tests
         [TestCase("character varying")]
         [TestCase("character varying(10)[]")]
         [TestCase("character(10)")]
-        [TestCase("character")]
+        [TestCase("character", "character(1)")]
         [TestCase("numeric(1000, 2)")]
         [TestCase("numeric(1000)")]
         [TestCase("numeric")]
@@ -382,18 +382,20 @@ namespace Npgsql.Tests
         [TestCase("time(2) with time zone")]
         [TestCase("interval")]
         [TestCase("interval(2)")]
-        [TestCase("bit")]
+        [TestCase("bit", "bit(1)")]
         [TestCase("bit(3)")]
         [TestCase("bit varying")]
         [TestCase("bit varying(3)")]
-        public void GetDataTypeName(string typeName)
+        public void GetDataTypeName(string typeName, string normalizedName=null)
         {
+            if (normalizedName == null)
+                normalizedName = typeName;
             using (var conn = OpenConnection())
             using (var cmd = new NpgsqlCommand($"SELECT NULL::{typeName} AS some_column", conn))
             using (var reader = cmd.ExecuteReader(Behavior))
             {
                 reader.Read();
-                Assert.That(reader.GetDataTypeName(0), Is.EqualTo(typeName));
+                Assert.That(reader.GetDataTypeName(0), Is.EqualTo(normalizedName));
             }
         }
 


### PR DESCRIPTION
Fixes #2243 

Let's try to merge this quickly, I'd like to backport for the imminent 4.0.4 release...