### PR TITLE
Recycle NpgsqlTransaction

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -531,7 +531,8 @@ namespace Npgsql
                 if (connector.InTransaction)
                     throw new InvalidOperationException("A transaction is already in progress; nested/concurrent transactions aren't supported.");
 
-                return new NpgsqlTransaction(this, level);
+                connector.Transaction.Init(level);
+                return connector.Transaction;
             }
         }
 

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -19,6 +19,9 @@ namespace Npgsql.Tests
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 tx.Commit();
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(1));
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
+                tx.Dispose();
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -32,6 +35,9 @@ namespace Npgsql.Tests
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 await tx.CommitAsync();
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(1));
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
+                tx.Dispose();
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -50,6 +56,9 @@ namespace Npgsql.Tests
                 tx.Rollback();
                 Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
+                tx.Dispose();
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -68,6 +77,9 @@ namespace Npgsql.Tests
                 await tx.RollbackAsync();
                 Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
+                tx.Dispose();
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -80,7 +92,6 @@ namespace Npgsql.Tests
                 var tx = conn.BeginTransaction();
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 tx.Dispose();
-                Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
             }
         }
@@ -100,8 +111,8 @@ namespace Npgsql.Tests
                     tx = conn2.BeginTransaction();
                     conn2.ExecuteNonQuery($"INSERT INTO {tableName} (name) VALUES ('X')", tx);
                 }
-                Assert.That(tx.IsCompleted);
                 Assert.That(conn1.ExecuteScalar($"SELECT COUNT(*) FROM {tableName}"), Is.EqualTo(0));
+                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
                 conn1.ExecuteNonQuery($"DROP TABLE {tableName}");
             }
         }


### PR DESCRIPTION
Since PostgreSQL only supports on transaction on a given connection, we reycle the NpgsqlTransaction object.

Closes #2416

@YohDeadfall @austindrenski the lifecycle changes here aren't exactly trivial, so I'd appreciate a good review. In the end I think the logic is actually simplified, since the NpgsqlTransaction's state simply mirrors the connector's TransactionStatus (except for disposal, which is still managed on the NpgsqlTransaction since it's user-controlled).