### PR TITLE
Fixes related to ADO.NET specification tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,7 @@ before_build:
 build_script:
   - dotnet build "test\Npgsql.Tests" -c Debug
   - dotnet build "test\Npgsql.PluginTests" -c Debug
+  - dotnet build "test\Npgsql.Specification.Tests" -c Debug
   - dotnet build "src\Npgsql" -c Release
   - msbuild src\VSIX\VSIX.csproj /p:Configuration=Release /v:Minimal
 # WIX hasn't been released yet for VS 2019
@@ -44,8 +45,10 @@ test:
   assemblies:
     - test\Npgsql.Tests\bin\Debug\net461\Npgsql.Tests.dll
     - test\Npgsql.PluginTests\bin\Debug\net461\Npgsql.PluginTests.dll
+    - test\Npgsql.Specification.Tests\bin\Debug\net461\Npgsql.Specification.Tests.dll
     - test\Npgsql.Tests\bin\Debug\netcoreapp3.0\Npgsql.Tests.dll
     - test\Npgsql.PluginTests\bin\Debug\netcoreapp3.0\Npgsql.PluginTests.dll
+    - test\Npgsql.Specification.Tests\bin\Debug\netcoreapp3.0\Npgsql.Specification.Tests.dll
 artifacts:
   - path: 'src\**\*.nupkg'
     name: Nuget

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -229,8 +229,11 @@ namespace Npgsql
                     var timeout = new NpgsqlTimeout(TimeSpan.FromSeconds(ConnectionTimeout));
                     Transaction? transaction = null;
 
-                    if (_pool == null) // Un-pooled connection
+                    if (_pool == null) // Un-pooled connection (or user forgot to set connection string)
                     {
+                        if (string.IsNullOrEmpty(_connectionString))
+                            throw new InvalidOperationException("The ConnectionString property has not been initialized.");
+
                         if (!Settings.PersistSecurityInfo)
                             _userFacingConnectionString = Settings.ToStringWithoutPassword();
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1038,7 +1038,7 @@ namespace Npgsql
 
             // Attempt to read beyond the end of the column
             if (dataOffset2 + length > ColumnLen)
-                length = ColumnLen - dataOffset2;
+                length = Math.Max(ColumnLen - dataOffset2, 0);
 
             var left = length;
             while (left > 0)
@@ -1167,11 +1167,8 @@ namespace Npgsql
                 decoder.Reset();
                 PosInColumn += bytesSkipped;
                 _charPos += charsSkipped;
-                if (charsSkipped < charsToSkip)
-                {
-                    // TODO: What is the actual required behavior here?
-                    throw new IndexOutOfRangeException();
-                }
+                if (charsSkipped < charsToSkip) // data offset is beyond the column's end
+                    return 0;
             }
 
             // We're now positioned at the start of the segment of characters we need to read.

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -487,7 +487,7 @@ namespace Npgsql.Tests
             var conn = new NpgsqlConnection();
             Assert.That(conn.ConnectionTimeout, Is.EqualTo(NpgsqlConnectionStringBuilder.DefaultTimeout));
             Assert.That(conn.ConnectionString, Is.SameAs(string.Empty));
-            Assert.That(() => conn.Open(), Throws.Exception.TypeOf<ArgumentException>());
+            Assert.That(() => conn.Open(), Throws.Exception.TypeOf<InvalidOperationException>());
         }
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/703")]


### PR DESCRIPTION
Contains two fixes to make the spec tests pass, and activates running the tests on Appveyor. This should currently fail until rebased on #2428.

/cc @bgrainger @divega @ajcvickers @bricelam