### PR TITLE
Build netcoreapp5.0 only if DeveloperBuild=true

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -5,7 +5,8 @@
     <PackageTags>npgsql postgresql postgres ado ado.net database sql</PackageTags>
     <!-- At this point we target netcoreapp3.0 to avoid taking a dependency on System.Text.Json, which is
          necessary for all other TFMs. -->
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">net461;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,8 @@
 
   <!-- Build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">$(TargetFrameworks);net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
When developing locally, building (and testing) all TFMs is a burden and slows everything down. If the DeveloperBuild environment variable is equal to true, build the latest TFM only.