### PR TITLE
Changes to usage of C# 8 nullable reference types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <PackageIcon>postgresql.png</PackageIcon>
 
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <NoWarn>NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,19 @@
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!--
+  We only turn on C# 8.0 nullable reference types for newer TFMs where the BCL is annotated, otherwise there are
+  issues (e.g. Debug.Assert(x != null) doesn't work).
+  This means we must ignore warnings of nullable reference type use in the older TFMs
+  -->
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net461' AND '$(TargetFramework)' != 'netstandard2.0' ">
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" $(Nullable) != 'enable' ">
+    <NoWarn>$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
 
   <!-- Signing configuration -->

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -29,6 +29,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.GeoJSON", "src\Npgsq
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Npgsql.Specification.Tests", "test\Npgsql.Specification.Tests\Npgsql.Specification.Tests.csproj", "{A77E5FAF-D775-4AB4-8846-8965C2104E60}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{87B8241E-FFEC-4D4D-A867-9526261ACAD8}"
+ProjectSection(SolutionItems) = preProject
+	Directory.Build.props = Directory.Build.props
+	Directory.Build.targets = Directory.Build.targets
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -3,7 +3,7 @@
     <Authors>Yoh Deadfall, Shay Rojansky</Authors>
     <Description>GeoJSON plugin for Npgsql, allowing mapping of PostGIS geometry types to GeoJSON types.</Description>
     <PackageTags>npgsql postgresql postgres postgis geojson spatial ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -3,7 +3,7 @@
     <Authors>Shay Rojansky</Authors>
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql postgresql json postgres ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
+++ b/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
@@ -3,7 +3,7 @@
     <Authors>Shay Rojansky</Authors>
     <Description>PostGIS plugin for Npgsql, allowing mapping of PostGIS types to the legacy types (e.g. PostgisPoint).</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -3,8 +3,8 @@
     <Authors>Yoh Deadfall, Shay Rojansky</Authors>
     <Description>NetTopologySuite plugin for Npgsql, allowing mapping of PostGIS geometry types to NetTopologySuite types.</Description>
     <PackageTags>npgsql postgresql postgres postgis nts ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <NoWarn>NU5104</NoWarn>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NetTopologySuite.IO.PostGIS" />

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -3,7 +3,7 @@
     <Authors>Shay Rojansky</Authors>
     <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
     <PackageTags>npgsql postgresql postgres nodatime date time ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" />

--- a/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
+++ b/src/Npgsql.RawPostgis/Npgsql.RawPostgis.csproj
@@ -3,7 +3,7 @@
     <Authors>Shay Rojansky</Authors>
     <Description>PostGIS plugin for Npgsql, allowing raw byte access to PostGIS ypes.</Description>
     <PackageTags>npgsql postgresql postgres postgis spatial geometry geography ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />


### PR DESCRIPTION
* We only turn on C# 8.0 nullable reference types for newer TFMs where the BCL is annotated, otherwise there are issues (e.g. Debug.Assert(x != null) doesn't work).
* Ignore warnings of NRT use for older TFMs
* Target netstandard2.1 in plugins to have at least one TFM where NRTs are enabled.
