### PR TITLE
Add ADO.NET specification tests

### DIFF
--- a/Npgsql.all.sln
+++ b/Npgsql.all.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.NetTopologySuite", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.GeoJSON", "src\Npgsql.GeoJSON\Npgsql.GeoJSON.csproj", "{04052CCF-CABC-4B37-B89D-F95721D95407}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.Specification.Tests", "test\Npgsql.Specification.Tests\Npgsql.Specification.Tests.csproj", "{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -144,6 +146,14 @@ Global
 		{04052CCF-CABC-4B37-B89D-F95721D95407}.Release|Any CPU.Build.0 = Release|Any CPU
 		{04052CCF-CABC-4B37-B89D-F95721D95407}.Release|x86.ActiveCfg = Release|Any CPU
 		{04052CCF-CABC-4B37-B89D-F95721D95407}.Release|x86.Build.0 = Release|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -161,6 +171,7 @@ Global
 		{B7E92398-DD4E-410E-923C-E256992F6687} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{20D889AA-82DC-4AA0-B508-7CE68B83BB27} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{04052CCF-CABC-4B37-B89D-F95721D95407} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
+		{F0DD1CE7-D753-41AB-A30F-1CC7CDE9B8EF} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -32,6 +32,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.NetTopologySuite", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.GeoJSON", "src\Npgsql.GeoJSON\Npgsql.GeoJSON.csproj", "{F7C53EBD-0075-474F-A083-419257D04080}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.Specification.Tests", "test\Npgsql.Specification.Tests\Npgsql.Specification.Tests.csproj", "{A77E5FAF-D775-4AB4-8846-8965C2104E60}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +122,14 @@ Global
 		{F7C53EBD-0075-474F-A083-419257D04080}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F7C53EBD-0075-474F-A083-419257D04080}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7C53EBD-0075-474F-A083-419257D04080}.Release|x86.Build.0 = Release|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Debug|x86.Build.0 = Debug|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|x86.ActiveCfg = Release|Any CPU
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -135,6 +145,7 @@ Global
 		{5BF3516D-5559-46A8-8362-0F4D931EEAB9} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{6CB12050-DC9B-4155-BADD-BFDD54CDD70F} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{F7C53EBD-0075-474F-A083-419257D04080} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
+		{A77E5FAF-D775-4AB4-8846-8965C2104E60} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -538,7 +538,7 @@ namespace Npgsql
             using (connector.StartUserAction())
             {
                 if (connector.InTransaction)
-                    throw new NotSupportedException("Nested/Concurrent transactions aren't supported.");
+                    throw new InvalidOperationException("A transaction is already in progress; nested/concurrent transactions aren't supported.");
 
                 return new NpgsqlTransaction(this, level);
             }

--- a/test/Npgsql.Specification.Tests/Npgsql.Specification.Tests.csproj
+++ b/test/Npgsql.Specification.Tests/Npgsql.Specification.Tests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Npgsql/Npgsql.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AdoNet.Specification.Tests" Version="2.0.0-alpha3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+</Project>

--- a/test/Npgsql.Specification.Tests/NpgsqlCommandTests.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlCommandTests.cs
@@ -1,0 +1,12 @@
+using AdoNet.Specification.Tests;
+
+namespace Npgsql.Specification.Tests
+{
+    public sealed class NpgsqlCommandTests : CommandTestBase<NpgsqlDbFactoryFixture>
+    {
+        public NpgsqlCommandTests(NpgsqlDbFactoryFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Npgsql.Specification.Tests/NpgsqlConnectionTests.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlConnectionTests.cs
@@ -1,0 +1,12 @@
+using AdoNet.Specification.Tests;
+
+namespace Npgsql.Specification.Tests
+{
+    public sealed class NpgsqlConnectionTests : ConnectionTestBase<NpgsqlDbFactoryFixture>
+    {
+        public NpgsqlConnectionTests(NpgsqlDbFactoryFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/Npgsql.Specification.Tests/NpgsqlDataReaderTests.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlDataReaderTests.cs
@@ -1,0 +1,11 @@
+using AdoNet.Specification.Tests;
+using Xunit;
+
+namespace Npgsql.Specification.Tests
+{
+    public sealed class NpgsqlDataReaderTests : DataReaderTestBase<NpgsqlSelectValueFixture>
+    {
+        public NpgsqlDataReaderTests(NpgsqlSelectValueFixture fixture)
+            : base(fixture) {}
+    }
+}

--- a/test/Npgsql.Specification.Tests/NpgsqlDbFactoryFixture.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlDbFactoryFixture.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data.Common;
+using AdoNet.Specification.Tests;
+
+namespace Npgsql.Specification.Tests
+{
+    public class NpgsqlDbFactoryFixture : IDbFactoryFixture
+    {
+        public DbProviderFactory Factory => NpgsqlFactory.Instance;
+
+        const string DefaultConnectionString =
+            "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+
+        public string ConnectionString =>
+            Environment.GetEnvironmentVariable("NPGSQL_TEST_DB") ?? DefaultConnectionString;
+    }
+}

--- a/test/Npgsql.Specification.Tests/NpgsqlSelectValueFixture.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlSelectValueFixture.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Linq;
+using AdoNet.Specification.Tests;
+
+namespace Npgsql.Specification.Tests
+{
+    public class NpgsqlSelectValueFixture : NpgsqlDbFactoryFixture, ISelectValueFixture, IDisposable
+    {
+        public NpgsqlSelectValueFixture()
+        {
+            Utility.ExecuteNonQuery(this, @"DROP TABLE IF EXISTS select_value;
+CREATE TABLE select_value
+(
+	id INTEGER NOT NULL PRIMARY KEY,
+	""Binary"" bytea,
+	""Boolean"" boolean,
+	""Date"" date,
+	""DateTime"" timestamp,
+	""DateTimeOffset"" timestamp with time zone,
+	""Decimal"" numeric(57,28),
+	""Double"" double precision,
+	""Guid"" uuid,
+	""Int16"" smallint,
+	""Int32"" integer,
+	""Int64"" bigint,
+	""Single"" real,
+	""String"" varchar,
+	""Time"" time
+);
+INSERT INTO select_value VALUES
+(0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(1, E''::bytea, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL),
+(2, E'\\000'::bytea, false, NULL, NULL, NULL, 0, 0, '00000000-0000-0000-0000-000000000000', 0, 0, 0, 0, '0', '00:00:00'),
+(3, E'\\021'::bytea, true, '1111-11-11', '1111-11-11 11:11:11.111', '1111-11-11 11:11:11.111 +11:11', 1, 1, '11111111-1111-1111-1111-111111111111', 1, 1, 1, 1, '1', '11:11:11.111'),
+(4, NULL, false, '0001-01-01', '0001-01-01', '0001-01-01', 0.000000000000001, 2.23e-308, '33221100-5544-7766-9988-aabbccddeeff', -32768, -2147483648, -9223372036854775808, 1.18e-38, NULL, '00:00:00'),
+(5, NULL, true, '9999-12-31', '9999-12-31 23:59:59.999', '9999-12-31 23:59:59.999 +14:00', 99999999999999999999.999999999999999, 1.79e308, 'ccddeeff-aabb-8899-7766-554433221100', 32767, 2147483647, 9223372036854775807, 3.40e38, NULL, '23:59:59.999');
+");
+        }
+
+        public void Dispose() => Utility.ExecuteNonQuery(this, "DROP TABLE IF EXISTS select_value;");
+
+        public string CreateSelectSql(DbType dbType, ValueKind kind) =>
+            $"SELECT \"{dbType.ToString()}\" FROM select_value WHERE id = {(int)kind};";
+
+        public string CreateSelectSql(byte[] value) =>
+            $@"SELECT E'{string.Join("", value.Select(x => @"\x" + x.ToString("X2")))}'::bytea";
+
+        public string SelectNoRows => "SELECT 1 WHERE 0 = 1;";
+
+        public IReadOnlyCollection<DbType> SupportedDbTypes { get; } = new ReadOnlyCollection<DbType>(new[]
+        {
+            DbType.Binary,
+            DbType.Boolean,
+            DbType.Date,
+            DbType.DateTime,
+            DbType.DateTimeOffset,
+            DbType.Decimal,
+            DbType.Double,
+            DbType.Guid,
+            DbType.Int16,
+            DbType.Int32,
+            DbType.Int64,
+            DbType.Single,
+            DbType.String,
+            DbType.Time
+        });
+    }
+}

--- a/test/Npgsql.Specification.Tests/Utility.cs
+++ b/test/Npgsql.Specification.Tests/Utility.cs
@@ -1,0 +1,23 @@
+using System;
+using AdoNet.Specification.Tests;
+
+namespace Npgsql.Specification.Tests
+{
+    public static class Utility
+    {
+        public static void ExecuteNonQuery(IDbFactoryFixture factoryFixture, string sql)
+        {
+            using (var connection = factoryFixture.Factory.CreateConnection())
+            {
+                connection.ConnectionString = factoryFixture.ConnectionString;
+                connection.Open();
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+    }
+}

--- a/test/Npgsql.Tests/TestBase.cs
+++ b/test/Npgsql.Tests/TestBase.cs
@@ -15,7 +15,7 @@ namespace Npgsql.Tests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        const string DefaultConnectionString = "Server=localhost;User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+        const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
 
         #region Utilities for use by tests
 

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -206,7 +206,7 @@ namespace Npgsql.Tests
             using (var conn = OpenConnection())
             {
                 conn.BeginTransaction();
-                Assert.That(() => conn.BeginTransaction(), Throws.TypeOf<NotSupportedException>());
+                Assert.That(() => conn.BeginTransaction(), Throws.TypeOf<InvalidOperationException>());
             }
         }
 


### PR DESCRIPTION
See https://github.com/mysql-net/AdoNetApiTest.

Still have 5 failing tests for non-trivial stuff which we can look into a bit later.

Tracked by #2225, https://github.com/dotnet/corefx/issues/7810, https://github.com/aspnet/EntityFrameworkCore/issues/13833

/cc @bgrainger @divega @ajcvickers @bricelam