### PR TITLE
Make error decoding use the configured encoding

### DIFF
--- a/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
+++ b/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
@@ -61,22 +61,22 @@ namespace Npgsql.BackendMessages
                     // Null terminator; error message fully consumed.
                     return;
                 case ErrorFieldTypeCode.Severity:
-                    Severity = buf.ReadNullTerminatedString(PGUtil.RelaxedUTF8Encoding);
+                    Severity = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Code:
-                    Code = buf.ReadNullTerminatedString();
+                    Code = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Message:
-                    Message = buf.ReadNullTerminatedString(PGUtil.RelaxedUTF8Encoding);
+                    Message = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Detail:
-                    Detail = buf.ReadNullTerminatedString(PGUtil.RelaxedUTF8Encoding);
+                    Detail = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Hint:
-                    Hint = buf.ReadNullTerminatedString(PGUtil.RelaxedUTF8Encoding);
+                    Hint = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Position:
-                    var positionStr = buf.ReadNullTerminatedString();
+                    var positionStr = buf.ReadNullTerminatedStringRelaxed();
                     if (!int.TryParse(positionStr, out var position)) {
                         Log.Warn("Non-numeric position in ErrorResponse: " + positionStr);
                         continue;
@@ -84,7 +84,7 @@ namespace Npgsql.BackendMessages
                     Position = position;
                     break;
                 case ErrorFieldTypeCode.InternalPosition:
-                    var internalPositionStr = buf.ReadNullTerminatedString();
+                    var internalPositionStr = buf.ReadNullTerminatedStringRelaxed();
                     if (!Int32.TryParse(internalPositionStr, out var internalPosition)) {
                         Log.Warn("Non-numeric position in ErrorResponse: " + internalPositionStr);
                         continue;
@@ -92,38 +92,38 @@ namespace Npgsql.BackendMessages
                     InternalPosition = internalPosition;
                     break;
                 case ErrorFieldTypeCode.InternalQuery:
-                    InternalQuery = buf.ReadNullTerminatedString();
+                    InternalQuery = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Where:
-                    Where = buf.ReadNullTerminatedString();
+                    Where = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.File:
-                    File = buf.ReadNullTerminatedString(PGUtil.RelaxedUTF8Encoding);
+                    File = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Line:
-                    Line = buf.ReadNullTerminatedString();
+                    Line = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.Routine:
-                    Routine = buf.ReadNullTerminatedString();
+                    Routine = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.SchemaName:
-                    SchemaName = buf.ReadNullTerminatedString();
+                    SchemaName = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.TableName:
-                    TableName = buf.ReadNullTerminatedString();
+                    TableName = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.ColumnName:
-                    ColumnName = buf.ReadNullTerminatedString();
+                    ColumnName = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.DataTypeName:
-                    DataTypeName = buf.ReadNullTerminatedString();
+                    DataTypeName = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 case ErrorFieldTypeCode.ConstraintName:
-                    ConstraintName = buf.ReadNullTerminatedString();
+                    ConstraintName = buf.ReadNullTerminatedStringRelaxed();
                     break;
                 default:
                     // Unknown error field; consume and discard.
-                    buf.ReadNullTerminatedString();
+                    buf.ReadNullTerminatedStringRelaxed();
                     break;
                 }
             }

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -85,7 +85,7 @@ namespace Npgsql.Tests
         public void SetUp()
         {
             Underlying = new MemoryStream();
-            ReadBuffer = new NpgsqlReadBuffer(null, Underlying, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding);
+            ReadBuffer = new NpgsqlReadBuffer(null, Underlying, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding, PGUtil.RelaxedUTF8Encoding);
         }
 
         // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
Previously, decoding errors always used with UTF8 encoding, with fallback to ?. As a result, if PostgreSQL was configured with a non-UTF8 lc_messages, some error messages would come out garbled.

We already have an Encoding connstring param, which wasn't being used for error decoding - errors now use this encoding, allowing users to configure how errors are decoded.

Also made all error fields decode with relaxed encodings, so that we never get exceptions while decoding errors.

Fixes #1582