### PR TITLE
Checking field value for DBNull in unmapped composite handler

### DIFF
--- a/src/Npgsql/TypeHandlers/CompositeHandlers/UnmappedCompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/UnmappedCompositeHandler.cs
@@ -154,7 +154,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             {
                 totalLen += 4 + 4;  // type oid + field length
                 var fieldValue = f.Getter(value);
-                if (fieldValue == null)
+                if (fieldValue == null || fieldValue == DBNull.Value)
                     continue;
                 totalLen += f.Handler.ValidateObjectAndGetLength(fieldValue, ref lengthCache, null);
             }

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -865,5 +865,23 @@ CREATE TYPE address AS
                 }
             }
         }
+
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2831")]
+        public void UnmappedCompositeWithDbNull()
+        {
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                Pooling = false,
+                ApplicationName = nameof(NullablePropertyInStructComposite)
+            };
+            using var conn = OpenConnection(csb);
+
+            conn.ExecuteNonQuery("CREATE TYPE pg_temp.composite_with_db_null AS (foo INT)");
+            conn.ReloadTypes();
+
+            using var cmd = new NpgsqlCommand(@"SELECT @p1", conn);
+            cmd.Parameters.Add(new NpgsqlParameter("p1", new { foo = DBNull.Value }) { DataTypeName = "composite_with_db_null" });
+            cmd.ExecuteNonQuery();
+        }
     }
 }


### PR DESCRIPTION
`ValidateAndGetLength` returns -1 for `null` and `DBNull` which breaks message to the server and causes an error on its side.

Fixes #2831.