### PR TITLE
Don't throw exceptions when disposing after a COPY export has been cancelled

### DIFF
--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -240,7 +240,15 @@ namespace Npgsql
                         {
                             _readBuf.Skip(_leftToReadInDataMsg);
                         }
-                        _connector.SkipUntil(BackendMessageCode.ReadyForQuery);
+
+                        try
+                        {
+                            _connector.SkipUntil(BackendMessageCode.ReadyForQuery);
+                        }
+                        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.QueryCanceled)
+                        {
+                            Log.Error($"Caught exception when disposing the {nameof(NpgsqlRawCopyStream)} indicating that it was cancelled.", e, _connector.Id);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

When a `COPY` export is cancelled and Postgres still has `CopyData` messages queued to send, it will continue to send some `CopyData` messages before eventually sending an `ErrorResponse` message with the `SQLSTATE` equal to `57014` (`query_canceled`).

This error causes `Dispose()` of the returned object from `BeginTextExport()`, `BeginBinaryExport()`, and `BeginRawBinaryCopy()` to throw an exception.

The error/exception won't manifest in simple cases where Postgres is able to send all `CopyData` messages, the `CopyDone` message, and the `CommandComplete` message before the `CancelRequest` message is sent on the separate connector. For example, if everything can fit in the same TCP window.

## Solution

I think it's appropriate to match the behavior of all other places of cancelling (e.g. `NpgsqlRawCopyStream.Cancel()`) and protect against/swallow the possible exception. I'm by no means a Postgres protocol expert, so I would appreciate some guidance if this is the best approach. I was originally thinking to clean up the `COPY` during the `Cancel()`, but I didn't want to go too far down a rabbit hole without seeing if this should be done in the first place.

## Context

I'm using `COPY (...) TO STDOUT WITH (FORMAT CSV)` to efficiently generate a CSV from a particular query. I noticed this happening when cancelling an export with a "large" amount of data but my unit tests were passing just fine. I've tested this against Postgres 9.5.