### PR TITLE
Revert "Recycle NpgsqlTransaction" (#2416)

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -534,8 +534,7 @@ namespace Npgsql
                 if (connector.InTransaction)
                     throw new InvalidOperationException("A transaction is already in progress; nested/concurrent transactions aren't supported.");
 
-                connector.Transaction.Init(level);
-                return connector.Transaction;
+                return new NpgsqlTransaction(this, level);
             }
         }
 

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -19,31 +19,25 @@ namespace Npgsql
         /// Specifies the <see cref="NpgsqlConnection"/> object associated with the transaction.
         /// </summary>
         /// <value>The <see cref="NpgsqlConnection"/> object associated with the transaction.</value>
-        public new NpgsqlConnection? Connection
-        {
-            get
-            {
-                CheckReady();
-                return _connector.Connection;
-            }
-        }
+        public new NpgsqlConnection Connection { get; internal set; }
 
         // Note that with ambient transactions, it's possible for a transaction to be pending after its connection
         // is already closed. So we capture the connector and perform everything directly on it.
-        readonly NpgsqlConnector _connector;
+        NpgsqlConnector _connector;
+
+        /// <summary>
+        /// Specifies the completion state of the transaction.
+        /// </summary>
+        /// <value>The completion state of the transaction.</value>
+        public bool IsCompleted => _connector == null;
 
         /// <summary>
         /// Specifies the <see cref="NpgsqlConnection"/> object associated with the transaction.
         /// </summary>
         /// <value>The <see cref="NpgsqlConnection"/> object associated with the transaction.</value>
-        protected override DbConnection? DbConnection => Connection;
+        protected override DbConnection DbConnection => Connection;
 
-        /// <summary>
-        /// If true, the transaction has been committed/rolled back, but not disposed.
-        /// </summary>
-        internal bool IsCompleted => _connector.TransactionStatus == TransactionStatus.Idle;
-
-        internal bool IsDisposed;
+        bool _isDisposed;
 
         /// <summary>
         /// Specifies the <see cref="System.Data.IsolationLevel">IsolationLevel</see> for this transaction.
@@ -58,7 +52,7 @@ namespace Npgsql
                 return _isolationLevel;
             }
         }
-        IsolationLevel _isolationLevel;
+        readonly IsolationLevel _isolationLevel;
 
         static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlTransaction));
 
@@ -66,46 +60,46 @@ namespace Npgsql
 
         #endregion
 
-        #region Initialization
+        #region Constructors
 
-        internal NpgsqlTransaction(NpgsqlConnector connector)
-            => _connector = connector;
-
-        internal void Init(IsolationLevel isolationLevel = DefaultIsolationLevel)
+        internal NpgsqlTransaction(NpgsqlConnection conn, IsolationLevel isolationLevel = DefaultIsolationLevel)
         {
             Debug.Assert(isolationLevel != IsolationLevel.Chaos);
+
+            Connection = conn;
+            _connector = Connection.CheckReadyAndGetConnector();
 
             if (!_connector.DatabaseInfo.SupportsTransactions)
                 return;
 
             Log.Debug($"Beginning transaction with isolation level {isolationLevel}", _connector.Id);
-            switch (isolationLevel)
-            {
-            case IsolationLevel.RepeatableRead:
-            case IsolationLevel.Snapshot:
-                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransRepeatableRead, 2);
-                break;
-            case IsolationLevel.Serializable:
-                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransSerializable, 2);
-                break;
-            case IsolationLevel.ReadUncommitted:
-                // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still
-                // send as if.
-                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadUncommitted, 2);
-                break;
-            case IsolationLevel.ReadCommitted:
-                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadCommitted, 2);
-                break;
-            case IsolationLevel.Unspecified:
-                isolationLevel = DefaultIsolationLevel;
-                goto case DefaultIsolationLevel;
-            default:
-                throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
+            _connector.Transaction = this;
+            _connector.TransactionStatus = TransactionStatus.Pending;
+
+            switch (isolationLevel) {
+                case IsolationLevel.RepeatableRead:
+                case IsolationLevel.Snapshot:
+                    _connector.PrependInternalMessage(PregeneratedMessages.BeginTransRepeatableRead, 2);
+                    break;
+                case IsolationLevel.Serializable:
+                    _connector.PrependInternalMessage(PregeneratedMessages.BeginTransSerializable, 2);
+                    break;
+                case IsolationLevel.ReadUncommitted:
+                    // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still
+                    // send as if.
+                    _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadUncommitted, 2);
+                    break;
+                case IsolationLevel.ReadCommitted:
+                    _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadCommitted, 2);
+                    break;
+                case IsolationLevel.Unspecified:
+                    isolationLevel = DefaultIsolationLevel;
+                    goto case DefaultIsolationLevel;
+                default:
+                    throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
             }
 
-            _connector.TransactionStatus = TransactionStatus.Pending;
             _isolationLevel = isolationLevel;
-            IsDisposed = false;
         }
 
         #endregion
@@ -128,6 +122,7 @@ namespace Npgsql
             {
                 Log.Debug("Committing transaction", _connector.Id);
                 await _connector.ExecuteInternalCommand(PregeneratedMessages.CommitTransaction, async);
+                Clear();
             }
         }
 
@@ -162,12 +157,13 @@ namespace Npgsql
         /// </summary>
         public override void Rollback() => Rollback(false).GetAwaiter().GetResult();
 
-        Task Rollback(bool async)
+        async Task Rollback(bool async)
         {
             CheckReady();
-            return _connector.DatabaseInfo.SupportsTransactions
-                ? _connector.Rollback(async)
-                : Task.CompletedTask;
+            if (!_connector.DatabaseInfo.SupportsTransactions)
+                return;
+            await _connector.Rollback(async);
+            Clear();
         }
 
         /// <summary>
@@ -319,8 +315,7 @@ namespace Npgsql
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            if (IsDisposed)
-                return;
+            if (_isDisposed) { return; }
 
             if (disposing && !IsCompleted)
             {
@@ -328,7 +323,10 @@ namespace Npgsql
                 Rollback();
             }
 
-            IsDisposed = true;
+            Clear();
+
+            base.Dispose(disposing);
+            _isDisposed = true;
         }
 
 #if !NET461 && !NETSTANDARD2_0
@@ -337,8 +335,7 @@ namespace Npgsql
         /// </summary>
         public override async ValueTask DisposeAsync()
         {
-            if (IsDisposed)
-                return;
+            if (_isDisposed) { return; }
 
             if (!IsCompleted)
             {
@@ -349,15 +346,17 @@ namespace Npgsql
                 }
             }
 
-            IsDisposed = true;
+            _isDisposed = true;
         }
 #endif
 
-        /// <summary>
-        /// Disposes the transaction, without rolling back. Used only in special circumstances, e.g. when
-        /// the connection is broken.
-        /// </summary>
-        internal void DisposeImmediately() => IsDisposed = true;
+#pragma warning disable CS8625
+        internal void Clear()
+        {
+            _connector = null;
+            Connection = null;
+        }
+#pragma warning restore CS8625
 
         #endregion
 
@@ -365,10 +364,20 @@ namespace Npgsql
 
         void CheckReady()
         {
-            if (IsDisposed)
-                throw new ObjectDisposedException(typeof(NpgsqlTransaction).Name);
+            CheckDisposed();
+            CheckCompleted();
+        }
+
+        void CheckCompleted()
+        {
             if (IsCompleted)
                 throw new InvalidOperationException("This NpgsqlTransaction has completed; it is no longer usable.");
+        }
+
+        void CheckDisposed()
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(typeof(NpgsqlTransaction).Name);
         }
 
         #endregion

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -19,9 +19,6 @@ namespace Npgsql.Tests
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 tx.Commit();
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(1));
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
-                tx.Dispose();
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -35,9 +32,6 @@ namespace Npgsql.Tests
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 await tx.CommitAsync();
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(1));
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
-                tx.Dispose();
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -56,9 +50,6 @@ namespace Npgsql.Tests
                 tx.Rollback();
                 Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
-                tx.Dispose();
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -77,9 +68,6 @@ namespace Npgsql.Tests
                 await tx.RollbackAsync();
                 Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<InvalidOperationException>());
-                tx.Dispose();
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
             }
         }
 
@@ -92,6 +80,7 @@ namespace Npgsql.Tests
                 var tx = conn.BeginTransaction();
                 conn.ExecuteNonQuery("INSERT INTO data (name) VALUES ('X')", tx: tx);
                 tx.Dispose();
+                Assert.That(tx.IsCompleted);
                 Assert.That(conn.ExecuteScalar("SELECT COUNT(*) FROM data"), Is.EqualTo(0));
             }
         }
@@ -111,8 +100,8 @@ namespace Npgsql.Tests
                     tx = conn2.BeginTransaction();
                     conn2.ExecuteNonQuery($"INSERT INTO {tableName} (name) VALUES ('X')", tx);
                 }
+                Assert.That(tx.IsCompleted);
                 Assert.That(conn1.ExecuteScalar($"SELECT COUNT(*) FROM {tableName}"), Is.EqualTo(0));
-                Assert.That(() => tx.Connection, Throws.Exception.TypeOf<ObjectDisposedException>());
                 conn1.ExecuteNonQuery($"DROP TABLE {tableName}");
             }
         }


### PR DESCRIPTION
This reverts commit 7b8e117049f381c7130192ffd7fb4f608076d524 (issue #2416) for 4.1, which made us recycle transaction instances on a connector.

* As part of transaction recycling, NpgsqlTransaction.IsCompleted was made internal, since the transaction instance will be revived, IsCompleted will switch from true to false, leading to potential confusion/dangerous behavior. This was a problem for at least one user (#2607).
* Even with transaction recycling, it's still possible to expose an IsCompleted property that would only be valid until the instance is disposed. However, currently there's no requirement to dispose NpgsqlTransaction - the moment a transaction is committed or rolled back, a new one can be started again. Changing that would be an even bigger breaking change.

Note that the commit remains in dev for 5.0, where we should decide on the exact behavior we want, opened #2618 to track.