### PR TITLE
Fix JsonDocument loading

### DIFF
--- a/src/Npgsql/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/TypeHandlers/JsonHandler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.TypeHandlers
     /// See https://www.postgresql.org/docs/current/datatype-json.html.
     ///
     /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
     [TypeMapping("jsonb", NpgsqlDbType.Jsonb, typeof(JsonDocument))]
@@ -44,7 +44,7 @@ namespace Npgsql.TypeHandlers
     /// See https://www.postgresql.org/docs/current/datatype-json.html.
     ///
     /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
     [TypeMapping("json", NpgsqlDbType.Json)]
@@ -71,7 +71,7 @@ namespace Npgsql.TypeHandlers
     /// See https://www.postgresql.org/docs/current/datatype-json.html.
     ///
     /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
     public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
@@ -245,16 +245,8 @@ namespace Npgsql.TypeHandlers
 
             try
             {
-                // Unless we're in SequentialAccess mode, the entire value is already buffered in memory -
-                // deserialize it directly from bytes. Otherwise deserialize to string first - we can optimize this
-                // later.
-                if (buf.ReadBytesLeft >= byteLen)
-                {
-                    return typeof(T) == typeof(JsonDocument)
-                        ? (T)(object)JsonDocument.Parse(buf.ReadMemory(byteLen))
-                        : JsonSerializer.Deserialize<T>(buf.ReadSpan(byteLen), _serializerOptions);
-                }
-
+                // See #2818 for possibly returning a JsonDocument directly over our internal buffer, rather
+                // than deserializing to string.
                 var s = await _textHandler.Read(buf, byteLen, async, fieldDescription);
                 return typeof(T) == typeof(JsonDocument)
                     ? (T)(object)JsonDocument.Parse(s)

--- a/test/Npgsql.Tests/Types/JsonTests.cs
+++ b/test/Npgsql.Tests/Types/JsonTests.cs
@@ -166,6 +166,32 @@ namespace Npgsql.Tests.Types
             public string Summary { get; set; } = "";
         }
 
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/2811")]
+        [IssueLink("https://github.com/npgsql/efcore.pg/issues/1177")]
+        [IssueLink("https://github.com/npgsql/efcore.pg/issues/1082")]
+        public void CanReadTwoJsonDocuments()
+        {
+            using var conn = OpenConnection();
+
+            JsonDocument car;
+            using (var cmd = new NpgsqlCommand(@"SELECT '{""key"" : ""foo""}'::jsonb", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+                car = reader.GetFieldValue<JsonDocument>(0);
+            }
+
+            using (var cmd = new NpgsqlCommand(@"SELECT '{""key"" : ""bar""}'::jsonb", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+                reader.GetFieldValue<JsonDocument>(0);
+            }
+
+            Assert.That(car.RootElement.GetProperty("key").GetString(), Is.EqualTo("foo"));
+        }
+
         public JsonTests(NpgsqlDbType npgsqlDbType)
         {
             using (var conn = OpenConnection())


### PR DESCRIPTION
Always deserialize to string before passing to JsonDocument.Parse. We used to pass a Memory<byte> of our underlying buffer, which invalidated the JsonDocument when the buffer was reread.

Fixes #2811