### PR TITLE
Respect NOT NULL constraints on domain types in arrays.

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -113,7 +113,7 @@ namespace Npgsql
         static string GenerateTypesQuery(bool withRange, bool withEnum, bool withEnumSortOrder, bool loadTableComposites, bool withTypeCategory)
             => $@"
 /*** Load all supported types ***/
-SELECT ns.nspname, a.typname, a.oid, a.typbasetype,
+SELECT ns.nspname, a.typname, a.oid, a.typbasetype, a.typnotnull,
 CASE WHEN pg_proc.proname='array_recv' THEN 'a' ELSE a.typtype END AS typtype,
 CASE
   WHEN pg_proc.proname='array_recv' THEN a.typelem
@@ -264,7 +264,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};" : "")}
                             Log.Trace($"Domain type '{internalName}' refers to unknown base type with OID {baseTypeOID}, skipping", conn.ProcessID);
                             continue;
                         }
-                        var domainType = new PostgresDomainType(ns, internalName, oid, basePostgresType);
+                        var domainType = new PostgresDomainType(ns, internalName, oid, basePostgresType, reader.GetString("typnotnull") == "t");
                         byOID[domainType.OID] = domainType;
                         continue;
 

--- a/src/Npgsql/PostgresTypes/PostgresDomainType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresDomainType.cs
@@ -22,12 +22,19 @@ namespace Npgsql.PostgresTypes
         public PostgresType BaseType { get; }
 
         /// <summary>
+        /// <b>True</b> if the domain has a NOT NULL constraint, otherwise <b>false</b>.
+        /// </summary>
+        [PublicAPI]
+        public bool NotNull { get; }
+
+        /// <summary>
         /// Constructs a representation of a PostgreSQL domain data type.
         /// </summary>
-        protected internal PostgresDomainType(string ns, string name, uint oid, PostgresType baseType)
+        protected internal PostgresDomainType(string ns, string name, uint oid, PostgresType baseType, bool notNull)
             : base(ns, name, oid)
         {
             BaseType = baseType;
+            NotNull = notNull;
         }
 
         internal override PostgresFacets GetFacets(int typeModifier)


### PR DESCRIPTION
Return non-nullable arrays from NpgsqlDataReader.GetValue() for arrays
of a domain with a NOT NULL constraint.

Closes #2720