### PR TITLE
Only register cancellation token callbacks if needed

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -330,8 +330,17 @@ namespace Npgsql
                             }
                             else
                             {
-                                using (cancellationToken.Register(s => ((TaskCompletionSource<NpgsqlConnector?>)s!).SetCanceled(), tcs))
+                                CancellationTokenRegistration registration = default;
+                                if (cancellationToken.CanBeCanceled)
+                                    registration = cancellationToken.Register(s => ((TaskCompletionSource<NpgsqlConnector?>)s!).SetCanceled(), tcs);
+                                try
+                                {
                                     await tcs.Task;
+                                }
+                                finally
+                                {
+                                    registration.Dispose();
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
Rather than always doing registrations on cancellation tokens, do it only if the cancellation token supports it (i.e. isn't `CancellationToken.None`). This is probably not very meaningful for Npgsql, but why not do it (in hot paths).
                                             
|           Method |      Mean |     Error |    StdDev |        
|----------------- |----------:|----------:|----------:|
|         Register |  4.620 ns | 0.1257 ns | 0.1761 ns |              
|             Skip |  1.674 ns | 0.0089 ns | 0.0079 ns |
| SkipWithNullable | 10.556 ns | 0.1327 ns | 0.1241 ns |

Benchmark code:

```c#
public class CancellationRegistrationBenchmarks
{
    static readonly CancellationToken _token = CancellationToken.None;

    [Benchmark]
    public void Register()
    {
        using (_token.Register(x => _token.Register(() => Thread.Sleep(10)), this))
        {
        }
    }

    [Benchmark]
    public void Skip()
    {
        CancellationTokenRegistration registration = default;
        if (_token.CanBeCanceled)
            registration = _token.Register(x => _token.Register(() => Thread.Sleep(10)), this);

        try
        {

        }
        finally
        {
            registration.Dispose();
        }
    }

    [Benchmark]
    public void SkipWithNullable()
    {
        CancellationTokenRegistration? registration = default;
        if (_token.CanBeCanceled)
        {
            registration = _token.Register(x => _token.Register(() => Thread.Sleep(10)), this);
        }

        try
        {

        }
        finally
        {
            registration?.Dispose();
        }
    }
}
```