### PR TITLE
Unmapped Composite Types, System.Exception, could not match any on CLR type

### DIFF
--- a/src/Npgsql/TypeHandlers/CompositeHandlers/UnmappedCompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/UnmappedCompositeHandler.cs
@@ -226,8 +226,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 var typeMember = (
                     from m in type.GetMembers()
                     let attr = m.GetCustomAttribute<PgNameAttribute>()
-                    where attr != null && attr.PgName == member.PgName ||
-                          attr == null && _nameTranslator.TranslateMemberName(m.Name) == member.PgName
+                    where (attr != null && attr.PgName == member.PgName) ||
+                          (attr == null && _nameTranslator.TranslateMemberName(m.Name) == member.PgName) ||
+                          (attr == null && m.Name == member.PgName)
                     select m
                 ).SingleOrDefault();
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -194,7 +194,7 @@ namespace Npgsql.Tests
             var goodPassword = connString.Password;
             connString.Password = null;
 
-            bool getPasswordDelegateWasCalled = false;
+            var getPasswordDelegateWasCalled = false;
 
             using (var conn = new NpgsqlConnection(connString.ToString()) { ProvidePasswordCallback = ProvidePasswordCallback })
             {
@@ -205,7 +205,7 @@ namespace Npgsql.Tests
             string ProvidePasswordCallback(string host, int port, string database, string username)
             {
                 getPasswordDelegateWasCalled = true;
-                return goodPassword;
+                return goodPassword!;
             }
         }
 
@@ -279,7 +279,7 @@ namespace Npgsql.Tests
                 receivedDatabase = database;
                 receivedUsername = username;
 
-                return goodPassword;
+                return goodPassword!;
             }
         }
         #endregion

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <ItemGroup>
+    <Compile Remove="ConnectionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.CSharp" />

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -155,6 +155,7 @@ namespace Npgsql.Tests.Types
         }
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1779")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "<Pending>")]
         public void CompositePostgresType()
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
@@ -174,6 +175,10 @@ namespace Npgsql.Tests.Types
                     {
                         reader.Read();
                         var comp2Type = (PostgresCompositeType)reader.GetPostgresType(0);
+
+                        object[] vals = new object[100];
+                        reader.GetValues(vals);
+
                         Assert.That(comp2Type.Name, Is.EqualTo("comp2"));
                         Assert.That(comp2Type.FullName, Does.StartWith("pg_temp_") & Does.EndWith(".comp2"));
                         Assert.That(comp2Type.Fields, Has.Count.EqualTo(2));


### PR DESCRIPTION
Address System.Exception: 'PostgreSQL composite type ..pgtype.. contains field ..somefield.. which could not match any on CLR type ..clrtype..' when using unmapped composite types

The original code mixes && || and will fail if no PgName attribute is provided.
It also always translates the column name which is not necessarily desirable.
