### PR TITLE
Recycle RowDescription and FieldDescription

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -30,6 +30,17 @@ namespace Npgsql.BackendMessages
             _nameIndex = new Dictionary<string, int>();
         }
 
+        RowDescriptionMessage(RowDescriptionMessage source)
+        {
+            Fields = new List<FieldDescription>(source.Fields.Count);
+            foreach (var f in source.Fields)
+                Fields.Add(f.Clone());
+            _nameIndex = new Dictionary<string, int>(source._nameIndex);
+            if (source._insensitiveIndex != null)
+                _insensitiveIndex = new Dictionary<string, int>(source._insensitiveIndex);
+            _isInsensitiveIndexInitialized = source._isInsensitiveIndexInitialized;
+        }
+
         internal RowDescriptionMessage Load(NpgsqlReadBuffer buf, ConnectorTypeMapper typeMapper)
         {
             Fields.Clear();
@@ -44,8 +55,15 @@ namespace Npgsql.BackendMessages
             var numFields = buf.ReadInt16();
             for (var i = 0; i != numFields; ++i)
             {
-                // TODO: Recycle
-                var field = new FieldDescription();
+                FieldDescription field;
+                if (i >= Fields.Count)
+                {
+                    field = new FieldDescription();
+                    Fields.Add(field);
+                }
+                else
+                    field = Fields[i];
+
                 field.Populate(
                     typeMapper,
                     buf.ReadNullTerminatedString(), // Name
@@ -57,7 +75,6 @@ namespace Npgsql.BackendMessages
                     (FormatCode)buf.ReadInt16() // FormatCode
                 );
 
-                Fields.Add(field);
                 if (!_nameIndex.ContainsKey(field.Name))
                     _nameIndex.Add(field.Name, i);
             }
@@ -103,6 +120,8 @@ namespace Npgsql.BackendMessages
 
         public BackendMessageCode Code => BackendMessageCode.RowDescription;
 
+        internal RowDescriptionMessage Clone() => new RowDescriptionMessage(this);
+
         /// <summary>
         /// Comparer that's case-insensitive and Kana width-insensitive
         /// </summary>
@@ -129,6 +148,21 @@ namespace Npgsql.BackendMessages
     /// </summary>
     public sealed class FieldDescription
     {
+        internal FieldDescription() {}
+
+        internal FieldDescription(FieldDescription source)
+        {
+            _typeMapper = source._typeMapper;
+            Name = source.Name;
+            TableOID = source.TableOID;
+            ColumnAttributeNumber = source.ColumnAttributeNumber;
+            TypeOID = source.TypeOID;
+            TypeSize = source.TypeSize;
+            TypeModifier = source.TypeModifier;
+            FormatCode = source.FormatCode;
+            Handler = source.Handler;
+        }
+
         internal void Populate(
             ConnectorTypeMapper typeMapper, string name, uint tableOID, short columnAttributeNumber,
             uint oid, short typeSize, int typeModifier, FormatCode formatCode
@@ -219,6 +253,8 @@ namespace Npgsql.BackendMessages
 
         internal bool IsBinaryFormat => FormatCode == FormatCode.Binary;
         internal bool IsTextFormat => FormatCode == FormatCode.Text;
+
+        internal FieldDescription Clone() => new FieldDescription(this);
 
         /// <summary>
         /// Returns a string that represents the current object.

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -620,7 +620,9 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         switch (msg.Code)
                         {
                         case BackendMessageCode.RowDescription:
-                            var description = (RowDescriptionMessage)msg;
+                            // Clone the RowDescription for use with the prepared statement (the one we have is reused
+                            // by the connection)
+                            var description = ((RowDescriptionMessage)msg).Clone();
                             FixupRowDescription(description, isFirst);
                             statement.Description = description;
                             break;

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -236,6 +236,7 @@ namespace Npgsql
         readonly ReadyForQueryMessage        _readyForQueryMessage        = new ReadyForQueryMessage();
         readonly ParameterDescriptionMessage _parameterDescriptionMessage = new ParameterDescriptionMessage();
         readonly DataRowMessage              _dataRowMessage              = new DataRowMessage();
+        readonly RowDescriptionMessage       _rowDescriptionMessage       = new RowDescriptionMessage();
 
         // Since COPY is rarely used, allocate these lazily
         CopyInResponseMessage _copyInResponseMessage;
@@ -1020,9 +1021,7 @@ namespace Npgsql
             switch (code)
             {
                 case BackendMessageCode.RowDescription:
-                    // TODO: Recycle
-                    var rowDescriptionMessage = new RowDescriptionMessage();
-                    return rowDescriptionMessage.Load(buf, TypeMapper);
+                    return _rowDescriptionMessage.Load(buf, TypeMapper);
                 case BackendMessageCode.DataRow:
                     return _dataRowMessage.Load(len);
                 case BackendMessageCode.CompletedResponse:


### PR DESCRIPTION
We were allocating a new RowDescription message (and all of its FieldDescriptions) for every new statement execution (except for prepared statements). We now recycle these and reuse the same RowDescription cached on the physical connection. Prepared commands clone the description as they need their own, long-lived instance.