### PR TITLE
Add unit of measure and default to ConnectionTimeout

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -136,7 +136,7 @@ namespace Npgsql
 #nullable restore
 
         /// <summary>
-        /// Gets or sets the wait time before terminating the attempt  to execute a command and generating an error.
+        /// Gets or sets the wait time (in seconds) before terminating the attempt  to execute a command and generating an error.
         /// </summary>
         /// <value>The time (in seconds) to wait for the command to execute. The default value is 30 seconds.</value>
         [DefaultValue(DefaultTimeout)]

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -363,14 +363,14 @@ namespace Npgsql
 
         /// <summary>
         /// Gets the time (in seconds) to wait while trying to establish a connection
-        /// before terminating the attempt and generating an error. The default value is 15 seconds.
+        /// before terminating the attempt and generating an error.
         /// </summary>
         /// <value>The time (in seconds) to wait for a connection to open. The default value is 15 seconds.</value>
         public override int ConnectionTimeout => Settings.Timeout;
 
         /// <summary>
         /// Gets the time (in seconds) to wait while trying to execute a command
-        /// before terminating the attempt and generating an error. The default value is 20 seconds.
+        /// before terminating the attempt and generating an error.
         /// </summary>
         /// <value>The time (in seconds) to wait for a command to complete. The default value is 20 seconds.</value>
         public int CommandTimeout => Settings.CommandTimeout;

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -362,15 +362,15 @@ namespace Npgsql
         public int Port => Settings.Port;
 
         /// <summary>
-        /// Gets the time to wait while trying to establish a connection
-        /// before terminating the attempt and generating an error.
+        /// Gets the time (in seconds) to wait while trying to establish a connection
+        /// before terminating the attempt and generating an error. The default value is 15 seconds.
         /// </summary>
         /// <value>The time (in seconds) to wait for a connection to open. The default value is 15 seconds.</value>
         public override int ConnectionTimeout => Settings.Timeout;
 
         /// <summary>
-        /// Gets the time to wait while trying to execute a command
-        /// before terminating the attempt and generating an error.
+        /// Gets the time (in seconds) to wait while trying to execute a command
+        /// before terminating the attempt and generating an error. The default value is 20 seconds.
         /// </summary>
         /// <value>The time (in seconds) to wait for a command to complete. The default value is 20 seconds.</value>
         public int CommandTimeout => Settings.CommandTimeout;


### PR DESCRIPTION
The summary, not value, is what is shown by consumers  when using autocomplete.  This change allows consumers to easily see the unit of measure (seconds) as well as the default value when using autocomplete/code completion

I'm proposing this change because it wasn't clear to me if the timeout was in seconds or milliseconds.