### PR TITLE
WIP on replication support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           export PGDATA=/etc/postgresql/${{ matrix.pg_major }}/main
           sudo sed -i 's/#ssl = off/ssl = on/' $PGDATA/postgresql.conf
           sudo sed -i 's/#max_prepared_transactions = 0/max_prepared_transactions = 10/' $PGDATA/postgresql.conf
+          sudo sed -i 's/#wal_level = replica/wal_level = logical/' $PGDATA/postgresql.conf
           # Disable trust authentication, requiring MD5 passwords - some tests must fail if a password isn't provided.
           sudo sh -c "echo 'local all all trust' > $PGDATA/pg_hba.conf"
           sudo sh -c "echo 'host all all all md5' >> $PGDATA/pg_hba.conf"
@@ -83,7 +84,7 @@ jobs:
           pgsql/bin/initdb -D pgsql/PGDATA -E UTF8 -U postgres
           SOCKET_DIR=$(echo "$LOCALAPPDATA\Temp" | sed 's|\\|/|g')
           sed -i "s|#unix_socket_directories = ''|unix_socket_directories = '$SOCKET_DIR'|" pgsql/PGDATA/postgresql.conf
-          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10 -c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' start
+          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10 -c wal_level=logical -c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' start
 
           # Configure test account
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests SUPERUSER LOGIN PASSWORD 'npgsql_tests'"

--- a/src/Npgsql/Common.cs
+++ b/src/Npgsql/Common.cs
@@ -46,6 +46,7 @@ namespace Npgsql
         internal const byte Bind =      (byte)'B';
         internal const byte Close =     (byte)'C';
         internal const byte Query =     (byte)'Q';
+        internal const byte CopyData =  (byte)'d';
         internal const byte CopyDone =  (byte)'c';
         internal const byte CopyFail =  (byte)'f';
         internal const byte Terminate = (byte)'X';

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -83,7 +83,7 @@ namespace Npgsql
         static NpgsqlConnectionStringBuilder()
         {
             var properties = typeof(NpgsqlConnectionStringBuilder)
-                .GetProperties()
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .Where(p => p.GetCustomAttribute<NpgsqlConnectionStringPropertyAttribute>() != null)
                 .ToArray();
 
@@ -1142,6 +1142,19 @@ namespace Npgsql
         }
         bool _loadTableComposites;
 
+        [NpgsqlConnectionStringProperty]
+        [DisplayName("Replication Mode")]
+        internal ReplicationMode ReplicationMode
+        {
+            get => _replicationMode;
+            set
+            {
+                _replicationMode = value;
+                SetValue(nameof(ReplicationMode), value);
+            }
+        }
+        ReplicationMode _replicationMode;
+
         /// <summary>
         /// Set PostgreSQL configuration parameter default values for the connection.
         /// </summary>
@@ -1514,6 +1527,13 @@ namespace Npgsql
         /// Fail the connection if the server doesn't support SSL.
         /// </summary>
         Require,
+    }
+
+    enum ReplicationMode
+    {
+        Off,
+        Physical,
+        Logical
     }
 
     #endregion

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -222,9 +222,10 @@ namespace Npgsql
         readonly RowDescriptionMessage       _rowDescriptionMessage       = new RowDescriptionMessage();
 
         // Since COPY is rarely used, allocate these lazily
-        CopyInResponseMessage?  _copyInResponseMessage;
-        CopyOutResponseMessage? _copyOutResponseMessage;
-        CopyDataMessage?        _copyDataMessage;
+        CopyInResponseMessage?   _copyInResponseMessage;
+        CopyOutResponseMessage?  _copyOutResponseMessage;
+        CopyDataMessage?         _copyDataMessage;
+        CopyBothResponseMessage? _copyBothResponseMessage;
 
         #endregion
 
@@ -450,6 +451,16 @@ namespace Npgsql
             var timezone = Settings.Timezone ?? PostgresEnvironment.TimeZone;
             if (timezone != null)
                 startupParams["TimeZone"] = timezone;
+
+            switch (Settings.ReplicationMode)
+            {
+            case ReplicationMode.Logical:
+                startupParams["replication"] = "database";
+                break;
+            case ReplicationMode.Physical:
+                startupParams["replication"] = "true";
+                break;
+            }
 
             WriteStartup(startupParams);
         }
@@ -1029,6 +1040,9 @@ namespace Npgsql
                     return (_copyOutResponseMessage ??= new CopyOutResponseMessage()).Load(ReadBuffer);
                 case BackendMessageCode.CopyData:
                     return (_copyDataMessage ??= new CopyDataMessage()).Load(len);
+                case BackendMessageCode.CopyBothResponse:
+                    return (_copyBothResponseMessage ??= new CopyBothResponseMessage()).Load(ReadBuffer);
+
                 case BackendMessageCode.CopyDone:
                     return CopyDoneMessage.Instance;
 

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -506,7 +506,7 @@ namespace Npgsql
         {
             Debug.Assert(_copyMode);
             Debug.Assert(WritePosition == 0);
-            WriteByte((byte)BackendMessageCode.CopyData);
+            WriteByte(FrontendMessageCode.CopyData);
             // Leave space for the message length
             WriteInt32(0);
         }

--- a/src/Npgsql/Replication/NpgsqlLogicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/NpgsqlLogicalReplicationConnection.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Npgsql.BackendMessages;
+using Npgsql.Logging;
+using static Npgsql.Util.Statics;
+
+namespace Npgsql.Replication
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public sealed class NpgsqlLogicalReplicationConnection : NpgsqlReplicationConnection
+    {
+        static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlLogicalReplicationConnection));
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="NpgsqlLogicalReplicationConnection"/>.
+        /// </summary>
+        public NpgsqlLogicalReplicationConnection() {}
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="NpgsqlLogicalReplicationConnection"/>.
+        /// </summary>
+        public NpgsqlLogicalReplicationConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        #region Open
+
+        /// <summary>
+        /// Opens a database replication connection with the property settings specified by the
+        /// <see cref="NpgsqlReplicationConnection.ConnectionString">ConnectionString</see>.
+        /// </summary>
+        [PublicAPI]
+        public Task OpenAsync(CancellationToken cancellationToken = default)
+        {
+            using (NoSynchronizationContextScope.Enter())
+                return OpenAsync(new NpgsqlConnectionStringBuilder(ConnectionString)
+                {
+                    ReplicationMode = ReplicationMode.Logical
+                }, cancellationToken);
+        }
+
+        #endregion Open
+
+        #region Replication commands
+
+        /// <summary>
+        /// Create a logical replication slot.
+        /// </summary>
+        /// <param name="slotName">
+        /// The name of the slot to create. Must be a valid replication slot name
+        /// (see <a href="https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION">Section 26.2.6.1</a>).
+        /// </param>
+        /// <param name="isTemporary">
+        /// Specify that this replication slot is a temporary one.
+        /// Temporary slots are not saved to disk and are automatically dropped on error or when the session has finished.
+        /// </param>
+        /// <param name="outputPlugin">
+        /// The name of the output plugin used for logical decoding
+        /// (see <a href="https://www.postgresql.org/docs/current/logicaldecoding-output-plugin.html">Section 49.6</a>).
+        /// </param>
+        /// <param name="slotSnapshotInitMode">
+        /// Decides what to do with the snapshot created during logical slot initialization.
+        /// </param>
+        /// <returns>
+        /// An <see cref="NpgsqlLogicalReplicationSlotInfo"/> providing information on the newly-created slot.
+        /// </returns>
+        /// <remarks>
+        /// See https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS.
+        /// </remarks>
+        [PublicAPI]
+        public async Task<NpgsqlLogicalReplicationSlotInfo> CreateReplicationSlot(
+            string slotName,
+            string outputPlugin,
+            bool isTemporary = false,
+            SlotSnapshotInitMode slotSnapshotInitMode = SlotSnapshotInitMode.Export)
+        {
+            var sb = new StringBuilder("CREATE_REPLICATION_SLOT ").Append(slotName);
+            if (isTemporary)
+                sb.Append(" TEMPORARY");
+            sb.Append(" LOGICAL ").Append(outputPlugin);
+            switch (slotSnapshotInitMode)
+            {
+            case SlotSnapshotInitMode.Export:
+                sb.Append(" EXPORT_SNAPSHOT");
+                break;
+            case SlotSnapshotInitMode.Use:
+                sb.Append(" USE_SNAPSHOT");
+                break;
+            case SlotSnapshotInitMode.NoExport:
+                sb.Append(" NOEXPORT_SNAPSHOT");
+                break;
+            }
+
+            var results = await ReadSingleRow(sb.ToString());
+            return new NpgsqlLogicalReplicationSlotInfo(
+                (string)results[0],
+                (string)results[1],
+                (string)results[2],
+                (string)results[3]
+            );
+        }
+
+        /// <summary>
+        /// Instructs server to start streaming WAL for logical replication, starting at WAL location <paramref name="walLocation"/>.
+        /// The server can reply with an error, for example if the requested section of WAL has already been recycled.
+        /// </summary>
+        /// <param name="walLocation">
+        /// The WAL location from which to start streaming, in the format XXX/XXX.
+        /// </param>
+        /// <param name="slotName">
+        /// If a slot's name is provided, it will be updated as replication progresses so that the server knows which
+        /// WAL segments, and if hot_standby_feedback is on which transactions, are still needed by the standby.
+        /// </param>
+        /// <param name="options">
+        /// Options to be passed to the slot's logical decoding plugin.
+        /// </param>
+        [PublicAPI]
+        public async Task StartReplication(string slotName, string? walLocation = null, Dictionary<string, object>? options = null)
+        {
+            var sb = new StringBuilder("START_REPLICATION SLOT ")
+                .Append(slotName)
+                .Append(" LOGICAL ")
+                .Append(walLocation);
+
+            if (options != null)
+                sb
+                    .Append(' ')
+                    .Append(string.Join(", ", options.Select(kv => kv.Value is null ? kv.Key : kv.Key + " " + kv.Value)));
+
+            var connector = Connection.Connector!;
+            await connector.WriteQuery(sb.ToString(), true);
+            await connector.Flush(true);
+
+            var msg = await connector.ReadMessage(true);
+            switch (msg.Code)
+            {
+            case BackendMessageCode.CopyBothResponse:
+                State = ReplicationConnectionState.Streaming;
+                return;
+            case BackendMessageCode.CompletedResponse:
+                // TODO: This can happen when the client requests streaming at exactly the end of an old timeline.
+                // TODO: Figure out how to communicate these different states to the user
+                throw new NotImplementedException();
+            default:
+                throw Connection.Connector!.UnexpectedMessageReceived(msg.Code);
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        [PublicAPI]
+        public async ValueTask<XLogData?> GetNextMessage()
+        {
+            var connector = Connection.Connector!;
+            try
+            {
+                while (true)
+                {
+                    var msg = await connector.ReadMessage(true);
+                    switch (msg.Code)
+                    {
+                    case BackendMessageCode.CopyData:
+                        var copyData = (CopyDataMessage)msg;
+                        await connector.ReadBuffer.Ensure(copyData.Length, true);
+                        var xLogData = ParseCopyData((CopyDataMessage)msg);
+                        if (xLogData.HasValue)
+                            return xLogData.Value;
+                        continue;
+                    default:
+                        throw connector.UnexpectedMessageReceived(msg.Code);
+                    }
+                }
+            }
+            catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.QueryCanceled)
+            {
+                State = ReplicationConnectionState.Idle;
+                return null;
+            }
+        }
+
+        XLogData? ParseCopyData(CopyDataMessage copyDataMessage)
+        {
+            // TODO: Not all data is in the buffer
+            var buf = Connection.Connector!.ReadBuffer;
+            var len = copyDataMessage.Length;
+            var code = (char)buf.ReadByte();
+            switch (code)
+            {
+            case 'w': // XLogData
+            {
+                var walStart = buf.ReadInt64();
+                var walEnd = buf.ReadInt64();
+                var serverClock = buf.ReadInt64();
+                var dataLen = len - 1 - 8 - 8 - 8;
+                var data  = new XLogData(walStart, walEnd, serverClock,
+                    new ReadOnlyMemory<byte>(buf.Buffer, buf.ReadPosition, dataLen));
+                buf.ReadPosition += dataLen;
+                return data;
+                //var data = new byte[len - 1 - 8 - 8 - 8];
+                //buf.ReadBytes(data);
+                //return new XLogData(walStart, walEnd, serverClock, data);
+            }
+
+            case 'k': // Primary keepalive message
+            {
+                buf.Ensure(sizeof(long) + sizeof(long) + sizeof(byte));
+                var walEnd = buf.ReadInt64();
+                var serverClock = buf.ReadInt64();
+                var replyImmediately = buf.ReadByte() == 1;
+                return null;
+            }
+
+            default:
+                Connection.Connector.Break();
+                throw new NpgsqlException($"Unknown replication message code '{code}'");
+            }
+        }
+
+        #endregion Replication commands
+
+        #region Support types
+
+        // TODO: Inner type?
+        /// <summary>
+        /// Decides what to do with the snapshot created during logical slot initialization.
+        /// </summary>
+        [PublicAPI]
+        public enum SlotSnapshotInitMode
+        {
+            /// <summary>
+            /// Export the snapshot for use in other sessions. This is the default.
+            /// This option can't be used inside a transaction.
+            /// </summary>
+            Export,
+
+            /// <summary>
+            /// Use the snapshot for the current transaction executing the command.
+            /// This option must be used in a transaction, and CREATE_REPLICATION_SLOT must be the first command run
+            /// in that transaction.
+            /// </summary>
+            Use,
+
+            /// <summary>
+            /// Just use the snapshot for logical decoding as normal but don't do anything else with it.
+            /// </summary>
+            NoExport
+        }
+
+        /// <summary>
+        /// Contains information about a newly-created logical replication slot.
+        /// </summary>
+        [PublicAPI]
+        public readonly struct NpgsqlLogicalReplicationSlotInfo
+        {
+            internal NpgsqlLogicalReplicationSlotInfo(
+                string slotName,
+                string consistentPoint,
+                string snapshotName,
+                string outputPlugin)
+            {
+                SlotName = slotName;
+                ConsistentPoint = consistentPoint;
+                SnapshotName = snapshotName;
+                OutputPlugin = outputPlugin;
+            }
+
+            /// <summary>
+            /// The name of the newly-created replication slot.
+            /// </summary>
+            public string SlotName { get; }
+
+            /// <summary>
+            /// The WAL location at which the slot became consistent.
+            /// This is the earliest location from which streaming can start on this replication slot.
+            /// </summary>
+            public string ConsistentPoint { get; }
+
+            /// <summary>
+            /// The identifier of the snapshot exported by the command.
+            /// The snapshot is valid until a new command is executed on this connection or the replication connection is closed.
+            /// </summary>
+            public string SnapshotName { get; }
+
+            /// <summary>
+            /// The name of the output plugin used by the newly-created replication slot.
+            /// </summary>
+            public string OutputPlugin { get; }
+        }
+
+        /// <summary>
+        /// A message representing a section of the WAL data stream.
+        /// </summary>
+        [PublicAPI]
+        public readonly struct XLogData
+        {
+            internal XLogData(
+                long walStart,
+                long walEnd,
+                long serverClock,
+                ReadOnlyMemory<byte> data)
+            {
+                WalStart = walStart;
+                WalEnd = walEnd;
+                ServerClock = serverClock;
+                Data = data;
+            }
+
+            /// <summary>
+            /// The starting point of the WAL data in this message.
+            /// </summary>
+            public long WalStart { get; }
+
+            /// <summary>
+            /// The current end of WAL on the server.
+            /// </summary>
+            public long WalEnd { get; }
+
+            /// <summary>
+            /// The server's system clock at the time of transmission, as microseconds since midnight on 2000-01-01.
+            /// </summary>
+            public long ServerClock { get; }
+
+            // TODO: WRONG. This probably needs to be streamed.
+            /// <summary>
+            /// A section of the WAL data stream.
+            /// </summary>
+            /// <remarks>
+            /// A single WAL record is never split across two XLogData messages.
+            /// When a WAL record crosses a WAL page boundary, and is therefore already split using continuation records,
+            /// it can be split at the page boundary. In other words, the first main WAL record and its continuation
+            /// records can be sent in different XLogData messages.
+            /// </remarks>
+            public ReadOnlyMemory<byte> Data { get; }
+        }
+
+        #endregion Support types
+    }
+}

--- a/src/Npgsql/Replication/NpgsqlPhysicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/NpgsqlPhysicalReplicationConnection.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Npgsql.Logging;
+using Npgsql.Util;
+
+namespace Npgsql.Replication
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public sealed class NpgsqlPhysicalReplicationConnection : NpgsqlReplicationConnection
+    {
+        static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlPhysicalReplicationConnection));
+
+        #region Open
+
+        /// <summary>
+        /// Opens a database replication connection with the property settings specified by the
+        /// <see cref="NpgsqlReplicationConnection.ConnectionString">ConnectionString</see>.
+        /// </summary>
+        [PublicAPI]
+        public Task OpenAsync(CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        #endregion Open
+
+        #region Replication commands
+
+        /// <summary>
+        /// Create a physical replication slot.
+        /// </summary>
+        /// <param name="slotName">
+        /// The name of the slot to create. Must be a valid replication slot name
+        /// (see <a href="https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION">Section 26.2.6.1</a>).
+        /// </param>
+        /// <param name="isTemporary">
+        /// Specify that this replication slot is a temporary one.
+        /// Temporary slots are not saved to disk and are automatically dropped on error or when the session has finished.
+        /// </param>
+        /// <param name="reserveWal">
+        /// Specify that this physical replication slot reserves WAL immediately.
+        /// Otherwise, WAL is only reserved upon connection from a streaming replication client.
+        /// </param>
+        /// <returns>
+        /// An <see cref="NpgsqlPhysicalReplicationSlotInfo"/> providing information on the newly-created slot.
+        /// </returns>
+        /// <remarks>
+        /// See https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS.
+        /// </remarks>
+        [PublicAPI]
+        public Task<NpgsqlPhysicalReplicationSlotInfo> CreateReplicationSlot(
+            string slotName,
+            bool isTemporary,
+            bool reserveWal)
+            => throw new NotImplementedException();
+
+        // TODO: Default for timeline -1?
+        /// <summary>
+        /// Instructs server to start streaming WAL, starting at WAL location <paramref name="walLocation"/>.
+        /// </summary>
+        /// <param name="walLocation">
+        /// The WAL location from which to start streaming, in the format XXX/XXX.
+        /// </param>
+        /// <param name="slotName">
+        /// If a slot's name is provided, it will be updated as replication progresses so that the server knows which
+        /// WAL segments, and if hot_standby_feedback is on which transactions, are still needed by the standby.
+        /// </param>
+        /// <param name="timeline">
+        /// If specified, streaming starts on that timeline; otherwise, the server's current timeline is selected.
+        /// </param>
+        [PublicAPI]
+        public Task StartReplication(string walLocation, string? slotName = null, int timeline = -1)
+            => throw new NotImplementedException();
+
+        #endregion Replication commands
+    }
+
+    #region Support types
+
+    /// <summary>
+    /// Contains information about a newly-created physical replication slot.
+    /// </summary>
+    [PublicAPI]
+    public readonly struct NpgsqlPhysicalReplicationSlotInfo
+    {
+        internal NpgsqlPhysicalReplicationSlotInfo(string slotName, string consistentPoint)
+        {
+            SlotName = slotName;
+            ConsistentPoint = consistentPoint;
+        }
+
+        /// <summary>
+        /// The name of the newly-created replication slot.
+        /// </summary>
+        public string SlotName { get; }
+
+        /// <summary>
+        /// The WAL location at which the slot became consistent.
+        /// This is the earliest location from which streaming can start on this replication slot.
+        /// </summary>
+        public string ConsistentPoint { get; }
+    }
+
+    #endregion Support types
+}

--- a/src/Npgsql/Replication/NpgsqlReplicationConnection.cs
+++ b/src/Npgsql/Replication/NpgsqlReplicationConnection.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Npgsql.BackendMessages;
+using Npgsql.Logging;
+using static Npgsql.Util.Statics;
+
+namespace Npgsql.Replication
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public abstract class NpgsqlReplicationConnection : IDisposable
+    {
+        #region Fields
+
+        private protected NpgsqlConnection Connection = default!;
+
+        private protected ReplicationConnectionState State { get; set; }
+
+        /*
+        /// <summary>
+        /// The location of the last WAL byte + 1 received and written to disk in the standby.
+        /// </summary>
+        long _lastWrittenLsn;
+
+        /// <summary>
+        /// The location of the last WAL byte + 1 flushed to disk in the standby.
+        /// </summary>
+        long _lastFlushedLsn;
+
+        /// <summary>
+        /// The location of the last WAL byte + 1 applied in the standby.
+        /// </summary>
+        long _lastAppliedLsn;
+*/
+        static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlReplicationConnection));
+
+        #endregion Fields
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the string used to connect to a PostgreSQL database. See the manual for details.
+        /// </summary>
+        /// <value>The connection string that includes the server name,
+        /// the database name, and other parameters needed to establish
+        /// the initial connection. The default value is an empty string.
+        /// </value>
+#nullable disable
+        public string ConnectionString { get; set; }
+#nullable enable
+
+        #endregion Properties
+
+        /// <summary>
+        ///
+        /// </summary>
+        protected async Task OpenAsync(NpgsqlConnectionStringBuilder settings, CancellationToken cancellationToken)
+        {
+            settings.Pooling = settings.Enlist = false;
+            settings.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
+            // TODO: Keepalive
+
+            Connection = new NpgsqlConnection(settings.ToString());
+            await Connection.OpenAsync(cancellationToken);
+            State = ReplicationConnectionState.Idle;
+        }
+
+        #region Replication commands
+
+        // TODO: Return value...
+        /// <summary>
+        /// Requests the server to identify itself.
+        /// </summary>
+        [PublicAPI]
+        public async Task<NpgsqlReplicationIdentificationInfo> IdentifySystem()
+        {
+            CheckReady();
+            var results = await ReadSingleRow("IDENTIFY_SYSTEM");
+            return new NpgsqlReplicationIdentificationInfo(
+                (string)results[0],
+                (int)results[1],
+                (string)results[2],
+                (string)results[3]);
+        }
+
+        /// <summary>
+        /// Requests the server to send the current setting of a run-time parameter.
+        /// This is similar to the SQL command SHOW.
+        /// </summary>
+        [PublicAPI]
+        public async Task<string> Show(string parameterName)
+            => (string)(await ReadSingleRow("SHOW " + parameterName))[0];
+
+        /// <summary>
+        /// Drops a replication slot, freeing any reserved server-side resources.
+        /// If the slot is a logical slot that was created in a database other than
+        /// the database the walsender is connected to, this command fails.
+        /// </summary>
+        /// <param name="slotName">The name of the slot to drop.</param>
+        /// <param name="wait">
+        /// This option causes the command to wait if the slot is active until it becomes inactive,
+        /// instead of the default behavior of raising an error.
+        /// </param>
+        [PublicAPI]
+        public async Task DropReplicationSlot(string slotName, bool wait = false)
+        {
+            CheckReady();
+
+            var command = "DROP_REPLICATION_SLOT " + slotName;
+            if (wait)
+                command += " WAIT";
+
+            var connector = Connection.Connector!;
+            await connector.WriteQuery(command, true);
+            await connector.Flush(true);
+
+            Expect<CommandCompleteMessage>(await connector.ReadMessage(true), connector);
+            Expect<CommandCompleteMessage>(await connector.ReadMessage(true), connector);  // Two CommandComplete are returned
+            Expect<ReadyForQueryMessage>(await connector.ReadMessage(true), connector);
+        }
+
+        /// <summary>
+        /// Stops an in-progress replication.
+        /// </summary>
+        [PublicAPI]
+        public void Cancel()
+        {
+            if (State != ReplicationConnectionState.Streaming)
+                throw new InvalidOperationException("Replication connection isn't in streaming state, can't cancel");
+
+            Connection.Connector!.CancelRequest();
+        }
+
+        #endregion Replication commands
+
+        private protected async Task<object[]> ReadSingleRow(string command)
+        {
+            var connector = Connection.Connector!;
+            await connector.WriteQuery(command, true);
+            await connector.Flush(true);
+
+            var description = Expect<RowDescriptionMessage>(await connector.ReadMessage(true), connector);
+            Expect<DataRowMessage>(await connector.ReadMessage(true), connector);
+            var buf = connector.ReadBuffer;
+            var results = new object[buf.ReadInt16()];
+            for (var i = 0; i < results.Length; i++)
+            {
+                var len = buf.ReadInt32();
+                if (len == -1)
+                    continue;
+                var str = buf.ReadString(len);
+                var field = description.Fields[i];
+                switch (field.PostgresType.Name)
+                {
+                case "text":
+                    results[i] = str;
+                    continue;
+                case "integer":
+                    if (!int.TryParse(str, out var num))
+                    {
+                        connector.Break();
+                        throw new NpgsqlException($"Could not parse '{str}' as integer in field {field.Name}");
+                    }
+
+                    results[i] = num;
+                    continue;
+                default:
+                    connector.Break();
+                    throw new NpgsqlException($"Field {field.Name} has PostgreSQL type {field.PostgresType.Name} which isn't supported yet");
+                }
+            }
+
+            Expect<CommandCompleteMessage>(await connector.ReadMessage(true), connector);
+            Expect<ReadyForQueryMessage>(await connector.ReadMessage(true), connector);
+            return results;
+        }
+
+        /// <summary>
+        /// Immediately sends a status update to PostgreSQL with the given WAL tracking information.
+        /// The information is recorded by Npgsql and will be used in subsequent periodic status updates.
+        /// </summary>
+        /// <param name="lastWrittenLsn">The location of the last WAL byte + 1 received and written to disk in the standby.</param>
+        /// <param name="lastFlushedLsn">The location of the last WAL byte + 1 flushed to disk in the standby.</param>
+        /// <param name="lastAppliedLsn">The location of the last WAL byte + 1 applied in the standby.</param>
+        /// <remarks>
+        /// In typical use cases, Npgsql will send period status updates by itself, and this API isn't needed.
+        /// </remarks>
+        /// <returns>A Task representing the sending fo the status update (and not any PostgreSQL response.</returns>
+        [PublicAPI]
+        public async Task SendStatusUpdate(long lastWrittenLsn, long lastFlushedLsn, long lastAppliedLsn)
+        {
+            if (State != ReplicationConnectionState.Streaming)
+                throw new InvalidOperationException("The connection must be streaming in order to send status updates");
+
+            var connector = Connection.Connector!;
+
+            // TODO: Clock
+            await connector.WriteReplicationStatusUpdate(lastWrittenLsn, lastFlushedLsn, lastAppliedLsn, 0, false);
+            await connector.Flush(true);
+        }
+
+        #region SSL
+
+        /// <summary>
+        /// Selects the local Secure Sockets Layer (SSL) certificate used for authentication.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.localcertificateselectioncallback(v=vs.110).aspx"/>
+        /// </remarks>
+        [PublicAPI]
+        public ProvideClientCertificatesCallback? ProvideClientCertificatesCallback { get; set; }
+
+        /// <summary>
+        /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+        /// Ignored if <see cref="NpgsqlConnectionStringBuilder.TrustServerCertificate"/> is set.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>
+        /// </remarks>
+        [PublicAPI]
+        public RemoteCertificateValidationCallback? UserCertificateValidationCallback { get; set; }
+
+        #endregion SSL
+
+        #region Close / Dispose
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (State == ReplicationConnectionState.Disposed)
+                return;
+            Connection?.Dispose();
+            Connection = null!;
+            State = ReplicationConnectionState.Disposed;
+        }
+
+        #endregion Close / Dispose
+
+        void CheckReady()
+        {
+            switch (State)
+            {
+            case ReplicationConnectionState.Closed:
+                throw new InvalidOperationException("Connection is not open");
+            case ReplicationConnectionState.Streaming:
+                throw new InvalidOperationException("Connection is currently streaming, cancel before attempting a new operation");
+            case ReplicationConnectionState.Disposed:
+                throw new ObjectDisposedException(GetType().Name);
+            }
+            Connection.CheckReadyAndGetConnector();
+        }
+
+        private protected enum ReplicationConnectionState
+        {
+            Closed,
+            Idle,
+            Streaming,
+            Disposed
+        }
+    }
+
+    #region Support types
+
+    /// <summary>
+    /// Contains server identification information returned from <see cref="NpgsqlReplicationConnection.IdentifySystem"/>.
+    /// </summary>
+    [PublicAPI]
+    public readonly struct NpgsqlReplicationIdentificationInfo
+    {
+        internal NpgsqlReplicationIdentificationInfo(
+            string systemId,
+            int timeline,
+            string xLogPos,
+            string dbName)
+        {
+            SystemId = systemId;
+            Timeline = timeline;
+            XLogPos = xLogPos;
+            DbName = dbName;
+        }
+
+        /// <summary>
+        /// The unique system identifier identifying the cluster.
+        /// This can be used to check that the base backup used to initialize the standby came from the same cluster.
+        /// </summary>
+        public string SystemId { get; }
+
+        /// <summary>
+        /// Current timeline ID. Also useful to check that the standby is consistent with the master.
+        /// </summary>
+        public int Timeline { get; }
+
+        /// <summary>
+        /// Current WAL flush location. Useful to get a known location in the write-ahead log where streaming can start.
+        /// </summary>
+        public string XLogPos { get; }
+
+        /// <summary>
+        /// Database connected to or null.
+        /// </summary>
+        public string DbName { get; }
+    }
+
+    /// <summary>
+    /// Contains the timeline history file for a timeline.
+    /// </summary>
+    public readonly struct NpgsqlTimelineHistoryFile
+    {
+        internal NpgsqlTimelineHistoryFile(string filename, string content)
+        {
+            Filename = filename;
+            Content = content;
+        }
+
+        /// <summary>
+        /// File name of the timeline history file, e.g., 00000002.history.
+        /// </summary>
+        public string Filename { get; }
+
+        /// <summary>
+        /// Contents of the timeline history file.
+        /// </summary>
+        public string Content { get; }
+    }
+
+    #endregion Support types
+}

--- a/test/Npgsql.Tests/ReplicationTests.cs
+++ b/test/Npgsql.Tests/ReplicationTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Npgsql.Replication;
+using NUnit.Framework;
+
+namespace Npgsql.Tests
+{
+    public class ReplicationTests : TestBase
+    {
+        [Test, NonParallelizable]
+        public async Task EndToEnd()
+        {
+            using var conn = OpenConnection();
+            using var replConn = new NpgsqlLogicalReplicationConnection(ConnectionString);
+            var slotName = nameof(EndToEnd);
+
+            conn.ExecuteNonQuery("DROP TABLE IF EXISTS end_to_end_replication");
+            conn.ExecuteNonQuery("CREATE TABLE end_to_end_replication (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT)");
+
+            await replConn.OpenAsync();
+            await replConn.CreateReplicationSlot(slotName, "test_decoding");
+
+            var confirmedFlushLsn = conn.ExecuteScalar($"SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = '{slotName}'");
+            Assert.That(confirmedFlushLsn, Is.Null);
+            //Assert.That((await replConn.IdentifySystem()).XLogPos, Is.EqualTo(confirmedFlushLsn));
+
+            // Make some changes
+            conn.ExecuteNonQuery("INSERT INTO end_to_end_replication (name) VALUES ('val1')");
+            conn.ExecuteNonQuery("UPDATE end_to_end_replication SET name='val2' WHERE name='val1'");
+
+            await replConn.StartReplication(slotName, "0/0");
+
+            Assert.That(UTF8Encoding.UTF8.GetString((await replConn.GetNextMessage())!.Value.Data.ToArray()),
+                Does.StartWith("BEGIN "));
+            Assert.That(UTF8Encoding.UTF8.GetString((await replConn.GetNextMessage())!.Value.Data.ToArray()),
+                Is.EqualTo("table public.end_to_end_replication: INSERT: id[integer]:1 name[text]:'val1'"));
+            var msg = (await replConn.GetNextMessage())!.Value;
+            Assert.That(UTF8Encoding.UTF8.GetString(msg.Data.ToArray()), Does.StartWith("COMMIT "));
+
+            // Pretend we've completely processed this transaction, inform the server manually
+            // (in real life we can wait until the automatic periodic update does this)
+            //await replConn.SendStatusUpdate(msg.WalEnd, msg.WalEnd, msg.WalEnd);
+            //confirmedFlushLsn = conn.ExecuteScalar($"SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = '{slotName}'");
+            //Assert.That(confirmedFlushLsn, Is.Not.Null);  // There's obviously a misunderstanding here
+
+            Assert.That(UTF8Encoding.UTF8.GetString((await replConn.GetNextMessage())!.Value.Data.ToArray()),
+                Does.StartWith("BEGIN "));
+            Assert.That(UTF8Encoding.UTF8.GetString((await replConn.GetNextMessage())!.Value.Data.ToArray()),
+                Is.EqualTo("table public.end_to_end_replication: UPDATE: id[integer]:1 name[text]:'val2'"));
+            Assert.That(UTF8Encoding.UTF8.GetString((await replConn.GetNextMessage())!.Value.Data.ToArray()),
+                Does.StartWith("COMMIT "));
+
+            replConn.Cancel();
+
+            // TODO: Bad example: pretend we don't know what's coming
+            // Drain any messages
+            while (await replConn.GetNextMessage() != null) ;
+
+            // Make sure the connection is back to idle state
+            Assert.That(await replConn.Show("integer_datetimes"), Is.EqualTo("on"));
+
+            await replConn.DropReplicationSlot(slotName);
+        }
+
+        [Test]
+        public async Task IdentifySystem()
+        {
+            using var conn = new NpgsqlLogicalReplicationConnection(ConnectionString);
+            await conn.OpenAsync();
+            var identificationInfo = await conn.IdentifySystem();
+            Assert.That(identificationInfo.DbName, Is.EqualTo(new NpgsqlConnectionStringBuilder(ConnectionString).Database));
+        }
+
+        [Test]
+        public async Task Show()
+        {
+            using var conn = new NpgsqlLogicalReplicationConnection(ConnectionString);
+            await conn.OpenAsync();
+            Assert.That(await conn.Show("integer_datetimes"), Is.EqualTo("on"));
+        }
+
+        [Test]
+        public async Task CreateDropLogicalSlot()
+        {
+            using var conn = new NpgsqlLogicalReplicationConnection(ConnectionString);
+            await conn.OpenAsync();
+            await conn.CreateReplicationSlot(nameof(CreateDropLogicalSlot), "test_decoding");
+            await conn.DropReplicationSlot(nameof(CreateDropLogicalSlot));
+        }
+
+        #region Support
+
+        [SetUp]
+        public void Setup()
+        {
+            using var conn = OpenConnection();
+            var walLevel = (string)conn.ExecuteScalar("SHOW wal_level");
+            if (walLevel != "logical")
+                TestUtil.IgnoreExceptOnBuildServer("wal_level needs to be set to 'logical' in the PostgreSQL conf");
+            DropAllReplicationSlots();
+        }
+
+        void DropAllReplicationSlots()
+        {
+            using var conn = OpenConnection();
+
+            var slots = new List<string>();
+            using (var cmd = new NpgsqlCommand("SELECT slot_name FROM pg_replication_slots", conn))
+            using (var reader = cmd.ExecuteReader())
+                while (reader.Read())
+                    slots.Add(reader.GetString(0));
+
+            foreach (var slot in slots)
+                conn.ExecuteNonQuery($"SELECT pg_drop_replication_slot('{slot}')");
+
+        }
+
+        #endregion Support
+    }
+}


### PR DESCRIPTION
This PR is a WIP draft for adding logical and physical replication support to Npgsql. It is in a quite advanced state, but still lacks several features to be complete - it's meant to get feedback on the general approach etc.

Notable remaining issues:
* The keepalive and status update parts of the protocol aren't yet implemented.
* The XLogData struct currently exposes a `ReadOnlyMemory<byte>`, but as data may be large we should probably expose a streaming API instead (feedback would be welcome!).

Note that this is in a too early state for nitpicking and other minor feedback.