### PR TITLE
Fix hiding PostgresException #2406

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -866,11 +866,12 @@ namespace Npgsql
                     }
                 }
 
+                PostgresException? error = null;
+
                 try
                 {
                     ReceiveTimeout = UserTimeout;
-                    PostgresException? error = null;
-
+                    
                     while (true)
                     {
                         await ReadBuffer.Ensure(5, async, readingNotifications2);
@@ -955,6 +956,13 @@ namespace Npgsql
                     {
                         EndUserAction();
                     }
+                    throw;
+                }
+                catch (NpgsqlException)
+                {
+                    // An ErrorResponse isn't followed by ReadyForQuery
+                    if (error != null)
+                        throw error;
                     throw;
                 }
             }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -8,6 +8,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -962,7 +963,7 @@ namespace Npgsql
                 {
                     // An ErrorResponse isn't followed by ReadyForQuery
                     if (error != null)
-                        throw error;
+                        ExceptionDispatchInfo.Capture(error).Throw();
                     throw;
                 }
             }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -98,8 +98,7 @@ namespace Npgsql.Tests
                 // Allow some time for the pg_terminate to kill our connection
                 using (var cmd = CreateSleepCommand(conn, 10))
                     Assert.That(() => cmd.ExecuteNonQuery(), Throws.Exception
-                        .TypeOf<NpgsqlException>()
-                        .With.InnerException.InstanceOf<IOException>()
+                        .TypeOf<PostgresException>()
                     );
 
                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));

--- a/test/Npgsql.Tests/NotificationTests.cs
+++ b/test/Npgsql.Tests/NotificationTests.cs
@@ -184,7 +184,7 @@ namespace Npgsql.Tests
                         conn2.ExecuteNonQuery($"SELECT pg_terminate_backend({conn.ProcessID})");
                 });
 
-                Assert.That(() => conn.Wait(), Throws.Exception.TypeOf<NpgsqlException>());
+                Assert.That(() => conn.Wait(), Throws.Exception.TypeOf<PostgresException>());
                 Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
             }
         }


### PR DESCRIPTION
I fix issue #2406 (src/NpgsqlConnector.cs and test/Npgsql.Tests/ConnectionTests.cs, NotificationTests.cs).

Problem
---
NpgsqlConnector don't throw PostgresException due to NpgsqlReadBuffer throwing NpgsqlException when an ErrorResponse isn't followed by a ReadyForQuery.

This issue occurs such as when pooler(pgbouncer) is used and disconnect between pooler and PostgreSQL.


Solution
---
If NpgsqlReadBuffer throw NpgsqlException, NpgsqlConnector catch NpgsqlException. And if `PostgresException? error` isn't null, throw error. 

```
catch (NpgsqlException)
{
    if (error != null)
        throw error;
    throw;
}
```

Should I leave a log about NpgsqlException when NpgsqlConnector throw PostgresException(`if(error != null)`)

I would be very happy if you give some comments and advice.