### PR TITLE
Mild tweaks

### DIFF
--- a/src/Npgsql/NoSynchronizationContextScope.cs
+++ b/src/Npgsql/NoSynchronizationContextScope.cs
@@ -17,17 +17,7 @@ namespace Npgsql
     /// </remarks>
     static class NoSynchronizationContextScope
     {
-        internal static Disposable Enter()
-        {
-            var sc = SynchronizationContext.Current;
-            if (sc is null)
-            {
-                // Don't need to set SynchronizationContext or store current one if its already null
-                return default;
-            }
-
-            return new Disposable(sc);
-        }
+        internal static Disposable Enter() => new Disposable(SynchronizationContext.Current);
 
         internal struct Disposable : IDisposable
         {
@@ -35,9 +25,9 @@ namespace Npgsql
 
             internal Disposable(SynchronizationContext synchronizationContext)
             {
-                // Calling the constructor, this means we need to set current SynchronizationContext to null
-                // and store the passed in one so we can restore it.
-                SynchronizationContext.SetSynchronizationContext(null);
+                if (synchronizationContext != null)
+                    SynchronizationContext.SetSynchronizationContext(null);
+
                 _synchronizationContext = synchronizationContext;
             }
 

--- a/src/Npgsql/NoSynchronizationContextScope.cs
+++ b/src/Npgsql/NoSynchronizationContextScope.cs
@@ -23,7 +23,7 @@ namespace Npgsql
         {
             readonly SynchronizationContext? _synchronizationContext;
 
-            internal Disposable(SynchronizationContext synchronizationContext)
+            internal Disposable(SynchronizationContext? synchronizationContext)
             {
                 if (synchronizationContext != null)
                     SynchronizationContext.SetSynchronizationContext(null);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1328,7 +1328,7 @@ namespace Npgsql
             Log.Trace("Cleaning up connector", Id);
             try
             {
-                _stream.Dispose();
+                _stream?.Dispose();
             }
             catch
             {


### PR DESCRIPTION
In NoSynchronizationContextScope if the SynchronizationContext is already `null`, we don't need to set it to `null`, nor go via the the constructor as we can just return `default`.

NpgsqlConnector in certain circumstances would call dispose on null `_stream`; while this wasn't a problem as the catch swallowed the exception; its faster not to throw it in the first place.