### PR TITLE
Implement new .NET Core 3.0 ADO.NET APIs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
   - powershell .build\setup_appveyor.ps1
   # The following can be used to install a custom version of .NET Core
   - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
-  - ps: .\install-dotnet.ps1 -Version 3.0.100-preview4-011223 -InstallDir "dotnetcli"
+  - ps: .\install-dotnet.ps1 -Version 3.0.100-preview6-012264 -InstallDir "dotnetcli"
 services:
   - postgresql101
 before_build:

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "sdk": {
-        "version": "3.0.100-preview4-011223"
+        "version": "3.0.100-preview6-012264"
     }
 }

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -4,7 +4,7 @@
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
     <VersionPrefix>4.1.0</VersionPrefix>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -556,9 +556,11 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// Creates a server-side prepared statement on the PostgreSQL server.
         /// This will make repeated future executions of this command much faster.
         /// </summary>
-#pragma warning disable CA1801 // Review unused parameters
+#if !NET461 && !NETSTANDARD2_0 && !NETSTANDARD2_1
+        public override Task PrepareAsync(CancellationToken cancellationToken)
+#else
         public Task PrepareAsync(CancellationToken cancellationToken)
-#pragma warning restore CA1801 // Review unused parameters
+#endif
         {
             cancellationToken.ThrowIfCancellationRequested();
             using (NoSynchronizationContextScope.Enter())

--- a/src/Npgsql/NpgsqlFactory.cs
+++ b/src/Npgsql/NpgsqlFactory.cs
@@ -51,6 +51,18 @@ namespace Npgsql
         /// </summary>
         public override DbDataAdapter CreateDataAdapter() => new NpgsqlDataAdapter();
 
+#if !NET461 && !NETSTANDARD2_0 && !NETSTANDARD2_1
+        /// <summary>
+        /// Specifies whether the specific <see cref="DbProviderFactory"/> supports the <see cref="DbDataAdapter"/> class.
+        /// </summary>
+        public override bool CanCreateDataAdapter => true;
+
+        /// <summary>
+        /// Specifies whether the specific <see cref="DbProviderFactory"/> supports the <see cref="DbCommandBuilder"/> class.
+        /// </summary>
+        public override bool CanCreateCommandBuilder => true;
+#endif
+
         #region IServiceProvider Members
 
         /// <summary>

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -136,7 +136,12 @@ namespace Npgsql
         /// Commits the database transaction.
         /// </summary>
         [PublicAPI]
+
+#if !NET461 && !NETSTANDARD2_0 && !NETSTANDARD2_1
+        public override Task CommitAsync(CancellationToken cancellationToken = default)
+#else
         public Task CommitAsync(CancellationToken cancellationToken = default)
+#endif
         {
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
@@ -165,7 +170,11 @@ namespace Npgsql
         /// Rolls back a transaction from a pending state.
         /// </summary>
         [PublicAPI]
+#if !NET461 && !NETSTANDARD2_0 && !NETSTANDARD2_1
+        public override Task RollbackAsync(CancellationToken cancellationToken = default)
+#else
         public Task RollbackAsync(CancellationToken cancellationToken = default)
+#endif
         {
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);


### PR DESCRIPTION
Pin dotnet sdk to 3.0.0-preview6 and implement new ADO.NET APIs introduced in .NET Core 3.0:
* https://github.com/dotnet/corefx/issues/35564
* https://github.com/dotnet/corefx/issues/35012

Note: we cross-target netcoreapp3.0 since the new APIs aren't yet
available in netstandard2.1, but this is expected to happen soon.

Fixes #2481