### PR TITLE
Don't allocate a string for ReadOnlySpan StringBuilder overload on .NET Standard 2.0 and .NET 4.6.1

### DIFF
--- a/src/Npgsql/Util/StringBuilderExtensions.cs
+++ b/src/Npgsql/Util/StringBuilderExtensions.cs
@@ -10,13 +10,25 @@ namespace Npgsql.Util
     static class StringBuilderExtensions
     {
         /// <summary>
-        /// Appends the provided <see cref="ReadOnlySpan{T}"/> to the <see cref="StringBuilder"/> by calling ToString on
-        /// the span.
+        /// Appends the provided <see cref="ReadOnlySpan{T}"/> to the <see cref="StringBuilder"/>.
         /// </summary>
         /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to.</param>
         /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to append.</param>
-        public static void Append(this StringBuilder stringBuilder, ReadOnlySpan<char> span)
-            => stringBuilder.Append(span.ToString());
+        public static StringBuilder Append(this StringBuilder stringBuilder, ReadOnlySpan<char> span)
+        {
+            if (span.Length > 0)
+            {
+                unsafe
+                {
+                    fixed (char* value = &span.GetPinnableReference())
+                    {
+                        return stringBuilder.Append(value, span.Length);
+                    }
+                }
+            }
+
+            return stringBuilder;
+        }
     }
 }
 #endif


### PR DESCRIPTION
This is also what the built-in overload does: https://github.com/dotnet/corefx/blob/d866aa6eb7f4f5c2df5892b09d694280d2982150/src/Common/src/CoreLib/System/Text/StringBuilder.cs#L1210-L1223.