### PR TITLE
Allow hstore columns to be represented as IReadOnlyDictionary<string, string?>.

### DIFF
--- a/test/Npgsql.Tests/Types/HstoreTests.cs
+++ b/test/Npgsql.Tests/Types/HstoreTests.cs
@@ -78,7 +78,7 @@ namespace Npgsql.Tests.Types
             {
                 Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Dictionary<string, string>)));
                 Assert.That(reader.GetFieldValue<ImmutableDictionary<string, string?>>(i), Is.EqualTo(expected));
-                Assert.That(reader.GetFieldValue<IReadOnlyDictionary<string, string>>(i), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<IReadOnlyDictionary<string, string?>>(i), Is.EqualTo(expected));
             }
         }
 #endif

--- a/test/Npgsql.Tests/Types/HstoreTests.cs
+++ b/test/Npgsql.Tests/Types/HstoreTests.cs
@@ -78,7 +78,7 @@ namespace Npgsql.Tests.Types
             {
                 Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Dictionary<string, string>)));
                 Assert.That(reader.GetFieldValue<ImmutableDictionary<string, string?>>(i), Is.EqualTo(expected));
-                Assert.That(reader.GetFieldValue<ImmutableDictionary<string, string?>>(i), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<IReadOnlyDictionary<string, string>>(i), Is.EqualTo(expected));
             }
         }
 #endif


### PR DESCRIPTION
This adds support for `IReadOnlyDictionary<string, string>` based on `ImmutableDictionary<string, string?>` off the back of #2776 - it's required for the work in npgsql/efcore.pg#1184.