### PR TITLE
Depend on .NET Framework targeting pack nugets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,4 +26,11 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Npgsql.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <!-- Reference .NET Framework reference assemblies, allows building on environments without .NET Framework installed
+       (e.g. Linux). Gets ignored on non-framework TFMs. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres postgis geojson spatial ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -4,7 +4,6 @@
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql postgresql json postgres ado ado.net database sql</PackageTags>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
+++ b/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres postgis nts ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres nodatime date time ado ado.net database sql</PackageTags>
     <VersionPrefix>4.1.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.4" />

--- a/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
+++ b/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -5,7 +5,6 @@
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
     <VersionPrefix>4.1.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,6 +4,5 @@
   <!-- Build configuration -->
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Depend on .NET Framework reference assemblies via the new nuget packages. This allows us to build .NET Framework on systems where .NET Framework isn't installed (e.g. Linux). See https://github.com/dotnet/designs/pull/33.

~Also, stop targeting .NET Framework in plugins - now that our minimum targeted TFM is net461, we no longer need to multitarget - we can simply target netstandard2.0, which can be consumed from net461 applications.~ (reverted this based on https://github.com/npgsql/npgsql/pull/2462#discussion_r281034779).