### PR TITLE
Check cancellation token at start of WaitAsync()

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1228,6 +1228,9 @@ namespace Npgsql
         [PublicAPI]
         public Task WaitAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+                return PGUtil.CancelledTask;
+
             CheckConnectionOpen();
             Debug.Assert(Connector != null);
             Log.Debug("Starting to wait asynchronously...", Connector.Id);

--- a/test/Npgsql.Tests/NotificationTests.cs
+++ b/test/Npgsql.Tests/NotificationTests.cs
@@ -160,9 +160,17 @@ namespace Npgsql.Tests
         {
             using (var conn = OpenConnection())
             {
+                Assert.That(async () => await conn.WaitAsync(new CancellationToken(true)),
+                    Throws.Exception.TypeOf<TaskCanceledException>());
+                Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
+            }
+
+            using (var conn = OpenConnection())
+            {
                 conn.ExecuteNonQuery("LISTEN notifytest");
                 var cts = new CancellationTokenSource(1000);
-                Assert.That(async () => await conn.WaitAsync(cts.Token), Throws.Exception.TypeOf<OperationCanceledException>());
+                Assert.That(async () => await conn.WaitAsync(cts.Token),
+                    Throws.Exception.TypeOf<OperationCanceledException>());
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
             }
         }


### PR DESCRIPTION
Otherwise passing a cancelled token makes WaitAsync() crash.

Note that a race condition still exists if the token is cancelled after our check but before WaitAsync starts its job.

Fixes #2506

The fix for dev will be part of #2443