### PR TITLE
Align empty CommandText behavior to SqlClient

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -74,7 +74,7 @@ namespace Npgsql
         /// <summary>
         /// Initializes a new instance of the <see cref="NpgsqlCommand">NpgsqlCommand</see> class.
         /// </summary>
-        public NpgsqlCommand() : this(string.Empty, null, null) {}
+        public NpgsqlCommand() : this(null, null, null) {}
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NpgsqlCommand">NpgsqlCommand</see> class with the text of the query.
@@ -123,9 +123,6 @@ namespace Npgsql
             get => _commandText;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
                 _commandText = value;
                 ResetExplicitPreparation();
                 // TODO: Technically should do this also if the parameter list (or type) changes
@@ -680,6 +677,9 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         void ProcessRawQuery(bool deriveParameters = false)
         {
+            if (string.IsNullOrEmpty(CommandText))
+                throw new InvalidOperationException("CommandText property has not been initialized");
+
             NpgsqlStatement statement;
             switch (CommandType) {
             case CommandType.Text:

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -517,12 +517,21 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public void EmptyQuery()
+        public void CommandTextNotSet()
         {
             using (var conn = OpenConnection())
             {
-                conn.ExecuteNonQuery("");
-                conn.ExecuteNonQuery(";");
+                using (var cmd = new NpgsqlCommand())
+                {
+                    cmd.Connection = conn;
+                    Assert.That(cmd.ExecuteNonQuery, Throws.Exception.TypeOf<InvalidOperationException>());
+                    cmd.CommandText = null;
+                    Assert.That(cmd.ExecuteNonQuery, Throws.Exception.TypeOf<InvalidOperationException>());
+                    cmd.CommandText = "";
+                }
+
+                using (var cmd = conn.CreateCommand())
+                    Assert.That(cmd.ExecuteNonQuery, Throws.Exception.TypeOf<InvalidOperationException>());
             }
         }
 


### PR DESCRIPTION
Executing a command without setting CommandText now throws. Same happens when CommandText is set to empty string or null (the latter was previously not possible).

Fixes #2323