### PR TITLE
Bad hack to reallow output params with sequential

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1137,8 +1137,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 using (cancellationToken.Register(cmd => ((NpgsqlCommand)cmd).Cancel(), this))
                 {
                     ValidateParameters();
-                    if ((behavior & CommandBehavior.SequentialAccess) != 0 && Parameters.HasOutputParameters)
-                        throw new NotSupportedException("Output parameters aren't supported with SequentialAccess");
 
                     if (IsExplicitlyPrepared)
                     {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -367,7 +367,7 @@ namespace Npgsql
         /// Internal implementation of NextResult
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected virtual async Task<bool> NextResult(bool async, bool isConsuming=false)
+        async Task<bool> NextResult(bool async, bool isConsuming=false)
         {
             IBackendMessage msg;
             Debug.Assert(!IsSchemaOnly);
@@ -464,7 +464,30 @@ namespace Npgsql
                     }
                 }
 
-                msg = await ReadMessage(async);
+                // The following is a pretty awful hack to bring back output parameters for sequential readers (#2091)
+                // We should definitely clean up the entire reader design (#1853)
+                if (StatementIndex == 0 && RowDescription != null && Command.Parameters.HasOutputParameters)
+                {
+                    // If output parameters are present and this is the first row of the first resultset,
+                    // we must read it in non-sequential mode because it will be traversed twice (once
+                    // here for the parameters, then as a regular row).
+                    msg = await Connector.ReadMessage(async);
+
+                    // If we got an actual first row (i.e. resultset wasn't empty), we process the message so it can
+                    // be read by PopulateOutputParameters(). We then rewind the buffer to the start of the row, and
+                    // continue to the normal flow, where we will process it again, as if we're reading a totally
+                    // new row (using the same first row).
+                    if (msg is DataRowMessage row)
+                    {
+                        var pos = Connector.ReadBuffer.ReadPosition;
+                        ProcessMessage(row);
+                        PopulateOutputParameters();
+                        Connector.ReadBuffer.ReadPosition = pos;
+                    }
+                }
+                else
+                    msg = await ReadMessage(async);
+
                 if (RowDescription == null)
                 {
                     // Statement did not generate a resultset (e.g. INSERT)
@@ -500,6 +523,45 @@ namespace Npgsql
             ProcessMessage(Expect<ReadyForQueryMessage>(await Connector.ReadMessage(async)));
             RowDescription = null;
             return false;
+        }
+
+        void PopulateOutputParameters()
+        {
+            // The first row in a stored procedure command that has output parameters needs to be traversed twice -
+            // once for populating the output parameters and once for the actual result set traversal. So in this
+            // case we can't be sequential.
+            Debug.Assert(Command.Parameters.Any(p => p.IsOutputDirection));
+            Debug.Assert(StatementIndex == 0);
+            Debug.Assert(RowDescription != null);
+            Debug.Assert(State == ReaderState.BeforeResult);
+
+            // Temporarily set our state to InResult to allow us to read the values
+            State = ReaderState.InResult;
+
+            var pending = new Queue<object>();
+            var taken = new List<NpgsqlParameter>();
+            for (var i = 0; i < FieldCount; i++)
+            {
+                if (Command.Parameters.TryGetValue(GetName(i), out var p) && p.IsOutputDirection)
+                {
+                    p.Value = GetValue(i);
+                    taken.Add(p);
+                }
+                else
+                    pending.Enqueue(GetValue(i));
+            }
+
+            // Not sure where this odd behavior comes from: all output parameters which did not get matched by
+            // name now get populated with column values which weren't matched. Keeping this for backwards compat,
+            // opened #2252 for investigation.
+            foreach (var p in Command.Parameters.Where(p => p.IsOutputDirection && !taken.Contains(p)))
+            {
+                if (pending.Count == 0)
+                    break;
+                p.Value = pending.Dequeue();
+            }
+
+            State = ReaderState.BeforeResult;  // Set the state back
         }
 
         /// <summary>

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -818,19 +818,19 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public void InputAndOutputParameters()
+        [TestCase(CommandBehavior.Default)]
+        [TestCase(CommandBehavior.SequentialAccess)]
+        public void InputAndOutputParameters(CommandBehavior behavior)
         {
             using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand())
+            using (var cmd = new NpgsqlCommand("SELECT @c-1 AS c, @a+2 AS b", conn))
             {
-                cmd.Connection = conn;
-                cmd.CommandText = "Select :a + 2 as b, :c - 1 as c";
+                cmd.Parameters.Add(new NpgsqlParameter("a", 3));
                 var b = new NpgsqlParameter { ParameterName = "b", Direction = ParameterDirection.Output };
                 cmd.Parameters.Add(b);
-                cmd.Parameters.Add(new NpgsqlParameter("a", 3));
                 var c = new NpgsqlParameter { ParameterName = "c", Direction = ParameterDirection.InputOutput, Value = 4 };
                 cmd.Parameters.Add(c);
-                using (cmd.ExecuteReader())
+                using (cmd.ExecuteReader(behavior))
                 {
                     Assert.AreEqual(5, b.Value);
                     Assert.AreEqual(3, c.Value);

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -549,8 +549,6 @@ namespace Npgsql.Tests
         [Test]
         public void ExecuteReaderGettingEmptyResultSetWithOutputParameter()
         {
-            if (IsSequential)
-                Assert.Pass("Not supported in sequential mode");
             using (var conn = OpenConnection())
             {
                 conn.ExecuteNonQuery("CREATE TEMP TABLE data (name TEXT)");


### PR DESCRIPTION
Npgsql 4.0 accidentally removed support for output parameters when using CommandBehavior.Sequential, but unfortunately DbDataAdapter relies on that.

4.0's refactoring into two reader classes (sequential, non-sequential) made this support very hacky, as the 1st row needs to be traversed twice, once for output param population and once as a regular row.
We definitely need to clean this up in 4.1.

Fixes #2091

@YohDeadfall @austindrenski I don't usually hack things this way, but I don't think we have much choice.