### PR TITLE
Read empty multidimensional array

### DIFF
--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -88,6 +88,9 @@ namespace Npgsql.TypeHandlers
             if (dimensions == 0)
                 return expectedDimensions > 1 ? Array.CreateInstance(typeof(TRequestedElement), new int[expectedDimensions]) : Array.Empty<TRequestedElement>();
 
+            if (expectedDimensions > 0 && dimensions != expectedDimensions)
+                throw new InvalidOperationException($"Cannot read an array with {expectedDimensions} dimension(s) from an array with {dimensions} dimension(s)");
+
             if (dimensions == 1)
             {
                 await buf.Ensure(8, async);

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -133,6 +133,21 @@ namespace Npgsql.Tests.Types
             Assert.That(reader.GetFieldValue<int[]>(0), Is.SameAs(Array.Empty<int>()));
         }
 
+        [Test, Description("Roundtrips an empty multi-dimensional array.")]
+        public void EmptyMultidimensionalArray()
+        {
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT @p", conn);
+
+            var expected = new int[0, 0];
+            cmd.Parameters.AddWithValue("p", NpgsqlDbType.Array | NpgsqlDbType.Integer, expected);
+
+            var reader = cmd.ExecuteReader();
+            reader.Read();
+
+            Assert.That(reader.GetFieldValue<int[,]>(0), Is.EqualTo(expected));
+        }
+
         [Test, Description("Verifies that the array type returned from NpgsqlDataReader.GetValue() is always compatible with null values.")]
         public void GetValueArrayTypeForValueTypesIsNullable()
         {

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -148,6 +148,19 @@ namespace Npgsql.Tests.Types
             Assert.That(reader.GetFieldValue<int[,]>(0), Is.EqualTo(expected));
         }
 
+        [Test, Description("Verifies that an InvalidOperationException is thrown when the returned array has a different number of dimensions from what was requested.")]
+        public void WrongArrayDimensions()
+        {
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT ARRAY[[1], [2]]", conn);
+
+            var reader = cmd.ExecuteReader();
+            reader.Read();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => reader.GetFieldValue<int[]>(0));
+            Assert.That(ex.Message, Is.EqualTo("Cannot read an array with 1 dimension(s) from an array with 2 dimension(s)"));
+        }
+
         [Test, Description("Verifies that the array type returned from NpgsqlDataReader.GetValue() is always compatible with null values.")]
         public void GetValueArrayTypeForValueTypesIsNullable()
         {


### PR DESCRIPTION
Current handling for empty arrays returns Array.Empty, which is always one-dimensional. This is problematic when the array is expected to be multidimensional when not empty. This fixes that so, when requesting an array with more than one dimension and the array from the database happens to be empty, an empty array with the correct number of dimensions is created and returned. When not given an array type, or the given array type has one dimension, it still uses Array.Empty.

I also went ahead and made it throw an exception if the requested number of dimensions doesn't match the number of dimensions in the returned array. This just prevents it from needlessly creating an array with the wrong number of dimensions just to ultimately throw an InvalidCastException, so this isn't really necessary. If you'd like this done differently or not at all, I can change it or remove it.