### PR TITLE
Support System.Text.Json.JsonDocument

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -3,11 +3,13 @@
     <Authors>Shay Rojansky;Yoh Deadfall;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <!-- At this point we target netcoreapp3.0 to avoid taking a dependency on System.Text.Json, which is
+         necessary for all other TFMs. -->
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview7.19362.9" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview8.19405.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Transactions" Pack="false" />
@@ -19,6 +21,6 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Text.Json" Version="4.6.0-preview7.19362.9" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview8.19405.3" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -364,6 +364,12 @@ namespace Npgsql
             return new ReadOnlySpan<byte>(Buffer, ReadPosition, len);
         }
 
+        public ReadOnlyMemory<byte> ReadMemory(int len)
+        {
+            Debug.Assert(len <= ReadBytesLeft);
+            return new ReadOnlyMemory<byte>(Buffer, ReadPosition, len);
+        }
+
         #endregion
 
         #region Read Complex


### PR DESCRIPTION
Closes #2572

Notes:
* While reading is implemented efficiently, writing is quite awful at the moment. This is related to our architecture, which does at least two passes for validation/length calculation, followed by a separate pass for actual writing. We need to implement one-pass writing (#1727), probably by reworking the driver to use System.IO.Pipelines (#2035).
* There is no good story for customizing JSON serialization options. This would be implemented as part of #2568 - mapping to JSON would provide the API where options could be given. Also, at this point three different form of options would be relevant: JsonSerializerOptions, JsonDocumentOptions and JsonWriterOptions. I don't expect us to provide a good story in 4.1, we'll tackle this later.