### PR TITLE
Change parameters-per-statement limit check back from 32767 to 65535

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -741,8 +741,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             }
 
             foreach (var s in _statements)
-                if (s.InputParameters.Count > short.MaxValue)
-                    throw new NpgsqlException($"A statement cannot have more than {short.MaxValue} parameters");
+                if (s.InputParameters.Count > ushort.MaxValue)
+                    throw new NpgsqlException($"A statement cannot have more than {ushort.MaxValue} parameters");
         }
 
         #endregion


### PR DESCRIPTION
Fixes #2795