### PR TITLE
Improved perf by avoiding array copy in ensure

### DIFF
--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -54,8 +54,10 @@ namespace Npgsql.TypeHandlers
             var numBits = buf.ReadInt32();
             var result = new BitArray(numBits);
             var bytesLeft = len - 4;  // Remove leading number of bits
-            var bitNo = 0;
+            if (bytesLeft == 0)
+                return result;
 
+            var bitNo = 0;
             while (true)
             {
                 var iterationEndPos = bytesLeft > buf.ReadBytesLeft

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -58,7 +58,10 @@ namespace Npgsql.TypeHandlers
 
             while (true)
             {
-                var iterationEndPos = bytesLeft - Math.Min(bytesLeft, buf.ReadBytesLeft) + 1;
+                var iterationEndPos = bytesLeft > buf.ReadBytesLeft
+                    ? bytesLeft - buf.ReadBytesLeft
+                    : 1;
+
                 for (; bytesLeft > iterationEndPos; bytesLeft--)
                 {
                     // ReSharper disable ShiftExpressionRealShiftCountIsZero
@@ -73,14 +76,11 @@ namespace Npgsql.TypeHandlers
                     result[bitNo++] = (chunk & (1 << 0)) != 0;
                 }
 
-                if (bytesLeft <= 1)
+                if (bytesLeft == 1)
                     break;
 
                 if (bytesLeft != 0)
-                {
-                    Debug.Assert(buf.ReadBytesLeft == 0);
                     await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
-                }
             }
 
             if (bitNo < result.Length)

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -79,8 +79,8 @@ namespace Npgsql.TypeHandlers
                 if (bytesLeft == 1)
                     break;
 
-                if (bytesLeft != 0)
-                    await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
+                Debug.Assert(buf.ReadBytesLeft == 0);
+                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
             }
 
             if (bitNo < result.Length)


### PR DESCRIPTION
Finishes work done by #2799. The change removes magic addition of 1 and uses the whole buffer without calling `Array.Copy`.