### PR TITLE
"Unmapped" Composites Proposal

### DIFF
--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -111,31 +111,6 @@ namespace Npgsql.TypeMapping
             INpgsqlNameTranslator? nameTranslator = null);
 
         /// <summary>
-        /// Maps a CLR type to a PostgreSQL composite type.
-        /// </summary>
-        /// <remarks>
-        /// Maps CLR fields and properties by string to PostgreSQL column names.
-        /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
-        /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
-        /// If there is a discrepancy between the .NET and database column names while a composite is read or written,
-        /// an exception will be raised.
-        /// </remarks>
-        /// <param name="compType">The .NET type to be mapped</param>
-        /// <param name="pgName">
-        /// A PostgreSQL type name for the corresponding type in the database. This type is required and must exist in the PostgreSQL database.
-        /// </param>
-        /// <param name="nameTranslator">
-        /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
-        /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
-        /// </param>
-        [NotNull]
-        INpgsqlTypeMapper MapComposite(
-            Type compType,
-            string pgName,
-            INpgsqlNameTranslator? nameTranslator = null);
-
-
-        /// <summary>
         /// Removes an existing enum mapping.
         /// </summary>
         /// <param name="pgName">
@@ -147,6 +122,48 @@ namespace Npgsql.TypeMapping
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         bool UnmapComposite<T>(
+            string? pgName = null,
+            INpgsqlNameTranslator? nameTranslator = null);
+
+        /// <summary>
+        /// Maps a CLR type to a composite type.
+        /// </summary>
+        /// <remarks>
+        /// Maps CLR fields and properties by string to PostgreSQL column names.
+        /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+        /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+        /// If there is a discrepancy between the .NET and database column names while a composite is read or written,
+        /// an exception will be raised.
+        /// </remarks>
+        /// <param name="compType">The .NET type to be mapped.</param>
+        /// <param name="pgName">
+        /// A PostgreSQL type name for the corresponding composite type in the database.
+        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// </param>
+        /// <param name="nameTranslator">
+        /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+        /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
+        /// </param>
+        [NotNull]
+        INpgsqlTypeMapper MapComposite(
+            Type compType,
+            string? pgName = null,
+            INpgsqlNameTranslator? nameTranslator = null);
+
+        /// <summary>
+        /// Removes an existing composite type.
+        /// </summary>
+        /// <param name="compType">The .NET type to be unmapped.</param>
+        /// <param name="pgName">
+        /// A PostgreSQL type name for the corresponding composite type in the database.
+        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// </param>
+        /// <param name="nameTranslator">
+        /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+        /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
+        /// </param>
+        bool UnmapComposite(
+            Type compType,
             string? pgName = null,
             INpgsqlNameTranslator? nameTranslator = null);
 

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -56,7 +56,7 @@ namespace Npgsql.TypeMapping
         /// </remarks>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding enum type in the database.
-        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
@@ -89,16 +89,16 @@ namespace Npgsql.TypeMapping
         /// Maps a CLR type to a PostgreSQL composite type.
         /// </summary>
         /// <remarks>
-        /// CLR fields and properties by string to PostgreSQL enum labels.
+        /// CLR fields and properties by string to PostgreSQL names.
         /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
         /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
-        /// You can also use the <see cref="PgNameAttribute"/> on your members to manually specify a PostgreSQL enum label.
-        /// If there is a discrepancy between the .NET and database labels while a composite is read or written,
+        /// You can also use the <see cref="PgNameAttribute"/> on your members to manually specify a PostgreSQL name.
+        /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
         /// an exception will be raised.
         /// </remarks>
         /// <param name="pgName">
-        /// A PostgreSQL type name for the corresponding enum type in the database.
-        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// A PostgreSQL type name for the corresponding composite type in the database.
+        /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
@@ -111,11 +111,11 @@ namespace Npgsql.TypeMapping
             INpgsqlNameTranslator? nameTranslator = null);
 
         /// <summary>
-        /// Removes an existing enum mapping.
+        /// Removes an existing composite mapping.
         /// </summary>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding composite type in the database.
-        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
@@ -129,16 +129,16 @@ namespace Npgsql.TypeMapping
         /// Maps a CLR type to a composite type.
         /// </summary>
         /// <remarks>
-        /// Maps CLR fields and properties by string to PostgreSQL column names.
+        /// Maps CLR fields and properties by string to PostgreSQL names.
         /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
         /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
-        /// If there is a discrepancy between the .NET and database column names while a composite is read or written,
+        /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
         /// an exception will be raised.
         /// </remarks>
         /// <param name="compType">The .NET type to be mapped.</param>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding composite type in the database.
-        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
@@ -151,12 +151,12 @@ namespace Npgsql.TypeMapping
             INpgsqlNameTranslator? nameTranslator = null);
 
         /// <summary>
-        /// Removes an existing composite type.
+        /// Removes an existing composite mapping.
         /// </summary>
         /// <param name="compType">The .NET type to be unmapped.</param>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding composite type in the database.
-        /// If null, the name translator given in <paramref name="nameTranslator"/>will be used.
+        /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
         /// </param>
         /// <param name="nameTranslator">
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -111,6 +111,31 @@ namespace Npgsql.TypeMapping
             INpgsqlNameTranslator? nameTranslator = null);
 
         /// <summary>
+        /// Maps a CLR type to a PostgreSQL composite type.
+        /// </summary>
+        /// <remarks>
+        /// Maps CLR fields and properties by string to PostgreSQL column names.
+        /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+        /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+        /// If there is a discrepancy between the .NET and database column names while a composite is read or written,
+        /// an exception will be raised.
+        /// </remarks>
+        /// <param name="compType">The .NET type to be mapped</param>
+        /// <param name="pgName">
+        /// A PostgreSQL type name for the corresponding type in the database. This type is required and must exist in the PostgreSQL database.
+        /// </param>
+        /// <param name="nameTranslator">
+        /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+        /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
+        /// </param>
+        [NotNull]
+        INpgsqlTypeMapper MapComposite(
+            Type compType,
+            string pgName,
+            INpgsqlNameTranslator? nameTranslator = null);
+
+
+        /// <summary>
         /// Removes an existing enum mapping.
         /// </summary>
         /// <param name="pgName">

--- a/src/Npgsql/TypeMapping/TypeMapperBase.cs
+++ b/src/Npgsql/TypeMapping/TypeMapperBase.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeMapping
             if (nameTranslator == null)
                 nameTranslator = DefaultNameTranslator;
             if (pgName == null)
-                pgName = GetPgName<TEnum>(nameTranslator);
+                pgName = GetPgName(typeof(TEnum), nameTranslator);
 
             return AddMapping(new NpgsqlTypeMappingBuilder
             {
@@ -70,7 +70,7 @@ namespace Npgsql.TypeMapping
             if (nameTranslator == null)
                 nameTranslator = DefaultNameTranslator;
             if (pgName == null)
-                pgName = GetPgName<TEnum>(nameTranslator);
+                pgName = GetPgName(typeof(TEnum), nameTranslator);
 
             return RemoveMapping(pgName);
         }
@@ -126,10 +126,6 @@ namespace Npgsql.TypeMapping
         #region Misc
 
         // TODO: why does ReSharper think `GetCustomAttribute<T>` is non-nullable?
-        // ReSharper disable once ConstantConditionalAccessQualifier ConstantNullCoalescingCondition
-        static string GetPgName<T>(INpgsqlNameTranslator nameTranslator)
-            => GetPgName(typeof(T), nameTranslator);
-
         // ReSharper disable once ConstantConditionalAccessQualifier ConstantNullCoalescingCondition
         static string GetPgName(Type compType, INpgsqlNameTranslator nameTranslator)
             => compType.GetCustomAttribute<PgNameAttribute>()?.PgName

--- a/src/Npgsql/TypeMapping/TypeMapperBase.cs
+++ b/src/Npgsql/TypeMapping/TypeMapperBase.cs
@@ -80,33 +80,21 @@ namespace Npgsql.TypeMapping
         #region Composite mapping
 
         public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-        {
+            => MapComposite(typeof(T), pgName, nameTranslator);
+
+        public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+            => UnmapComposite(typeof(T), pgName, nameTranslator);
+
+        public INpgsqlTypeMapper MapComposite(Type compType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) {
             if (pgName != null && pgName.Trim() == "")
                 throw new ArgumentException("pgName can't be empty", nameof(pgName));
 
             if (nameTranslator == null)
                 nameTranslator = DefaultNameTranslator;
             if (pgName == null)
-                pgName = GetPgName<T>(nameTranslator);
+                pgName = GetPgName(compType, nameTranslator);
 
-            return AddMapping(new NpgsqlTypeMappingBuilder
-            {
-                PgTypeName = pgName,
-                ClrTypes = new[] { typeof(T) },
-                TypeHandlerFactory = new CompositeTypeHandlerFactory<T>(nameTranslator)
-            }.Build());
-        }
-
-        public INpgsqlTypeMapper MapComposite(Type compType, string pgName, INpgsqlNameTranslator? nameTranslator = null)
-        {
-            if (string.IsNullOrWhiteSpace(pgName))
-                throw new ArgumentException("pgName can't be empty", nameof(pgName));
-
-            if (nameTranslator == null)
-                nameTranslator = DefaultNameTranslator;
-
-            Type thfType = typeof(CompositeTypeHandlerFactory<>);
-
+            var thfType = typeof(CompositeTypeHandlerFactory<>);
             var thf = (NpgsqlTypeHandlerFactory)Activator.CreateInstance(
                 thfType.MakeGenericType(compType),
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
@@ -121,15 +109,14 @@ namespace Npgsql.TypeMapping
             }.Build());
         }
 
-        public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-        {
+        public bool UnmapComposite(Type compType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) {
             if (pgName != null && pgName.Trim() == "")
                 throw new ArgumentException("pgName can't be empty", nameof(pgName));
 
             if (nameTranslator == null)
                 nameTranslator = DefaultNameTranslator;
             if (pgName == null)
-                pgName = GetPgName<T>(nameTranslator);
+                pgName = GetPgName(compType, nameTranslator);
 
             return RemoveMapping(pgName);
         }
@@ -141,8 +128,12 @@ namespace Npgsql.TypeMapping
         // TODO: why does ReSharper think `GetCustomAttribute<T>` is non-nullable?
         // ReSharper disable once ConstantConditionalAccessQualifier ConstantNullCoalescingCondition
         static string GetPgName<T>(INpgsqlNameTranslator nameTranslator)
-            => typeof(T).GetCustomAttribute<PgNameAttribute>()?.PgName
-               ?? nameTranslator.TranslateTypeName(typeof(T).Name);
+            => GetPgName(typeof(T), nameTranslator);
+
+        // ReSharper disable once ConstantConditionalAccessQualifier ConstantNullCoalescingCondition
+        static string GetPgName(Type compType, INpgsqlNameTranslator nameTranslator)
+            => compType.GetCustomAttribute<PgNameAttribute>()?.PgName
+               ?? nameTranslator.TranslateTypeName(compType.Name);
 
         #endregion Misc
     }


### PR DESCRIPTION
This is a suggestion to add a way to add mapping for composites by System.Type instead of an explicitly known class, which requires it to be defined in source code.
This works for parameters and get/put

I got inspiration for this in https://github.com/npgsql/npgsql/issues/2689 (due to the requirement for this feature).

used as follows:
Conn.TypeMapper.MapComposite(someType, "Some_PG_Type_Name", new NpgsqlNullNameTranslator());

someType is of type System.Type. If the CLR type _name_ is available, a System.Type can be created without the need for the class to be explicitly declared in source.
