### PR TITLE
Rename properties on NpgsqlNotificationEventArgs

### DIFF
--- a/src/Npgsql/NpgsqlNotificationEventArgs.cs
+++ b/src/Npgsql/NpgsqlNotificationEventArgs.cs
@@ -35,7 +35,7 @@ namespace Npgsql
         /// An optional payload string that was sent with this notification.
         /// </summary>
         [Obsolete("Use Payload instead")]
-        public string AdditionalInformation { get; }
+        public string AdditionalInformation => Payload;
 
         internal NpgsqlNotificationEventArgs(NpgsqlReadBuffer buf)
         {

--- a/src/Npgsql/NpgsqlNotificationEventArgs.cs
+++ b/src/Npgsql/NpgsqlNotificationEventArgs.cs
@@ -29,7 +29,7 @@ namespace Npgsql
         /// The channel on which the notification was sent.
         /// </summary>
         [Obsolete("Use Channel instead")]
-        public string Condition { get; }
+        public string Condition => Channel;
 
         /// <summary>
         /// An optional payload string that was sent with this notification.

--- a/src/Npgsql/NpgsqlNotificationEventArgs.cs
+++ b/src/Npgsql/NpgsqlNotificationEventArgs.cs
@@ -18,18 +18,30 @@ namespace Npgsql
         /// <summary>
         /// The channel on which the notification was sent.
         /// </summary>
+        public string Channel { get; }
+
+        /// <summary>
+        /// An optional payload string that was sent with this notification.
+        /// </summary>
+        public string Payload { get; }
+
+        /// <summary>
+        /// The channel on which the notification was sent.
+        /// </summary>
+        [Obsolete("Use Channel instead")]
         public string Condition { get; }
 
         /// <summary>
         /// An optional payload string that was sent with this notification.
         /// </summary>
+        [Obsolete("Use Payload instead")]
         public string AdditionalInformation { get; }
 
         internal NpgsqlNotificationEventArgs(NpgsqlReadBuffer buf)
         {
             PID = buf.ReadInt32();
-            Condition = buf.ReadNullTerminatedString();
-            AdditionalInformation = buf.ReadNullTerminatedString();
+            Channel = buf.ReadNullTerminatedString();
+            Payload = buf.ReadNullTerminatedString();
         }
     }
 }


### PR DESCRIPTION
From Condition to Channel, from AdditionalInformation to Payload.
The old names have been kept as obsolete properties.