### PR TITLE
Fix idle pruning #2708

### DIFF
--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -83,7 +83,7 @@ namespace Npgsql
                 var pool = kv.Pool;
                 if (pool == null)
                     return sum;
-                sum += pool.State.Idle;
+                sum += pool.Statistics.Idle;
             }
             return sum;
         }
@@ -98,7 +98,7 @@ namespace Npgsql
                 var pool = kv.Pool;
                 if (pool == null)
                     return sum;
-                var (_, _, busy) = pool.State;
+                var (_, _, busy, _) = pool.Statistics;
                 sum += busy;
             }
             return sum;

--- a/test/Npgsql.Tests/PoolManagerTests.cs
+++ b/test/Npgsql.Tests/PoolManagerTests.cs
@@ -43,11 +43,11 @@ namespace Npgsql.Tests
             using (OpenConnection()) {}
             // Now have one connection in the pool
             Assert.That(PoolManager.TryGetValue(ConnectionString, out var pool), Is.True);
-            Assert.That(pool!.State.Idle, Is.EqualTo(1));
+            Assert.That(pool!.Statistics.Idle, Is.EqualTo(1));
 
             NpgsqlConnection.ClearAllPools();
-            Assert.That(pool.State.Idle, Is.Zero);
-            Assert.That(pool.State.Open, Is.Zero);
+            Assert.That(pool.Statistics.Idle, Is.Zero);
+            Assert.That(pool.Statistics.Open, Is.Zero);
         }
 
         [Test]
@@ -61,11 +61,11 @@ namespace Npgsql.Tests
 
                 NpgsqlConnection.ClearAllPools();
                 Assert.That(PoolManager.TryGetValue(ConnectionString, out pool), Is.True);
-                Assert.That(pool!.State.Idle, Is.Zero);
-                Assert.That(pool.State.Open, Is.EqualTo(1));
+                Assert.That(pool!.Statistics.Idle, Is.Zero);
+                Assert.That(pool.Statistics.Open, Is.EqualTo(1));
             }
-            Assert.That(pool.State.Idle, Is.Zero);
-            Assert.That(pool.State.Open, Is.Zero);
+            Assert.That(pool.Statistics.Idle, Is.Zero);
+            Assert.That(pool.Statistics.Open, Is.Zero);
         }
 
         [SetUp]

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace Npgsql.Tests
 {
+    [NonParallelizable]
     class PoolTests : TestBase
     {
         [Test]

--- a/test/Npgsql.Tests/SystemTransactionTests.cs
+++ b/test/Npgsql.Tests/SystemTransactionTests.cs
@@ -150,7 +150,7 @@ namespace Npgsql.Tests
             }
             AssertNumberOfRows(1);
             Assert.True(PoolManager.TryGetValue(connString, out var pool));
-            Assert.That(pool!.State.Idle, Is.EqualTo(1));
+            Assert.That(pool!.Statistics.Idle, Is.EqualTo(1));
 
             using (var conn = new NpgsqlConnection(connString))
                 NpgsqlConnection.ClearPool(conn);

--- a/test/Npgsql.Tests/TestBase.cs
+++ b/test/Npgsql.Tests/TestBase.cs
@@ -19,11 +19,17 @@ namespace Npgsql.Tests
 
         #region Utilities for use by tests
 
-        protected virtual NpgsqlConnection OpenConnection(string? connectionString = null)
+        protected virtual NpgsqlConnection CreateConnection(string? connectionString = null)
         {
             if (connectionString == null)
                 connectionString = ConnectionString;
             var conn = new NpgsqlConnection(connectionString);
+            return conn;
+        }
+
+        protected virtual NpgsqlConnection OpenConnection(string? connectionString = null)
+        {
+            var conn = CreateConnection(connectionString);
             try
             {
                 conn.Open();


### PR DESCRIPTION
Fix for #2708.
Relatively minor fixes in the pool, though I must apologize for the sloppiness, the off by ones  completely slipped by me.

I believe the _min tests are correct like this, the Enable side has to go past _min which is why prevOpenCount is faithful, "we're past that". While Disable has to do it at openCount == _min current state inclusive.

@roji I'm not super happy the tests are so coupled to the specific timer implementation but it seems pretty unavoidable.

@rmurdough thanks for the report and @kae for the fixes!