### PR TITLE
Range cleanup and support range with two CLR types

### DIFF
--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -48,7 +48,7 @@ namespace Npgsql.TypeHandlers
             => throw new NotSupportedException();
 
         /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
+        public override IRangeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => throw new NotSupportedException();
 
         #region Read

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -48,7 +48,7 @@ namespace Npgsql.TypeHandlers
             => throw new NotSupportedException();
 
         /// <inheritdoc />
-        public override RangeHandler CreateRangeHandler(PostgresRangeType rangeBackendType)
+        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => throw new NotSupportedException();
 
         #region Read

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -46,6 +46,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         public TimestampTzHandler(PostgresType postgresType, bool convertInfinityDateTime)
             : base(postgresType, convertInfinityDateTime) {}
 
+        /// <inheritdoc />
+        public override IRangeHandler CreateRangeHandler(PostgresType rangeBackendType)
+            => new RangeHandler<DateTime, DateTimeOffset>(rangeBackendType, this);
+
         #region Read
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -156,7 +156,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Creates a type handler for ranges of this handler's type.
         /// </summary>
-        public abstract RangeHandler CreateRangeHandler(PostgresRangeType rangeBackendType);
+        public abstract NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType);
 
         /// <summary>
         /// Used to create an exception when the provided type can be converted and written, but an

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -156,7 +156,7 @@ namespace Npgsql.TypeHandling
         /// <summary>
         /// Creates a type handler for ranges of this handler's type.
         /// </summary>
-        public abstract NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType);
+        public abstract IRangeHandler CreateRangeHandler(PostgresType rangeBackendType);
 
         /// <summary>
         /// Used to create an exception when the provided type can be converted and written, but an

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -284,7 +284,7 @@ namespace Npgsql.TypeHandling
             => new ArrayHandler<TDefault>(arrayBackendType, this);
 
         /// <inheritdoc />
-        public override RangeHandler CreateRangeHandler(PostgresRangeType rangeBackendType)
+        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => new RangeHandler<TDefault>(rangeBackendType, this);
 
         #endregion Misc

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -284,7 +284,7 @@ namespace Npgsql.TypeHandling
             => new ArrayHandler<TDefault>(arrayBackendType, this);
 
         /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType rangeBackendType)
+        public override IRangeHandler CreateRangeHandler(PostgresType rangeBackendType)
             => new RangeHandler<TDefault>(rangeBackendType, this);
 
         #endregion Misc

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -381,20 +381,14 @@ namespace Npgsql.TypeMapping
                 ? NpgsqlDbType.Range | elementNpgsqlDbType.Value
                 : (NpgsqlDbType?)null;
 
+            // We only want to bind supported range CLR types whose element CLR types are being bound as well.
+            var clrTypes = elementClrTypes is null
+                ? null
+                : rangeHandler.SupportedRangeClrTypes
+                    .Where(r => elementClrTypes.Contains(r.GenericTypeArguments[0]))
+                    .ToArray();
 
-            Type[]? clrTypes = null;
-            if (elementClrTypes != null)
-            {
-                // Somewhat hacky. Although the element may have more than one CLR mapping,
-                // its range will only be mapped to the "main" one for now.
-                var defaultElementType = elementHandler.GetFieldType();
-
-                clrTypes = elementClrTypes.Contains(defaultElementType)
-                    ? new[] { rangeHandler.GetFieldType() }
-                    : null;
-            }
-
-            BindType(rangeHandler, pgRangeType, rangeNpgsqlDbType, null, clrTypes);
+            BindType((NpgsqlTypeHandler)rangeHandler, pgRangeType, rangeNpgsqlDbType, null, clrTypes);
         }
 
         #endregion Binding

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -197,6 +197,25 @@ namespace Npgsql.Tests.Types
             Assert.AreNotEqual(b.GetHashCode(), c.GetHashCode());
         }
 
+        [Test]
+        public async Task TimestampTzRangeWithDateTimeOffset()
+        {
+            // The default CLR mapping for timestamptz is DateTime, but it also supports DateTimeOffset.
+            // The range should also support both, defaulting to the first.
+            using var conn = await OpenConnectionAsync();
+            using var cmd = new NpgsqlCommand("SELECT @p", conn);
+
+            var dto1 = new DateTimeOffset(2010, 1, 3, 10, 0, 0, TimeSpan.Zero);
+            var dto2 = new DateTimeOffset(2010, 1, 4, 10, 0, 0, TimeSpan.Zero);
+            var range = new NpgsqlRange<DateTimeOffset>(dto1, dto2);
+            cmd.Parameters.AddWithValue("p", range);
+            using var reader = await cmd.ExecuteReaderAsync();
+
+            await reader.ReadAsync();
+            var actual = reader.GetFieldValue<NpgsqlRange<DateTimeOffset>>(0);
+            Assert.That(actual, Is.EqualTo(range));
+        }
+
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {


### PR DESCRIPTION
The first commit cleans up so messiness around the design of the range handler, making it inherit directly from NpgsqlTypeHandler<T> and removing lots of needlessly duplicated code.

The second commit makes it possible for the range handler to handle more than one CLR type, and adds support for `NpgsqlRange<DateTimeOffset>`, fixing #2436.