### PR TITLE
Add TestUtil.MaximumPgVersion() and ignore tests using 'WITH OIDS'

### DIFF
--- a/test/Npgsql.Tests/ReaderOldSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderOldSchemaTests.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Tests
                                 field_pk2                      INT2 NOT NULL,
                                 field_serial                   SERIAL,
                                 CONSTRAINT data2_pkey PRIMARY KEY (field_pk1, field_pk2)
-                                ) WITH OIDS");
+                                )");
 
                 using (var command = new NpgsqlCommand("SELECT * FROM DATA2", conn))
                 using (var dr = command.ExecuteReader(CommandBehavior.KeyInfo))

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -42,6 +42,18 @@ namespace Npgsql.Tests
             }
         }
 
+        public static void MaximumPgVersionExclusive(NpgsqlConnection conn, string maxVersion, string? ignoreText = null)
+        {
+            var max = new Version(maxVersion);
+            if (conn.PostgreSqlVersion >= max)
+            {
+                var msg = $"Postgresql backend version {conn.PostgreSqlVersion} is greater than or equal to the required (exclusive) maximum of {maxVersion}";
+                if (ignoreText != null)
+                    msg += ": " + ignoreText;
+                Assert.Ignore(msg);
+            }
+        }
+
         static readonly Version MinCreateExtensionVersion = new Version(9, 1);
         public static void EnsureExtension(NpgsqlConnection conn, string extension, string? minVersion = null)
         {


### PR DESCRIPTION
Support for 'CREATE TABLE ... WITH OIDS' has been removed in PostgreSQL 12.0.
See https://www.postgresql.org/docs/12/release-12.html#id-1.11.6.5.4