### PR TITLE
First implementation of frontend timeouts for async methods

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -834,7 +834,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         void BeginSend(NpgsqlConnector connector)
         {
-            connector.WriteBuffer.Timeout = CommandTimeout * 1000;
+            connector.WriteBuffer.Timeout = TimeSpan.FromSeconds(CommandTimeout);
             connector.WriteBuffer.CurrentCommand = this;
             FlushOccurred = false;
         }

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -834,6 +834,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         void BeginSend(NpgsqlConnector connector)
         {
+            connector.WriteBuffer.Timeout = CommandTimeout * 1000;
             connector.WriteBuffer.CurrentCommand = this;
             FlushOccurred = false;
         }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -186,11 +186,6 @@ namespace Npgsql
         /// </summary>
         internal int UserTimeout { private get; set; }
 
-        int ReceiveTimeout
-        {
-            set => ReadBuffer.Timeout = TimeSpan.FromMilliseconds(value);
-        }
-
         /// <summary>
         /// A lock that's taken while a user action is in progress, e.g. a command being executed.
         /// Only used when keepalive is enabled, otherwise null.
@@ -1029,7 +1024,7 @@ namespace Npgsql
                     try
                     {
                         // TODO: There could be room for optimization here, rather than the async call(s)
-                        ReceiveTimeout = InternalCommandTimeout;
+                        ReadBuffer.Timeout = TimeSpan.FromMilliseconds(InternalCommandTimeout);
                         for (; _pendingPrependedResponses > 0; _pendingPrependedResponses--)
                             await ReadMessageLong(DataRowLoadingMode.Skip, false, true);
                     }
@@ -1043,7 +1038,7 @@ namespace Npgsql
 
                 try
                 {
-                    ReceiveTimeout = UserTimeout;
+                    ReadBuffer.Timeout = TimeSpan.FromMilliseconds(UserTimeout);
 
                     while (true)
                     {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -580,8 +580,14 @@ namespace Npgsql
                     RelaxedTextEncoding = Encoding.GetEncoding(Settings.Encoding, EncoderFallback.ReplacementFallback, DecoderFallback.ReplacementFallback);
                 }
 
-                ReadBuffer = new NpgsqlReadBuffer(this, _stream, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding);
-                WriteBuffer = new NpgsqlWriteBuffer(this, _stream, Settings.WriteBufferSize, TextEncoding);
+                ReadBuffer = new NpgsqlReadBuffer(this, _stream, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding)
+                {
+                    UnderlyingSocket = _socket   
+                };
+                WriteBuffer = new NpgsqlWriteBuffer(this, _stream, Settings.WriteBufferSize, TextEncoding)
+                {
+                    UnderlyingSocket = _socket
+                };
 
                 if (SslMode == SslMode.Require || SslMode == SslMode.Prefer)
                 {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -188,7 +188,7 @@ namespace Npgsql
 
         int ReceiveTimeout
         {
-            set => ReadBuffer.Timeout = value;
+            set => ReadBuffer.Timeout = TimeSpan.FromMilliseconds(value);
         }
 
         /// <summary>

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -651,9 +651,7 @@ namespace Npgsql
             catch
             {
 #pragma warning disable CS8625
-                try { _stream?.Dispose(); }
-                catch
-                {
+                try { _stream?.Dispose(); } catch {
                     // ignored
                 }
                 _stream = null;

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -188,10 +188,7 @@ namespace Npgsql
 
         int ReceiveTimeout
         {
-            set
-            {
-                ReadBuffer.ReadTimeout = value;
-            }
+            set => ReadBuffer.Timeout = value;
         }
 
         /// <summary>

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1072,14 +1072,16 @@ namespace Npgsql
                         {
                             if (len > ReadBuffer.Size)
                             {
-                                var oversizeBuffer = ReadBuffer.AllocateOversize(len);
-
                                 if (_origReadBuffer == null)
                                     _origReadBuffer = ReadBuffer;
                                 else
+                                {
+                                    // Disposing ReadBuffer only disposes internal CancellationTokenSource
+                                    // So it's fine to call ReadBuffer.AllocateOversize later
                                     ReadBuffer.Dispose();
+                                } 
 
-                                ReadBuffer = oversizeBuffer;
+                                ReadBuffer = ReadBuffer.AllocateOversize(len);
                             }
 
                             await ReadBuffer.Ensure(len, async);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -651,6 +651,12 @@ namespace Npgsql
                     // ignored
                 }
                 ReadBuffer = null;
+                try { WriteBuffer?.Dispose(); }
+                catch
+                {
+                    // ignored
+                }
+                WriteBuffer = null;
                 try { _stream?.Dispose(); }
                 catch
                 {
@@ -1565,6 +1571,7 @@ namespace Npgsql
             _origReadBuffer = null;
             ReadBuffer?.Dispose();
             ReadBuffer = null;
+            WriteBuffer?.Dispose();
             WriteBuffer = null;
             Connection = null;
             PostgresParameters.Clear();

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1628,6 +1628,7 @@ namespace Npgsql
             // TODO: Replace this with array pooling, #2326
             if (_origReadBuffer != null)
             {
+                ReadBuffer.Dispose();
                 ReadBuffer = _origReadBuffer;
                 _origReadBuffer = null;
             }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -645,18 +645,6 @@ namespace Npgsql
             catch
             {
 #pragma warning disable CS8625
-                try { ReadBuffer?.Dispose(); }
-                catch
-                {
-                    // ignored
-                }
-                ReadBuffer = null;
-                try { WriteBuffer?.Dispose(); }
-                catch
-                {
-                    // ignored
-                }
-                WriteBuffer = null;
                 try { _stream?.Dispose(); }
                 catch
                 {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -580,14 +580,8 @@ namespace Npgsql
                     RelaxedTextEncoding = Encoding.GetEncoding(Settings.Encoding, EncoderFallback.ReplacementFallback, DecoderFallback.ReplacementFallback);
                 }
 
-                ReadBuffer = new NpgsqlReadBuffer(this, _stream, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding)
-                {
-                    UnderlyingSocket = _socket   
-                };
-                WriteBuffer = new NpgsqlWriteBuffer(this, _stream, Settings.WriteBufferSize, TextEncoding)
-                {
-                    UnderlyingSocket = _socket
-                };
+                ReadBuffer = new NpgsqlReadBuffer(this, _stream, _socket, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding);
+                WriteBuffer = new NpgsqlWriteBuffer(this, _stream, _socket, Settings.WriteBufferSize, TextEncoding);
 
                 if (SslMode == SslMode.Require || SslMode == SslMode.Prefer)
                 {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1072,16 +1072,14 @@ namespace Npgsql
                         {
                             if (len > ReadBuffer.Size)
                             {
+                                var oversizeBuffer = ReadBuffer.AllocateOversize(len);
+
                                 if (_origReadBuffer == null)
                                     _origReadBuffer = ReadBuffer;
                                 else
-                                {
-                                    // Disposing ReadBuffer only disposes internal CancellationTokenSource
-                                    // So it's fine to call ReadBuffer.AllocateOversize later
                                     ReadBuffer.Dispose();
-                                } 
 
-                                ReadBuffer = ReadBuffer.AllocateOversize(len);
+                                ReadBuffer = oversizeBuffer;
                             }
 
                             await ReadBuffer.Ensure(len, async);

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -32,19 +32,19 @@ namespace Npgsql
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 
         /// <summary>
-        /// Underlying socket ReceiveTimeout
+        /// Timeout for sync and async reads
         /// </summary>
         internal TimeSpan Timeout
         {
-            get => _currentSocketTimeout;
+            get => _currentTimeout;
             set
             {
-                if (_currentSocketTimeout != value)
+                if (_currentTimeout != value)
                 {
                     Debug.Assert(_underlyingSocket != null);
 
                     _underlyingSocket.ReceiveTimeout = value > TimeSpan.Zero ? (int)value.TotalMilliseconds : -1;
-                    _currentSocketTimeout = value;
+                    _currentTimeout = value;
                 }
             }
         }
@@ -52,9 +52,9 @@ namespace Npgsql
         /// <summary>
         /// Contains the current value of the Socket's RecieveTimeout, used to determine whether
         /// we need to change it when commands are received.
-        /// It's used only for sync IO (<see cref="Stream.Read(byte[], int, int)"/>)
+        /// Also, used as a timeout for async reads.
         /// </summary>
-        TimeSpan _currentSocketTimeout;
+        TimeSpan _currentTimeout;
 
         /// <summary>
         /// The total byte length of the buffer.
@@ -106,7 +106,7 @@ namespace Npgsql
             Connector = connector;
             Underlying = stream;
             _underlyingSocket = socket;
-            _currentSocketTimeout = TimeSpan.Zero;
+            _currentTimeout = TimeSpan.Zero;
             Size = size;
             Buffer = new byte[Size];
             TextEncoding = textEncoding;

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -181,6 +181,8 @@ namespace Npgsql
                         // Most of the time, it should be fine to reset cancellation token source, so we can use it again
                         // It's still possible for cancellation token to cancel between reading and resetting (although highly improbable)
                         // In this case, we consider it as timed out and fail with OperationCancelledException on next ReadAsync
+                        // Or we consider it not timed out if we have already read everything (count == 0)
+                        // In which case we reinitialize it on the next call to EnsureLong()
                         if (async)
                         {
                             _timeoutCts.CancelAfter(Timeout);

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -198,17 +198,17 @@ namespace Npgsql
                 )
                 {
                     if (dontBreakOnTimeouts)
-                        throw new TimeoutException("Timeout while reading from stream");
+                        throw new TimeoutException("Timeout while reading from stream", e);
                     else
-                        throw Connector.Break(new NpgsqlException("Exception while reading from stream", new TimeoutException("Timeout during reading attempt")));
+                        throw Connector.Break(new NpgsqlException("Exception while reading from stream", new TimeoutException("Timeout during reading attempt", e)));
                 }
                 // async timeout
-                catch (OperationCanceledException)
+                catch (OperationCanceledException e)
                 {
                     if (dontBreakOnTimeouts)
-                        throw new TimeoutException("Timeout while reading from stream");
+                        throw new TimeoutException("Timeout while reading from stream", e);
                     else
-                        throw Connector.Break(new NpgsqlException("Exception while reading from stream", new TimeoutException("Timeout during reading attempt")));
+                        throw Connector.Break(new NpgsqlException("Exception while reading from stream", new TimeoutException("Timeout during reading attempt", e)));
                 }
                 catch (Exception e)
                 {

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -230,10 +230,9 @@ namespace Npgsql
         internal NpgsqlReadBuffer AllocateOversize(int count)
         {
             Debug.Assert(count > Size);
-            var tempBuf = new NpgsqlReadBuffer(Connector, Underlying, _underlyingSocket, count, TextEncoding, RelaxedTextEncoding)
-            {
-                Timeout = Timeout,
-            };
+            var tempBuf = new NpgsqlReadBuffer(Connector, Underlying, _underlyingSocket, count, TextEncoding, RelaxedTextEncoding);
+            if (_underlyingSocket != null)
+                tempBuf.Timeout = Timeout;
             CopyTo(tempBuf);
             Clear();
             return tempBuf;

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -150,9 +150,7 @@ namespace Npgsql
                 catch (Exception e)
                 {
                     if (e is OperationCanceledException)
-                    {
                         e = new TimeoutException("Timeout during reading attempt");
-                    }
 
                     throw Connector.Break(new NpgsqlException("Exception while reading from stream", e));
                 }

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -27,7 +27,7 @@ namespace Npgsql
 
         internal Stream Underlying { private get; set; }
 
-        internal Socket UnderlyingSocket { private get; set; }
+        internal Socket? UnderlyingSocket { private get; set; }
 
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -27,7 +27,7 @@ namespace Npgsql
 
         internal Stream Underlying { private get; set; }
 
-        readonly Socket _underlyingSocket;
+        readonly Socket? _underlyingSocket;
 
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 
@@ -93,7 +93,7 @@ namespace Npgsql
         internal NpgsqlReadBuffer(
             NpgsqlConnector connector,
             Stream stream,
-            Socket socket,
+            Socket? socket,
             int size,
             Encoding textEncoding,
             Encoding relaxedTextEncoding)

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -41,8 +41,7 @@ namespace Npgsql
             {
                 if (_currentSocketTimeout != value)
                 {
-                    if (_underlyingSocket == null)
-                        throw new InvalidOperationException("Unable to set timeout as underlying socket is null");
+                    Debug.Assert(_underlyingSocket != null);
 
                     _underlyingSocket.ReceiveTimeout = value > TimeSpan.Zero ? (int)value.TotalMilliseconds : -1;
                     _currentSocketTimeout = value;

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -180,6 +180,15 @@ namespace Npgsql
                         count -= read;
                         FilledBytes += read;
                         totalRead += read;
+
+                        // Most of the time, it should be fine to reset cancellation token source, so we can use it again
+                        // It's still possible for cancellation token to cancel between reading and resetting (although highly improbable)
+                        // In this case, we consider it as timed out and fail with OperationCancelledException on next ReadAsync
+                        if (async)
+                        {
+                            var timeoutTimeSpan = TimeSpan.FromMilliseconds(Timeout);
+                            _timeoutCts.CancelAfter(timeoutTimeSpan);
+                        }
                     }
 
                     // Resetting cancellation token source, so we can use it again

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -27,7 +27,7 @@ namespace Npgsql
 
         internal Stream Underlying { private get; set; }
 
-        readonly Socket? _underlyingSocket;
+        readonly Socket _underlyingSocket;
 
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -124,8 +124,6 @@ namespace Npgsql
 
         internal Task Ensure(int count, bool async, bool dontBreakOnTimeouts)
         {
-            CheckDisposed();
-
             return count <= ReadBytesLeft ? Task.CompletedTask : EnsureLong();
 
             async Task EnsureLong()
@@ -214,8 +212,6 @@ namespace Npgsql
 
         internal NpgsqlReadBuffer AllocateOversize(int count)
         {
-            CheckDisposed();
-
             Debug.Assert(count > Size);
             var tempBuf = new NpgsqlReadBuffer(Connector, Underlying, count, TextEncoding, RelaxedTextEncoding)
             {
@@ -543,13 +539,6 @@ namespace Npgsql
             _timeoutCts.Dispose();
 
             _disposed = true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void CheckDisposed()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(typeof(NpgsqlReadBuffer).Name);
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -182,6 +182,10 @@ namespace Npgsql
                         totalRead += read;
                     }
 
+                    // Resetting cancellation token source, so we can use it again
+                    if (async)
+                        _timeoutCts.CancelAfter(-1);
+
                     NpgsqlEventSource.Log.BytesRead(totalRead);
                 }
                 // We have a special case when reading async notifications - a timeout may be normal

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -25,7 +25,7 @@ namespace Npgsql
 
         internal Stream Underlying { private get; set; }
 
-        internal Socket UnderlyingSocket { private get; set; }
+        internal Socket? UnderlyingSocket { private get; set; }
 
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -30,29 +30,29 @@ namespace Npgsql
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 
         /// <summary>
-        /// Underlying socket SendTimeout
+        /// Timeout for sync and async writes
         /// </summary>
         internal TimeSpan Timeout
         {
-            get => _currentSocketTimeout;
+            get => _currentTimeout;
             set
             {
-                if (_currentSocketTimeout != value)
+                if (_currentTimeout != value)
                 {
                     Debug.Assert(_underlyingSocket != null);
 
                     _underlyingSocket.SendTimeout = value > TimeSpan.Zero ? (int)value.TotalMilliseconds : -1;
-                    _currentSocketTimeout = value;
+                    _currentTimeout = value;
                 }
             }
         }
 
         /// <summary>
         /// Contains the current value of the Socket's SendTimeout, used to determine whether
-        /// we need to change it when commands are received.
-        /// It's used only for sync IO (<see cref="Stream.Write(byte[], int, int)"/> and <see cref="Stream.Flush"/>)
+        /// we need to change it when commands are send.
+        /// Also, used as a timeout for async writes.
         /// </summary>
-        TimeSpan _currentSocketTimeout;
+        TimeSpan _currentTimeout;
 
         /// <summary>
         /// The total byte length of the buffer.
@@ -91,7 +91,7 @@ namespace Npgsql
             Connector = connector;
             Underlying = stream;
             _underlyingSocket = socket;
-            _currentSocketTimeout = TimeSpan.Zero;
+            _currentTimeout = TimeSpan.Zero;
             Size = size;
             Buffer = new byte[Size];
             TextEncoding = textEncoding;

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -138,6 +139,18 @@ namespace Npgsql
                 else
                     Underlying.Write(Buffer, 0, WritePosition);
             }
+            // sync timeout
+            // Note that mono throws SocketException with the wrong error (see #1330)
+            catch (IOException e) when ((e.InnerException as SocketException)?.SocketErrorCode ==
+                   (Type.GetType("Mono.Runtime") == null ? SocketError.TimedOut : SocketError.WouldBlock))
+            {
+                throw Connector.Break(new NpgsqlException("Exception while writing to stream", new TimeoutException("Timeout during writing attempt")));
+            }
+            // async timeout
+            catch (OperationCanceledException)
+            {
+                throw Connector.Break(new NpgsqlException("Exception while writing to stream", new TimeoutException("Timeout during writing attempt")));
+            }
             catch (Exception e)
             {
                 throw Connector.Break(new NpgsqlException("Exception while writing to stream", e));
@@ -149,6 +162,18 @@ namespace Npgsql
                     await Underlying.FlushAsync(timeoutCt);
                 else
                     Underlying.Flush();
+            }
+            // sync timeout
+            // Note that mono throws SocketException with the wrong error (see #1330)
+            catch (IOException e) when ((e.InnerException as SocketException)?.SocketErrorCode ==
+                   (Type.GetType("Mono.Runtime") == null ? SocketError.TimedOut : SocketError.WouldBlock))
+            {
+                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt")));
+            }
+            // async timeout
+            catch (OperationCanceledException)
+            {
+                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt")));
             }
             catch (Exception e)
             {

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -39,8 +39,7 @@ namespace Npgsql
             {
                 if (_currentSocketTimeout != value)
                 {
-                    if (_underlyingSocket == null)
-                        throw new InvalidOperationException("Unable to set timeout as underlying socket is null");
+                    Debug.Assert(_underlyingSocket != null);
 
                     _underlyingSocket.SendTimeout = value > TimeSpan.Zero ? (int)value.TotalMilliseconds : -1;
                     _currentSocketTimeout = value;
@@ -92,7 +91,7 @@ namespace Npgsql
             Connector = connector;
             Underlying = stream;
             _underlyingSocket = socket;
-            _currentSocketTimeout =TimeSpan.Zero;
+            _currentSocketTimeout = TimeSpan.Zero;
             Size = size;
             Buffer = new byte[Size];
             TextEncoding = textEncoding;

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -25,7 +25,7 @@ namespace Npgsql
 
         internal Stream Underlying { private get; set; }
 
-        readonly Socket _underlyingSocket;
+        readonly Socket? _underlyingSocket;
 
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 
@@ -83,7 +83,7 @@ namespace Npgsql
 
         #region Constructors
 
-        internal NpgsqlWriteBuffer(NpgsqlConnector connector, Stream stream, Socket socket, int size, Encoding textEncoding)
+        internal NpgsqlWriteBuffer(NpgsqlConnector connector, Stream stream, Socket? socket, int size, Encoding textEncoding)
         {
             if (size < MinimumSize)
                 throw new ArgumentOutOfRangeException(nameof(size), size, "Buffer size must be at least " + MinimumSize);

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -148,7 +148,11 @@ namespace Npgsql
             try
             {
                 if (async)
+                {
                     await Underlying.FlushAsync(timeoutCt);
+                    // Resetting cancellation token source, so we can use it again
+                    _timeoutCts.CancelAfter(-1);
+                }
                 else
                     Underlying.Flush();
             }
@@ -159,11 +163,7 @@ namespace Npgsql
             catch (Exception e)
             {
                 throw Connector.Break(new NpgsqlException("Exception while flushing stream", e));
-            }
-
-            // Resetting cancellation token source, so we can use it again
-            if (async)
-                _timeoutCts.CancelAfter(-1);
+            }   
 
             NpgsqlEventSource.Log.BytesWritten(WritePosition);
             //NpgsqlEventSource.Log.RequestFailed();

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -167,7 +167,7 @@ namespace Npgsql
             catch (Exception e)
             {
                 throw Connector.Break(new NpgsqlException("Exception while flushing stream", e));
-            }   
+            }
 
             NpgsqlEventSource.Log.BytesWritten(WritePosition);
             //NpgsqlEventSource.Log.RequestFailed();

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -168,12 +168,12 @@ namespace Npgsql
             catch (IOException e) when ((e.InnerException as SocketException)?.SocketErrorCode ==
                    (Type.GetType("Mono.Runtime") == null ? SocketError.TimedOut : SocketError.WouldBlock))
             {
-                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt")));
+                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt", e)));
             }
             // async timeout
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e)
             {
-                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt")));
+                throw Connector.Break(new NpgsqlException("Exception while flushing stream", new TimeoutException("Timeout during flushing attempt", e)));
             }
             catch (Exception e)
             {

--- a/src/Npgsql/PregeneratedMessages.cs
+++ b/src/Npgsql/PregeneratedMessages.cs
@@ -12,7 +12,7 @@ namespace Npgsql
 #pragma warning disable CS8625
             // This is the only use of a write buffer without a connector, for in-memory construction of
             // pregenerated messages.
-            var buf = new NpgsqlWriteBuffer(null, new MemoryStream(), NpgsqlWriteBuffer.MinimumSize, Encoding.ASCII);
+            using var buf = new NpgsqlWriteBuffer(null, new MemoryStream(), NpgsqlWriteBuffer.MinimumSize, Encoding.ASCII);
 #pragma warning restore CS8625
 
             BeginTransRepeatableRead    = Generate(buf, "BEGIN ISOLATION LEVEL REPEATABLE READ");

--- a/src/Npgsql/PregeneratedMessages.cs
+++ b/src/Npgsql/PregeneratedMessages.cs
@@ -12,7 +12,7 @@ namespace Npgsql
 #pragma warning disable CS8625
             // This is the only use of a write buffer without a connector, for in-memory construction of
             // pregenerated messages.
-            using var buf = new NpgsqlWriteBuffer(null, new MemoryStream(), NpgsqlWriteBuffer.MinimumSize, Encoding.ASCII);
+            using var buf = new NpgsqlWriteBuffer(null, new MemoryStream(), null, NpgsqlWriteBuffer.MinimumSize, Encoding.ASCII);
 #pragma warning restore CS8625
 
             BeginTransRepeatableRead    = Generate(buf, "BEGIN ISOLATION LEVEL REPEATABLE READ");

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -50,8 +50,8 @@ namespace Npgsql.Benchmarks.TypeHandlers
         {
             _stream = new EndlessStream();
             _handler = handler ?? throw new ArgumentNullException(nameof(handler));
-            _readBuffer = new NpgsqlReadBuffer(null, _stream, NpgsqlReadBuffer.MinimumSize, Encoding.UTF8, PGUtil.RelaxedUTF8Encoding);
-            _writeBuffer = new NpgsqlWriteBuffer(null, _stream, NpgsqlWriteBuffer.MinimumSize, Encoding.UTF8);
+            _readBuffer = new NpgsqlReadBuffer(null, _stream, null, NpgsqlReadBuffer.MinimumSize, Encoding.UTF8, PGUtil.RelaxedUTF8Encoding);
+            _writeBuffer = new NpgsqlWriteBuffer(null, _stream, null, NpgsqlWriteBuffer.MinimumSize, Encoding.UTF8);
         }
 
         protected static PostgresType GetPostgresType(string pgType)

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -158,17 +158,34 @@ namespace Npgsql.Tests
 
             // Mono throws a socket exception with WouldBlock instead of TimedOut (see #1330)
             var isMono = Type.GetType("Mono.Runtime") != null;
-            using (var conn = await OpenConnectionAsync(ConnectionString + ";CommandTimeout=1"))
-            using (var cmd = CreateSleepCommand(conn, 10))
-            {
-                Assert.That(() => cmd.ExecuteNonQuery(), Throws.Exception
-                    .TypeOf<NpgsqlException>()
-                    .With.InnerException.TypeOf<IOException>()
-                    .With.InnerException.InnerException.TypeOf<SocketException>()
-                    .With.InnerException.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(isMono ? SocketError.WouldBlock : SocketError.TimedOut)
-                    );
-                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
-            }
+            using var conn = await OpenConnectionAsync(ConnectionString + ";CommandTimeout=1");
+            using var cmd = CreateSleepCommand(conn, 10);
+            Assert.That(() => cmd.ExecuteNonQuery(), Throws.Exception
+                .TypeOf<NpgsqlException>()
+                .With.InnerException.TypeOf<TimeoutException>()
+                .With.InnerException.InnerException.TypeOf<IOException>()
+                .With.InnerException.InnerException.InnerException.TypeOf<SocketException>()
+                .With.InnerException.InnerException.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(isMono ? SocketError.WouldBlock : SocketError.TimedOut)
+                );
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
+        }
+
+        [Test, Description("Checks that CommandTimeout gets enforced for async queries")]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/607")]
+        [Timeout(10000)]
+        public async Task TimeoutAsync()
+        {
+            if (IsMultiplexing)
+                return; // Multiplexing, Timeout
+
+            using var conn = await OpenConnectionAsync(ConnectionString + ";CommandTimeout=1");
+            using var cmd = CreateSleepCommand(conn, 10);
+            Assert.That(async () => await cmd.ExecuteNonQueryAsync(), Throws.Exception
+                .TypeOf<NpgsqlException>()
+                .With.InnerException.TypeOf<TimeoutException>()
+                .With.InnerException.InnerException.TypeOf<OperationCanceledException>()
+                );
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
         }
 
         [Test]

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -162,10 +162,9 @@ namespace Npgsql.Tests
             using var cmd = CreateSleepCommand(conn, 10);
             Assert.That(() => cmd.ExecuteNonQuery(), Throws.Exception
                 .TypeOf<NpgsqlException>()
-                .With.InnerException.TypeOf<TimeoutException>()
-                .With.InnerException.InnerException.TypeOf<IOException>()
-                .With.InnerException.InnerException.InnerException.TypeOf<SocketException>()
-                .With.InnerException.InnerException.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(isMono ? SocketError.WouldBlock : SocketError.TimedOut)
+                .With.InnerException.TypeOf<IOException>()
+                .With.InnerException.InnerException.TypeOf<SocketException>()
+                .With.InnerException.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(isMono ? SocketError.WouldBlock : SocketError.TimedOut)
                 );
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
         }

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -169,6 +169,8 @@ namespace Npgsql.Tests
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
         }
 
+// Timeout for async queries is not supported for .net 4.6.1
+#if !NET461
         [Test, Description("Checks that CommandTimeout gets enforced for async queries")]
         [IssueLink("https://github.com/npgsql/npgsql/issues/607")]
         [Timeout(10000)]
@@ -186,6 +188,7 @@ namespace Npgsql.Tests
                 );
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
         }
+#endif
 
         [Test]
         public async Task TimeoutFromConnectionString()

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Tests
             if (IsMultiplexing)
                 Assert.Ignore("Multiplexing: fails");
 
-            using (var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 3 }))
+            using (var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 5 }))
             {
                 await using var _ = await GetTempTableName(conn, out var table1);
                 await using var __ = await GetTempTableName(conn, out var table2);

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Tests
             if (IsMultiplexing)
                 Assert.Ignore("Multiplexing: fails");
 
-            using (var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 5 }))
+            using (var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 3 }))
             {
                 await using var _ = await GetTempTableName(conn, out var table1);
                 await using var __ = await GetTempTableName(conn, out var table2);
@@ -31,10 +31,15 @@ namespace Npgsql.Tests
                 using (var cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = $"CREATE TABLE {table1} AS SELECT * FROM generate_series(1, {rowCount}) id";
+                    // Creating table can take some time, so we set quite large timeout
+                    cmd.CommandTimeout = 30;
                     await cmd.ExecuteNonQueryAsync();
                     cmd.CommandText = $"ALTER TABLE {table1} ADD CONSTRAINT {table1}_pk PRIMARY KEY (id)";
                     await cmd.ExecuteNonQueryAsync();
                     cmd.CommandText = $"CREATE TABLE {table2} (master_id integer NOT NULL REFERENCES {table1} (id))";
+                    // We need to fail with timeout while calling writer.Complete() and conn.BeginBinaryImport reuses timeout from previous command
+                    // so we set default timeout here
+                    cmd.CommandTimeout = 3;
                     await cmd.ExecuteNonQueryAsync();
                 }
 

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -60,7 +60,7 @@ namespace Npgsql.Tests
         public void SetUp()
         {
             Underlying = new MemoryStream();
-            ReadBuffer = new NpgsqlReadBuffer(null, Underlying, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding, PGUtil.RelaxedUTF8Encoding);
+            ReadBuffer = new NpgsqlReadBuffer(null, Underlying, null, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding, PGUtil.RelaxedUTF8Encoding);
         }
 #pragma warning restore CS8625
 

--- a/test/Npgsql.Tests/Types/BitStringTests.cs
+++ b/test/Npgsql.Tests/Types/BitStringTests.cs
@@ -200,7 +200,7 @@ namespace Npgsql.Tests.Types
         }
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2766")]
-        [Timeout(1000)]
+        [Timeout(3000)]
         public async Task SequentialReadOfOversizedBitArray()
         {
             using var conn = await OpenConnectionAsync();

--- a/test/Npgsql.Tests/WriteBufferTests.cs
+++ b/test/Npgsql.Tests/WriteBufferTests.cs
@@ -56,7 +56,7 @@ namespace Npgsql.Tests
         public void SetUp()
         {
             Underlying = new MemoryStream();
-            WriteBuffer = new NpgsqlWriteBuffer(null, Underlying, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding);
+            WriteBuffer = new NpgsqlWriteBuffer(null, Underlying, null, NpgsqlReadBuffer.DefaultSize, PGUtil.UTF8Encoding);
         }
 #pragma warning restore CS8625
 


### PR DESCRIPTION
Took a stab at #607.

While it's relatively simple fix (on the first glance), I may have missed quite a few corner cases.
What I'm definitely not sure is an exception I throw (took inspiration from [NpgsqlConnector.ConnectAsync](https://github.com/npgsql/npgsql/blob/4df534f42a4a0b1324f4d0a7ba58fb4f76f8f09f/src/Npgsql/NpgsqlConnector.cs#L724)).
Also, maybe timeout exceptions for sync and async Read should be the same?