### PR TITLE
Some cleanup work around cancellation tokens

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -550,19 +550,15 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// Creates a server-side prepared statement on the PostgreSQL server.
         /// This will make repeated future executions of this command much faster.
         /// </summary>
-        public Task PrepareAsync() => PrepareAsync(CancellationToken.None);
-
-        /// <summary>
-        /// Creates a server-side prepared statement on the PostgreSQL server.
-        /// This will make repeated future executions of this command much faster.
-        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
 #if !NET461 && !NETSTANDARD2_0
-        public override Task PrepareAsync(CancellationToken cancellationToken)
+        public override Task PrepareAsync(CancellationToken cancellationToken = default)
 #else
-        public Task PrepareAsync(CancellationToken cancellationToken)
+        public Task PrepareAsync(CancellationToken cancellationToken = default)
 #endif
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Prepare(true);
         }
@@ -1062,7 +1058,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// Executes the command text against the connection.
         /// </summary>
         /// <param name="behavior">An instance of <see cref="CommandBehavior"/>.</param>
-        /// <param name="cancellationToken">A task representing the operation.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns></returns>
         protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -124,7 +124,7 @@ namespace Npgsql
         /// <remarks>
         /// Do not invoke other methods and properties of the <see cref="NpgsqlConnection"/> object until the returned Task is complete.
         /// </remarks>
-        /// <param name="cancellationToken">The cancellation instruction.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
@@ -1162,24 +1162,18 @@ namespace Npgsql
         /// Waits asynchronously until an asynchronous PostgreSQL messages (e.g. a notification)
         /// arrives, and exits immediately. The asynchronous message is delivered via the normal events
         /// (<see cref="Notification"/>, <see cref="Notice"/>).
-        /// CancellationToken can not cancel wait operation if underlying NetworkStream does not support it
-        /// (see https://stackoverflow.com/questions/12421989/networkstream-readasync-with-a-cancellation-token-never-cancels ).
         /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         [PublicAPI]
-        public Task WaitAsync(CancellationToken cancellationToken)
+        public Task WaitAsync(CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+
             var connector = CheckConnectionOpen();
             Log.Debug("Starting to wait asynchronously...", connector.Id);
-
             return connector.WaitAsync(cancellationToken);
         }
-
-        /// <summary>
-        /// Waits asynchronously until an asynchronous PostgreSQL messages (e.g. a notification)
-        /// arrives, and exits immediately. The asynchronous message is delivered via the normal events
-        /// (<see cref="Notification"/>, <see cref="Notice"/>).
-        /// </summary>
-        public Task WaitAsync() => WaitAsync(CancellationToken.None);
 
         #endregion
 

--- a/src/Npgsql/NpgsqlLargeObjectManager.cs
+++ b/src/Npgsql/NpgsqlLargeObjectManager.cs
@@ -80,13 +80,13 @@ namespace Npgsql
         /// Create an empty large object in the database. If an oid is specified but is already in use, an PostgresException will be thrown.
         /// </summary>
         /// <param name="preferredOid">A preferred oid, or specify 0 if one should be automatically assigned</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The oid for the large object created</returns>
         /// <exception cref="PostgresException">If an oid is already in use</exception>
-#pragma warning disable CA1801
-        public Task<uint> CreateAsync(uint preferredOid, CancellationToken cancellationToken)
-#pragma warning restore CA1801 // Review unused parameters
-            => Create(preferredOid, true);
+        public Task<uint> CreateAsync(uint preferredOid, CancellationToken cancellationToken = default)
+            => cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<uint>(cancellationToken)
+                : Create(preferredOid, true);
 
         Task<uint> Create(uint preferredOid, bool async)
             => ExecuteFunction<uint>("lo_create", async, (int)preferredOid);
@@ -109,11 +109,12 @@ namespace Npgsql
         /// Note that this method, as well as operations on the stream must be wrapped inside a transaction.
         /// </summary>
         /// <param name="oid">Oid of the object</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>An NpgsqlLargeObjectStream</returns>
-        public Task<NpgsqlLargeObjectStream> OpenReadAsync(uint oid, CancellationToken cancellationToken)
+        public Task<NpgsqlLargeObjectStream> OpenReadAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<NpgsqlLargeObjectStream>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return OpenRead(oid, true);
         }
@@ -138,11 +139,12 @@ namespace Npgsql
         /// Note that this method, as well as operations on the stream must be wrapped inside a transaction.
         /// </summary>
         /// <param name="oid">Oid of the object</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>An NpgsqlLargeObjectStream</returns>
-        public Task<NpgsqlLargeObjectStream> OpenReadWriteAsync(uint oid, CancellationToken cancellationToken)
+        public Task<NpgsqlLargeObjectStream> OpenReadWriteAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<NpgsqlLargeObjectStream>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return OpenReadWrite(oid, true);
         }
@@ -164,10 +166,11 @@ namespace Npgsql
         /// Deletes a large object on the backend.
         /// </summary>
         /// <param name="oid">Oid of the object to delete</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        public Task UnlinkAsync(uint oid, CancellationToken cancellationToken)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task UnlinkAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return ExecuteFunction<object>("lo_unlink", true, (int)oid);
         }
@@ -185,10 +188,11 @@ namespace Npgsql
         /// </summary>
         /// <param name="oid">Oid of the object to export</param>
         /// <param name="path">Path to write the file on the backend</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        public Task ExportRemoteAsync(uint oid, string path, CancellationToken cancellationToken)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task ExportRemoteAsync(uint oid, string path, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return ExecuteFunction<object>("lo_export", true, (int)oid, path);
         }
@@ -206,10 +210,11 @@ namespace Npgsql
         /// </summary>
         /// <param name="path">Path to read the file on the backend</param>
         /// <param name="oid">A preferred oid, or specify 0 if one should be automatically assigned</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        public Task ImportRemoteAsync(string path, uint oid, CancellationToken cancellationToken)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task ImportRemoteAsync(string path, uint oid, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return ExecuteFunction<object>("lo_import", true, path, (int)oid);
         }

--- a/src/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/src/Npgsql/NpgsqlLargeObjectStream.cs
@@ -53,11 +53,12 @@ namespace Npgsql
         /// <param name="buffer">The buffer where read data should be stored.</param>
         /// <param name="offset">The offset in the buffer where the first byte should be read.</param>
         /// <param name="count">The maximum number of bytes that should be read.</param>
-        /// <param name="cancellationToken">Cancellation token</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>How many bytes actually read, or 0 if end of file was already reached.</returns>
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Read(buffer, offset, count, true);
         }
@@ -106,10 +107,11 @@ namespace Npgsql
         /// <param name="buffer">The buffer to write data from.</param>
         /// <param name="offset">The offset in the buffer at which to begin copying bytes.</param>
         /// <param name="count">The number of bytes to write.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Write(buffer, offset, count, true);
         }
@@ -181,20 +183,18 @@ namespace Npgsql
         /// <summary>
         /// Gets the length of the large object. This internally seeks to the end of the stream to retrieve the length, and then back again.
         /// </summary>
-#pragma warning disable CA1721 
         public override long Length => GetLength(false).GetAwaiter().GetResult();
-#pragma warning restore CA1721
 
         /// <summary>
         /// Gets the length of the large object. This internally seeks to the end of the stream to retrieve the length, and then back again.
         /// </summary>
-        public Task<long> GetLengthAsync()
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task<long> GetLengthAsync(CancellationToken cancellationToken = default)
         {
             using (NoSynchronizationContextScope.Enter())
                 return GetLength(true);
         }
 
-#pragma warning disable CA1721 
         async Task<long> GetLength(bool async)
         {
             CheckDisposed();
@@ -204,7 +204,6 @@ namespace Npgsql
                 await Seek(old, SeekOrigin.Begin, async);
             return retval;
         }
-#pragma warning restore CA1721
 
         /// <summary>
         /// Seeks in the stream to the specified position. This requires a round-trip to the backend.
@@ -220,11 +219,11 @@ namespace Npgsql
         /// </summary>
         /// <param name="offset">A byte offset relative to the <i>origin</i> parameter.</param>
         /// <param name="origin">A value of type SeekOrigin indicating the reference point used to obtain the new position.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns></returns>
-        public Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken)
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<long>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Seek(offset, origin, true);
         }

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -135,8 +135,7 @@ namespace Npgsql
         /// <summary>
         /// Commits the database transaction.
         /// </summary>
-        [PublicAPI]
-
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
 #if !NET461 && !NETSTANDARD2_0
         public override Task CommitAsync(CancellationToken cancellationToken = default)
 #else
@@ -169,7 +168,7 @@ namespace Npgsql
         /// <summary>
         /// Rolls back a transaction from a pending state.
         /// </summary>
-        [PublicAPI]
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
 #if !NET461 && !NETSTANDARD2_0
         public override Task RollbackAsync(CancellationToken cancellationToken = default)
 #else
@@ -208,12 +207,14 @@ namespace Npgsql
         /// <summary>
         /// Creates a transaction save point.
         /// </summary>
+        /// <param name="name">The name of the savepoint.</param>
         public void Save(string name) => Save(name, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Creates a transaction save point.
         /// </summary>
-        [PublicAPI]
+        /// <param name="name">The name of the savepoint.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task SaveAsync(string name, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -244,12 +245,14 @@ namespace Npgsql
         /// <summary>
         /// Rolls back a transaction from a pending savepoint state.
         /// </summary>
+        /// <param name="name">The name of the savepoint.</param>
         public void Rollback(string name) => Rollback(name, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Rolls back a transaction from a pending savepoint state.
         /// </summary>
-        [PublicAPI]
+        /// <param name="name">The name of the savepoint.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task RollbackAsync(string name, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -280,12 +283,14 @@ namespace Npgsql
         /// <summary>
         /// Releases a transaction from a pending savepoint state.
         /// </summary>
+        /// <param name="name">The name of the savepoint.</param>
         public void Release(string name) => Release(name, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Releases a transaction from a pending savepoint state.
         /// </summary>
-        [PublicAPI]
+        /// <param name="name">The name of the savepoint.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task ReleaseAsync(string name, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)

--- a/test/Npgsql.Tests/NotificationTests.cs
+++ b/test/Npgsql.Tests/NotificationTests.cs
@@ -158,9 +158,17 @@ namespace Npgsql.Tests
         {
             using (var conn = OpenConnection())
             {
+                Assert.That(async () => await conn.WaitAsync(new CancellationToken(true)),
+                    Throws.Exception.TypeOf<TaskCanceledException>());
+                Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
+            }
+
+            using (var conn = OpenConnection())
+            {
                 conn.ExecuteNonQuery("LISTEN notifytest");
                 var cts = new CancellationTokenSource(1000);
-                Assert.That(async () => await conn.WaitAsync(cts.Token), Throws.Exception.TypeOf<OperationCanceledException>());
+                Assert.That(async () => await conn.WaitAsync(cts.Token),
+                    Throws.Exception.TypeOf<OperationCanceledException>());
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
             }
         }


### PR DESCRIPTION
* Make sure async methods returned cancelled tasks rather than throw   exceptions when passed a cancelled token.
* Added cancellation token parameter to NpgsqlDataReader.Get{Stream,TextReader}Async(). This is a binary breaking change.

Closes #2417