### PR TITLE
Change minimum supported .NET Framework from 4.5.2 to 4.6.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,8 +27,8 @@ before_build:
   - appveyor-retry dotnet restore -v Minimal Npgsql.sln
   - appveyor-retry nuget restore src\VSIX\packages.config -SolutionDirectory . -Verbosity quiet -NonInteractive
 build_script:
-  - dotnet build "test\Npgsql.Tests" -c Debug -f net452
-  - dotnet build "test\Npgsql.PluginTests" -c Debug -f net452
+  - dotnet build "test\Npgsql.Tests" -c Debug -f net461
+  - dotnet build "test\Npgsql.PluginTests" -c Debug -f net461
   - msbuild src\VSIX\VSIX.csproj /p:Configuration=Release /v:Minimal
   - msbuild src\MSI\MSI.wixproj /p:Configuration=Release /v:Minimal
 after_build:
@@ -40,8 +40,8 @@ after_build:
   - dotnet pack src\Npgsql.NetTopologySuite\Npgsql.NetTopologySuite.csproj -c Release
 test:
   assemblies:
-    - test\Npgsql.Tests\bin\Debug\net452\Npgsql.Tests.dll
-    - test\Npgsql.PluginTests\bin\Debug\net452\Npgsql.PluginTests.dll
+    - test\Npgsql.Tests\bin\Debug\net461\Npgsql.Tests.dll
+    - test\Npgsql.PluginTests\bin\Debug\net461\Npgsql.PluginTests.dll
 artifacts:
   - path: 'src\**\*.nupkg'
     name: Nuget

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <!-- Build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -63,7 +63,7 @@
   <Import Project="$(WixTargetsPath)" />
   <Target Name="CreateWixProperties" BeforeTargets="Compile">
     <!-- Get the programs assembly version from the .exe file -->
-    <GetAssemblyIdentity AssemblyFiles="..\Npgsql\bin\$(Configuration)\net452\Npgsql.dll">
+    <GetAssemblyIdentity AssemblyFiles="..\Npgsql\bin\$(Configuration)\net461\Npgsql.dll">
       <Output TaskParameter="Assemblies" ItemName="AsmInfo" />
     </GetAssemblyIdentity>
     <CreateProperty Value="%(AsmInfo.Version)">

--- a/src/MSI/Npgsql.wxs
+++ b/src/MSI/Npgsql.wxs
@@ -109,35 +109,35 @@
         <Component Id="Npgsql" Guid="f842fa5e-5623-41aa-80aa-6d2e5bf97435">
           <File Id="Npgsql"
                 Name="Npgsql.dll"
-                Source="..\npgsql\bin\$(var.Configuration)\net452\Npgsql.dll"
+                Source="..\npgsql\bin\$(var.Configuration)\net461\Npgsql.dll"
                 KeyPath="yes"
                 Assembly=".net" />
         </Component>
         <Component Id="System.Threading.Tasks.Extensions" Guid="d978c06f-7e7f-4865-858e-b9eee77d7470">
           <File Id="System.Threading.Tasks.Extensions"
                 Name="System.Threading.Tasks.Extensions.dll"
-                Source="..\npgsql\bin\$(var.Configuration)\net452\System.Threading.Tasks.Extensions.dll"
+                Source="..\npgsql\bin\$(var.Configuration)\net461\System.Threading.Tasks.Extensions.dll"
                 KeyPath="yes"
                 Assembly=".net" />
         </Component>
         <Component Id="System.ValueTuple" Guid="07cfe929-4a0c-4b90-87df-37cceaa970b8">
           <File Id="System.ValueTuple"
                 Name="System.ValueTuple.dll"
-                Source="..\npgsql\bin\$(var.Configuration)\net452\System.ValueTuple.dll"
+                Source="..\npgsql\bin\$(var.Configuration)\net461\System.ValueTuple.dll"
                 KeyPath="yes"
                 Assembly=".net" />
         </Component>
         <Component Id="System.Runtime.CompilerServices.Unsafe" Guid="36194b8d-d2af-4dd6-a9a0-fb6942502e53">
           <File Id="System.Runtime.CompilerServices.Unsafe"
                 Name="System.Runtime.CompilerServices.Unsafe.dll"
-                Source="..\npgsql\bin\$(var.Configuration)\net452\System.Runtime.CompilerServices.Unsafe.dll"
+                Source="..\npgsql\bin\$(var.Configuration)\net461\System.Runtime.CompilerServices.Unsafe.dll"
                 KeyPath="yes"
                 Assembly=".net" />
         </Component>
         <Component Id="System.Memory" Guid="3cf4b30c-ccf9-4c65-b2ba-cf00684e35cb">
           <File Id="System.Memory"
                 Name="System.Memory.dll"
-                Source="..\npgsql\bin\$(var.Configuration)\net452\System.Memory.dll"
+                Source="..\npgsql\bin\$(var.Configuration)\net461\System.Memory.dll"
                 KeyPath="yes"
                 Assembly=".net" />
         </Component>

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -251,11 +251,7 @@ namespace Npgsql.NetTopologySuite
         Task WriteCore(IGeometry value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
         {
             _writer.Write(value, buf.GetStream());
-#if NET452
-            return Task.Delay(0);
-#else
             return Task.CompletedTask;
-#endif
         }
 
         #endregion

--- a/src/Npgsql/Common.cs
+++ b/src/Npgsql/Common.cs
@@ -55,7 +55,7 @@ namespace Npgsql
                 return FlushAndWrite(buf, async);
             Debug.Assert(Length <= buf.WriteSpaceLeft, $"Message of type {GetType().Name} has length {Length} which is bigger than the buffer ({buf.WriteSpaceLeft})");
             WriteFully(buf);
-            return PGUtil.CompletedTask;
+            return Task.CompletedTask;
         }
 
         async Task FlushAndWrite(NpgsqlWriteBuffer buf, bool async)

--- a/src/Npgsql/Counters.cs
+++ b/src/Npgsql/Counters.cs
@@ -61,7 +61,7 @@ namespace Npgsql
                 var enabled = false;
                 var expensiveEnabled = false;
 
-#if NET452
+#if NET461
                 try
                 {
                     if (usePerfCounters)
@@ -108,7 +108,7 @@ namespace Npgsql
     /// </summary>
     sealed class Counter : IDisposable
     {
-#if NET452
+#if NET461
         internal const string DiagnosticsCounterCategory = ".NET Data Provider for PostgreSQL (Npgsql)";
 
         [CanBeNull]
@@ -122,7 +122,7 @@ namespace Npgsql
             if (!enabled)
                 return;
 
-#if NET452
+#if NET461
             DiagnosticsCounter = new PerformanceCounter
             {
                 CategoryName = DiagnosticsCounterCategory,
@@ -141,28 +141,28 @@ namespace Npgsql
 
         internal void Increment()
         {
-#if NET452
+#if NET461
             DiagnosticsCounter?.Increment();
 #endif
         }
 
         internal void Decrement()
         {
-#if NET452
+#if NET461
             DiagnosticsCounter?.Decrement();
 #endif
         }
 
         public void Dispose()
         {
-#if NET452
+#if NET461
             var diagnosticsCounter = DiagnosticsCounter;
             DiagnosticsCounter = null;
             diagnosticsCounter?.RemoveInstance();
 #endif
         }
 
-#if NET452
+#if NET461
         void OnProcessExit(object sender, EventArgs e) => Dispose();
         void OnDomainUnload(object sender, EventArgs e) => Dispose();
         void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Transactions" Pack="false" />
     <Reference Include="System.DirectoryServices" Pack="false" />
   </ItemGroup>

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -591,7 +591,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             // all statements. Nothing to do here, move along.
             return needToPrepare
                 ? PrepareLong()
-                : PGUtil.CompletedTask;
+                : Task.CompletedTask;
 
             async Task PrepareLong()
             {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -221,7 +221,7 @@ namespace Npgsql
             Debug.Assert(Connector.Connection != null, "Open done but connector not set on Connection");
             Log.Debug("Connection opened", Connector.Id);
             OnStateChange(new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open));
-            return PGUtil.CompletedTask;
+            return Task.CompletedTask;
 
             async Task OpenLong()
             {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -493,7 +493,7 @@ namespace Npgsql
             if (!string.IsNullOrEmpty(username))
                 return Settings.Username;
 
-#if NET452
+#if NET461
             if (PGUtil.IsWindows && Type.GetType("Mono.Runtime") == null)
             {
                 username = WindowsUsernameProvider.GetUsername(Settings.IncludeRealm);

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -31,7 +31,7 @@ namespace Npgsql
 #pragma warning disable CA1010
     public sealed class NpgsqlDataReader : DbDataReader
 #pragma warning restore CA1010
-#if !NET452
+#if !NET461
         , IDbColumnSchemaGenerator
 #endif
     {
@@ -1648,7 +1648,7 @@ namespace Npgsql
             => new DbColumnSchemaGenerator(_connection, RowDescription, _behavior.HasFlag(CommandBehavior.KeyInfo))
                 .GetColumnSchema();
 
-#if !NET452
+#if !NET461
         ReadOnlyCollection<DbColumn> IDbColumnSchemaGenerator.GetColumnSchema()
             => new ReadOnlyCollection<DbColumn>(GetColumnSchema().Cast<DbColumn>().ToList());
 #endif
@@ -1739,7 +1739,7 @@ namespace Npgsql
             if (_isSequential)
                 return SeekToColumnSequential(column, async);
             SeekToColumnNonSequential(column);
-            return PGUtil.CompletedTask;
+            return Task.CompletedTask;
         }
 
         void SeekToColumnNonSequential(int column)
@@ -1822,7 +1822,7 @@ namespace Npgsql
 
             Buffer.ReadPosition = _columns[_column].Offset + posInColumn;
             PosInColumn = posInColumn;
-            return PGUtil.CompletedTask;
+            return Task.CompletedTask;
 
             async Task SeekInColumnSequential(int posInColumn2, bool async2)
             {
@@ -1855,7 +1855,7 @@ namespace Npgsql
             else
             {
                 ConsumeRowNonSequential();
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             async Task ConsumeRowSequential(bool async2)

--- a/src/Npgsql/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.Stream.cs
@@ -131,7 +131,7 @@ namespace Npgsql
                 if (buffer.Length - offset < count)
                     throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
                 if (cancellationToken.IsCancellationRequested)
-                    return new ValueTask<int>(PGUtil.CancelledTask);
+                    return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
 
                 count = Math.Min(count, _len - _read);
 

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -104,7 +104,7 @@ namespace Npgsql
 
         internal Task Ensure(int count, bool async, bool dontBreakOnTimeouts)
         {
-            return count <= ReadBytesLeft ? PGUtil.CompletedTask : EnsureLong();
+            return count <= ReadBytesLeft ? Task.CompletedTask : EnsureLong();
 
             async Task EnsureLong()
             {

--- a/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
@@ -45,7 +45,7 @@ namespace Npgsql
             {
                 CheckDisposed();
                 return cancellationToken.IsCancellationRequested
-                    ? PGUtil.CancelledTask : PGUtil.CompletedTask;
+                    ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
             }
 
             public override int Read(byte[] buffer, int offset, int count)
@@ -76,7 +76,7 @@ namespace Npgsql
                 if (buffer.Length - offset < count)
                     throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
                 if (cancellationToken.IsCancellationRequested)
-                    return PGUtil.CancelledTask;
+                    return Task.FromCanceled(cancellationToken);
 
                 while (count > 0)
                 {
@@ -90,7 +90,7 @@ namespace Npgsql
                     count -= slice;
                 }
 
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             async Task WriteLong(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -269,7 +269,7 @@ namespace Npgsql
             if (byteLen <= WriteSpaceLeft)
             {
                 WriteString(s, charLen);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
             return WriteStringLong();
 
@@ -303,7 +303,7 @@ namespace Npgsql
             if (byteLen <= WriteSpaceLeft)
             {
                 WriteChars(chars, offset, charLen);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
             return WriteCharsLong();
 
@@ -361,7 +361,7 @@ namespace Npgsql
             if (bytes.Length <= WriteSpaceLeft)
             {
                 WriteBytes(bytes);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
             return WriteBytesLong();
 

--- a/src/Npgsql/PGUtil.cs
+++ b/src/Npgsql/PGUtil.cs
@@ -64,22 +64,13 @@ namespace Npgsql
         internal static int RotateShift(int val, int shift)
             => (val << shift) | (val >> (BitsInInt - shift));
 
-        internal static readonly Task CompletedTask = Task.FromResult(0);
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
         internal static readonly Task<bool> FalseTask = Task.FromResult(false);
-        internal static readonly Task<int> CancelledTask = CreateCancelledTask<int>();
-
-        static Task<T> CreateCancelledTask<T>()
-        {
-            var source = new TaskCompletionSource<T>();
-            source.SetCanceled();
-            return source.Task;
-        }
 
         internal static StringComparer InvariantCaseIgnoringStringComparer => StringComparer.InvariantCultureIgnoreCase;
 
         internal static bool IsWindows =>
-#if NET452
+#if NET461
             Environment.OSVersion.Platform == PlatformID.Win32NT;
 #else
             System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
@@ -92,7 +83,7 @@ namespace Npgsql
         Binary = 1
     }
 
-    internal static class EnumerableExtensions
+    static class EnumerableExtensions
     {
         internal static string Join(this IEnumerable<string> values, string separator)
         {
@@ -137,7 +128,7 @@ namespace Npgsql
         internal CultureSetter(CultureInfo newCulture)
         {
             _oldCulture = CultureInfo.CurrentCulture;
-#if NET452
+#if NET461
             Thread.CurrentThread.CurrentCulture = newCulture;
 #else
             CultureInfo.CurrentCulture = newCulture;
@@ -146,7 +137,7 @@ namespace Npgsql
 
         public void Dispose()
         {
-#if NET452
+#if NET461
             Thread.CurrentThread.CurrentCulture = _oldCulture;
 #else
             CultureInfo.CurrentCulture = _oldCulture;

--- a/src/Npgsql/Schema/DbColumn.cs
+++ b/src/Npgsql/Schema/DbColumn.cs
@@ -1,4 +1,4 @@
-﻿#if NET452
+﻿#if NET461
 
 using System;
 

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -26,7 +26,7 @@ namespace Npgsql.TypeHandlers
         public override RangeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => throw new NotSupportedException();
     }
-    
+
     /// <summary>
     /// Base class for all type handlers which handle PostgreSQL arrays.
     /// </summary>
@@ -246,7 +246,7 @@ namespace Npgsql.TypeHandlers
             if (value == null || typeof(TAny) == typeof(DBNull))
             {
                 buf.WriteInt32(-1);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             return WriteWithLength();

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -124,7 +124,7 @@ namespace Npgsql.TypeHandlers
             if (value == null || typeof(TAny) == typeof(DBNull))
             {
                 buf.WriteInt32(-1);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             return WriteWithLengthCore();

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -159,7 +159,7 @@ namespace Npgsql.TypeHandling
                 if (buf.WriteSpaceLeft < 4)
                     return WriteWithLengthLong();
                 buf.WriteInt32(-1);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             Debug.Assert(this is INpgsqlSimpleTypeHandler<TAny>);
@@ -170,7 +170,7 @@ namespace Npgsql.TypeHandling
                 return WriteWithLengthLong();
             buf.WriteInt32(elementLen);
             typedHandler.Write(value, buf, parameter);
-            return PGUtil.CompletedTask;
+            return Task.CompletedTask;
 
             async Task WriteWithLengthLong()
             {

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -129,7 +129,7 @@ namespace Npgsql.TypeHandling
             if (value == null || typeof(TAny) == typeof(DBNull))
             {
                 buf.WriteInt32(-1);
-                return PGUtil.CompletedTask;
+                return Task.CompletedTask;
             }
 
             return WriteWithLength(value, buf, lengthCache, parameter, async);

--- a/src/Npgsql/Util/StringBuilderExtensions.cs
+++ b/src/Npgsql/Util/StringBuilderExtensions.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0 || NET452
+#if NETSTANDARD2_0 || NET461
 using System;
 using System.Text;
 
@@ -7,7 +7,7 @@ namespace Npgsql.Util
     /// <summary>
     /// A set of extension methods to <see cref="StringBuilder"/> to allow runtime compatibility.
     /// </summary>
-    internal static class StringBuilderExtensions
+    static class StringBuilderExtensions
     {
         /// <summary>
         /// Appends the provided <see cref="ReadOnlySpan{T}"/> to the <see cref="StringBuilder"/> by calling ToString on

--- a/src/Npgsql/WindowsUsernameProvider.cs
+++ b/src/Npgsql/WindowsUsernameProvider.cs
@@ -1,4 +1,4 @@
-﻿#if NET452
+﻿#if NET461
 using System;
 using System.Collections.Generic;
 using System.DirectoryServices;

--- a/src/VSIX/VSIX.csproj
+++ b/src/VSIX/VSIX.csproj
@@ -30,6 +30,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <!-- https://stackoverflow.com/questions/45938814/the-version-of-microsoft-net-sdk-used-by-this-project-is-insufficient-to-support -->
+    <DependsOnNETStandard>false</DependsOnNETStandard>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -49,7 +51,7 @@
     <RootNamespace>Npgsql.VSIX</RootNamespace>
     <AssemblyName>Npgsql.VSIX</AssemblyName>
     <TargetVsixContainerName>Npgsql.vsix</TargetVsixContainerName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
@@ -217,19 +219,19 @@
     </Reference>
     <!-- Note the extra project reference to Npgsql which makes msbuild compile it, but which has Private=true -->
     <Reference Include="Npgsql">
-      <HintPath>..\Npgsql\bin\$(Configuration)\net452\Npgsql.dll</HintPath>
+      <HintPath>..\Npgsql\bin\$(Configuration)\net461\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe">
-      <HintPath>..\Npgsql\bin\$(Configuration)\net452\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\Npgsql\bin\$(Configuration)\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\Npgsql\bin\$(Configuration)\net452\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\Npgsql\bin\$(Configuration)\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\Npgsql\bin\$(Configuration)\net452\System.ValueTuple.dll</HintPath>
+      <HintPath>..\Npgsql\bin\$(Configuration)\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory">
-      <HintPath>..\Npgsql\bin\$(Configuration)\net452\System.Memory.dll</HintPath>
+      <HintPath>..\Npgsql\bin\$(Configuration)\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <!-- Build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
+++ b/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Npgsql.Benchmarks</AssemblyName>

--- a/test/Npgsql.PluginTests/Support/DebugAssertSetupFixture.cs
+++ b/test/Npgsql.PluginTests/Support/DebugAssertSetupFixture.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 
-#if NET452
+#if NET461
 // ReSharper disable once CheckNamespace
 [SetUpFixture]
 public class PluginsDebugAssertSetupFixture : DebugAssertSetupFixture {}

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1045,7 +1045,7 @@ namespace Npgsql.Tests
             }
         }
 
-#if NET452
+#if NET461
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/392")]
         public void NonUTF8Encoding()
         {

--- a/test/Npgsql.Tests/DistributedTransactionTests.cs
+++ b/test/Npgsql.Tests/DistributedTransactionTests.cs
@@ -7,7 +7,7 @@ using System.Transactions;
 using NUnit.Framework;
 
 // TransactionScope exists in netstandard20, but distributed transactions do not
-#if NET452
+#if NET461
 
 namespace Npgsql.Tests
 {
@@ -545,7 +545,7 @@ Start formatting event queue, going to sleep a bit for late events
         #endregion Utilities
 
         #region Setup
-        
+
         NpgsqlConnection _controlConn;
 
         [OneTimeSetUp]

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Npgsql.Tests/PerformanceCounterTests.cs
+++ b/test/Npgsql.Tests/PerformanceCounterTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET452
+﻿#if NET461
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/test/Npgsql.Tests/Support/DebugAssertSetupFixture.cs
+++ b/test/Npgsql.Tests/Support/DebugAssertSetupFixture.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Npgsql.Tests;
 using NUnit.Framework;
 
-#if NET452
+#if NET461
 // ReSharper disable once CheckNamespace
 [SetUpFixture]
 public class DebugAssertSetupFixture

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -105,7 +105,7 @@ namespace Npgsql.Tests
             using (cmd)
                 return cmd.ExecuteNonQuery();
         }
-        
+
         public static object ExecuteScalar(this NpgsqlConnection conn, string sql, NpgsqlTransaction tx = null)
         {
             var cmd = tx == null ? new NpgsqlCommand(sql, conn) : new NpgsqlCommand(sql, conn, tx);
@@ -119,7 +119,7 @@ namespace Npgsql.Tests
             using (cmd)
                 return await cmd.ExecuteNonQueryAsync();
         }
-        
+
         public static async Task<object> ExecuteScalarAsync(this NpgsqlConnection conn, string sql, NpgsqlTransaction tx = null)
         {
             var cmd = tx == null ? new NpgsqlCommand(sql, conn) : new NpgsqlCommand(sql, conn, tx);
@@ -247,10 +247,11 @@ namespace Npgsql.Tests
         NotPrepared
     }
 
-#if !NET452
+#if !NET461
     // When using netcoreapp, we use NUnit's portable library which doesn't include TimeoutAttribute
     // (probably because it can't enforce it). So we define it here to allow us to compile, once there's
     // proper support for netcoreapp this should be removed.
+    // https://github.com/nunit/nunit/issues/1638
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
     class TimeoutAttribute : Attribute
     {


### PR DESCRIPTION
Following on conversation in #2122, I now think it's a good idea to change our minimum supported .NET Framework version to 4.6.1 - there are increasingly areas where we need various workarounds around the lack of certain APIs in 4.5.2.

Note that we need to test that both the VSIX and MSI build and install correctly.