### PR TITLE
Remove Console.WriteLine from NpgsqlEventSource

### DIFF
--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -147,10 +147,8 @@ namespace Npgsql
                     DisplayName = "Failed Commands"
                 };
 
-//                _preparedCommandsRatioCounter = new PollingCounter("prepared-commands-ratio", this, () => (double)_totalPreparedCommands / (double)_totalCommands)
                 _preparedCommandsRatioCounter = new PollingCounter("prepared-commands-ratio", this, () =>
                 {
-                    Console.WriteLine($"{(double)_totalPreparedCommands} / {(double)_totalCommands}");
                     return (double)_totalPreparedCommands / (double)_totalCommands;
                 })
                 {


### PR DESCRIPTION
If application starts listening to `NpgsqlEventSource` events, then console ouput is polluted with "random numbers".

Introduced in https://github.com/npgsql/npgsql/pull/2571 pull request