### PR TITLE
Fix dev Documentation (test.md)

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -25,6 +25,7 @@ By default, the test suite expects an account named `npgsql_tests` with a passwo
 ```
 $ psql -h localhost -U postgres
 postgres=# CREATE USER npgsql_tests PASSWORD 'npgsql_tests' SUPERUSER;
+postgres=# CREATE DATABASE npgsql_tests OWNER npgsql_tests;
 ```
 
 _Note: superuser access is required to create and drop test databases, load extensions (e.g. `hstore`, `postgis`), etc._
@@ -33,7 +34,8 @@ _Note: superuser access is required to create and drop test databases, load exte
 
 ```
 cd ~
-git clone git@github.com:npgsql/npgsql.git
+git clone git@github.com:npgsql/npgsql.git	(use ssh)
+git clone https://github.com/npgsql/npgsql.git	(use https)
 ```
 
 ### Run the test suite


### PR DESCRIPTION
I fixed dev Documentation(doc/dev/tests.md).
When I cloned npgsql and ran the test suite(`dotnet test ./test/Npgsql.Tests`), errors occured.
PostgreSQL log related to this errors were "FATEL: database npgsql_tests does not exist".
So I created database "npgsql_tests" and test succeeded.
Therefore in [Create the npgsql_tests account], I added command `postgres=# CREATE DATABASE npgsql_tests OWNER npgsql_tests;`.

Environment: dev-branch, Visual Studio 2019,

Extra:
When I ran the test suite(`dotnet test ./test/Npgsql.Tests`), errors related to data type 'money' in PostgreSQL occured due to locale(lc_monetary).
Should I add comment to Documentation?
