### PR TITLE
Downgrade some package versions for .NET Framework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,8 @@
     <Copyright>Copyright 2020 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <NoWarn>NU5105</NoWarn>
+    <!-- We suppress NU1605 because of System.Text.Json on .NET Framework (see note in Directory.Build.targets) -->
+    <NoWarn>$(NoWarn);NU5105;NU1605</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,23 @@
 ﻿<Project>
-  <ItemGroup>
+  <PropertyGroup>
+    <!--
+    The following is necessary because:
+     a. We must depend on System.RuntimeCompilerServices.Unsafe 4.5.2, since we also depend on
+        System.Threading.Tasks.Extensions 4.5.3 which depends on that version (there's no newer version).
+     b. We depend on System.Text.Json, which depends on System.RuntimeCompilerServices.Unsafe 4.6.0.
+     c. Any mismatch causes assembly load errors in .NET Framework, requiring binding redirects and leading to
+        many issues and much confusion
+    -->
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net461' ">
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
-    <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Update="System.Memory" Version="4.5.3" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="System.Text.Json" Version="4.6.0" />

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -259,11 +259,11 @@ namespace Npgsql
 
                 if (_columnLen == -1)
                 {
-#pragma warning disable CS8653 // A default expression introduces a null value when 'T' is a non-nullable reference type.
+#pragma warning disable CS8603,CS8653
                     // When T is a Nullable<T>, we support returning null
                     if (NullableHandler<T>.Exists)
                         return default;
-#pragma warning restore CS8653
+#pragma warning restore CS8653,CS8603
                     throw new InvalidCastException("Column is null");
                 }
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -161,8 +161,8 @@ namespace NpgsqlTypes
         /// <param name="upperBound">The upper bound of the range.</param>
         /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
         /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-        public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite,
-                           T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
+        public NpgsqlRange([AllowNull] T lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite,
+                           [AllowNull] T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
             : this(
                 lowerBound,
                 upperBound,
@@ -204,7 +204,7 @@ namespace NpgsqlTypes
         /// <returns>
         /// True if the range is implicitly empty; otherwise, false.
         /// </returns>
-        static bool IsEmptyRange(T lowerBound, T upperBound, RangeFlags flags)
+        static bool IsEmptyRange([AllowNull] T lowerBound, [AllowNull] T upperBound, RangeFlags flags)
         {
             // ---------------------------------------------------------------------------------
             // We only want to check for those conditions that are unambiguously erroneous:
@@ -235,7 +235,7 @@ namespace NpgsqlTypes
 
             return lower != null && !lower.Equals(default!) &&
                    upper != null && !upper.Equals(default!) &&
-                   lower.Equals(upperBound);
+                   lower.Equals(upper);
         }
 
         /// <summary>
@@ -304,8 +304,8 @@ namespace NpgsqlTypes
 
             if (HasEquatableBounds)
                 return
-                    (LowerBound == null ? other.LowerBound == null : ((IEquatable<T>)LowerBound).Equals(other.LowerBound)) &&
-                    (UpperBound == null ? other.UpperBound == null : ((IEquatable<T>)UpperBound).Equals(other.UpperBound));
+                    (LowerBound == null ? other.LowerBound == null : ((IEquatable<T>)LowerBound).Equals(other.LowerBound!)) &&
+                    (UpperBound == null ? other.UpperBound == null : ((IEquatable<T>)UpperBound).Equals(other.UpperBound!));
 
             return
                 (LowerBound?.Equals(other.LowerBound) ?? other.LowerBound == null) &&

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -123,10 +123,10 @@ namespace Npgsql.TypeHandlers
             if (!value.IsEmpty)
             {
                 if (!value.LowerBoundInfinite)
-                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.LowerBound, ref lengthCache, null);
+                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.LowerBound!, ref lengthCache, null);
 
                 if (!value.UpperBoundInfinite)
-                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.UpperBound, ref lengthCache, null);
+                    totalLen += 4 + _elementHandler.ValidateAndGetLength(value.UpperBound!, ref lengthCache, null);
             }
 
             // If we're traversing an already-populated length cache, rewind to first element slot so that

--- a/test/Npgsql.Tests/Types/JsonTests.cs
+++ b/test/Npgsql.Tests/Types/JsonTests.cs
@@ -1,3 +1,5 @@
+// Using JSON support on .NET Framework requires some binding redirects (see comment in Directory.Build.targets)
+#if !NET461
 using System;
 using System.Text;
 using System.Text.Json;
@@ -204,3 +206,4 @@ namespace Npgsql.Tests.Types
         readonly NpgsqlDbType NpgsqlDbType;
     }
 }
+#endif


### PR DESCRIPTION
4.1.0 bumped the following dependencies:

* System.Runtime.CompilerServices.Unsafe from 4.5.2 to 4.6.0
* System.Threading.Tasks.Extensions from 4.5.2 to 4.5.3

Unfortunately System.Text.Json, which we also added in 4.1.0, depends on S.R.C.U 4.6.0 but also on S.T.T.E 4.5.3, which itself depends on S.R.C.U 4.5.2. In other words, there's no way to use System.Text.Json in a .NET Framework application withou binding redirects.

This downgrades the versions back to where they were in 4.0.10; people who want to use 4.1's JSON capabilities will have to define binding redirects.

Note that S.R.C.U is held back only for .NET Framework (our .NET Core version depends on a different version).

Fixes #2677