### PR TITLE
Fix mapping when two types exist with same name

### DIFF
--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -251,11 +251,29 @@ namespace Npgsql.TypeMapping
             // (i.e. missing database type for some unused defined binding shouldn't fail the connection)
 
             var pgName = mapping.PgTypeName;
-            var found = pgName.IndexOf('.') == -1
-                ? DatabaseInfo.ByName.TryGetValue(pgName, out var pgType)  // No dot, partial type name
-                : DatabaseInfo.ByFullName.TryGetValue(pgName, out pgType); // Full type name with namespace
 
-            if (!found)
+            PostgresType pgType = null;
+            if (pgName.IndexOf('.') > -1)
+                DatabaseInfo.ByFullName.TryGetValue(pgName, out pgType);  // Full type name with namespace
+            else if (DatabaseInfo.ByName.TryGetValue(pgName, out pgType)) // No dot, partial type name
+            {
+                if (pgType is null)
+                {
+                    // If the name was found but the value is null, that means that there are
+                    // two db types with the same name (different schemas).
+                    // Try to fall back to pg_catalog, otherwise fail.
+                    if (!DatabaseInfo.ByFullName.TryGetValue($"pg_catalog.{pgName}", out pgType))
+                    {
+                        var msg = $"More than one PostgreSQL type was found with the name {mapping.PgTypeName}, please specify a full name including schema";
+                        if (externalCall)
+                            throw new ArgumentException(msg);
+                        Log.Debug(msg);
+                        return;
+                    }
+                }
+            }
+
+            if (pgType is null)
             {
                 var msg = $"A PostgreSQL type with the name {mapping.PgTypeName} was not found in the database";
                 if (externalCall)
@@ -263,15 +281,7 @@ namespace Npgsql.TypeMapping
                 Log.Debug(msg);
                 return;
             }
-            else if (pgType == null)
-            {
-                var msg = $"More than one PostgreSQL type was found with the name {mapping.PgTypeName}, please specify a full name including schema";
-                if (externalCall)
-                    throw new ArgumentException(msg);
-                Log.Debug(msg);
-                return;
-            }
-            else if (pgType is PostgresDomainType)
+            if (pgType is PostgresDomainType)
             {
                 var msg = "Cannot add a mapping to a PostgreSQL domain type";
                 if (externalCall)

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Transactions;
+using System.Threading.Tasks;
+using NpgsqlTypes;
 using NUnit.Framework;
+using System.Transactions;
 
 namespace Npgsql.Tests
 {
@@ -397,6 +401,29 @@ namespace Npgsql.Tests
         {
             Left,
             Right
+        }
+
+        [Test]
+        public void Bug2296()
+        {
+            using (var conn = OpenConnection())
+            {
+                try
+                {
+                    conn.ExecuteNonQuery("CREATE DOMAIN pg_temp.\"boolean\" AS bool");
+                    conn.ExecuteNonQuery("CREATE TEMP TABLE data (mybool \"boolean\")");
+                    conn.ExecuteNonQuery("INSERT INTO data (mybool) VALUES (TRUE)");
+
+                    conn.ReloadTypes();
+
+                    conn.ExecuteScalar("SELECT mybool FROM data");
+                }
+                finally
+                {
+                    conn.ExecuteNonQuery("DROP TABLE IF EXISTS data; DROP TYPE IF EXISTS \"boolean\"");
+                    conn.ReloadTypes();
+                }
+            }
         }
 
         #region Bug1285


### PR DESCRIPTION
When two PostgreSQL types exist with the same name (e.g. user created a type called "boolean"), the built-in mappings fail because they use relative type names. Added a fallback to try a full-name lookup in
pg_catalog for the built-in mappings.

Fixes #2296 

Note that there is another possibility for fixing this... We could implicitly [make all built-in type mappings](https://github.com/npgsql/Npgsql/blob/c90bf5ea9ca86a5a0ae4606f8caeaece26256b20/src/Npgsql/TypeMapping/GlobalTypeMapper.cs#L199) be full-name on pg_catalog, rather than relative-name. The problem with this is that `hstore` is an extension type, which can therefore be created in any schema... We could move it out to an extension, and then I think all built-in mappings would really come from pg_catalog. But this seems like a pretty esoteric problem and I wouldn't like to change things too much just to fix it.

@YohDeadfall and @austindrenski let me know what you think...
