### PR TITLE
Hacky support for ReadOnlyIPAddress

### DIFF
--- a/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -25,7 +25,6 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     {
         // ReSharper disable InconsistentNaming
         const byte IPv4 = 2;
-
         const byte IPv6 = 3;
         // ReSharper restore InconsistentNaming
 
@@ -48,9 +47,7 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             var numBytes = buf.ReadByte();
             var bytes = new byte[numBytes];
             for (var i = 0; i < numBytes; i++)
-            {
                 bytes[i] = buf.ReadByte();
-            }
 
             return (new IPAddress(bytes), mask);
         }

--- a/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -16,12 +16,16 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
     /// <remarks>
     /// http://www.postgresql.org/docs/current/static/datatype-net-types.html
     /// </remarks>
-    [TypeMapping("inet", NpgsqlDbType.Inet, new[] { typeof(IPAddress), typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet) })]
+    [TypeMapping(
+        "inet",
+        NpgsqlDbType.Inet,
+        new[] { typeof(IPAddress), typeof((IPAddress Address, int Subnet)), typeof(NpgsqlInet) })]
     class InetHandler : NpgsqlSimpleTypeHandlerWithPsv<IPAddress, (IPAddress Address, int Subnet)>,
         INpgsqlSimpleTypeHandler<NpgsqlInet>
     {
         // ReSharper disable InconsistentNaming
         const byte IPv4 = 2;
+
         const byte IPv6 = 3;
         // ReSharper restore InconsistentNaming
 
@@ -37,23 +41,27 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
             [CanBeNull] FieldDescription fieldDescription,
             bool isCidrHandler)
         {
-            buf.ReadByte();  // addressFamily
+            buf.ReadByte(); // addressFamily
             var mask = buf.ReadByte();
             var isCidr = buf.ReadByte() == 1;
             Debug.Assert(isCidrHandler == isCidr);
             var numBytes = buf.ReadByte();
             var bytes = new byte[numBytes];
-            for (var i = 0; i < numBytes; i++) {
+            for (var i = 0; i < numBytes; i++)
+            {
                 bytes[i] = buf.ReadByte();
             }
+
             return (new IPAddress(bytes), mask);
         }
 #pragma warning restore CA1801 // Review unused parameters
 
-        protected override (IPAddress Address, int Subnet) ReadPsv(NpgsqlReadBuffer buf, int len, FieldDescription fieldDescription = null)
+        protected override (IPAddress Address, int Subnet) ReadPsv(NpgsqlReadBuffer buf, int len,
+            FieldDescription fieldDescription = null)
             => DoRead(buf, len, fieldDescription, false);
 
-        NpgsqlInet INpgsqlSimpleTypeHandler<NpgsqlInet>.Read(NpgsqlReadBuffer buf, int len, [CanBeNull] FieldDescription fieldDescription)
+        NpgsqlInet INpgsqlSimpleTypeHandler<NpgsqlInet>.Read(NpgsqlReadBuffer buf, int len,
+            [CanBeNull] FieldDescription fieldDescription)
         {
             var (address, subnet) = DoRead(buf, len, fieldDescription, false);
             return new NpgsqlInet(address, subnet);
@@ -64,18 +72,24 @@ namespace Npgsql.TypeHandlers.NetworkHandlers
         #region Write
 
         protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
-            => value == null || value is DBNull
-                ? -1
-                : value is IPAddress ip
-                    ? ValidateAndGetLength(ip, parameter)
-                    : throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}");
+            => value switch {
+                null => -1,
+                DBNull _ => -1,
+                IPAddress ip => ValidateAndGetLength(ip, parameter),
+                ValueTuple<IPAddress, int> tup => ValidateAndGetLength(tup, parameter),
+                NpgsqlInet inet => ValidateAndGetLength(inet, parameter),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}")
+            };
 
         protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
-            => value == null || value is DBNull // For null just go through the default WriteWithLengthInternal
-                ? WriteWithLengthInternal<DBNull>(null, buf, lengthCache, parameter, async)
-                : value is IPAddress ip
-                    ? WriteWithLengthInternal(ip, buf, lengthCache, parameter, async)
-                    : throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}");
+            => value switch {
+                null => WriteWithLengthInternal<DBNull>(null, buf, lengthCache, parameter, async),
+                DBNull _ => WriteWithLengthInternal<DBNull>(null, buf, lengthCache, parameter, async),
+                IPAddress ip => WriteWithLengthInternal(ip, buf, lengthCache, parameter, async),
+                ValueTuple<IPAddress, int> tup => WriteWithLengthInternal(tup, buf, lengthCache, parameter, async),
+                NpgsqlInet inet => WriteWithLengthInternal(inet, buf, lengthCache, parameter, async),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}")
+            };
 
         public override int ValidateAndGetLength(IPAddress value, NpgsqlParameter parameter)
             => GetLength(value);

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading;
 using Npgsql.NameTranslation;
@@ -204,6 +205,27 @@ namespace Npgsql.TypeMapping
                         TypeHandlerFactory = factory
                     }.Build());
                 }
+            }
+
+            // This is an extremely ugly hack to support ReadOnlyIPAddress, which as an internal subclass of IPAddress
+            // added to .NET Core 3.0 (see https://github.com/dotnet/corefx/issues/33373)
+            if (_typeToNpgsqlDbType.ContainsKey(typeof(IPAddress)) &&
+                Mappings.TryGetValue("inet", out var inetMapping) &&
+                typeof(IPAddress).GetNestedType("ReadOnlyIPAddress", BindingFlags.NonPublic) is Type readOnlyIpType)
+            {
+                _typeToNpgsqlDbType[readOnlyIpType] = _typeToNpgsqlDbType[typeof(IPAddress)];
+                var augmentedClrType = new Type[inetMapping.ClrTypes.Length];
+                Array.Copy(inetMapping.ClrTypes, augmentedClrType, inetMapping.ClrTypes.Length);
+                augmentedClrType[augmentedClrType.Length - 1] = readOnlyIpType;
+                Mappings["inet"] = new NpgsqlTypeMappingBuilder
+                {
+                    PgTypeName = "inet",
+                    NpgsqlDbType = inetMapping.NpgsqlDbType,
+                    DbTypes = inetMapping.DbTypes,
+                    ClrTypes = augmentedClrType,
+                    InferredDbType = inetMapping.InferredDbType,
+                    TypeHandlerFactory = inetMapping.TypeHandlerFactory
+                }.Build();
             }
         }
 

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -214,7 +214,7 @@ namespace Npgsql.TypeMapping
                 typeof(IPAddress).GetNestedType("ReadOnlyIPAddress", BindingFlags.NonPublic) is Type readOnlyIpType)
             {
                 _typeToNpgsqlDbType[readOnlyIpType] = _typeToNpgsqlDbType[typeof(IPAddress)];
-                var augmentedClrType = new Type[inetMapping.ClrTypes.Length];
+                var augmentedClrType = new Type[inetMapping.ClrTypes.Length + 1];
                 Array.Copy(inetMapping.ClrTypes, augmentedClrType, inetMapping.ClrTypes.Length);
                 augmentedClrType[augmentedClrType.Length - 1] = readOnlyIpType;
                 Mappings["inet"] = new NpgsqlTypeMappingBuilder

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Npgsql.Tests/Types/NetworkTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NetworkTypeTests.cs
@@ -127,6 +127,24 @@ namespace Npgsql.Tests.Types
             }
         }
 
+        [Test, Description("Tests support for ReadOnlyIPAddress, see https://github.com/dotnet/corefx/issues/33373")]
+        public void IPAddressAny()
+        {
+            using (var conn = OpenConnection())
+            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn))
+            {
+                cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Inet) { Value = IPAddress.Any });
+                cmd.Parameters.Add(new NpgsqlParameter<IPAddress>("p2", NpgsqlDbType.Inet) { TypedValue = IPAddress.Any });
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p3", Value = IPAddress.Any });
+                using (var reader = cmd.ExecuteReader())
+                {
+                    reader.Read();
+                    for (var i = 0; i < reader.FieldCount; i++)
+                        Assert.That(reader.GetFieldValue<IPAddress>(i), Is.EqualTo(IPAddress.Any));
+                }
+            }
+        }
+
         [Test]
         public void Cidr()
         {


### PR DESCRIPTION
.NET Core 3.0 adds ReadOnlyIPAddress, an internal subclass of IPAddress, used for some constants (e.g. IPAddress.Any).

This adds support for writig that type in a very hacky way, to enable backporting also to 4.0. We'll do it better later.

Fixes #2360