### PR TITLE
Check if cancel request returns any data

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1263,7 +1263,7 @@ namespace Npgsql
                 // Now wait for the server to close the connection, better chance of the cancellation
                 // actually being delivered before we continue with the user's logic.
                 var count = _stream.Read(ReadBuffer.Buffer, 0, 1);
-                if (count != -1)
+                if (count > 0)
                     Log.Error("Received response after sending cancel request, shouldn't happen! First byte: " + ReadBuffer.Buffer[0]);
             }
             finally


### PR DESCRIPTION
`NetworkStream.Read(...)` returns `0` if the connection is closed. The previous logic checked for `-1`, which led to previous data in the buffer being erroneously logged as having resulted from a response to the cancel message.

Fixes: #1284