### PR TITLE
Align versions for CI artifact consistency

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2019 Preview
-version: 4.1.0-{build}
+version: 5.0.0-{build}
 environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -7,7 +7,7 @@ environment:
     NPGSQL_TEST_DB: Host=localhost;Database=postgres;Username=postgres;Password=Password12!
     PGUSER: postgres
     PGPASSWORD: Password12!
-    POSTGIS_EXE: postgis-bundle-pg10x64-setup-2.5.1-1.exe
+    POSTGIS_EXE: postgis-bundle-pg11x64-setup-2.5.2-1.exe
     NoPackageAnalysis: true  # Suppresses warning about SemVer 2.0.0 version suffixes when packing
 cache:
   - '%USERPROFILE%\.nuget\packages -> **\*.csproj'
@@ -20,10 +20,10 @@ install:
   - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
   - ps: .\install-dotnet.ps1 -Version 3.0.100-preview6-012264 -InstallDir "dotnetcli"
 services:
-  - postgresql101
+  - postgresql111
 before_build:
-  - '"C:\Program Files\PostgreSQL\10\bin\psql" -c "CREATE EXTENSION citext"'
-  - '"C:\Program Files\PostgreSQL\10\bin\psql" -c "CREATE EXTENSION postgis"'
+  - '"C:\Program Files\PostgreSQL\11\bin\psql" -c "CREATE EXTENSION citext"'
+  - '"C:\Program Files\PostgreSQL\11\bin\psql" -c "CREATE EXTENSION postgis"'
   - appveyor-retry dotnet restore -v Minimal Npgsql.sln
   - appveyor-retry nuget restore src\VSIX\packages.config -SolutionDirectory . -Verbosity quiet -NonInteractive
 build_script:

--- a/.build/setup_appveyor.ps1
+++ b/.build/setup_appveyor.ps1
@@ -4,18 +4,20 @@
 ###################
 
 Write-Host Enabling PostgreSQL prepared transactions...
-Add-Content 'C:\Program Files\PostgreSQL\10\data\postgresql.conf' "`nmax_prepared_transactions = 10"
+Add-Content 'C:\Program Files\PostgreSQL\11\data\postgresql.conf' "`nmax_prepared_transactions = 10"
 
 Write-Host Enabling PostgreSQL SSL...
-Add-Content 'C:\Program Files\PostgreSQL\10\data\postgresql.conf' "`nssl = true"
-Copy-Item .build\server.* "C:\Program Files\PostgreSQL\10\data"
+Add-Content 'C:\Program Files\PostgreSQL\11\data\postgresql.conf' "`nssl = true"
+Copy-Item .build\server.* "C:\Program Files\PostgreSQL\11\data"
 
 Write-Host Enabling PostGIS...
 If (!(Test-Path $env:POSTGIS_EXE)) {
   Write-Host Downloading PostGIS...
-  (New-Object Net.WebClient).DownloadFile("http://download.osgeo.org/postgis/windows/pg10/$env:POSTGIS_EXE", "$env:POSTGIS_EXE")
+  (New-Object Net.WebClient).DownloadFile("http://download.osgeo.org/postgis/windows/pg11/$env:POSTGIS_EXE", "$env:POSTGIS_EXE")
 }
-iex ".\$env:POSTGIS_EXE /S /D='C:\Program Files\PostgreSQL\10'"
+ls '/Program Files/PostgreSQL'
+net start postgresql-x64-11;
+iex ".\$env:POSTGIS_EXE /S /D='C:\Program Files\PostgreSQL\11'"
 
 ########################
 ## Set version variables

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <Copyright>Copyright 2019 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
-    
+    <VersionPrefix>4.1.0</VersionPrefix>
+
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/npgsql/npgsql</RepositoryUrl>
-    
+
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>http://www.npgsql.org</PackageProjectUrl>
     <PackageIconUrl>http://www.npgsql.org/img/postgresql.gif</PackageIconUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Copyright>Copyright 2019 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
 
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/npgsql/npgsql</RepositoryUrl>

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -3,7 +3,6 @@
     <Authors>Yoh Deadfall, Shay Rojansky</Authors>
     <Description>GeoJSON plugin for Npgsql, allowing mapping of PostGIS geometry types to GeoJSON types.</Description>
     <PackageTags>npgsql postgresql postgres postgis geojson spatial ado ado.net database sql</PackageTags>
-    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -4,7 +4,6 @@
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql postgresql json postgres ado ado.net database sql</PackageTags>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
+++ b/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
@@ -3,7 +3,6 @@
     <Authors>Shay Rojansky</Authors>
     <Description>PostGIS plugin for Npgsql, allowing mapping of PostGIS types to the legacy types (e.g. PostgisPoint).</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
-    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -3,7 +3,6 @@
     <Authors>Yoh Deadfall, Shay Rojansky</Authors>
     <Description>NetTopologySuite plugin for Npgsql, allowing mapping of PostGIS geometry types to NetTopologySuite types.</Description>
     <PackageTags>npgsql postgresql postgres postgis nts ado ado.net database sql</PackageTags>
-    <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -3,7 +3,6 @@
     <Authors>Shay Rojansky</Authors>
     <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
     <PackageTags>npgsql postgresql postgres nodatime date time ado ado.net database sql</PackageTags>
-    <VersionPrefix>4.1.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
+++ b/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
@@ -3,7 +3,6 @@
     <Authors>Shay Rojansky</Authors>
     <Description>PostGIS plugin for Npgsql, allowing raw byte access to PostGIS ypes.</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
-    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -3,7 +3,6 @@
     <Authors>Shay Rojansky;Yoh Deadfall;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
-    <VersionPrefix>4.1.0</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/VSIX/Properties/AssemblyInfo.cs
+++ b/src/VSIX/Properties/AssemblyInfo.cs
@@ -19,4 +19,4 @@ using Microsoft.VisualStudio.Shell;
 // Specifically, the EF6 provider usuall depends on some old Npgsql, and trying to generate an EDM
 // model from an existing database will fail because of this. The following line redirects the EF6
 // to use our own Npgsql instead.
-[assembly: ProvideBindingRedirection(AssemblyName = "Npgsql", NewVersion = "4.1.0.0", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.1.0.0")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Npgsql", NewVersion = "5.0.0.0", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "5.0.0.0")]

--- a/src/VSIX/source.extension.vsixmanifest
+++ b/src/VSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Npgsql.VSIX.07074491-d0c6-4138-9d44-ea3f8920e84b" Version="4.1.0" Language="en-US" Publisher="npgsql" />
+    <Identity Id="Npgsql.VSIX.07074491-d0c6-4138-9d44-ea3f8920e84b" Version="5.0.0" Language="en-US" Publisher="npgsql" />
     <DisplayName>Npgsql PostgreSQL Integration</DisplayName>
     <Description xml:space="preserve">Allows you to connect to PostgreSQL from within Visual Studio via Server Explorer, create EF6 model from existing database, etc.</Description>
     <MoreInfo>http://www.npgsql.org/doc/ddex.html</MoreInfo>


### PR DESCRIPTION
We've talked about this before (or maybe that was regarding EF Core), but I can't recall where we left it.

Targeting CI builds of Npgsql and friends (i.e. plugins) is causing me grief on the EF Core side. Opening this to get a clean set of CI artifacts for some testing.