### PR TITLE
Backport: Guard against NRE during broken COPY cleanup

### DIFF
--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -323,8 +323,15 @@ namespace Npgsql
 
         void Cleanup()
         {
-            Log.Debug("COPY operation ended", _connector.Id);
-            _connector = null;
+            var connector = _connector;
+            Log.Debug("COPY operation ended", connector?.Id ?? -1);
+
+            if (connector != null)
+            {
+                connector.CurrentCopyOperation = null;
+                _connector = null;
+            }
+
             _typeMapper = null;
             _buf = null;
             _isDisposed = true;

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -367,9 +367,15 @@ namespace Npgsql
 
         void Cleanup()
         {
-            Log.Debug("COPY operation ended", _connector.Id);
-            _connector.CurrentCopyOperation = null;
-            _connector = null;
+            var connector = _connector;
+            Log.Debug("COPY operation ended", connector?.Id ?? -1);
+
+            if (connector != null)
+            {
+                connector.CurrentCopyOperation = null;
+                _connector = null;
+            }
+
             _buf = null;
             _state = ImporterState.Disposed;
         }

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -35,6 +35,40 @@ namespace Npgsql.Tests
 {
     public class CopyTests : TestBase
     {
+        #region issue 2257
+
+        [Test, Description("Reproduce #2257")]
+        public void Issue2257()
+        {
+            using (var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 3 }))
+            {
+                const int rowCount = 1000000;
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = $"CREATE TEMP TABLE test_2257_master AS SELECT * FROM generate_series(1, {rowCount}) id";
+                    cmd.ExecuteNonQuery();
+                    cmd.CommandText = "ALTER TABLE test_2257_master ADD CONSTRAINT master_pk PRIMARY KEY (id)";
+                    cmd.ExecuteNonQuery();
+                    cmd.CommandText = "CREATE TEMP TABLE test_2257_detail (master_id integer NOT NULL REFERENCES test_2257_master (id))";
+                    cmd.ExecuteNonQuery();
+                }
+
+                using (var writer = conn.BeginBinaryImport("COPY test_2257_detail FROM STDIN BINARY"))
+                {
+                    for (var i = 1; i <= rowCount; ++i)
+                    {
+                        writer.StartRow();
+                        writer.Write(i);
+                    }
+
+                    var e = Assert.Throws<NpgsqlException>(() => writer.Complete());
+                    Assert.That(e.InnerException, Is.TypeOf<IOException>());
+                }
+            }
+        }
+
+        #endregion
+
         #region Raw
 
         [Test, Description("Exports data in binary format (raw mode) and then loads it back in")]


### PR DESCRIPTION
Just opening to check the CI, will merge on passing build.

See: #2398 