### PR TITLE
Fix idle pruning with sampling based implementation

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -189,11 +189,6 @@ namespace Npgsql
         NpgsqlCommand? _currentCommand;
 
         /// <summary>
-        /// If pooled, the timestamp when this connector was returned to the pool.
-        /// </summary>
-        internal DateTime ReleaseTimestamp { get; set; } = DateTime.MaxValue;
-
-        /// <summary>
         /// If pooled, the pool index on which this connector will be returned to the pool.
         /// </summary>
         internal int PoolIndex { get; set; } = int.MaxValue;

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -201,8 +201,8 @@ namespace Npgsql.Tests
             }
         }
 
-        //[Test, NonParallelizable]
-        //[Explicit("Flaky, based on timing")]
+        [Test, NonParallelizable]
+        [Explicit("Flaky, based on timing")]
         public void PruneIdleConnectors()
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
@@ -224,12 +224,12 @@ namespace Npgsql.Tests
 
                 Thread.Sleep(1500);
 
-                // Pruning attempted, but ConnectionIdleLifetime not yet reached
+                // ConnectionIdleLifetime not yet reached.
                 AssertPoolState(pool, 2, 1);
 
                 Thread.Sleep(1500);
 
-                // ConnectionIdleLifetime reached, but only one idle connection should be pruned (MinPoolSize=2)
+                // ConnectionIdleLifetime reached, one idle connection should be pruned (MinPoolSize=2)
                 AssertPoolState(pool, 1, 1);
             }
         }

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Sockets;
 using System.Threading;


### PR DESCRIPTION
Fixes idle pruning with sampling based implementation.
This type of manual reset/reactivation timer has a smaller lock range and no need for array copies compared to one where you'd have to worry about overlapping callbacks.

There's one possible case where enable/disable is called right when the median is calculated that might take a bit longer than we want but that entirely depends on the sample size to sort.
Ideally I'd rip this Enable/Disable from any allocate/release flows and replace it with some timer logic that uses a back-off period instead, what do you think @roji?

Also I haven't removed ReleaseTimestamp from Connector yet, now that it's not used anymore should I do that?

Fixes #2224.