### PR TITLE
Implement DisposeAsync

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -452,16 +452,12 @@ namespace Npgsql
                 openCount = prevState.Open - 1;
             }
             else
-            {
                 openCount = Interlocked.Decrement(ref State.Open);
-            }
 
             // Unblock a single waiter, if any, to get the slot that just opened up.
             while (_waiting.TryDequeue(out var waiter))
-            {
                 if (waiter.TaskCompletionSource.TrySetResult(null))
                     break;
-            }
 
             // Only turn off the timer one time, when it was this Close that brought Open back to _min.
             if (openCount == _min)


### PR DESCRIPTION
The main scenario to be handled asynchronously, is when a connection (or transaction) is disposed by an open reader is still active, with its resultset needing to be consumed.

Fixes #2597