### PR TITLE
Decreased memory usage in name translator

### DIFF
--- a/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
+++ b/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
@@ -47,22 +47,22 @@ namespace Npgsql.NameTranslation
         /// <summary>
         /// Converts a string to its snake_case equivalent.
         /// </summary>
-        /// <param name="value">The value to convert.</param>
-        public static string ConvertToSnakeCase(string value)
+        /// <param name="name">The value to convert.</param>
+        public static string ConvertToSnakeCase(string name)
         {
-            const char underscore = '_';
-            const UnicodeCategory noneCategory = UnicodeCategory.Control;
+            if (string.IsNullOrEmpty(name))
+                return name;
 
-            var builder = new StringBuilder();
-            var previousCategory = noneCategory;
+            var builder = new StringBuilder(name.Length + Math.Min(2, name.Length / 5));
+            var previousCategory = default(UnicodeCategory?);
 
-            for (var currentIndex = 0; currentIndex< value.Length; currentIndex++)
+            for (var currentIndex = 0; currentIndex < name.Length; currentIndex++)
             {
-                var currentChar = value[currentIndex];
-                if (currentChar == underscore)
+                var currentChar = name[currentIndex];
+                if (currentChar == '_')
                 {
-                    builder.Append(underscore);
-                    previousCategory = noneCategory;
+                    builder.Append('_');
+                    previousCategory = null;
                     continue;
                 }
 
@@ -75,10 +75,10 @@ namespace Npgsql.NameTranslation
                             previousCategory == UnicodeCategory.LowercaseLetter ||
                             previousCategory != UnicodeCategory.DecimalDigitNumber &&
                             currentIndex > 0 &&
-                            currentIndex + 1 < value.Length &&
-                            char.IsLower(value[currentIndex + 1]))
+                            currentIndex + 1 < name.Length &&
+                            char.IsLower(name[currentIndex + 1]))
                         {
-                            builder.Append(underscore);
+                            builder.Append('_');
                         }
 
                         currentChar = char.ToLower(currentChar);
@@ -87,11 +87,11 @@ namespace Npgsql.NameTranslation
                     case UnicodeCategory.LowercaseLetter:
                     case UnicodeCategory.DecimalDigitNumber:
                         if (previousCategory == UnicodeCategory.SpaceSeparator)
-                            builder.Append(underscore);
+                            builder.Append('_');
                         break;
 
                     default:
-                        if (previousCategory != noneCategory)
+                        if (previousCategory != null)
                             previousCategory = UnicodeCategory.SpaceSeparator;
                         continue;
                 }


### PR DESCRIPTION
During review dotnet/corefx#41354 it was found that the snake case translator allocates a lot of memory, so this PR is going to fix it and synchronize implementations.

Will backport this to 4.1.2.