### PR TITLE
Fix corner case bug in ArrayHandler.ReadList<TRequestedElement>()

### DIFF
--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -140,17 +140,15 @@ namespace Npgsql.TypeHandlers
         {
             await buf.Ensure(12, async);
             var dimensions = buf.ReadInt32();
+            var containsNulls = buf.ReadInt32() == 1;
+            buf.ReadUInt32(); // Element OID. Ignored.
 
             if (dimensions == 0)
                 return ElementTypeInfo<TRequestedElement>.EmptyList;
             if (dimensions > 1)
                 throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TRequestedElement).Name}>");
-
-            var containsNulls = buf.ReadInt32() == 1;
             if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
                 throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
-
-            buf.ReadUInt32(); // Element OID. Ignored.
 
             await buf.Ensure(8, async);
             var length = buf.ReadInt32();


### PR DESCRIPTION
When reading a zero-dimensional array as List\<T> we left eight bytes in the buffer.