### PR TITLE
Issue 2849 - write buffer free space check for chunked workflow

### DIFF
--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -448,7 +448,7 @@ namespace Npgsql
         internal void WriteStringChunked(char[] chars, int charIndex, int charCount,
                                          bool flush, out int charsUsed, out bool completed)
         {
-            if (WriteSpaceLeft < _textEncoder.GetByteCount(chars, charIndex, 1, true))
+            if (WriteSpaceLeft < _textEncoder.GetByteCount(chars, charIndex, 1, flush: false))
             {
                 charsUsed = 0;
                 completed = false;
@@ -468,7 +468,7 @@ namespace Npgsql
             fixed (char* sPtr = s)
             fixed (byte* bufPtr = Buffer)
             {
-                if (WriteSpaceLeft < _textEncoder.GetByteCount(sPtr + charIndex, 1, true))
+                if (WriteSpaceLeft < _textEncoder.GetByteCount(sPtr + charIndex, 1, flush: false))
                 {
                     charsUsed = 0;
                     completed = false;

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1165,7 +1165,7 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
                     // This string needs to be long enough to be eligible for chunking, and start with a unicode character that will
                     // get encoded to multiple bytes
                     var longStringStartingWithAforementionedUnicodeCharacter = unicodeCharacterThatEncodesToThreeBytesInUtf8 + new string('a', 10000);
-                    await binaryImporter.WriteAsync(longStringStartingWithAforementionedUnicodeCharacter, NpgsqlTypes.NpgsqlDbType.Text);
+                    await binaryImporter.WriteAsync(longStringStartingWithAforementionedUnicodeCharacter, NpgsqlDbType.Text);
 
                     await binaryImporter.CompleteAsync();
                 }

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1146,7 +1146,11 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2849")]
         public async Task ChunkedStringWriteBufferEncodingSpace()
         {
-            using var conn = OpenConnection();
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString);
+            // write buffer size must be 8192 for this test to work
+            // so guard against changes to the default / a change in the test harness
+            builder.WriteBufferSize = 8192;
+            using var conn = OpenConnection(builder.ConnectionString);
 
             try
             {
@@ -1179,7 +1183,11 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2849")]
         public async Task ChunkedCharArrayWriteBufferEncodingSpace()
         {
-            using var conn = OpenConnection();
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString);
+            // write buffer size must be 8192 for this test to work
+            // so guard against changes to the default / a change in the test harness
+            builder.WriteBufferSize = 8192;
+            using var conn = OpenConnection(builder.ConnectionString);
 
             try
             {

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1142,5 +1142,38 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
   CONSTRAINT ""pk_OrganisatieQmo_Organisatie_QueryModelObjects_Imp"" PRIMARY KEY (""Id"")
 )";
         #endregion Bug1285
+
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2849")]
+        public async Task ChunkedStringWriteBufferEncodingSpace()
+        {
+            using var conn = OpenConnection();
+
+            try
+            {
+                conn.ExecuteNonQuery("CREATE TABLE bug_2849 (col1 text, col2 text)");
+
+                using (var binaryImporter = conn.BeginBinaryImport("COPY bug_2849 FROM STDIN (FORMAT BINARY);"))
+                {
+                    // 8163 writespace left
+                    await binaryImporter.StartRowAsync();
+
+                    // we need to almost fill the write buffer - we need one byte left in the buffer before we chunk the string for the column after this one!
+                    var almostBufferFillingString = new string('a', 8152);
+                    await binaryImporter.WriteAsync(almostBufferFillingString, NpgsqlTypes.NpgsqlDbType.Text);
+
+                    var unicodeCharacterThatEncodesToThreeBytesInUtf8 = '\uD55C';
+                    // This string needs to be long enough to be eligible for chunking, and start with a unicode character that will
+                    // get encoded to multiple bytes
+                    var longStringStartingWithAforementionedUnicodeCharacter = unicodeCharacterThatEncodesToThreeBytesInUtf8 + new string('a', 10000);
+                    await binaryImporter.WriteAsync(longStringStartingWithAforementionedUnicodeCharacter, NpgsqlTypes.NpgsqlDbType.Text);
+
+                    await binaryImporter.CompleteAsync();
+                }
+            }
+            finally
+            {
+                conn.ExecuteNonQuery("DROP TABLE IF EXISTS bug_2849");
+            }
+        }
     }
 }

--- a/test/Npgsql.Tests/WriteBufferTests.cs
+++ b/test/Npgsql.Tests/WriteBufferTests.cs
@@ -23,6 +23,34 @@ namespace Npgsql.Tests
             Assert.That(completed, Is.False);
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2849")]
+        public void ChunkedStringEncodingFits()
+        {
+            WriteBuffer.WriteBytes(new byte[WriteBuffer.Size - 1], 0, WriteBuffer.Size - 1);
+            Assert.That(WriteBuffer.WriteSpaceLeft, Is.EqualTo(1));
+
+            var charsUsed = 1;
+            var completed = true;
+            // This unicode character is three bytes when encoded in UTF8
+            Assert.That(() => WriteBuffer.WriteStringChunked("\uD55C", 0, 1, true, out charsUsed, out completed), Throws.Nothing);
+            Assert.That(charsUsed, Is.EqualTo(0));
+            Assert.That(completed, Is.False);
+        }
+
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2849")]
+        public void ChunkedByteArrayEncodingFits()
+        {
+            WriteBuffer.WriteBytes(new byte[WriteBuffer.Size - 1], 0, WriteBuffer.Size - 1);
+            Assert.That(WriteBuffer.WriteSpaceLeft, Is.EqualTo(1));
+
+            var charsUsed = 1;
+            var completed = true;
+            // This unicode character is three bytes when encoded in UTF8
+            Assert.That(() => WriteBuffer.WriteStringChunked("\uD55C".ToCharArray(), 0, 1, true, out charsUsed, out completed), Throws.Nothing);
+            Assert.That(charsUsed, Is.EqualTo(0));
+            Assert.That(completed, Is.False);
+        }
+
 #pragma warning disable CS8625
         [SetUp]
         public void SetUp()


### PR DESCRIPTION
Fixes #2849 

When chunking strings and char arrays, make sure we have enough space in the write buffer for at least the first character after encoding.

I wasn't sure whether or not to leave the `WriteSpaceLeft == 0` in there as well as a short circuit for performance reasons, since that will be the majority case and we'll save ourselves the call to `GetByteCount` - I don't have a good feeling for how expensive that is.

An alternative to this would be change the `WriteSpaceLeft == 0` condition to `WriteSpaceLeft < 4`, but I wasn't sure if we could guarantee that `_textEncoder` won't provide more than 4 bytes for a character (e.g. can the encoder be user-provided and potentially return more than this?). Not sure whether it would be more performant to avoid this method call altogether and lose 4 bytes of the write buffer - you folks probably have a better feel for which is more sensible!

I did try using BenchmarkDotNet with the following code in `CopyImport.cs`, but I was getting results saying it was faster under the `< 4` modification, which didn't seem to make a lot of sense to me, so I'm not sure if I'm doing it right 😅 (Need to create a table called `text_data` with a single text column in the setup, and truncate it along with `data` in `_truncateCmd`.) Wasn't sure whether this benchmark was worth committing?

```
[Benchmark]
public void ImportText()
{
    var longString = new string('a', 10000);
    using (var importer = _conn.BeginBinaryImport("COPY text_data FROM STDIN (FORMAT BINARY)"))
    {
        for (var row = 0; row < Rows; row++)
        {
            importer.StartRow();
            importer.Write(longString, NpgsqlDbType.Text);
        }
    }
}
```

Thanks for your time!