### PR TITLE
Handle ordinates for empty `IGeometryCollection`

### DIFF
--- a/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlPostGisWriter.cs
@@ -508,8 +508,8 @@ namespace Npgsql.NetTopologySuite
                 return CheckOrdinates(((ILineString)geometry).CoordinateSequence);
             if (geometry is IPolygon)
                 return CheckOrdinates((((IPolygon)geometry).ExteriorRing).CoordinateSequence);
-            if (geometry is IGeometryCollection)
-                return CheckOrdinates(geometry.GetGeometryN(0));
+            if (geometry is IGeometryCollection collection)
+                return collection.Count == 0 ? Ordinates.None : CheckOrdinates(collection.GetGeometryN(0));
 
             Assert.ShouldNeverReachHere();
             return Ordinates.None;

--- a/test/Npgsql.PluginTests/NetTopologySuiteTests.cs
+++ b/test/Npgsql.PluginTests/NetTopologySuiteTests.cs
@@ -151,6 +151,12 @@ namespace Npgsql.PluginTests
 
                 yield return new TestCaseData(
                     Ordinates.None,
+                    GeometryCollection.Empty,
+                    "st_geomfromtext('GEOMETRYCOLLECTION EMPTY')"
+                );
+
+                yield return new TestCaseData(
+                    Ordinates.None,
                     new GeometryCollection(new IGeometry[]
                     {
                         new Point(new Coordinate(1d, 1d)),


### PR DESCRIPTION
See: npgsql/Npgsql.EntityFrameworkCore.PostgreSQL#732

/cc @roji @YohDeadfall @airbreather