### PR TITLE
Fixes potential PoolState.Waiting overflow and includes some minor changes

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -263,7 +263,7 @@ namespace Npgsql
                     // Start the pruning timer if we're above MinPoolSize
                     if (_pruningTimer == null && newState.Total > _min)
                     {
-                        var newPruningTimer = new Timer(PruneIdleConnectors);
+                        var newPruningTimer = new Timer(s => PruneIdleConnectors(s));
                         if (Interlocked.CompareExchange(ref _pruningTimer, newPruningTimer, null) == null)
                             newPruningTimer.Change(_pruningInterval, _pruningInterval);
                         else

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -336,14 +336,12 @@ namespace Npgsql
                             {
                                 if (timeout.IsSet)
                                 {
-                                    var timeLeft = timeout.TimeLeft.TotalMilliseconds;
-                                    if (timeLeft > int.MaxValue)
-                                        throw new ArgumentOutOfRangeException(nameof(timeout), "timeout.TimeLeft.TotalMilliseconds must be smaller than int.MaxValue.");
-                                    if (timeLeft <= 0 || !tcs.Task.Wait((int)timeLeft, cancellationToken))
+                                    var timeLeft = timeout.TimeLeft;
+                                    if (timeLeft <= TimeSpan.Zero || !tcs.Task.Wait(timeLeft))
                                         throw new NpgsqlException($"The connection pool has been exhausted, either raise MaxPoolSize (currently {_max}) or Timeout (currently {Settings.Timeout} seconds)");
                                 }
                                 else
-                                    tcs.Task.Wait(cancellationToken);
+                                    tcs.Task.Wait();
                             }
                         }
                         catch

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -336,11 +336,11 @@ namespace Npgsql
                                 if (timeout.IsSet)
                                 {
                                     var timeLeft = timeout.TimeLeft;
-                                    if (timeLeft <= TimeSpan.Zero || !tcs.Task.Wait(timeLeft))
+                                    if (timeLeft <= TimeSpan.Zero || !tcs.Task.Wait((int)timeLeft.TotalMilliseconds, cancellationToken))
                                         throw new NpgsqlException($"The connection pool has been exhausted, either raise MaxPoolSize (currently {_max}) or Timeout (currently {Settings.Timeout} seconds)");
                                 }
                                 else
-                                    tcs.Task.Wait();
+                                    tcs.Task.Wait(cancellationToken);
                             }
                         }
                         catch

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -87,7 +87,7 @@ namespace Npgsql
         static readonly TimerCallback PruningTimerCallback = PruneIdleConnectors;
         Timer? _pruningTimer;
         readonly TimeSpan _pruningInterval;
-        
+
         /// <summary>
         /// Maximum number of possible connections in any pool.
         /// </summary>
@@ -101,7 +101,7 @@ namespace Npgsql
         {
             Debug.Assert(PoolSizeLimit <= short.MaxValue,
                 "PoolSizeLimit cannot be larger than short.MaxValue unless PoolState is refactored to hold larger values.");
-            
+
             if (settings.MaxPoolSize < settings.MinPoolSize)
                 throw new ArgumentException($"Connection can't have MaxPoolSize {settings.MaxPoolSize} under MinPoolSize {settings.MinPoolSize}");
 
@@ -542,8 +542,7 @@ namespace Npgsql
             var idle = pool._idle;
             var now = DateTime.UtcNow;
             var idleLifetime = pool.Settings.ConnectionIdleLifetime;
-                
-            
+
             for (var i = 0; i < idle.Length; i++)
             {
                 if (pool.State.Total <= pool._min)

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -15,7 +14,8 @@ namespace Npgsql.Tests
         [Test]
         public void MinPoolSizeEqualsMaxPoolSize()
         {
-            using (var conn = new NpgsqlConnection(new NpgsqlConnectionStringBuilder(ConnectionString) {
+            using (var conn = new NpgsqlConnection(new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 MinPoolSize = 30,
                 MaxPoolSize = 30
             }.ToString()))
@@ -59,7 +59,8 @@ namespace Npgsql.Tests
         [Test, Timeout(10000)]
         public void GetConnectorFromExhaustedPool()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 MaxPoolSize = 1,
                 Timeout = 0
             }.ToString();
@@ -100,7 +101,8 @@ namespace Npgsql.Tests
         [Test]
         public void TimeoutGettingConnectorFromExhaustedPool()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 MaxPoolSize = 1,
                 Timeout = 2
             }.ToString();
@@ -138,11 +140,12 @@ namespace Npgsql.Tests
             using (var conn3 = new NpgsqlConnection(connString))
                 conn3.Open();
         }
-        
+
         [Test]
         public void OverflowExceptionWhenTooManyWaiting()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 ApplicationName = nameof(OverflowExceptionWhenTooManyWaiting),
                 MaxPoolSize = 1,
             }.ToString();
@@ -164,7 +167,7 @@ namespace Npgsql.Tests
                 finally
                 {
                     // Restore state for the closes work correctly.
-                    pool!.State = state; 
+                    pool!.State = state;
                 }
             }
         }
@@ -173,7 +176,8 @@ namespace Npgsql.Tests
         //[Explicit("Timing-based")]
         public async Task CancelOpenAsync()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 ApplicationName = nameof(CancelOpenAsync),
                 MaxPoolSize = 1,
             }.ToString();
@@ -334,7 +338,8 @@ namespace Npgsql.Tests
         [Test]
         public void ClearWithNoPool()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 ApplicationName = nameof(ClearWithNoPool)
             }.ToString();
             using (var conn = new NpgsqlConnection(connString))
@@ -344,7 +349,8 @@ namespace Npgsql.Tests
         [Test, Description("https://github.com/npgsql/npgsql/commit/45e33ecef21f75f51a625c7b919a50da3ed8e920#r28239653")]
         public void PhysicalOpenFailure()
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 ApplicationName = nameof(PhysicalOpenFailure),
                 Port = 44444,
                 MaxPoolSize = 1
@@ -367,7 +373,8 @@ namespace Npgsql.Tests
         //[TestCase(10, 20, 30, false)]
         public void ExercisePool(int maxPoolSize, int numTasks, int seconds, bool async)
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) 
+            {
                 ApplicationName = nameof(ExercisePool),
                 MaxPoolSize = maxPoolSize
             }.ToString();

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -138,6 +138,36 @@ namespace Npgsql.Tests
             using (var conn3 = new NpgsqlConnection(connString))
                 conn3.Open();
         }
+        
+        [Test]
+        public void OverflowExceptionWhenTooManyWaiting()
+        {
+            var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
+                ApplicationName = nameof(OverflowExceptionWhenTooManyWaiting),
+                MaxPoolSize = 1,
+            }.ToString();
+
+            using (var conn = new NpgsqlConnection(connString))
+            {
+                conn.Open();
+                Assert.True(PoolManager.TryGetValue(connString, out var pool));
+                var state = pool!.State;
+
+                try
+                {
+                    var newState = state;
+                    newState.Waiting = int.MaxValue;
+                    pool!.State = newState;
+                    var conn2 = new NpgsqlConnection(connString);
+                    Assert.Catch<OverflowException>(() => conn2.Open());
+                }
+                finally
+                {
+                    // Restore state for the closes work correctly.
+                    pool!.State = state; 
+                }
+            }
+        }
 
         //[Test, Timeout(10000)]
         //[Explicit("Timing-based")]


### PR DESCRIPTION
Changes the `PoolState.Waiting` short to an int and adds a checked increment (one branch instruction that'll always be branch predicted away). There's a test that asserts whether it's throwing OverflowException correctly.

I've also added an assert to create a dependency for PoolSizeLimit on the max value allowed by the state idle and busy primitives. I don't expect it to ever be valuable as a runtime test but it's a good case to be reminded of if this limit should become customizable.

The cancellation token commit feels more consistent with the intent of the work being done whether it's being awaited asynchronously or not but I'm entirely ambivalent either way it goes.

I also did take a look at any other potential places to optimize but it's pretty trimmed!

P.S. 'asking for a friend'
How easy would it be to add another layer of abstraction between the actual pg connection and the pool so we could multiplex work? 