### PR TITLE
Removed default build properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,16 +15,10 @@
   <!-- Language configuration -->
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     
     <!-- This is somehow important for Microsoft.CodeQuality.Analyzers -->
     <Features>IOperation</Features>
-  </PropertyGroup>
-
-  <!-- Debug configuration -->
-  <PropertyGroup>
-    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <!-- Siging configuration -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,6 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    
-    <!-- This is somehow important for Microsoft.CodeQuality.Analyzers -->
-    <Features>IOperation</Features>
   </PropertyGroup>
 
   <!-- Siging configuration -->


### PR DESCRIPTION
Reasons:

* `Deterministic` is `true` by default ([source](https://github.com/dotnet/sdk/blob/2eb6c546931b5bcb92cd3128b93932a980553ea1/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L34)).
* `DebugType` is `portable` by default ([source](https://github.com/dotnet/sdk/blob/2eb6c546931b5bcb92cd3128b93932a980553ea1/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L76)).