### PR TITLE
Properly deal with command failure on auto-prepare

### DIFF
--- a/src/Npgsql/PreparedStatement.cs
+++ b/src/Npgsql/PreparedStatement.cs
@@ -140,15 +140,14 @@ namespace Npgsql
 
         /// <summary>
         /// The statement has been selected for preparation, but the preparation hasn't started yet.
-        /// This is a temporary state that only occurs during preparation.
-        /// Specifically, no protocol message (Parse) has been sent yet. Specifically, it means that
-        /// a Parse message for the statement has already been written to the write buffer.
+        /// This is a temporary state that only occurs during preparation, and indicates that no
+        /// no protocol message (Parse) has been sent yet.
         /// </summary>
         ToBePrepared,
 
         /// <summary>
         /// The statement is in the process of being prepared. This is a temporary state that only occurs during
-        /// preparation. Specifically, it means that a Parse message for the statement has already been written
+        /// preparation, and indicates that a Parse protocol message for the statement has already been written
         /// to the write buffer.
         /// </summary>
         BeingPrepared,


### PR DESCRIPTION
Fixes #2178

An alternative to #2185 which does the correct bookkeeping up-front, when the failure is received from the database, rather than leaving the prepared statement in a dangling state until next time.

/cc @JustBSka