### PR TITLE
Revert breaking change in NpgsqlTypeMapping.TypeHandlerFactory

### DIFF
--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/Int2VectorHandler.cs
@@ -8,13 +8,13 @@ using NpgsqlTypes;
 namespace Npgsql.TypeHandlers.InternalTypeHandlers
 {
     [TypeMapping("int2vector", NpgsqlDbType.Int2Vector)]
-    class Int2VectorHandlerFactory : INpgsqlTypeHandlerFactory
+    class Int2VectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
-        public NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
+        public override NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn)
             => new Int2VectorHandler(pgType, conn.Connector!.TypeMapper.DatabaseInfo.ByName["smallint"]
                                              ?? throw new NpgsqlException("Two types called 'smallint' defined in the database"));
 
-        public Type DefaultValueType => typeof(short[]);
+        public override Type DefaultValueType => typeof(short[]);
     }
 
     /// <summary>

--- a/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalTypeHandlers/OIDVectorHandler.cs
@@ -8,13 +8,13 @@ using NpgsqlTypes;
 namespace Npgsql.TypeHandlers.InternalTypeHandlers
 {
     [TypeMapping("oidvector", NpgsqlDbType.Oidvector)]
-    class OIDVectorHandlerFactory : INpgsqlTypeHandlerFactory
+    class OIDVectorHandlerFactory : NpgsqlTypeHandlerFactory
     {
-        public NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
+        public override NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn)
             => new OIDVectorHandler(pgType, conn.Connector!.TypeMapper.DatabaseInfo.ByName["oid"]
                                     ?? throw new NpgsqlException("Two types called 'oid' defined in the database"));
 
-        public Type DefaultValueType => typeof(uint[]);
+        public override Type DefaultValueType => typeof(uint[]);
     }
 
     /// <summary>

--- a/src/Npgsql/TypeHandling/DefaultTypeHandlerFactory.cs
+++ b/src/Npgsql/TypeHandling/DefaultTypeHandlerFactory.cs
@@ -7,7 +7,7 @@ namespace Npgsql.TypeHandling
     /// <summary>
     /// A type handler factory used to instantiate Npgsql's built-in type handlers.
     /// </summary>
-    class DefaultTypeHandlerFactory : INpgsqlTypeHandlerFactory
+    class DefaultTypeHandlerFactory : NpgsqlTypeHandlerFactory
     {
         readonly Type _handlerType;
 
@@ -27,9 +27,9 @@ namespace Npgsql.TypeHandling
             _handlerType = handlerType;
         }
 
-        public NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn)
+        public override NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn)
             => (NpgsqlTypeHandler)Activator.CreateInstance(_handlerType, pgType)!;
 
-        public Type DefaultValueType { get; }
+        public override Type DefaultValueType { get; }
     }
 }

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandlerFactory.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandlerFactory.cs
@@ -5,21 +5,23 @@ using Npgsql.TypeMapping;
 namespace Npgsql.TypeHandling
 {
     /// <summary>
-    /// Interface for all type handler factories, which construct type handlers that know how
+    /// Base class for all type handler factories, which construct type handlers that know how
     /// to read and write CLR types from/to PostgreSQL types.
-    /// Do not inherit from this class, inherit from <see cref="NpgsqlTypeHandlerFactory{T}"/> instead.
     /// </summary>
-    public interface INpgsqlTypeHandlerFactory
+    /// <remarks>
+    /// In general, do not inherit from this class, inherit from <see cref="NpgsqlTypeHandlerFactory{T}"/> instead.
+    /// </remarks>
+    public abstract class NpgsqlTypeHandlerFactory
     {
         /// <summary>
         /// Creates a type handler.
         /// </summary>
-        NpgsqlTypeHandler Create(PostgresType pgType, NpgsqlConnection conn);
+        public abstract NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn);
 
         /// <summary>
         /// The default CLR type that handlers produced by this factory will read and write.
         /// </summary>
-        Type DefaultValueType { get; }
+        public abstract Type DefaultValueType { get; }
     }
 
     /// <summary>
@@ -31,17 +33,18 @@ namespace Npgsql.TypeHandling
     /// <seealso cref="NpgsqlConnection.GlobalTypeMapper"/>
     /// <seealso cref="NpgsqlConnection.TypeMapper"/>
     /// <typeparam name="TDefault">The default CLR type that handlers produced by this factory will read and write.</typeparam>
-    public abstract class NpgsqlTypeHandlerFactory<TDefault> : INpgsqlTypeHandlerFactory
+    public abstract class NpgsqlTypeHandlerFactory<TDefault> : NpgsqlTypeHandlerFactory
     {
         /// <summary>
         /// Creates a type handler
         /// </summary>
         public abstract NpgsqlTypeHandler<TDefault> Create(PostgresType pgType, NpgsqlConnection conn);
 
-        NpgsqlTypeHandler INpgsqlTypeHandlerFactory.Create(PostgresType pgType, NpgsqlConnection conn)
+        /// <inheritdoc />
+        public override NpgsqlTypeHandler CreateNonGeneric(PostgresType pgType, NpgsqlConnection conn)
             => Create(pgType, conn);
 
         /// <inheritdoc />
-        public Type DefaultValueType => typeof(TDefault);
+        public override Type DefaultValueType => typeof(TDefault);
     }
 }

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -285,7 +285,7 @@ namespace Npgsql.TypeMapping
                 return;
             }
 
-            var handler = mapping.TypeHandlerFactory.Create(pgType, connector.Connection!);
+            var handler = mapping.TypeHandlerFactory.CreateNonGeneric(pgType, connector.Connection!);
             BindType(handler, pgType, mapping.NpgsqlDbType, mapping.DbTypes, mapping.ClrTypes);
 
             if (!externalCall)

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -158,13 +158,13 @@ namespace Npgsql.TypeMapping
         void SetupGlobalTypeMapper()
         {
             // Look for TypeHandlerFactories with mappings in our assembly, set them up
-            foreach (var t in typeof(TypeMapperBase).GetTypeInfo().Assembly.GetTypes().Where(t => typeof(INpgsqlTypeHandlerFactory).IsAssignableFrom(t.GetTypeInfo())))
+            foreach (var t in typeof(TypeMapperBase).GetTypeInfo().Assembly.GetTypes().Where(t => typeof(NpgsqlTypeHandlerFactory).IsAssignableFrom(t.GetTypeInfo())))
             {
                 var mappingAttributes = t.GetTypeInfo().GetCustomAttributes(typeof(TypeMappingAttribute), false);
                 if (!mappingAttributes.Any())
                     continue;
 
-                var factory = (INpgsqlTypeHandlerFactory)Activator.CreateInstance(t)!;
+                var factory = (NpgsqlTypeHandlerFactory)Activator.CreateInstance(t)!;
 
                 foreach (TypeMappingAttribute m in mappingAttributes)
                 {

--- a/src/Npgsql/TypeMapping/NpgsqlTypeMapping.cs
+++ b/src/Npgsql/TypeMapping/NpgsqlTypeMapping.cs
@@ -53,7 +53,7 @@ namespace Npgsql.TypeMapping
         /// A factory for a type handler that will be used to read and write values for PostgreSQL type.
         /// </summary>
         [DisallowNull]
-        public INpgsqlTypeHandlerFactory? TypeHandlerFactory { get; set; }
+        public NpgsqlTypeHandlerFactory? TypeHandlerFactory { get; set; }
 
         /// <summary>
         /// Builds an <see cref="NpgsqlTypeMapping"/> that can be added to an <see cref="INpgsqlTypeMapper"/>.
@@ -82,7 +82,7 @@ namespace Npgsql.TypeMapping
         internal NpgsqlTypeMapping(
             string pgTypeName,
             NpgsqlDbType? npgsqlDbType, DbType[]? dbTypes, Type[]? clrTypes, DbType? inferredDbType,
-            INpgsqlTypeHandlerFactory typeHandlerFactory)
+            NpgsqlTypeHandlerFactory typeHandlerFactory)
         {
             PgTypeName = pgTypeName;
             NpgsqlDbType = npgsqlDbType;
@@ -132,7 +132,7 @@ namespace Npgsql.TypeMapping
         /// <summary>
         /// A factory for a type handler that will be used to read and write values for PostgreSQL type.
         /// </summary>
-        public INpgsqlTypeHandlerFactory TypeHandlerFactory { get; }
+        public NpgsqlTypeHandlerFactory TypeHandlerFactory { get; }
 
         /// <summary>
         /// The default CLR type that handlers produced by this factory will read and write.


### PR DESCRIPTION
Its type is now NpgsqlTypeHandlerFactory again, instead of INpgsqlTypeHandlerFactory.

Fixes #2607