### PR TITLE
Fixed AppVeyor build script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ install:
   - powershell .build\setup_appveyor.ps1
   # The following can be used to install a custom version of .NET Core
   - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "install-dotnet.ps1"
-  - ps: .\install-dotnet.ps1 -Version 3.0.100 -InstallDir "dotnetcli"
+  - ps: .\install-dotnet.ps1 -Version 3.1.100 -InstallDir "dotnetcli"
 services:
   - postgresql111
 before_build:
@@ -46,9 +46,9 @@ test:
     - test\Npgsql.Tests\bin\Debug\net461\Npgsql.Tests.dll
     - test\Npgsql.PluginTests\bin\Debug\net461\Npgsql.PluginTests.dll
     - test\Npgsql.Specification.Tests\bin\Debug\net461\Npgsql.Specification.Tests.dll
-    - test\Npgsql.Tests\bin\Debug\netcoreapp3.0\Npgsql.Tests.dll
-    - test\Npgsql.PluginTests\bin\Debug\netcoreapp3.0\Npgsql.PluginTests.dll
-    - test\Npgsql.Specification.Tests\bin\Debug\netcoreapp3.0\Npgsql.Specification.Tests.dll
+    - test\Npgsql.Tests\bin\Debug\netcoreapp3.1\Npgsql.Tests.dll
+    - test\Npgsql.PluginTests\bin\Debug\netcoreapp3.1\Npgsql.PluginTests.dll
+    - test\Npgsql.Specification.Tests\bin\Debug\netcoreapp3.1\Npgsql.Specification.Tests.dll
 artifacts:
   - path: 'src\**\*.nupkg'
     name: Nuget


### PR DESCRIPTION
Fixes incomplete update to .NET Core 3.1 introduced in 62fb2ab7b81799b4ccddda17145456a2ec552b9f.