### PR TITLE
fix getting FOREIGN TABLE issue for PG 9 and PG 10

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -224,11 +224,10 @@ namespace Npgsql
 
             var getTables = new StringBuilder();
 
-            //getTables.Append("SELECT * FROM (SELECT table_catalog, table_schema, table_name, table_type FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema NOT IN ('pg_catalog', 'information_schema')) tmp");
             getTables.Append(@"
 SELECT table_catalog, table_schema, table_name, table_type
 FROM information_schema.tables
-WHERE table_type IN ('BASE TABLE', 'FOREIGN') AND table_schema NOT IN ('pg_catalog', 'information_schema')");
+WHERE table_type IN ('BASE TABLE', 'FOREIGN', 'FOREIGN TABLE') AND table_schema NOT IN ('pg_catalog', 'information_schema')");
 
             using (var command = BuildCommand(conn, getTables, restrictions, false, "table_catalog", "table_schema", "table_name", "table_type"))
             using (var adapter = new NpgsqlDataAdapter(command))


### PR DESCRIPTION
In #2525 , the PR only fix foreign table issue for PG 11.x. However, PG 11 changed the foreign table type from 'FOREIGN TABLE' to 'FOREIGN'. In this case, it's inpossible to get foreign tables from PG 9 and PG 10.

### Reference

https://www.postgresql.org/docs/10/infoschema-tables.html

https://www.postgresql.org/docs/9.3/infoschema-tables.html