### PR TITLE
support connection URI

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -148,7 +148,7 @@ namespace Npgsql
                 try
                 {
                     var convertedValue = p.PropertyType.GetTypeInfo().IsEnum && value is string str
-                        ? Enum.Parse(p.PropertyType, str)
+                        ? Enum.Parse(p.PropertyType, str, true)
                         : Convert.ChangeType(value, p.PropertyType);
                     p.SetValue(this, convertedValue);
                 }
@@ -273,6 +273,7 @@ namespace Npgsql
         [Description("The hostname or IP address of the PostgreSQL server to connect to.")]
         [DisplayName("Host")]
         [NpgsqlConnectionStringProperty("Server")]
+        [NpgsqlConnectionURIParameter("host", "hostaddr")]
         public string? Host
         {
             get => _host;
@@ -292,6 +293,7 @@ namespace Npgsql
         [Description("The TCP port of the PostgreSQL server.")]
         [DisplayName("Port")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("port")]
         [DefaultValue(NpgsqlConnection.DefaultPort)]
         public int Port
         {
@@ -315,6 +317,7 @@ namespace Npgsql
         [Description("The PostgreSQL database to connect to.")]
         [DisplayName("Database")]
         [NpgsqlConnectionStringProperty("DB")]
+        [NpgsqlConnectionURIParameter("dbname", "database", "db")]
         public string? Database
         {
             get => _database;
@@ -333,6 +336,7 @@ namespace Npgsql
         [Description("The username to connect with. Not required if using IntegratedSecurity.")]
         [DisplayName("Username")]
         [NpgsqlConnectionStringProperty("User Name", "UserId", "User Id", "UID")]
+        [NpgsqlConnectionURIParameter("user", "username", "user_name", "user_id", "uid")]
         public string? Username
         {
             get => _username;
@@ -352,6 +356,7 @@ namespace Npgsql
         [PasswordPropertyText(true)]
         [DisplayName("Password")]
         [NpgsqlConnectionStringProperty("PSW", "PWD")]
+        [NpgsqlConnectionURIParameter("password", "psw", "pwd")]
         public string? Password
         {
             get => _password;
@@ -370,6 +375,7 @@ namespace Npgsql
         [Description("Path to a PostgreSQL password file (PGPASSFILE), from which the password would be taken.")]
         [DisplayName("Passfile")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("passfile")]
         public string? Passfile
         {
             get => _passfile;
@@ -389,6 +395,7 @@ namespace Npgsql
         [Description("The optional application name parameter to be sent to the backend during connection initiation")]
         [DisplayName("Application Name")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("application_name", "fallback_application_name")]
         public string? ApplicationName
         {
             get => _applicationName;
@@ -408,6 +415,7 @@ namespace Npgsql
         [DisplayName("Enlist")]
         [DefaultValue(true)]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("enlist")]
         public bool Enlist
         {
             get => _enlist;
@@ -426,6 +434,7 @@ namespace Npgsql
         [Description("Gets or sets the schema search path.")]
         [DisplayName("Search Path")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("search_path")]
         public string? SearchPath
         {
             get => _searchPath;
@@ -444,6 +453,7 @@ namespace Npgsql
         [Description("Gets or sets the client_encoding parameter.")]
         [DisplayName("Client Encoding")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("client_encoding")]
         public string? ClientEncoding
         {
             get => _clientEncoding;
@@ -463,6 +473,7 @@ namespace Npgsql
         [DisplayName("Encoding")]
         [DefaultValue("UTF8")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("encoding")]
         public string Encoding
         {
             get => _encoding;
@@ -481,6 +492,7 @@ namespace Npgsql
         [Description("Gets or sets the PostgreSQL session timezone, in Olson/IANA database format.")]
         [DisplayName("Timezone")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("timezone")]
         public string? Timezone
         {
             get => _timezone;
@@ -503,6 +515,7 @@ namespace Npgsql
         [Description("Controls whether SSL is required, disabled or preferred, depending on server support.")]
         [DisplayName("SSL Mode")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("sslmode", "ssl")]
         public SslMode SslMode
         {
             get => _sslMode;
@@ -521,6 +534,7 @@ namespace Npgsql
         [Description("Whether to trust the server certificate without validating it.")]
         [DisplayName("Trust Server Certificate")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("trust_server_certificate")]
         public bool TrustServerCertificate
         {
             get => _trustServerCertificate;
@@ -539,6 +553,7 @@ namespace Npgsql
         [Description("Location of a client certificate to be sent to the server.")]
         [DisplayName("Client Certificate")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("sslcert", "client_certificate")]
         public string? ClientCertificate
         {
             get => _clientCertificate;
@@ -558,6 +573,7 @@ namespace Npgsql
         [Description("Whether to check the certificate revocation list during authentication.")]
         [DisplayName("Check Certificate Revocation")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("check_certificate_revocation")]
         public bool CheckCertificateRevocation
         {
             get => _checkCertificateRevocation;
@@ -576,6 +592,7 @@ namespace Npgsql
         [Description("Whether to use Windows integrated security to log in.")]
         [DisplayName("Integrated Security")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("integrated_security")]
         public bool IntegratedSecurity
         {
             get => _integratedSecurity;
@@ -598,6 +615,7 @@ namespace Npgsql
         [Description("The Kerberos service name to be used for authentication.")]
         [DisplayName("Kerberos Service Name")]
         [NpgsqlConnectionStringProperty("Krbsrvname")]
+        [NpgsqlConnectionURIParameter("krbsrvname")]
         [DefaultValue("postgres")]
         public string KerberosServiceName
         {
@@ -617,6 +635,7 @@ namespace Npgsql
         [Description("The Kerberos realm to be used for authentication.")]
         [DisplayName("Include Realm")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("include_realm")]
         public bool IncludeRealm
         {
             get => _includeRealm;
@@ -635,6 +654,7 @@ namespace Npgsql
         [Description("Gets or sets a Boolean value that indicates if security-sensitive information, such as the password, is not returned as part of the connection if the connection is open or has ever been in an open state.")]
         [DisplayName("Persist Security Info")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("persist_security_info")]
         public bool PersistSecurityInfo
         {
             get => _persistSecurityInfo;
@@ -657,6 +677,7 @@ namespace Npgsql
         [Description("Whether connection pooling should be used.")]
         [DisplayName("Pooling")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("pooling")]
         [DefaultValue(true)]
         public bool Pooling
         {
@@ -676,6 +697,7 @@ namespace Npgsql
         [Description("The minimum connection pool size.")]
         [DisplayName("Minimum Pool Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("minimum_pool_size")]
         [DefaultValue(0)]
         public int MinPoolSize
         {
@@ -698,6 +720,7 @@ namespace Npgsql
         [Description("The maximum connection pool size.")]
         [DisplayName("Maximum Pool Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("maximum_pool_size")]
         [DefaultValue(100)]
         public int MaxPoolSize
         {
@@ -722,6 +745,7 @@ namespace Npgsql
         [Description("The time to wait before closing unused connections in the pool if the count of all connections exceeds MinPoolSize.")]
         [DisplayName("Connection Idle Lifetime")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("connection_idle_lifetime")]
         [DefaultValue(300)]
         public int ConnectionIdleLifetime
         {
@@ -743,6 +767,7 @@ namespace Npgsql
         [Description("How many seconds the pool waits before attempting to prune idle connections that are beyond idle lifetime.")]
         [DisplayName("Connection Pruning Interval")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("connection_pruning_interval")]
         [DefaultValue(10)]
         public int ConnectionPruningInterval
         {
@@ -767,6 +792,7 @@ namespace Npgsql
         [Description("The time to wait (in seconds) while trying to establish a connection before terminating the attempt and generating an error.")]
         [DisplayName("Timeout")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("connect_timeout")]
         [DefaultValue(DefaultTimeout)]
         public int Timeout
         {
@@ -793,6 +819,7 @@ namespace Npgsql
         [DisplayName("Command Timeout")]
         [NpgsqlConnectionStringProperty]
         [DefaultValue(NpgsqlCommand.DefaultTimeout)]
+        [NpgsqlConnectionURIParameter("command_timeout")]
         public int CommandTimeout
         {
             get => _commandTimeout;
@@ -814,6 +841,7 @@ namespace Npgsql
         [Description("The time to wait (in seconds) while trying to execute a an internal command before terminating the attempt and generating an error. -1 uses CommandTimeout, 0 means no timeout.")]
         [DisplayName("Internal Command Timeout")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("internal_command_timeout")]
         [DefaultValue(-1)]
         public int InternalCommandTimeout
         {
@@ -845,6 +873,7 @@ namespace Npgsql
         [Description("The database template to specify when creating a database in Entity Framework. If not specified, PostgreSQL defaults to \"template1\".")]
         [DisplayName("EF Template Database")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("ef_template_database")]
         public string? EntityTemplateDatabase
         {
             get => _entityTemplateDatabase;
@@ -865,6 +894,7 @@ namespace Npgsql
         [Description("The database admin to specify when creating and dropping a database in Entity Framework. If not specified, defaults to \"template1\".")]
         [DisplayName("EF Admin Database")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("ef_admin_database")]
         public string? EntityAdminDatabase
         {
             get => _entityAdminDatabase;
@@ -888,6 +918,7 @@ namespace Npgsql
         [Description("The number of seconds of connection inactivity before Npgsql sends a keepalive query.")]
         [DisplayName("Keepalive")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("query_keepalives_time")]
         public int KeepAlive
         {
             get => _keepAlive;
@@ -909,6 +940,7 @@ namespace Npgsql
         [Description("Whether to use TCP keepalive with system defaults if overrides isn't specified.")]
         [DisplayName("TCP Keepalive")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("keepalives")]
         public bool TcpKeepAlive
         {
             get => _tcpKeepAlive;
@@ -921,7 +953,7 @@ namespace Npgsql
         bool _tcpKeepAlive;
 
         /// <summary>
-        /// The number of seconds of connection inactivity before a TCP keepalive query is sent.
+        /// The number of milliseconds of connection inactivity before a TCP keepalive query is sent.
         /// Use of this option is discouraged, use <see cref="KeepAlive"/> instead if possible.
         /// Set to 0 (the default) to disable. Supported only on Windows.
         /// </summary>
@@ -929,6 +961,7 @@ namespace Npgsql
         [Description("The number of milliseconds of connection inactivity before a TCP keepalive query is sent.")]
         [DisplayName("TCP Keepalive Time")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("keepalives_time")]
         public int TcpKeepAliveTime
         {
             get => _tcpKeepAliveTime;
@@ -952,6 +985,7 @@ namespace Npgsql
         [Description("The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.")]
         [DisplayName("TCP Keepalive Interval")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("keepalives_interval")]
         public int TcpKeepAliveInterval
         {
             get => _tcpKeepAliveInterval;
@@ -973,6 +1007,7 @@ namespace Npgsql
         [Description("Determines the size of the internal buffer Npgsql uses when reading. Increasing may improve performance if transferring large values from the database.")]
         [DisplayName("Read Buffer Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("read_buffer_size")]
         [DefaultValue(NpgsqlReadBuffer.DefaultSize)]
         public int ReadBufferSize
         {
@@ -992,6 +1027,7 @@ namespace Npgsql
         [Description("Determines the size of the internal buffer Npgsql uses when writing. Increasing may improve performance if transferring large values to the database.")]
         [DisplayName("Write Buffer Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("write_buffer_size")]
         [DefaultValue(NpgsqlWriteBuffer.DefaultSize)]
         public int WriteBufferSize
         {
@@ -1011,6 +1047,7 @@ namespace Npgsql
         [Description("Determines the size of socket receive buffer.")]
         [DisplayName("Socket Receive Buffer Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("socket_receive_buffer_size")]
         public int SocketReceiveBufferSize
         {
             get => _socketReceiveBufferSize;
@@ -1029,6 +1066,7 @@ namespace Npgsql
         [Description("Determines the size of socket send buffer.")]
         [DisplayName("Socket Send Buffer Size")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("socket_send_buffer_size")]
         public int SocketSendBufferSize
         {
             get => _socketSendBufferSize;
@@ -1049,6 +1087,7 @@ namespace Npgsql
         [Description("The maximum number SQL statements that can be automatically prepared at any given point. Beyond this number the least-recently-used statement will be recycled. Zero (the default) disables automatic preparation.")]
         [DisplayName("Max Auto Prepare")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("max_auto_prepare")]
         public int MaxAutoPrepare
         {
             get => _maxAutoPrepare;
@@ -1071,6 +1110,7 @@ namespace Npgsql
         [Description("The minimum number of usages an SQL statement is used before it's automatically prepared. Defaults to 5.")]
         [DisplayName("Auto Prepare Min Usages")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("auto_prepare_min_usages")]
         [DefaultValue(5)]
         public int AutoPrepareMinUsages
         {
@@ -1093,6 +1133,7 @@ namespace Npgsql
         [Description("Writes connection performance information to performance counters.")]
         [DisplayName("Use Perf Counters")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("use_perf_counters")]
         public bool UsePerfCounters
         {
             get => _usePerfCounters;
@@ -1112,6 +1153,7 @@ namespace Npgsql
         [Description("If set to true, a pool connection's state won't be reset when it is closed (improves performance). Do not specify this unless you know what you're doing.")]
         [DisplayName("No Reset On Close")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("no_reset_on_close")]
         public bool NoResetOnClose
         {
             get => _noResetOnClose;
@@ -1130,6 +1172,7 @@ namespace Npgsql
         [Description("Load table composite type definitions, and not just free-standing composite types.")]
         [DisplayName("Load Table Composites")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("load_table_composites")]
         public bool LoadTableComposites
         {
             get => _loadTableComposites;
@@ -1152,6 +1195,7 @@ namespace Npgsql
         [Description("A compatibility mode for special PostgreSQL server types.")]
         [DisplayName("Server Compatibility Mode")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("server_compatibility_mode")]
         public ServerCompatibilityMode ServerCompatibilityMode
         {
             get => _serverCompatibilityMode;
@@ -1170,6 +1214,7 @@ namespace Npgsql
         [Description("Makes MaxValue and MinValue timestamps and dates readable as infinity and negative infinity.")]
         [DisplayName("Convert Infinity DateTime")]
         [NpgsqlConnectionStringProperty]
+        [NpgsqlConnectionURIParameter("convert_infinity_datetime")]
         public bool ConvertInfinityDateTime
         {
             get => _convertInfinityDateTime;
@@ -1390,6 +1435,27 @@ namespace Npgsql
         public NpgsqlConnectionStringPropertyAttribute(params string[] synonyms)
         {
             Synonyms = synonyms;
+        }
+    }
+
+    /// <summary>
+    /// Marks on <see cref="NpgsqlConnectionStringBuilder"/> which participate in the connection
+    /// URI. Optionally holds a set of synonyms for the property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class NpgsqlConnectionURIParameterAttribute : Attribute
+    {
+        /// <summary>
+        /// Holds a list of synonyms for the property.
+        /// </summary>
+        public string[] Keywords { get; }
+
+        /// <summary>
+        /// Creates a <see cref="NpgsqlConnectionStringPropertyAttribute"/>.
+        /// </summary>
+        public NpgsqlConnectionURIParameterAttribute(string keyword, params string[] aliases)
+        {
+            Keywords = new[] { keyword }.Concat(aliases).ToArray();
         }
     }
 

--- a/src/Npgsql/NpgsqlConnectionUri.cs
+++ b/src/Npgsql/NpgsqlConnectionUri.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Represents a connection URI and easy access to its contents.
+    /// </summary>
+    internal class NpgsqlConnectionUri
+    {
+        #region Fields
+
+        /// <summary>
+        /// Maps URI parameter name (e.g. connect_timeout), which is set by the property's [NpgsqlConnectionURIParameter], 
+        /// to their property info (e.g. Timeout)
+        /// </summary>
+        static readonly Dictionary<string, PropertyInfo?> PropertiesByParameter;
+
+        /// <summary>
+        /// Maps CLR property names (e.g. CommandTimeout) to their canonical keyword name, which is the
+        /// property's [DisplayName] (e.g. Command Timeout)
+        /// </summary>
+        static readonly Dictionary<string, string> PropertyNameToCanonicalKeyword;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The hostname or IP address of the PostgreSQL server to connect to.
+        /// </summary>
+        public string? Scheme { get; protected set; }
+
+        /// <summary>
+        /// The hostname or IP address of the PostgreSQL server to connect to.
+        /// </summary>
+        public string? Host { get; protected set; }
+
+        /// <summary>
+        /// The TCP/IP port of the PostgreSQL server.
+        /// </summary>
+        public int? Port { get; protected set; }
+
+        ///<summary>
+        /// The PostgreSQL database to connect to.
+        /// </summary>
+        public string? Database { get; protected set; }
+
+        /// <summary>
+        /// The user name to connect with.
+        /// </summary>
+        public string? Username { get; protected set; }
+
+        /// <summary>
+        /// The password to connect with.
+        /// </summary>
+        public string? Password { get; protected set; }
+
+        public IReadOnlyList<KeyValuePair<string, string?>> Parameters => _parameters;
+        List<KeyValuePair<string, string?>> _parameters;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the NpgsqlConnectionUri class.
+        /// </summary>
+        /// <param name="connectionUri">The connection URI used to open the PostgreSQL database.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="UriFormatException"></exception>
+        /// <exception cref="NotSupportedException"></exception>
+        public NpgsqlConnectionUri(string connectionUri)
+        {
+            if (connectionUri == null)
+                throw new ArgumentNullException(nameof(connectionUri));
+
+            var preprocessedUri = ReplaceHostComponent(connectionUri, out var host);
+            var uri = new Uri(preprocessedUri);
+
+            Scheme = uri.Scheme;
+            switch (Scheme.ToLower())
+            {
+                case "postgres":
+                case "postgresql":
+                    break;
+                default:
+                    throw new UriFormatException("Invalid Connection URI: The provided connection URI had unsupported scheme.");
+            }
+
+            var userInfo = uri.UserInfo.Split(new[] { ':' }, 2);
+            if (userInfo[0].Length > 0)
+                Username = Uri.UnescapeDataString(userInfo[0]);
+            if (userInfo.Length > 1 && userInfo[1].Length > 0)
+                Password = Uri.UnescapeDataString(userInfo[1]);
+
+            if (host.Length > 0)
+            {
+                if (host.Contains(','))
+                    throw new NotSupportedException("Specifying multiple hosts in a connection URI is not supported.");
+                var match = Regex.Match(host, @"^\[([a-fA-F0-9:]+)\]$");
+                if (match.Length > 0)
+                    Host = match.Groups[1].Value;
+                else if (host.Length > 0)
+                    Host = Uri.UnescapeDataString(host);
+            }
+
+            if (uri.Port >= 0)
+                Port = uri.Port;
+
+            var path = new string(uri.AbsolutePath.Skip(1).ToArray());
+            if (path.Length > 0)
+                Database = Uri.UnescapeDataString(path);
+
+            _parameters = uri.Query
+                .Split(new[] { '?', '&' })
+                .Where(p => p.Length > 0)
+                .Select(p =>
+                {
+                    var param = p.Split(new[] { '=' }, 2);
+                    if (param.Length < 2)
+                        throw new UriFormatException($"Invalid Connection URI: URI parameter {p} was not followed by value.");
+                    return new KeyValuePair<string, string?>(Uri.UnescapeDataString(param[0]), p.Length < 2 || param[1].Length == 0 ? null : Uri.UnescapeDataString(param[1]));
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Extract the host component from a URI and replace it with a dummy host name.
+        /// </summary>
+        /// <param name="uri">Connection URI</param>
+        /// <param name="host"></param>
+        /// <returns>The connection URI which host component is replaced with "x".</returns>
+        /// <remarks>
+        /// The forms of URI listed below are all valid for psql, but a System.UriFormatException is thrown in the parse of System.Uri class.
+        /// This method separates such part from URI and allows to handle it outside the System.Uri parse.
+        /// <list type="bullet">
+        /// <item><description>The authority part exists but the host component is empty. (e.g. postgresql://user@/dbname)</description></item>
+        /// <item><description>A percent-encoded path is specified in the host component, which is the case of a non-standard Unix-domain socket directory. (e.g. postgresql://%2Fvar%2Flib%2Fpostgresql/dbname)</description></item>
+        /// <item><description>Multiple sets of host and port are specified in the authrity part. (e.g. postgresql://host1,host2/dbname)</description></item>
+        /// </list>
+        /// </remarks>
+        static string ReplaceHostComponent(string uri, out string host)
+        {
+            var authorityStart = uri.IndexOf("://", StringComparison.InvariantCulture);
+            if (authorityStart < 0)
+            {
+                host = "";
+                return uri;
+            }
+            authorityStart += 3;
+
+            var queryStart = uri.IndexOf('?', authorityStart);
+            var userinfoEnd = uri.IndexOf('@', authorityStart) + 1;
+            if (queryStart >= 0 && userinfoEnd > queryStart)
+                userinfoEnd = -1;
+            var pathStart = uri.IndexOf('/', authorityStart);
+            var fragmentStart = uri.IndexOf('#');
+
+            var hostStart = Math.Max(authorityStart, userinfoEnd);
+            var hostEnd = uri.Length;
+            if (0 < hostStart && hostStart < uri.Length && uri[hostStart] == '[')
+                hostEnd = uri.IndexOf(']', hostStart + 1) + 1;
+            else
+            {
+                var portStart = uri.IndexOf(':', hostStart);
+                var hostEndCandidates = new[] { portStart, pathStart, queryStart, fragmentStart }
+                    .Where(i => i >= 0);
+                if (hostEndCandidates.Count() > 0)
+                    hostEnd = hostEndCandidates.Min();
+            }
+            host = uri.Substring(hostStart, hostEnd - hostStart);
+            return uri.Substring(0, hostStart) + "x" + uri.Substring(hostEnd, uri.Length - hostEnd);
+        }
+
+        #endregion
+
+        #region Static initialization
+
+        static NpgsqlConnectionUri()
+        {
+            var properties = typeof(NpgsqlConnectionStringBuilder)
+                .GetProperties()
+                .Select(p => new
+                {
+                    Property = p,
+                    UriParameter = p.GetCustomAttribute<NpgsqlConnectionURIParameterAttribute>(),
+                    DisplayName = p.GetCustomAttribute<DisplayNameAttribute>()
+                })
+                .Where(p => p.UriParameter != null)
+                .ToArray();
+
+            PropertiesByParameter = (
+                from p in properties
+                from k in p.UriParameter.Keywords
+                select new { Keyword = k, p.Property }
+            ).ToDictionary(p => p.Keyword, p => (PropertyInfo?)p.Property);
+
+            PropertyNameToCanonicalKeyword = properties.ToDictionary(
+                p => p.Property.Name,
+                p => p.DisplayName!.DisplayName
+            );
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Returns an instance of <see cref="NpgsqlConnectionStringBuilder"/> that represents this connection URI.
+        /// </summary>
+        public NpgsqlConnectionStringBuilder ToSettings()
+        {
+            var components = new Dictionary<string, string?>
+            {
+                { "host", Host },
+                { "port", Port?.ToString() },
+                { "dbname", Database },
+                { "user", Username },
+                { "password", Password },
+                { "keepalives", "1" },
+                { "sslmode", "prefer" },
+            }
+            .ToList();
+            _parameters.ForEach(p => components.Add(new KeyValuePair<string, string?>(p.Key, p.Value)));
+
+            var respectedComponents = (
+                from param in components
+                from prop in PropertiesByParameter.Where(p => param.Key == p.Key)
+                    .DefaultIfEmpty(new KeyValuePair<string, PropertyInfo?>(param.Key, null))
+                group new { param, prop } by (prop.Value?.Name ?? param.Key) into g
+                select g.Last()
+            ).ToDictionary(p => p.param.Key, p => new { p.param.Value, Property = p.prop.Value });
+
+            if (respectedComponents.ContainsKey("hostaddr"))
+                respectedComponents.Remove("host");
+
+            if (respectedComponents.ContainsKey("fallback_application_name")
+                && respectedComponents.ContainsKey("application_name"))
+                respectedComponents.Remove("fallback_application_name");
+
+            var settings = new NpgsqlConnectionStringBuilder();
+            foreach (var component in respectedComponents)
+            {
+                if (component.Value.Property == null)
+                    throw new NotSupportedException("URI parameter not supported: " + component.Key);
+                var canonicalKeyword = PropertyNameToCanonicalKeyword[component.Value.Property.Name];
+                settings[canonicalKeyword] = ConvertParameter(component.Key, component.Value.Value, component.Value.Property);
+            }
+
+            return settings;
+        }
+
+        object? ConvertParameter(string key, string? value, PropertyInfo property)
+        {
+            if (property.Name == "Host")
+            {
+                if (string.IsNullOrEmpty(value))
+                    return "localhost";
+                if (value!.Split(',').Count() > 1)
+                    throw new NotSupportedException("The host parameter does not support multiple hosts in Npgsql.");
+            }
+            else if (property.Name == "Port")
+            {
+                if (string.IsNullOrEmpty(value))
+                    return null;
+                if (value!.Split(',').Count() > 1)
+                    throw new NotSupportedException("The port parameter does not support multiple hosts in Npgsql.");
+                if (int.TryParse(value, out var port))
+                    return port;
+                throw new UriFormatException("Invalid Connection URI: The format of port number in the connection URI parameter was invalid.");
+            }
+            else if (property.Name == "SslMode")
+            {
+                switch (value?.ToLower())
+                {
+                    case "true":
+                    case "1":
+                        return SslMode.Require;
+                    case "false":
+                    case "0":
+                        return SslMode.Disable;
+                }
+            }
+            else if (property.Name == "TcpKeepAliveTime" || property.Name == "TcpKeepAliveInterval")
+            {
+                return value + "000";
+            }
+            else if (property.PropertyType == typeof(bool))
+            {
+                if (int.TryParse(value, out var n))
+                    switch (n)
+                    {
+                        case 0:
+                            return false;
+                        case 1:
+                            return true;
+                    }
+
+                throw new UriFormatException("Invalid Connection URI: Couldn't set parameter " + key);
+            }
+
+            return value;
+        }
+    }
+}

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1351,5 +1351,37 @@ namespace Npgsql.Tests
         }
 
         #endregion
+
+        #region Connection URI
+
+        [Category("ConnectionUri")]
+        [Test]
+        public void ConnectionUri()
+        {
+            var builder1 = new NpgsqlConnection("postgresql://");
+
+            Assert.That(builder1.Host, Is.EqualTo("localhost"));
+            Assert.That(builder1.Port, Is.EqualTo(5432));
+            Assert.That(builder1.Database, Is.Null);
+            Assert.That(builder1.UserName, Is.Null);
+            Assert.That(builder1.Password, Is.Null);
+
+            var builder2 = new NpgsqlConnection("postgresql://other:pass@testhost:4321/otherdb?connect_timeout=10&application_name=myapp&keepalives=0");
+
+            Assert.That(builder2.Host, Is.EqualTo("testhost"));
+            Assert.That(builder2.Port, Is.EqualTo(4321));
+            Assert.That(builder2.UserName, Is.EqualTo("other"));
+            Assert.That(builder2.Password, Is.EqualTo("pass"));
+            Assert.That(builder2.Database, Is.EqualTo("otherdb"));
+            Assert.That(builder2.Settings.ApplicationName, Is.EqualTo("myapp"));
+            Assert.That(builder2.ConnectionTimeout, Is.EqualTo(10));
+            Assert.That(builder2.Settings.SslMode, Is.EqualTo(SslMode.Prefer));
+            Assert.That(builder2.Settings.TcpKeepAlive, Is.EqualTo(false));
+
+            Assert.That(() => new NpgsqlConnection("http://localhost/mydb"),
+                Throws.InstanceOf(typeof(UriFormatException)));
+        }
+
+        #endregion
     }
 }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1354,7 +1354,6 @@ namespace Npgsql.Tests
 
         #region Connection URI
 
-        [Category("ConnectionUri")]
         [Test]
         public void ConnectionUri()
         {

--- a/test/Npgsql.Tests/ConnectionUriTests.cs
+++ b/test/Npgsql.Tests/ConnectionUriTests.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 
 namespace Npgsql.Tests
 {
-    [Category("ConnectionUri")]
     public class ConnectionUriTests : TestBase
     {
         [Test]

--- a/test/Npgsql.Tests/ConnectionUriTests.cs
+++ b/test/Npgsql.Tests/ConnectionUriTests.cs
@@ -1,0 +1,697 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Npgsql.Tests
+{
+    [Category("ConnectionUri")]
+    public class ConnectionUriTests : TestBase
+    {
+        [Test]
+        public void InvalidArgument()
+        {
+            Assert.That(() => new NpgsqlConnectionUri(null!),
+                Throws.InstanceOf(typeof(ArgumentNullException)));
+
+            Assert.That(() => new NpgsqlConnectionUri(""),
+                Throws.InstanceOf(typeof(UriFormatException)));
+        }
+
+        [Test]
+        public void InvalidConnectionUri()
+        {
+            Assert.That(() => new NpgsqlConnectionUri("http://localhost/mydb"),
+                Throws.InstanceOf(typeof(UriFormatException)));
+
+            Assert.That(() => new NpgsqlConnectionUri("postgresql://host1,host2/mydb"),
+                Throws.InstanceOf(typeof(NotSupportedException)));
+
+            Assert.That(() => new NpgsqlConnectionUri("postgresql://host:port"),
+                Throws.InstanceOf(typeof(UriFormatException)));
+
+            Assert.That(() => new NpgsqlConnectionUri("postgresql://testhost/mydb?port=a432").ToSettings(),
+                Throws.InstanceOf(typeof(UriFormatException)));
+
+            Assert.That(() => new NpgsqlConnectionUri("postgresql:///mydb?host=host1,host2").ToSettings(),
+                Throws.InstanceOf(typeof(NotSupportedException)));
+
+            Assert.That(() => new NpgsqlConnectionUri("postgresql:///mydb?port=4321,1234&host=host1,host2").ToSettings(),
+                Throws.InstanceOf(typeof(NotSupportedException)));
+        }
+
+        [Test]
+        public void ValidDbNameWithSlash()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql:///invalid/dbname");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("invalid/dbname"));
+        }
+
+        [Test]
+        public void ValidHost()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://host:1234/mydb?application_name=myapp@npgsql.org");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("mydb"));
+            Assert.That(settings.ApplicationName, Is.EqualTo("myapp@npgsql.org"));
+        }
+
+        [Test]
+        public void ValidHostIpv6()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://[2001:db8::1234]/database");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("2001:db8::1234"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("database"));
+        }
+
+        [Test]
+        public void ValidHostUnixDomainSocketDirectory1()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://%2Fvar%2Flib%2Fpostgresql/dbname");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("/var/lib/postgresql"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("dbname"));
+        }
+
+        [Test]
+        public void ValidHostUnixDomainSocketDirectory2()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://?host=/var/lib/postgresql");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.Host, Is.EqualTo("/var/lib/postgresql"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart1()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user@");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart2()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://:pwd@");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart3()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart4()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://host");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart5()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user@host");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart6()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://:pwd@host");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart7()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart8()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart9()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user@:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart10()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://:pwd@:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart11()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart12()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://host:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart13()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user@host:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart14()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://:pwd@host:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidAuthorityPart15()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri1()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri2()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri3()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql:///path");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri4()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/path");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri5()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://?application_name=myapp&ssl=require");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri6()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234?application_name=myapp&ssl=require");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri7()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql:///path?application_name=myapp&ssl=require");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri8()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/path?application_name=myapp&ssl=require");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri9()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri10()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri11()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql:///path#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri12()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/path#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri13()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://?application_name=myapp&ssl=require#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri14()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234?application_name=myapp&ssl=require#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.Null);
+        }
+
+        [Test]
+        public void ValidConnectionUri15()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql:///path?application_name=myapp&ssl=require#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("localhost"));
+            Assert.That(settings.Port, Is.EqualTo(5432));
+            Assert.That(settings.Username, Is.Null);
+            Assert.That(settings.Password, Is.Null);
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ValidConnectionUri16()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/path?application_name=myapp&ssl=require#frag");
+            var settings = uri.ToSettings();
+            Assert.That(settings.Host, Is.EqualTo("host"));
+            Assert.That(settings.Port, Is.EqualTo(1234));
+            Assert.That(settings.Username, Is.EqualTo("user"));
+            Assert.That(settings.Password, Is.EqualTo("pwd"));
+            Assert.That(settings.Database, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void ParameterDefaults()
+        {
+            var connUri = new NpgsqlConnection("postgresql://");
+            var connStr = new NpgsqlConnection("");
+
+
+            Assert.That(connUri.Settings.Host, Is.EqualTo("localhost"));
+            Assert.That(connUri.Settings.Port, Is.EqualTo(connStr.Settings.Port));
+            Assert.That(connUri.Settings.Username, Is.EqualTo(connStr.Settings.Username));
+            Assert.That(connUri.Settings.Password, Is.EqualTo(connStr.Settings.Password));
+            Assert.That(connUri.Settings.Database, Is.EqualTo(connStr.Settings.Database));
+
+            Assert.That(connUri.Settings.Passfile, Is.EqualTo(connStr.Settings.Passfile)); // TODO
+            Assert.That(connUri.Settings.Enlist, Is.EqualTo(connStr.Settings.Enlist));
+
+            Assert.That(connUri.Settings.SslMode, Is.EqualTo(SslMode.Prefer));
+            Assert.That(connUri.Settings.TrustServerCertificate, Is.EqualTo(connStr.Settings.TrustServerCertificate));
+            Assert.That(connUri.Settings.ClientCertificate, Is.EqualTo(connStr.Settings.ClientCertificate));
+            Assert.That(connUri.Settings.CheckCertificateRevocation, Is.EqualTo(connStr.Settings.CheckCertificateRevocation));
+            Assert.That(connUri.Settings.IntegratedSecurity, Is.EqualTo(connStr.Settings.IntegratedSecurity));
+            Assert.That(connUri.Settings.KerberosServiceName, Is.EqualTo(connStr.Settings.KerberosServiceName));
+            Assert.That(connUri.Settings.IncludeRealm, Is.EqualTo(connStr.Settings.IncludeRealm));
+            Assert.That(connUri.Settings.PersistSecurityInfo, Is.EqualTo(connStr.Settings.PersistSecurityInfo));
+
+            Assert.That(connUri.Settings.Pooling, Is.EqualTo(connStr.Settings.Pooling));
+            Assert.That(connUri.Settings.MinPoolSize, Is.EqualTo(connStr.Settings.MinPoolSize));
+            Assert.That(connUri.Settings.MaxPoolSize, Is.EqualTo(connStr.Settings.MaxPoolSize));
+            Assert.That(connUri.Settings.ConnectionIdleLifetime, Is.EqualTo(connStr.Settings.ConnectionIdleLifetime));
+            Assert.That(connUri.Settings.ConnectionPruningInterval, Is.EqualTo(connStr.Settings.ConnectionPruningInterval));
+
+            Assert.That(connUri.Settings.Timeout, Is.EqualTo(connStr.Settings.Timeout));
+            Assert.That(connUri.Settings.CommandTimeout, Is.EqualTo(connStr.Settings.CommandTimeout));
+            Assert.That(connUri.Settings.InternalCommandTimeout, Is.EqualTo(connStr.Settings.InternalCommandTimeout));
+
+            Assert.That(connUri.Settings.EntityTemplateDatabase, Is.EqualTo(connStr.Settings.EntityTemplateDatabase));
+            Assert.That(connUri.Settings.EntityAdminDatabase, Is.EqualTo(connStr.Settings.EntityAdminDatabase));
+
+            Assert.That(connUri.Settings.KeepAlive, Is.EqualTo(connStr.Settings.KeepAlive));
+            Assert.That(connUri.Settings.TcpKeepAlive, Is.True);
+            Assert.That(connUri.Settings.TcpKeepAliveTime, Is.EqualTo(connStr.Settings.TcpKeepAliveTime)); // TODO
+            Assert.That(connUri.Settings.TcpKeepAliveInterval, Is.EqualTo(connStr.Settings.TcpKeepAliveInterval)); // TODO
+            Assert.That(connUri.Settings.ReadBufferSize, Is.EqualTo(connStr.Settings.ReadBufferSize));
+            Assert.That(connUri.Settings.WriteBufferSize, Is.EqualTo(connStr.Settings.WriteBufferSize));
+            Assert.That(connUri.Settings.SocketReceiveBufferSize, Is.EqualTo(connStr.Settings.SocketReceiveBufferSize));
+            Assert.That(connUri.Settings.SocketSendBufferSize, Is.EqualTo(connStr.Settings.SocketSendBufferSize));
+            Assert.That(connUri.Settings.MaxAutoPrepare, Is.EqualTo(connStr.Settings.MaxAutoPrepare));
+            Assert.That(connUri.Settings.AutoPrepareMinUsages, Is.EqualTo(connStr.Settings.AutoPrepareMinUsages));
+            Assert.That(connUri.Settings.UsePerfCounters, Is.EqualTo(connStr.Settings.UsePerfCounters));
+            Assert.That(connUri.Settings.NoResetOnClose, Is.EqualTo(connStr.Settings.NoResetOnClose));
+            Assert.That(connUri.Settings.LoadTableComposites, Is.EqualTo(connStr.Settings.LoadTableComposites));
+
+            Assert.That(connUri.Settings.ServerCompatibilityMode, Is.EqualTo(connStr.Settings.ServerCompatibilityMode));
+            Assert.That(connUri.Settings.ConvertInfinityDateTime, Is.EqualTo(connStr.Settings.ConvertInfinityDateTime));
+        }
+
+        [Test]
+        public void ValidParameters1()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?host=otherhost"
+                + "&port=9876"
+                + "&dbname=otherdb"
+                + "&user=otheruser"
+                + "&password=asdf");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.Host, Is.EqualTo("otherhost"));
+            Assert.That(settings.Port, Is.EqualTo(9876));
+            Assert.That(settings.Username, Is.EqualTo("otheruser"));
+            Assert.That(settings.Password, Is.EqualTo("asdf"));
+            Assert.That(settings.Database, Is.EqualTo("otherdb"));
+        }
+
+        [Test]
+        public void ValidParameters2()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?passfile=/user/.pgpass"
+                + "&application_name=myapp"
+                + "&enlist=1"
+                + "&search_path=namespaceA"
+                + "&client_encoding=SJIS"
+                + "&encoding=euc-jp"
+                + "&timezone=NZT");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.Passfile, Is.EqualTo("/user/.pgpass"));
+            Assert.That(settings.ApplicationName, Is.EqualTo("myapp"));
+            Assert.That(settings.Enlist, Is.True);
+            Assert.That(settings.SearchPath, Is.EqualTo("namespaceA"));
+            Assert.That(settings.ClientEncoding, Is.EqualTo("SJIS"));
+            Assert.That(settings.Encoding, Is.EqualTo("euc-jp"));
+            Assert.That(settings.Timezone, Is.EqualTo("NZT"));
+        }
+
+        [Test]
+        public void ValidParameters3()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?sslmode=require"
+                + "&trust_server_certificate=1"
+                + "&sslcert=client.cert"
+                + "&check_certificate_revocation=1"
+                + (Type.GetType("Mono.Runtime") == null ? "&integrated_security=1" : "")
+                + "&krbsrvname=MyKerberosService"
+                + "&include_realm=1"
+                + "&persist_security_info=1");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.SslMode, Is.EqualTo(SslMode.Require));
+            Assert.That(settings.TrustServerCertificate, Is.True);
+            Assert.That(settings.ClientCertificate, Is.EqualTo("client.cert"));
+            Assert.That(settings.CheckCertificateRevocation, Is.True);
+            if (Type.GetType("Mono.Runtime") == null)
+                Assert.That(settings.IntegratedSecurity, Is.True);
+            else
+                Assert.That(settings.IntegratedSecurity, Is.False);
+            Assert.That(settings.KerberosServiceName, Is.EqualTo("MyKerberosService"));
+            Assert.That(settings.IncludeRealm, Is.True);
+            Assert.That(settings.PersistSecurityInfo, Is.True);
+        }
+
+        [Test]
+        public void ValidParameters4()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?pooling=0"
+                + "&minimum_pool_size=10"
+                + "&maximum_pool_size=20"
+                + "&connection_idle_lifetime=60"
+                + "&connection_pruning_interval=20");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.Pooling, Is.False);
+            Assert.That(settings.MinPoolSize, Is.EqualTo(10));
+            Assert.That(settings.MaxPoolSize, Is.EqualTo(20));
+            Assert.That(settings.ConnectionIdleLifetime, Is.EqualTo(60));
+            Assert.That(settings.ConnectionPruningInterval, Is.EqualTo(20));
+        }
+
+        [Test]
+        public void ValidParameters5()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?connect_timeout=5"
+                + "&command_timeout=10"
+                + "&internal_command_timeout=20");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.Timeout, Is.EqualTo(5));
+            Assert.That(settings.CommandTimeout, Is.EqualTo(10));
+            Assert.That(settings.InternalCommandTimeout, Is.EqualTo(20));
+        }
+
+        [Test]
+        public void ValidParameters6()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?ef_template_database=template2"
+                + "&ef_admin_database=dba");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.EntityTemplateDatabase, Is.EqualTo("template2"));
+            Assert.That(settings.EntityAdminDatabase, Is.EqualTo("dba"));
+        }
+
+        [Test]
+        public void ValidParameters7()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?query_keepalives_time=5"
+                + "&keepalives=0"
+                + "&keepalives_time=5"
+                + "&keepalives_interval=1"
+                + "&read_buffer_size=4096"
+                + "&write_buffer_size=2048"
+                + "&socket_receive_buffer_size=1024"
+                + "&socket_send_buffer_size=512"
+                + "&max_auto_prepare=10"
+                + "&auto_prepare_min_usages=2"
+                + "&use_perf_counters=1"
+                + "&no_reset_on_close=1"
+                + "&load_table_composites=1");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.KeepAlive, Is.EqualTo(5));
+            Assert.That(settings.TcpKeepAlive, Is.False);
+            Assert.That(settings.TcpKeepAliveTime, Is.EqualTo(5000));
+            Assert.That(settings.TcpKeepAliveInterval, Is.EqualTo(1000));
+            Assert.That(settings.ReadBufferSize, Is.EqualTo(4096));
+            Assert.That(settings.WriteBufferSize, Is.EqualTo(2048));
+            Assert.That(settings.SocketReceiveBufferSize, Is.EqualTo(1024));
+            Assert.That(settings.SocketSendBufferSize, Is.EqualTo(512));
+            Assert.That(settings.MaxAutoPrepare, Is.EqualTo(10));
+            Assert.That(settings.AutoPrepareMinUsages, Is.EqualTo(2));
+            Assert.That(settings.UsePerfCounters, Is.True);
+            Assert.That(settings.NoResetOnClose, Is.True);
+            Assert.That(settings.LoadTableComposites, Is.True);
+        }
+
+        [Test]
+        public void ValidParameters8()
+        {
+            var uri = new NpgsqlConnectionUri("postgresql://user:pwd@host:1234/dbname"
+                + "?server_compatibility_mode=NoTypeLoading"
+                + "&convert_infinity_datetime=1");
+            var settings = uri.ToSettings();
+
+            Assert.That(settings.ServerCompatibilityMode, Is.EqualTo(ServerCompatibilityMode.NoTypeLoading));
+            Assert.That(settings.ConvertInfinityDateTime, Is.True);
+        }
+
+        [Test]
+        public void InvalidParameters()
+        {
+            Assert.That(() => new NpgsqlConnectionUri("postgresql://?host").ToSettings(),
+                Throws.InstanceOf(typeof(UriFormatException)));
+            Assert.That(() => new NpgsqlConnectionUri("postgresql://?options=asdf").ToSettings(),
+                Throws.InstanceOf(typeof(NotSupportedException)));
+        }
+    }
+}


### PR DESCRIPTION
resolves #2090 

Based on the comments in #2090, I assumed the following requirements and designed the specification as follows.

However, a couple of questions remained. Please refer the questions on the bottom and give me an advice.

## Requirements
When initializing NpgsqlConnection with a Connection URI,  Npgsql should behave as defined in [PostgreSQL's documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS). However, the following features are not supported at this phase.
* Multiple hosts
* Multiple ports
* URI parameter related to functionality Npgsql does not support
* URI parameter deprecated in Connection URI

## High-Level Specification
Refer [PostgreSQL's documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS).

For the individual behaviours which the document does not specify, Npgsql conforms to the behaviour of psql. Those are:
* The while path component of Connection URI is regarded as a database name, excluding the slash at the beginning.
* Any component in the hierarchical part of the URI can be omitted. For example, postgresql:// and postgresql://:@otherhost:/? are both valid as a Connection URI. In such a case, the default value applies.
* What components of the hierarchical part of URI specify, can be overwritten by a corresponding URI parameter.
* Empty value of a URI parameter means that the default value defined for the parameter applies. The empty value never results in fall-back to the equivalent component in the hierarchical part, nor fall-back to the duplicate parameters that appear earlier. When the PostgreSQL document does not define the default value for a URI parameter, the default value of the corresponding parameter in Connection String applies.
* Duplicate URI parameters in a URI is valid. In such a case, the later is respected.
* Connection URI that has an unexpected or unsupported URI parameter is invalid.
* Connection URI which URI parameter has unexpected or unsupported value is invalid
* In URI parameters, boolean type values are represented by 0 or 1, which is respectively false or true.

## URI Parameters
The followings are specification of connection URI parameters in Npgsql.

### Basic Connection
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| host | Host, Server | yes | localhost |  | 
| port | Port | yes | same as connection string does |  | 
| dbname, database, db | Database, DB | yes | same as connection string does | only "dbname" is defined in PostgreSQL doc | 
| user, username, user_name, user_id, uid | Username, User Name, UserId, User Id, UID | yes | same as connection string does | only "user" is defined in PostgreSQL doc | 
| password, psw, pwd | Password, PSW, PWD | yes | same as connection string does | only "password" is defined in PostgreSQL doc | 
| passfile | Passfile | yes | same as connection string does | The default path in Npgsql is different from the definition in connection URI | 
| application_name | Application Name | yes | same as connection string does |  | 
| enlist | Enlist | no | same as connection string does |  | 
| search_path | Search Path | no | same as connection string does |  | 
| client_encoding | Client Encoding | yes | same as connection string does |  | 
| encoding | Encoding | no | same as connection string does |  | 
| timezone | Timezone | no | same as connection string does |  | 

### Security and Encryption
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| sslmode, ssl | SSL Mode | yes | prefer | * The alias "ssl" and its acceptable values are defined in [the PostgreSQL's documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS)<br>* The default in Connection String is "Disabled"<br>* Not every the SSL modes defined in connection URI are supported. Supported values in Npgsql are "disable", "perfer" and "require". | 
| trust_server_certificate | Trust Server Certificate | no | same as connection string does |  | 
| sslcert, client_certificate | Client Certificate | yes | same as connection string does | only "sslcert" is defined in PostgreSQL doc<br>The default path in Npgsql is different from the definition in connection URI | 
| check_certificate_revocation | Check Certificate Revocation | no | same as connection string does |  | 
| integrated_security | Integrated Security | no | same as connection string does |  | 
| krbsrvname | Kerberos Service Name, Krbsrvname | yes | same as connection string does |  | 
| include_realm | Include Realm | no | same as connection string does |  | 
| persist_security_info | Persist Security Info | no | same as connection string does |  | 

### Pooling
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| pooling | Pooling | no | same as connection string does |  | 
| minimum_pool_size | Minimum Pool Size | no | same as connection string does |  | 
| maximum_pool_size | Maximum Pool Size | no | same as connection string does |  | 
| connection_idle_lifetime | Connection Idle Lifetime | no | same as connection string does |  | 
| connection_pruning_interval | Connection Pruning Interval | no | same as connection string does |  | 

### Timeouts
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| connect_timeout | Timeout | yes | same as connection string does |  | 
| command_timeout | Command Timeout | no | same as connection string does |  | 
| internal_command_timeout | Internal Command Timeout | no | same as connection string does |  | 

### Entity Framework
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| ef_template_database | EF Template Database | no | same as connection string does |  | 
| ef_admin_database | EF Admin Database | no | same as connection string does |  | 

### Advanced
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| query_keepalives_time | Keepalive | no | same as connection string does | **_named it "query_keepalives_time" because "keepalives" is defined for other property in Connection URI. The naming conforms to "keepalives_time"_** | 
| keepalives | TCP Keepalive | yes | 1 (enabled) | the default value in Connection String is "disabled" | 
| keepalives_time | TCP Keepalive Time | no | same as connection string does, which is 0 seconds | * The naming conforms to "keepalives" and "keepalives_interval", which are defined in Connection URI.<br>* **_What should the default value be? If it is defaulted to 0, property keepalives's default value, which is 1 (enabled), cannot be effective._**<br>* The unit of this parameter is "seconds" in Connection URI but it is "milliseconds" in Connection String | 
| keepalives_interval | TCP Keepalive Interval | yes | behaves as connection string does, which is 0 seconds | The unit of this parameter is "seconds" in Connection URI but it is "milliseconds" in Connection String | 
| read_buffer_size | Read Buffer Size | no | same as connection string does |  | 
| write_buffer_size | Write Buffer Size | no | same as connection string does |  | 
| socket_receive_buffer_size | Socket Receive Buffer Size | no | same as connection string does |  | 
| socket_send_buffer_size | Socket Send Buffer Size | no | same as connection string does |  | 
| max_auto_prepare | Max Auto Prepare | no | same as connection string does |  | 
| auto_prepare_min_usages | Auto Prepare Min Usages | no | same as connection string does |  | 
| use_perf_counters | Use Perf Counters | no | same as connection string does |  | 
| no_reset_on_close | No Reset On Close | no | same as connection string does |  | 
| load_table_composites | Load Table Composites | no | same as connection string does |  | 

### Compatibility
| Parameters in Connection URI | Corresponding Parameters in Connection String | Is [documented in PostgreSQL](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) | Default value in connection URI | Notes |
| ---------------------------- | ---------------------------- | -------- | ---------------------------- | -------------------------------------- | 
| server_compatibility_mode | Server Compatibility Mode | no | same as connection string does |  | 
| convert_infinity_datetime | Convert Infinity DateTime | no | same as connection string does |  | 



### Unsupported Parameters
The following URI parameters are defined in [PostgreSQL's documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) but Npgsql does not have any settings corresponding to them.
* options
* keepalives_idle
* keepalives_count
* tcp_user_timeout
* replication
* gssencmode
* sslcompression
* sslkey
* sslrootcert
* sslcrl
* gsslib
* service
* target_session_attrs

### Deprecated Paramters in Connection URI
The following URI parameters are deprecated in [PostgreSQL's documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) and Npgsql does not support those.
* requiressl

## Notes
In this implementation, I handled the host component of Connection URI separately from the parse by System.Uri. It is because System.Uri throws an exception with such URI as described below.
* Specifying unix-domain socket directory in host component causes System.Uri to throw System.UriFormatException. e.g. postgresql://%2Fvar%2Flib%2Fpostgresql/dbname
* Omitting host component in authority part causes System.Uri to throw System.UriFormatException, although omitting authority part is fine. For example, postgresql:///dbname is fine but postgresql://user@/dbname is not.
* Specifying muliple hosts in host component causes System.Uri to throw System.UriFormatException. e.g. postgresql://host1,host2/mydb

## Questions
1. I named _Keepalive_ parameter in Connection String "_query_keepalives_time_" in Connection URI. It is because "_keepalives_" is used by another property in Connection URI so that having "_keepalive_" for _Keepalive_ parameter can be confusing. The naming conforms to _keepalives_time_ URI parameter. Does it sound okay?
1. What should the default value of URI parameter _keepalives_time_ (TCP Keepalive Time) be? If the parameter is defaulted to 0, which Connection String does, the default value of _keepalives_ URI parameter, which is 1 (enabled), cannot be effective.
