### PR TITLE
Import PostGisWriter from NTS and fix some bugs

### DIFF
--- a/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
@@ -78,7 +78,7 @@ namespace Npgsql
 
             var typeHandlerFactory = new NetTopologySuiteHandlerFactory(
                 new PostGisReader(coordinateSequenceFactory, precisionModel, handleOrdinates),
-                new PostGisWriter() { HandleOrdinates = handleOrdinates });
+                new NpgsqlPostGisWriter());  // NOTE: We used our own patched-up version of PostGisWriter for now
 
             return mapper
                 .AddMapping(new NpgsqlTypeMappingBuilder

--- a/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
@@ -528,8 +528,9 @@ namespace Npgsql.NetTopologySuite
             }
             if ((sequence.Ordinates & Ordinates.M) != 0)
             {
+                // Fixed in Npgsql, see https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/pull/4
                 if (!double.IsNaN(sequence.GetOrdinate(0, Ordinate.M)))
-                    result |= Ordinates.Z;
+                    result |= Ordinates.M;
             }
             return result;
         }
@@ -550,12 +551,11 @@ namespace Npgsql.NetTopologySuite
         /// <inheritdoc cref="IGeometryIOSettings.HandleOrdinates"/>
         public Ordinates HandleOrdinates
         {
-            get { return _outputOrdinates; }
-            set
-            {
-                value |= Ordinates.XY;
-                _outputOrdinates = value & AllowedOrdinates;
-            }
+            get => _outputOrdinates;
+            // Fixed in Npgsql, see https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/pull/5
+            set => _outputOrdinates = value == Ordinates.None
+                ? Ordinates.None
+                : (value | Ordinates.XY) & AllowedOrdinates;
         }
         #endregion
 

--- a/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
@@ -1,0 +1,574 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GeoAPI.Geometries;
+using GeoAPI.IO;
+using NetTopologySuite.IO;
+using NetTopologySuite.Utilities;
+
+namespace Npgsql.NetTopologySuite
+{
+    // This is copied from NetTopologySuite.IO.PostGis, fixing some bugs until the fixes are merged upstream
+    class NpgsqlPostGisWriter : IBinaryGeometryWriter
+    {
+        /// <summary>
+        /// The byte order to use when writing geometries.
+        /// </summary>
+        /// <see cref="ByteOrder"/>
+        protected ByteOrder EncodingType;
+
+        private Ordinates _outputOrdinates;
+
+        /// <summary>
+        /// Initializes writer with LittleIndian byte order.
+        /// </summary>
+        public NpgsqlPostGisWriter() :
+            this(ByteOrder.LittleEndian)
+        { }
+
+        /// <summary>
+        /// Initializes writer with the specified byte order.
+        /// </summary>
+        /// <param name="encodingType">Encoding type</param>
+		public NpgsqlPostGisWriter(ByteOrder encodingType)
+        {
+            EncodingType = encodingType;
+            HandleOrdinates = Ordinates.None;
+        }
+
+        /// <inheritdoc cref="IGeometryWriter{TSink}.Write(IGeometry)"/>
+        public byte[] Write(IGeometry geometry)
+        {
+            return Write(geometry, HandleOrdinates);
+        }
+
+        /// <inheritdoc cref="IGeometryWriter{TSink}.Write(IGeometry, Stream)"/>
+        public void Write(IGeometry geometry, Stream stream)
+        {
+            Write(geometry, HandleOrdinates, stream);
+        }
+
+        /// <summary>
+        /// Writes a binary encoded PostGIS of the given <paramref name="geometry"/> to to an array of bytes.
+        /// </summary>
+        /// <param name="geometry">The geometry</param>
+        /// <param name="ordinates">The ordinates of each geometry's coordinate. <see cref="Ordinates.XY"/> area always written.</param>
+        /// <returns>An array of bytes.</returns>
+        private byte[] Write(IGeometry geometry, Ordinates ordinates)
+        {
+            int coordinateSpace = 8 * OrdinatesUtility.OrdinatesToDimension(ordinates);
+            byte[] bytes = GetBytes(geometry, coordinateSpace);
+            Write(geometry, ordinates, new MemoryStream(bytes));
+
+            return bytes;
+        }
+
+
+
+        /// <summary>
+        /// Writes a binary encoded PostGIS of the given <paramref name="geometry"/> to <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="geometry">The geometry</param>
+        /// <param name="ordinates">The ordinates of each geometry's coordinate. <see cref="Ordinates.XY"/> area always written.</param>
+        /// <param name="stream">The stream to write to</param>
+        private void Write(IGeometry geometry, Ordinates ordinates, Stream stream)
+        {
+            using (var writer = EncodingType == ByteOrder.LittleEndian ? new BinaryWriter(stream) : new BEBinaryWriter(stream))
+            {
+                Write(geometry, ordinates, EncodingType, writer);
+            }
+        }
+
+        ///// <summary>
+        ///// Writes a binary encoded PostGIS or the given <paramref name="geometry"/> using the provided <paramref name="writer"/>.
+        ///// </summary>
+        ///// <param name="geometry">The geometry to write.</param>
+        ///// <param name="writer">The writer to use.</param>
+        //private void Write(IGeometry geometry, BinaryWriter writer)
+        //{
+        //    Write(geometry, CheckOrdinates(geometry), EncodingType, writer);
+        //}
+
+        /// <summary>
+        /// Writes a binary encoded PostGIS or the given <paramref name="geometry"/> using the provided <paramref name="writer"/>.
+        /// </summary>
+        /// <param name="geometry">The geometry to write.</param>
+        /// <param name="ordinates">The ordinates of each geometry's coordinate. <see cref="Ordinates.XY"/> area always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IGeometry geometry, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            if (ordinates == Ordinates.None)
+                ordinates = CheckOrdinates(geometry);
+
+            if (geometry is IPoint)
+                Write(geometry as IPoint, ordinates, byteOrder, writer);
+            else if (geometry is ILinearRing)
+                Write(geometry as ILinearRing, ordinates, byteOrder, writer);
+            else if (geometry is ILineString)
+                Write(geometry as ILineString, ordinates, byteOrder, writer);
+            else if (geometry is IPolygon)
+                Write(geometry as IPolygon, ordinates, byteOrder, writer);
+            else if (geometry is IMultiPoint)
+                Write(geometry as IMultiPoint, ordinates, byteOrder, writer);
+            else if (geometry is IMultiLineString)
+                Write(geometry as IMultiLineString, ordinates, byteOrder, writer);
+            else if (geometry is IMultiPolygon)
+                Write(geometry as IMultiPolygon, ordinates, byteOrder, writer);
+            else if (geometry is IGeometryCollection)
+                Write(geometry as IGeometryCollection, ordinates, byteOrder, writer);
+            else throw new ArgumentException("Geometry not recognized: " + geometry);
+        }
+
+        /// <summary>
+        /// Writes the binary encoded PostGIS header.
+        /// </summary>
+        /// <param name="byteOrder">The byte order specified.</param>
+        /// <param name="type">The PostGIS geometry type.</param>
+        /// <param name="srid">The spatial reference of the geometry</param>
+        /// <param name="ordinates"></param>
+        /// <param name="writer">The writer to use.</param>
+        private static void WriteHeader(PostGisGeometryType type, int srid, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            writer.Write((byte)byteOrder);
+
+            // write typeword
+            uint typeword = (uint)type;
+
+            if ((ordinates & Ordinates.Z) != 0)
+                typeword |= 0x80000000;
+
+            if ((ordinates & Ordinates.M) != 0)
+                typeword |= 0x40000000;
+
+            if (srid != -1)
+                typeword |= 0x20000000;
+            writer.Write(typeword);
+
+            if (srid != -1)
+                writer.Write(srid);
+        }
+
+        private static void Write(ICoordinateSequence sequence, Ordinates ordinates, BinaryWriter writer, bool justOne)
+        {
+            if (sequence == null || sequence.Count == 0)
+                return;
+
+            int length = (justOne ? 1 : sequence.Count);
+
+            if (!justOne)
+                writer.Write(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                writer.Write(sequence.GetOrdinate(i, Ordinate.X));
+                writer.Write(sequence.GetOrdinate(i, Ordinate.Y));
+                if ((ordinates & Ordinates.Z) != 0)
+                {
+                    double z = sequence.GetOrdinate(i, Ordinate.Z);
+                    if (double.IsNaN(z)) z = 0d;
+                    writer.Write(z);
+                }
+                if ((ordinates & Ordinates.M) != 0)
+                {
+                    double m = sequence.GetOrdinate(i, Ordinate.M);
+                    if (double.IsNaN(m)) m = 0d;
+                    writer.Write(m);
+                }
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="byteOrder"></param>
+        /// <param name="point"></param>
+        /// <param name="ordinates"></param>
+        /// <param name="writer"></param>
+        private void Write(IPoint point, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.Point, HandleSRID ? point.SRID : -1, ordinates, byteOrder, writer);
+            Write(point.CoordinateSequence, ordinates, writer, true);
+        }
+
+        /// <summary>
+        /// Write an Array of "full" Geometries
+        /// </summary>
+        /// <param name="geometries"></param>
+        /// <param name="ordinates"></param>
+        /// <param name="byteOrder"></param>
+        /// <param name="writer"></param>
+        private void Write(IList<IGeometry> geometries, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            for (int i = 0; i < geometries.Count; i++)
+            {
+                Write(geometries[i], ordinates, byteOrder, writer);
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="lineString"></param>
+        /// <param name="ordinates"></param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer"></param>
+        private void Write(ILineString lineString, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.LineString, HandleSRID ? lineString.SRID : -1, ordinates, byteOrder, writer);
+            Write(lineString.CoordinateSequence, ordinates, writer, false);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="linearRing"></param>
+        /// <param name="ordinates"></param>
+        /// <param name="writer"></param>
+        private void Write(ILinearRing linearRing, Ordinates ordinates, BinaryWriter writer)
+        {
+            Write(linearRing.CoordinateSequence, ordinates, writer, false);
+        }
+
+        /// <summary>
+        /// Writes a 'Polygon' to the stream.
+        /// </summary>
+        /// <param name="polygon">The polygon to write.</param>
+        /// <param name="ordinates">The ordinates to write. <see cref="Ordinates.XY"/> are always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IPolygon polygon, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.Polygon,
+                HandleSRID ? polygon.SRID : -1,
+                ordinates, byteOrder, writer);
+            writer.Write(polygon.NumInteriorRings + 1);
+            Write(polygon.ExteriorRing as ILinearRing, ordinates, writer);
+            for (int i = 0; i < polygon.NumInteriorRings; i++)
+                Write((ILinearRing)polygon.InteriorRings[i], ordinates, writer);
+        }
+
+        /// <summary>
+        /// Writes a 'MultiPoint' to the stream.
+        /// </summary>
+        /// <param name="multiPoint">The polygon to write.</param>
+        /// <param name="ordinates">The ordinates to write. <see cref="Ordinates.XY"/> are always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IMultiPoint multiPoint, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.MultiPoint,
+                HandleSRID ? multiPoint.SRID : -1,
+                ordinates, byteOrder, writer);
+            writer.Write(multiPoint.NumGeometries);
+            Write(multiPoint.Geometries, ordinates, byteOrder, writer);
+        }
+
+        /// <summary>
+        /// Writes a 'MultiLineString' to the stream.
+        /// </summary>
+        /// <param name="multiLineString">The polygon to write.</param>
+        /// <param name="ordinates">The ordinates to write. <see cref="Ordinates.XY"/> are always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IMultiLineString multiLineString, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.MultiLineString, HandleSRID ? multiLineString.SRID : -1, ordinates, byteOrder, writer);
+            writer.Write(multiLineString.NumGeometries);
+            Write(multiLineString.Geometries, ordinates, byteOrder, writer);
+        }
+
+        /// <summary>
+        /// Writes a 'MultiPolygon' to the stream.
+        /// </summary>
+        /// <param name="multiPolygon">The polygon to write.</param>
+        /// <param name="ordinates">The ordinates to write. <see cref="Ordinates.XY"/> are always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IMultiPolygon multiPolygon, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.MultiPolygon, HandleSRID ? multiPolygon.SRID : -1, ordinates, byteOrder, writer);
+            writer.Write(multiPolygon.NumGeometries);
+            Write(multiPolygon.Geometries, ordinates, byteOrder, writer);
+        }
+
+        /// <summary>
+        /// Writes a 'GeometryCollection' to the stream.
+        /// </summary>
+        /// <param name="geomCollection">The polygon to write.</param>
+        /// <param name="ordinates">The ordinates to write. <see cref="Ordinates.XY"/> are always written.</param>
+        /// <param name="byteOrder">The byte order.</param>
+        /// <param name="writer">The writer to use.</param>
+        private void Write(IGeometryCollection geomCollection, Ordinates ordinates, ByteOrder byteOrder, BinaryWriter writer)
+        {
+            WriteHeader(PostGisGeometryType.GeometryCollection, HandleSRID ? geomCollection.SRID : -1, ordinates, byteOrder, writer);
+            writer.Write(geomCollection.NumGeometries);
+            Write(geomCollection.Geometries, ordinates, byteOrder, writer);
+        }
+
+        #region Prepare Buffer
+        /// <summary>
+        /// Supplies a byte array for the  length for Byte Stream.
+        /// </summary>
+        /// <param name="geometry">The geometry that needs to be written.</param>
+        /// <param name="coordinateSpace">The size that is needed per ordinate.</param>
+        /// <returns></returns>
+        private byte[] GetBytes(IGeometry geometry, int coordinateSpace)
+        {
+            return new byte[GetByteStreamSize(geometry, coordinateSpace)];
+        }
+
+        /// <summary>
+        /// Gets the required size for the byte stream's buffer to hold the geometry information.
+        /// </summary>
+        /// <param name="geometry">The geometry to write</param>
+        /// <param name="coordinateSpace">The size for each ordinate entry.</param>
+        /// <returns>The size</returns>
+        private int GetByteStreamSize(IGeometry geometry, int coordinateSpace)
+        {
+            int result = 0;
+
+            // write endian flag
+            result += 1;
+
+            // write typeword
+            result += 4;
+
+            if (HandleSRID & (geometry.SRID != -1))
+                result += 4;
+
+            if (geometry is IPoint)
+                result += GetByteStreamSize(geometry as IPoint, coordinateSpace);
+            else if (geometry is ILineString)
+                result += GetByteStreamSize(geometry as ILineString, coordinateSpace);
+            else if (geometry is IPolygon)
+                result += GetByteStreamSize(geometry as IPolygon, coordinateSpace);
+            else if (geometry is IMultiPoint)
+                result += GetByteStreamSize(geometry as IMultiPoint, coordinateSpace);
+            else if (geometry is IMultiLineString)
+                result += GetByteStreamSize(geometry as IMultiLineString, coordinateSpace);
+            else if (geometry is IMultiPolygon)
+                result += GetByteStreamSize(geometry as IMultiPolygon, coordinateSpace);
+            else if (geometry is IGeometryCollection)
+                result += GetByteStreamSize(geometry as IGeometryCollection, coordinateSpace);
+            else
+                throw new ArgumentException("ShouldNeverReachHere");
+
+            return result;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IGeometryCollection geometry, int coordinateSpace)
+        {
+            // 4-byte count + subgeometries
+            return 4 + GetByteStreamSize(geometry.Geometries, coordinateSpace);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IMultiPolygon geometry, int coordinateSpace)
+        {
+            // 4-byte count + subgeometries
+            return 4 + GetByteStreamSize(geometry.Geometries, coordinateSpace);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IMultiLineString geometry, int coordinateSpace)
+        {
+            // 4-byte count + subgeometries
+            return 4 + GetByteStreamSize(geometry.Geometries, coordinateSpace);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IMultiPoint geometry, int coordinateSpace)
+        {
+            // int size
+            int result = 4;
+            if (geometry.NumPoints > 0)
+            {
+                // We can shortcut here, as all subgeoms have the same fixed size
+                result += geometry.NumPoints * GetByteStreamSize(geometry.GetGeometryN(0), coordinateSpace);
+            }
+            return result;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IPolygon geometry, int coordinateSpace)
+        {
+            // int length
+            int result = 4;
+            result += GetByteStreamSize(geometry.ExteriorRing, coordinateSpace);
+            for (int i = 0; i < geometry.NumInteriorRings; i++)
+                result += GetByteStreamSize(geometry.InteriorRings[i], coordinateSpace);
+            return result;
+        }
+
+        /// <summary>
+        /// Write an Array of "full" Geometries
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private int GetByteStreamSize(IList<IGeometry> container, int coordinateSpace)
+        {
+            int result = 0;
+            for (int i = 0; i < container.Count; i++)
+            {
+                result += GetByteStreamSize(container[i], coordinateSpace);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Calculates the amount of space needed to write this coordinate sequence.
+        /// </summary>
+        /// <param name="sequence">The sequence</param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        private static int GetByteStreamSize(ICoordinateSequence sequence, int coordinateSpace)
+        {
+            // number of points
+            const int result = 4;
+
+            // And the amount of the points itsself, in consistent geometries
+            // all points have equal size.
+            if (sequence.Count == 0)
+                return result;
+
+            return result + sequence.Count * coordinateSpace;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        protected int GetByteStreamSize(ILineString geometry, int coordinateSpace)
+        {
+            return GetByteStreamSize(geometry.CoordinateSequence, coordinateSpace);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        protected int GetByteStreamSize(ILinearRing geometry, int coordinateSpace)
+        {
+            return GetByteStreamSize(geometry.CoordinateSequence, coordinateSpace);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <param name="coordinateSpace">The size needed for each coordinate</param>
+        /// <returns></returns>
+        protected int GetByteStreamSize(IPoint geometry, int coordinateSpace)
+        {
+            return coordinateSpace;
+        }
+
+        #endregion
+
+        #region Check ordinates
+
+        private static Ordinates CheckOrdinates(IGeometry geometry)
+        {
+            if (geometry is IPoint)
+                return CheckOrdinates(((IPoint)geometry).CoordinateSequence);
+            if (geometry is ILineString)
+                return CheckOrdinates(((ILineString)geometry).CoordinateSequence);
+            if (geometry is IPolygon)
+                return CheckOrdinates((((IPolygon)geometry).ExteriorRing).CoordinateSequence);
+            if (geometry is IGeometryCollection)
+                return CheckOrdinates(geometry.GetGeometryN(0));
+
+            Assert.ShouldNeverReachHere();
+            return Ordinates.None;
+
+        }
+
+        private static Ordinates CheckOrdinates(ICoordinateSequence sequence)
+        {
+            if (sequence == null || sequence.Count == 0)
+                return Ordinates.None;
+
+            var result = Ordinates.XY;
+            if ((sequence.Ordinates & Ordinates.Z) != 0)
+            {
+                if (!double.IsNaN(sequence.GetOrdinate(0, Ordinate.Z)))
+                    result |= Ordinates.Z;
+            }
+            if ((sequence.Ordinates & Ordinates.M) != 0)
+            {
+                if (!double.IsNaN(sequence.GetOrdinate(0, Ordinate.M)))
+                    result |= Ordinates.Z;
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region Implementation of IGeometryIOSettings
+
+        /// <inheritdoc cref="IGeometryIOSettings.HandleSRID"/>
+        public bool HandleSRID { get { return true; } set { } }
+
+        /// <inheritdoc cref="IGeometryIOSettings.AllowedOrdinates"/>
+        public Ordinates AllowedOrdinates
+        {
+            get { return Ordinates.XYZM; }
+        }
+
+        /// <inheritdoc cref="IGeometryIOSettings.HandleOrdinates"/>
+        public Ordinates HandleOrdinates
+        {
+            get { return _outputOrdinates; }
+            set
+            {
+                value |= Ordinates.XY;
+                _outputOrdinates = value & AllowedOrdinates;
+            }
+        }
+        #endregion
+
+        #region Implementation of IBinaryGeometryWriter
+
+
+        /// <inheritdoc cref="IBinaryGeometryWriter.ByteOrder"/>
+        public ByteOrder ByteOrder
+        {
+            get { return EncodingType; }
+            set { throw new InvalidOperationException(); }
+        }
+
+        #endregion
+    }
+}

--- a/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
@@ -9,6 +9,7 @@ using NetTopologySuite.Utilities;
 namespace Npgsql.NetTopologySuite
 {
     // This is copied from NetTopologySuite.IO.PostGis, fixing some bugs until the fixes are merged upstream
+    // https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/blob/master/NetTopologySuite.IO.PostGis/PostGisWriter.cs
     class NpgsqlPostGisWriter : IBinaryGeometryWriter
     {
         /// <summary>

--- a/src/Npgsql.NetTopologySuite/PostGisGeometryType.cs
+++ b/src/Npgsql.NetTopologySuite/PostGisGeometryType.cs
@@ -1,0 +1,45 @@
+namespace Npgsql.NetTopologySuite
+{
+    /// <summary>
+    /// PostGIS Geometry types as defined in the OGC WKB Spec
+    /// </summary>
+    internal enum PostGisGeometryType
+    {
+
+        /// <summary>
+        /// The OGIS geometry type number for points.
+        /// </summary>
+        Point = 1,
+
+        /// <summary>
+        /// The OGIS geometry type number for lines.
+        /// </summary>
+        LineString = 2,
+
+        /// <summary>
+        /// The OGIS geometry type number for polygons.
+        /// </summary>
+        Polygon = 3,
+
+        /// <summary>
+        /// The OGIS geometry type number for aggregate points.
+        /// </summary>
+        MultiPoint = 4,
+
+        /// <summary>
+        /// The OGIS geometry type number for aggregate lines.
+        /// </summary>
+        MultiLineString = 5,
+
+        /// <summary>
+        /// The OGIS geometry type number for aggregate polygons.
+        /// </summary>
+        MultiPolygon = 6,
+
+        /// <summary>
+        /// The OGIS geometry type number for feature collections.
+        /// </summary>
+        GeometryCollection = 7,
+
+    }
+}

--- a/src/Npgsql.NetTopologySuite/PostGisGeometryType.cs
+++ b/src/Npgsql.NetTopologySuite/PostGisGeometryType.cs
@@ -1,8 +1,7 @@
 namespace Npgsql.NetTopologySuite
 {
-    /// <summary>
-    /// PostGIS Geometry types as defined in the OGC WKB Spec
-    /// </summary>
+    // This is copied from NetTopologySuite.IO.PostGis, fixing some bugs until the fixes are merged upstream
+    // https://github.com/NetTopologySuite/NetTopologySuite.IO.PostGis/blob/master/NetTopologySuite.IO.PostGis/PostGisGeometryType.cs
     internal enum PostGisGeometryType
     {
 

--- a/test/Npgsql.PluginTests/NetTopologySuiteTests.cs
+++ b/test/Npgsql.PluginTests/NetTopologySuiteTests.cs
@@ -28,6 +28,8 @@ using NetTopologySuite.Geometries.Implementation;
 using Npgsql.Tests;
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
@@ -85,78 +87,78 @@ namespace Npgsql.PluginTests
             public string CommandText;
         }
 
-        static readonly TestData[] Tests =
-        {
-            // Two dimensional data
-            new TestData {
-                Geometry = new Point(new Coordinate(1d, 2500d)),
-                CommandText = "st_makepoint(1,2500)"
-            },
-            new TestData {
-                Geometry = new LineString(new[] { new Coordinate(1d, 1d), new Coordinate(1d, 2500d) }),
-                CommandText = "st_makeline(st_makepoint(1,1),st_makepoint(1,2500))"
-            },
-            new TestData {
-                Geometry = new Polygon(
-                    new LinearRing(new[] {
-                        new Coordinate(1d, 1d),
-                        new Coordinate(2d, 2d),
-                        new Coordinate(3d, 3d),
-                        new Coordinate(1d, 1d)
-                    })
-                ),
-                CommandText = "st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)]))"
-            },
-            new TestData {
-                Geometry = new MultiPoint(new[] { new Point (new Coordinate(1d, 1d)) }),
-                CommandText = "st_multi(st_makepoint(1, 1))"
-            },
-            new TestData {
-                Geometry = new MultiLineString(new[] {
-                    new LineString(new[] {
-                        new Coordinate(1d, 1d),
-                        new Coordinate(1d, 2500d)
-                    })
-                }),
-                CommandText = "st_multi(st_makeline(st_makepoint(1,1),st_makepoint(1,2500)))"
-            },
-            new TestData {
-                Geometry = new MultiPolygon(new[] {
+        public static IEnumerable TestCases {
+            get
+            {
+                // Two dimensional data
+                yield return new TestCaseData(Ordinates.None, new Point(1d, 2500d), "st_makepoint(1,2500)");
+
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new LineString(new[] { new Coordinate(1d, 1d), new Coordinate(1d, 2500d) }),
+                    "st_makeline(st_makepoint(1,1),st_makepoint(1,2500))"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
                     new Polygon(
-                        new LinearRing(new[] {
+                        new LinearRing(new[]
+                        {
                             new Coordinate(1d, 1d),
                             new Coordinate(2d, 2d),
                             new Coordinate(3d, 3d),
                             new Coordinate(1d, 1d)
                         })
-                    )
-                }),
-                CommandText = "st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)])))"
-            },
-            new TestData {
-                Geometry = new GeometryCollection(new IGeometry[] {
-                    new Point(new Coordinate(1d, 1d)),
-                    new MultiPolygon(new[] {
+                    ),
+                    "st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)]))"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new MultiPoint(new[] { new Point(new Coordinate(1d, 1d)) }),
+                    "st_multi(st_makepoint(1, 1))"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new MultiLineString(new[]
+                    {
+                        new LineString(new[]
+                        {
+                            new Coordinate(1d, 1d),
+                            new Coordinate(1d, 2500d)
+                        })
+                    }),
+                    "st_multi(st_makeline(st_makepoint(1,1),st_makepoint(1,2500)))"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new MultiPolygon(new[]
+                    {
                         new Polygon(
-                            new LinearRing(new[] {
+                            new LinearRing(new[]
+                            {
                                 new Coordinate(1d, 1d),
                                 new Coordinate(2d, 2d),
                                 new Coordinate(3d, 3d),
                                 new Coordinate(1d, 1d)
                             })
                         )
-                    })
-                }),
-                CommandText = "st_collect(st_makepoint(1,1),st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)]))))"
-            },
-            new TestData {
-                Geometry = new GeometryCollection(new IGeometry[] {
-                    new Point(new Coordinate(1d, 1d)),
-                    new GeometryCollection(new IGeometry[] {
+                    }),
+                    "st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)])))"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new GeometryCollection(new IGeometry[]
+                    {
                         new Point(new Coordinate(1d, 1d)),
-                        new MultiPolygon(new[] {
+                        new MultiPolygon(new[]
+                        {
                             new Polygon(
-                                new LinearRing(new[] {
+                                new LinearRing(new[]
+                                {
                                     new Coordinate(1d, 1d),
                                     new Coordinate(2d, 2d),
                                     new Coordinate(3d, 3d),
@@ -164,45 +166,66 @@ namespace Npgsql.PluginTests
                                 })
                             )
                         })
-                    })
-                }),
-                CommandText = "st_collect(st_makepoint(1,1),st_collect(st_makepoint(1,1),st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)])))))"
-            },
-            // Three dimensional data
-            new TestData {
-                Ordinates = Ordinates.XYZ,
-                Geometry = new Point(new Coordinate(1d, 2d, 3d)),
-                CommandText = "st_makepoint(1,2,3)"
-            },
-            // Four dimensional data
-            new TestData {
-                Ordinates = Ordinates.XYZM,
-                Geometry = new Point(
-                    new DotSpatialAffineCoordinateSequence(new[] { 1d, 2d }, new[] { 3d }, new[] { 4d }),
-                    GeometryFactory.Default),
-                CommandText = "st_makepoint(1,2,3,4)"
-            },
-        };
+                    }),
+                    "st_collect(st_makepoint(1,1),st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)]))))"
+                );
 
-        [Test, TestCaseSource(nameof(Tests))]
-        public void TestRead(TestData data)
+                yield return new TestCaseData(
+                    Ordinates.None,
+                    new GeometryCollection(new IGeometry[]
+                    {
+                        new Point(new Coordinate(1d, 1d)),
+                        new GeometryCollection(new IGeometry[]
+                        {
+                            new Point(new Coordinate(1d, 1d)),
+                            new MultiPolygon(new[]
+                            {
+                                new Polygon(
+                                    new LinearRing(new[]
+                                    {
+                                        new Coordinate(1d, 1d),
+                                        new Coordinate(2d, 2d),
+                                        new Coordinate(3d, 3d),
+                                        new Coordinate(1d, 1d)
+                                    })
+                                )
+                            })
+                        })
+                    }),
+                    "st_collect(st_makepoint(1,1),st_collect(st_makepoint(1,1),st_multi(st_makepolygon(st_makeline(ARRAY[st_makepoint(1,1),st_makepoint(2,2),st_makepoint(3,3),st_makepoint(1,1)])))))"
+                );
+
+                yield return new TestCaseData(Ordinates.XYZ, new Point(1d, 2d, 3d), "st_makepoint(1,2,3)");
+
+                yield return new TestCaseData(
+                    Ordinates.XYZM,
+                    new Point(
+                        new DotSpatialAffineCoordinateSequence(new[] { 1d, 2d }, new[] { 3d }, new[] { 4d }),
+                        GeometryFactory.Default),
+                    "st_makepoint(1,2,3,4)"
+                );
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestCases))]
+        public void TestRead(Ordinates ordinates, IGeometry geometry, string sqlRepresentation)
         {
             using (var conn = OpenConnection())
             using (var cmd = conn.CreateCommand())
             {
-                cmd.CommandText = "SELECT " + data.CommandText;
-                Assert.That(Equals(cmd.ExecuteScalar(), data.Geometry));
+                cmd.CommandText = $"SELECT {sqlRepresentation}";
+                Assert.That(Equals(cmd.ExecuteScalar(), geometry));
             }
         }
 
-        [Test, TestCaseSource(nameof(Tests))]
-        public void TestWrite(TestData data)
+        [Test, TestCaseSource(nameof(TestCases))]
+        public void TestWrite(Ordinates ordinates, IGeometry geometry, string sqlRepresentation)
         {
-            using (var conn = OpenConnection(handleOrdinates: data.Ordinates))
+            using (var conn = OpenConnection(handleOrdinates: ordinates))
             using (var cmd = conn.CreateCommand())
             {
-                cmd.Parameters.AddWithValue("p1", data.Geometry);
-                cmd.CommandText = "SELECT st_asewkb(@p1) = st_asewkb(" + data.CommandText + ")";
+                cmd.Parameters.AddWithValue("p1", geometry);
+                cmd.CommandText = $"SELECT st_asewkb(@p1) = st_asewkb({sqlRepresentation})";
                 Assert.That(cmd.ExecuteScalar(), Is.True);
             }
         }


### PR DESCRIPTION
Fixes two bugs in NTS's PostGisWriter, which are holding up our EF Core 2.2.0 release (PRs have been submitted upstream). After merging I will push a 4.0.4.1 version of Npgsql.NetTopologySuite to nuget, and we'll have EF Core depend on that. We also will merge this into dev.
