### PR TITLE
Fix "provide password callback" tests under GitHub Actions against Postgres on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,11 @@ jobs:
           pgsql/bin/psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
 
           # Disable trust authentication, allow md5 auth from anywhere for any user
-          # This does not require a server restart, pg_reload_conf, or SIGHUP under Windows to take effect for new connections
+          # This does not require a server restart, pg_reload_conf, or SIGHUP under Windows to take effect for new connections on PostgreSQL 10, 11, and 12
+          # according to the notes in the documentation:
+          # - https://www.postgresql.org/docs/10/auth-pg-hba-conf.html
+          # - https://www.postgresql.org/docs/11/auth-pg-hba-conf.html
+          # - https://www.postgresql.org/docs/12/auth-pg-hba-conf.html
           echo "host all all all md5" > pgsql/PGDATA/pg_hba.conf
 
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,11 @@ jobs:
           # Configure test account
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests SUPERUSER LOGIN PASSWORD 'npgsql_tests'"
           pgsql/bin/psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
+
+          # Disable trust authentication, allow md5 auth from anywhere for any user
+          # This does not require a server restart, pg_reload_conf, or SIGHUP under Windows to take effect for new connections
+          echo "host all all all md5" > pgsql/PGDATA/pg_hba.conf
+
         shell: bash
 
       - name: Setup .NET Core SDK

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -188,12 +188,6 @@ namespace Npgsql.Tests
         [Test, Description("ProvidePasswordCallback is used when password is not supplied in connection string")]
         public void ProvidePasswordCallbackDelegateIsUsed()
         {
-            if (TestUtil.IsOnBuildServer && PGUtil.IsWindows)
-            {
-                Assert.Ignore("Somehow on Github Actions on Windows we log in successfully with this");
-                return;
-            }
-
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 Pooling = false
@@ -239,12 +233,6 @@ namespace Npgsql.Tests
         [Test, Description("Exceptions thrown from client application are wrapped when using ProvidePasswordCallback Delegate")]
         public void ProvidePasswordCallbackDelegateExceptionsAreWrapped()
         {
-            if (TestUtil.IsOnBuildServer && PGUtil.IsWindows)
-            {
-                Assert.Ignore("Somehow on Github Actions on Windows we log in successfully with this");
-                return;
-            }
-
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 Pooling = false,
@@ -268,12 +256,6 @@ namespace Npgsql.Tests
         [Test, Description("Parameters passed to ProvidePasswordCallback delegate are correct")]
         public void ProvidePasswordCallbackDelegateGetsCorrectArguments()
         {
-            if (TestUtil.IsOnBuildServer && PGUtil.IsWindows)
-            {
-                Assert.Ignore("Somehow on Github Actions on Windows we log in successfully with this");
-                return;
-            }
-
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString) { Pooling = false };
             var goodPassword = connString.Password;
             connString.Password = null;


### PR DESCRIPTION
These tests were ignored when running against PostgreSQL on Windows under GitHub Actions because they were failing due to `trust` auth still being enabled in `pg_hba.conf` - this does the same thing as [is done for tests against PostgreSQL on Linux](https://github.com/npgsql/npgsql/blob/cb46ddb87ba86c1b4812e284fba1c044c9a6c847/.build/docker/initdb-npgsql.sh#L18) under GitHub Actions by replacing the default `pg_hba.conf` file with a single entry that allows MD5 authentication from any hosts for any user against any database.