### PR TITLE
Target .NET Standard 2.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019 Preview
 version: 4.1.0-{build}
 environment:
   global:
@@ -17,8 +17,8 @@ clone_depth: 10
 install:
   - powershell .build\setup_appveyor.ps1
   # The following can be used to install a custom version of .NET Core
-  # - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
-  # - ps: .\install-dotnet.ps1 -Version 2.1.300 -InstallDir "dotnetcli"
+  - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
+  - ps: .\install-dotnet.ps1 -Version 3.0.100-preview3-010431 -InstallDir "dotnetcli"
 services:
   - postgresql101
 before_build:
@@ -27,10 +27,11 @@ before_build:
   - appveyor-retry dotnet restore -v Minimal Npgsql.sln
   - appveyor-retry nuget restore src\VSIX\packages.config -SolutionDirectory . -Verbosity quiet -NonInteractive
 build_script:
-  - dotnet build "test\Npgsql.Tests" -c Debug -f net461
-  - dotnet build "test\Npgsql.PluginTests" -c Debug -f net461
+  - dotnet build "test\Npgsql.Tests" -c Debug
+  - dotnet build "test\Npgsql.PluginTests" -c Debug
   - msbuild src\VSIX\VSIX.csproj /p:Configuration=Release /v:Minimal
-  - msbuild src\MSI\MSI.wixproj /p:Configuration=Release /v:Minimal
+# WIX hasn't been released yet for VS 2019
+#  - msbuild src\MSI\MSI.wixproj /p:Configuration=Release /v:Minimal
 after_build:
   - dotnet pack src\Npgsql\Npgsql.csproj -c Release
   - dotnet pack src\Npgsql.Json.NET\Npgsql.Json.NET.csproj -c Release
@@ -42,6 +43,8 @@ test:
   assemblies:
     - test\Npgsql.Tests\bin\Debug\net461\Npgsql.Tests.dll
     - test\Npgsql.PluginTests\bin\Debug\net461\Npgsql.PluginTests.dll
+    - test\Npgsql.Tests\bin\Debug\netcoreapp3.0\Npgsql.Tests.dll
+    - test\Npgsql.PluginTests\bin\Debug\netcoreapp3.0\Npgsql.PluginTests.dll
 artifacts:
   - path: 'src\**\*.nupkg'
     name: Nuget

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,5 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Npgsql.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,8 @@
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>http://www.npgsql.org</PackageProjectUrl>
     <PackageIconUrl>http://www.npgsql.org/img/postgresql.gif</PackageIconUrl>
+
+   <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <!-- Language configuration -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,6 @@
 
   <!-- Build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -4,6 +4,8 @@
     <Description>GeoJSON plugin for Npgsql, allowing mapping of PostGIS geometry types to GeoJSON types.</Description>
     <PackageTags>npgsql postgresql postgres postgis geojson spatial ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -3,6 +3,8 @@
     <Authors>Shay Rojansky</Authors>
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql postgresql json postgres ado ado.net database sql</PackageTags>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
+++ b/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
@@ -4,6 +4,8 @@
     <Description>PostGIS plugin for Npgsql, allowing mapping of PostGIS types to the legacy types (e.g. PostgisPoint).</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -4,6 +4,8 @@
     <Description>NetTopologySuite plugin for Npgsql, allowing mapping of PostGIS geometry types to NetTopologySuite types.</Description>
     <PackageTags>npgsql postgresql postgres postgis nts ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.2</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -4,6 +4,8 @@
     <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
     <PackageTags>npgsql postgresql postgres nodatime date time ado ado.net database sql</PackageTags>
     <VersionPrefix>4.1.0</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.4" />

--- a/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
+++ b/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
@@ -4,6 +4,8 @@
     <Description>PostGIS plugin for Npgsql, allowing raw byte access to PostGIS ypes.</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />

--- a/src/Npgsql/BackendMessages/AuthenticationMessages.cs
+++ b/src/Npgsql/BackendMessages/AuthenticationMessages.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Npgsql.Logging;
+using Npgsql.Util;
 
 namespace Npgsql.BackendMessages
 {

--- a/src/Npgsql/BackendMessages/CopyMessages.cs
+++ b/src/Npgsql/BackendMessages/CopyMessages.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Npgsql.Util;
 
 namespace Npgsql.BackendMessages
 {

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -7,6 +7,7 @@ using Npgsql.PostgresTypes;
 using Npgsql.TypeHandlers;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
+using Npgsql.Util;
 
 namespace Npgsql.BackendMessages
 {

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using JetBrains.Annotations;
 using Npgsql.Logging;
+using Npgsql.Util;
 
 namespace Npgsql
 {

--- a/src/Npgsql/FrontendMessages/BindMessage.cs
+++ b/src/Npgsql/FrontendMessages/BindMessage.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Npgsql.Util;
 
 namespace Npgsql.FrontendMessages
 {

--- a/src/Npgsql/FrontendMessages/CopyFailMessage.cs
+++ b/src/Npgsql/FrontendMessages/CopyFailMessage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
+using Npgsql.Util;
 
 namespace Npgsql.FrontendMessages
 {

--- a/src/Npgsql/FrontendMessages/PasswordMessage.cs
+++ b/src/Npgsql/FrontendMessages/PasswordMessage.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Npgsql.Util;
 
 namespace Npgsql.FrontendMessages
 {

--- a/src/Npgsql/FrontendMessages/PregeneratedMessage.cs
+++ b/src/Npgsql/FrontendMessages/PregeneratedMessage.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using Npgsql.Util;
 
 namespace Npgsql.FrontendMessages
 {

--- a/src/Npgsql/FrontendMessages/StartupMessage.cs
+++ b/src/Npgsql/FrontendMessages/StartupMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Npgsql.Util;
 
 namespace Npgsql.FrontendMessages
 {

--- a/src/Npgsql/INpgsqlDatabaseInfoFactory.cs
+++ b/src/Npgsql/INpgsqlDatabaseInfoFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Npgsql.Util;
 
 namespace Npgsql
 {

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -4,16 +4,20 @@
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
     <VersionPrefix>4.1.0</VersionPrefix>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Transactions" Pack="false" />
     <Reference Include="System.DirectoryServices" Pack="false" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -7,7 +7,7 @@ using Npgsql.Logging;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
-using static Npgsql.Statics;
+using static Npgsql.Util.Statics;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -4,7 +4,7 @@ using Npgsql.BackendMessages;
 using Npgsql.FrontendMessages;
 using Npgsql.Logging;
 using NpgsqlTypes;
-using static Npgsql.Statics;
+using static Npgsql.Util.Statics;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -14,8 +14,9 @@ using JetBrains.Annotations;
 using Npgsql.BackendMessages;
 using Npgsql.FrontendMessages;
 using Npgsql.Logging;
+using Npgsql.Util;
 using NpgsqlTypes;
-using static Npgsql.Statics;
+using static Npgsql.Util.Statics;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -17,6 +17,7 @@ using Npgsql.NameTranslation;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
 using System.Transactions;
+using Npgsql.Util;
 using IsolationLevel = System.Data.IsolationLevel;
 
 namespace Npgsql

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -9,7 +9,8 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Npgsql.BackendMessages;
 using Npgsql.FrontendMessages;
-using static Npgsql.Statics;
+using Npgsql.Util;
+using static Npgsql.Util.Statics;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -18,7 +18,8 @@ using Npgsql.BackendMessages;
 using Npgsql.FrontendMessages;
 using Npgsql.Logging;
 using Npgsql.TypeMapping;
-using static Npgsql.Statics;
+using Npgsql.Util;
+using static Npgsql.Util.Statics;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -18,8 +18,9 @@ using Npgsql.PostgresTypes;
 using Npgsql.Schema;
 using Npgsql.TypeHandlers;
 using Npgsql.TypeHandling;
+using Npgsql.Util;
 using NpgsqlTypes;
-using static Npgsql.Statics;
+using static Npgsql.Util.Statics;
 
 #pragma warning disable CA2222 // Do not decrease inherited member visibility
 

--- a/src/Npgsql/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/NpgsqlDatabaseInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
+using Npgsql.Util;
 
 namespace Npgsql
 {

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
+using Npgsql.Util;
 using NpgsqlTypes;
 
 namespace Npgsql

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Npgsql.Util;
 using NpgsqlTypes;
 
 namespace Npgsql

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 using Npgsql.BackendMessages;
 using Npgsql.FrontendMessages;
 using Npgsql.Logging;
-using static Npgsql.Statics;
+using static Npgsql.Util.Statics;
 
 #pragma warning disable 1591
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Npgsql;
+using Npgsql.Util;
 
 #pragma warning disable 1591
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTypes.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTypes.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Npgsql;
+using Npgsql.Util;
 
 #pragma warning disable 1591
 

--- a/src/Npgsql/PgPassFile.cs
+++ b/src/Npgsql/PgPassFile.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
+using Npgsql.Util;
 
 namespace Npgsql
 {

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Npgsql.Logging;
 using Npgsql.PostgresTypes;
+using Npgsql.Util;
 
 // ReSharper disable StringLiteralTypo
 // ReSharper disable CommentTypo

--- a/src/Npgsql/PostgresMinimalDatabaseInfo.cs
+++ b/src/Npgsql/PostgresMinimalDatabaseInfo.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
+using Npgsql.Util;
 using NpgsqlTypes;
 
 namespace Npgsql

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Transactions;
 using Npgsql.BackendMessages;
 using Npgsql.TypeHandlers;
+using Npgsql.Util;
 
 namespace Npgsql.Schema
 {

--- a/src/Npgsql/Schema/NpgsqlDbColumn.cs
+++ b/src/Npgsql/Schema/NpgsqlDbColumn.cs
@@ -3,7 +3,7 @@ using JetBrains.Annotations;
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
 
-#if NETSTANDARD2_0
+#if !NET461
 using System.Data.Common;
 #endif
 

--- a/src/Npgsql/TaskExtensions.cs
+++ b/src/Npgsql/TaskExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql.Util;
 
 namespace Npgsql
 {

--- a/src/Npgsql/Util/PGUtil.cs
+++ b/src/Npgsql/Util/PGUtil.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Npgsql
+namespace Npgsql.Util
 {
     static class Statics
     {

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <!-- Build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
+++ b/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp2.2</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Npgsql.Benchmarks</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Npgsql.Util;
 
 namespace Npgsql.Benchmarks.TypeHandlers
 {

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Npgsql.Util;
 using NUnit.Framework;
 
 namespace Npgsql.Tests

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
+using Npgsql.Util;
 using NUnit.Framework;
 
 namespace Npgsql.Tests

--- a/test/Npgsql.Tests/Types/NumericTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTypeTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using Npgsql.Util;
 using NpgsqlTypes;
 using NUnit.Framework;
 

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Net;
+using Npgsql.Util;
 using NpgsqlTypes;
 using NUnit.Framework;
 

--- a/test/Npgsql.Tests/WriteBufferTests.cs
+++ b/test/Npgsql.Tests/WriteBufferTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Npgsql.Util;
 using NUnit.Framework;
 
 namespace Npgsql.Tests


### PR DESCRIPTION
Unlocks using more recent APIs which improve performance (e.g. new Span overloads). Tests and benchmarks now target .NET Core 3.0.

Note that each src project now specifies its own target frameworks, since at the moment only Npgsql needs to target .NET Standard 2.1 - other plugins may do so if they need any new APIs.

I'm tempted to also stop targeting net461 in the plugins, since it should be possible for .NET Framework applications to use a .NET Standard 2.0 assembly - does anyone have any experience or definitive info on whether this is OK?