### PR TITLE
Removed excessive elvis operator

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -928,7 +928,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 if (pStatement?.State != PreparedState.ToBePrepared)
                     continue;
 
-                var statementToClose = pStatement?.StatementBeingReplaced;
+                var statementToClose = pStatement.StatementBeingReplaced;
                 if (statementToClose != null)
                 {
                     // We have a prepared statement that replaces an existing statement - close the latter first.


### PR DESCRIPTION
pStatement is already checked for null on line 928. So we don't need to check it again.