### PR TITLE
Fix #2520: NpgsqlParameter.DataTypeName defaults to NpgsqlDbType

### DIFF
--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -369,7 +369,7 @@ namespace Npgsql
             {
                 if (_dataTypeName != null)
                     return _dataTypeName;
-                throw new NotImplementedException("Infer from others");
+                return NpgsqlDbType.ToString();
             }
             set
             {


### PR DESCRIPTION
Instead of inferring, I thought it best to use NpgsqlDbType as it uses interference interanlly and is closer to expected functionality 