### PR TITLE
Guard against double pool returns from NpgsqlConnection.Close

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -605,60 +605,56 @@ namespace Npgsql
 
         internal Task Close(bool wasBroken, bool async)
         {
-            if (Connector == null)
+            // Even though NpgsqlConnection isn't thread safe we'll make sure this part is.
+            // Because we really don't want double returns to the pool.
+            var connector = Interlocked.Exchange(ref Connector, null);
+            if (connector == null)
                 return Task.CompletedTask;
-            var connectorId = Connector.Id;
-            Log.Trace("Closing connection...", connectorId);
+
             _wasBroken = wasBroken;
 
-            if (Connector.HasOngoingOperation)
-                return CloseOngoingOperationAndFinish();
+            Log.Trace("Closing connection...", connector.Id);
 
-            FinishClose();
+            if (connector.HasOngoingOperation)
+                return CloseOngoingOperationAndFinish(this, connector, async);
+
+            FinishClose(this, connector);
             return Task.CompletedTask;
 
-            async Task CloseOngoingOperationAndFinish()
+            static async Task CloseOngoingOperationAndFinish(NpgsqlConnection connection, NpgsqlConnector connector, bool async)
             {
-                await Connector!.CloseOngoingOperations(async);
+                // This method could re-enter connection.Close() due to an underlying connection failure.
+                await connector.CloseOngoingOperations(async);
 
-                // The connector has closed us during CloseOngoingOperations due to an underlying failure.
-                if (Connector == null)
-                    return;
-
-                FinishClose();
+                FinishClose(connection, connector);
             }
 
-            void FinishClose()
+            static void FinishClose(NpgsqlConnection connection, NpgsqlConnector connector)
             {
-                var connector = Connector!;
-                if (Settings.Pooling)
+                // A System.Transactions transaction is still in progress, we need to wait for it to complete.
+                if (connection.EnlistedTransaction != null)
                 {
-                    if (EnlistedTransaction == null)
-                        _pool!.Release(connector);
-                    else
-                    {
-                        // A System.Transactions transaction is still in progress, we need to wait for it to complete.
-                        // Close the connection and disconnect it from the resource manager but leave the connector
-                        // in a enlisted pending list in the pool.
-                        _pool!.AddPendingEnlistedConnector(connector, EnlistedTransaction);
-                        connector.Connection = null;
-                        EnlistedTransaction = null;
-                    }
-                }
-                else // Non-pooled connection
-                {
-                    if (EnlistedTransaction == null)
-                        connector.Close();
+                    // Close the connection and disconnect it from the resource manager but leave the connector
+                    // in a enlisted pending list in the pool.
+                    if (connection.Settings.Pooling)
+                        connection._pool!.AddPendingEnlistedConnector(connector, connection.EnlistedTransaction);
+
                     // If a non-pooled connection is being closed but is enlisted in an ongoing
                     // TransactionScope, simply detach the connector from the connection and leave
                     // it open. It will be closed when the TransactionScope is disposed.
                     connector.Connection = null;
-                    EnlistedTransaction = null;
+                    connection.EnlistedTransaction = null;
+                }
+                else
+                {
+                    if (connection.Settings.Pooling)
+                        connection._pool!.Release(connector);
+                    else
+                        connector.Close();
                 }
 
-                Log.Debug("Connection closed", connectorId);
-                Connector = null;
-                OnStateChange(OpenToClosedEventArgs);
+                Log.Debug("Connection closed", connector.Id);
+                connection.OnStateChange(OpenToClosedEventArgs);
             }
         }
 


### PR DESCRIPTION
This could be a fix for the intermittent failures we see on CI #2552.
Generally it should also make me sleep better knowing no user code could cause multiple pool returns.

There's some extra changes to fix the local function sync/async pattern here. As local function capturing causes allocations when the local function is async or a generator. https://github.com/dotnet/roslyn/issues/18946