### PR TITLE
VSIX: Integrated security touch-up

### DIFF
--- a/src/VSIX/NpgsqlConnectionUIControl.cs
+++ b/src/VSIX/NpgsqlConnectionUIControl.cs
@@ -54,6 +54,18 @@ namespace Npgsql.VSIX
                 Site["Password"] = passwordTextBox.Text;
             else if (sender == savePasswordCheckBox)
                 Site["Persist Security Info"] = savePasswordCheckBox.Checked;
+            else if (sender == windowsAuthCheckbox)
+            {
+                var integratedSecurity = windowsAuthCheckbox.Checked;
+                Site["Integrated Security"] = integratedSecurity;
+                usernameTextBox.Enabled = !integratedSecurity;
+                passwordTextBox.Enabled = !integratedSecurity;
+                if (integratedSecurity)
+                {
+                    usernameTextBox.Text = "";
+                    passwordTextBox.Text = "";
+                }
+            }
 
             // TODO: Authentication!
         }


### PR DESCRIPTION
In the UI, when checking "Windows Authentication", the username and password should be cleared and fields disabled, and `Integrated Security=True` should be added to connection string.