### PR TITLE
Remove checks around DbCommand.Transaction and disable related specification tests

### DIFF
--- a/test/Npgsql.Specification.Tests/NpgsqlCommandTests.cs
+++ b/test/Npgsql.Specification.Tests/NpgsqlCommandTests.cs
@@ -8,5 +8,10 @@ namespace Npgsql.Specification.Tests
             : base(fixture)
         {
         }
+
+        // PostgreSQL only supports a single transaction on a given connection at a given time. As a result,
+        // Npgsql completely ignores DbCommand.Transaction.
+        public override void ExecuteReader_throws_when_transaction_required() {}
+        public override void ExecuteReader_throws_when_transaction_mismatched() {}
     }
 }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -631,9 +631,9 @@ namespace Npgsql.Tests
                 {
                     connection.Open();
                     command.Connection = connection;
-                    command.Transaction = connection.BeginTransaction();
+                    var tx = connection.BeginTransaction();
                     command.ExecuteScalar();
-                    command.Transaction.Commit();
+                    tx.Commit();
                 }
             }
         }


### PR DESCRIPTION
PostgreSQL only supports a single transaction on a given connection at a given time. As a result, Npgsql completely ignores DbCommand.Transaction.

We could introduce new checks, but apart from being a pretty massive breaking change (as currently Npgsql users don't bother to set DbCommand.Transaction) there seems to be no real value to this.

Part of #2225

/cc @bgrainger @divega @ajcvickers @bricelam