### PR TITLE
Do checked arithmetic at validation time

### DIFF
--- a/src/Npgsql/TypeHandlers/InternalCharHandler.cs
+++ b/src/Npgsql/TypeHandlers/InternalCharHandler.cs
@@ -46,35 +46,46 @@ namespace Npgsql.TypeHandlers
         #region Write
 
         /// <inheritdoc />
-        public override int ValidateAndGetLength(char value, NpgsqlParameter? parameter) => 1;
-        /// <inheritdoc />
         public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)          => 1;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)         => 1;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)           => 1;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)          => 1;
 
         /// <inheritdoc />
-        public override void Write(char value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => buf.WriteByte(checked((byte)value));
+        public override int ValidateAndGetLength(char value, NpgsqlParameter? parameter)
+        {
+            _ = checked((byte)value);
+            return 1;
+        }
 
         /// <inheritdoc />
-        public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => buf.WriteByte(value);
+        public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)
+        {
+            _ = checked((byte)value);
+            return 1;
+        }
 
         /// <inheritdoc />
-        public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => buf.WriteByte(checked((byte)value));
+        public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)
+        {
+            _ = checked((byte)value);
+            return 1;
+        }
 
         /// <inheritdoc />
-        public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => buf.WriteByte(checked((byte)value));
+        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)
+        {
+            _ = checked((byte)value);
+            return 1;
+        }
 
         /// <inheritdoc />
-        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => buf.WriteByte(checked((byte)value));
+        public override void Write(char value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteByte((byte)value);
+        /// <inheritdoc />
+        public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteByte(value);
+        /// <inheritdoc />
+        public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteByte((byte)value);
+        /// <inheritdoc />
+        public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteByte((byte)value);
+        /// <inheritdoc />
+        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteByte((byte)value);
 
         #endregion
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int16Handler.cs
@@ -59,26 +59,46 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public override int ValidateAndGetLength(short value, NpgsqlParameter? parameter) => 2;
         /// <inheritdoc />
-        public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)            => 2;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)           => 2;
-        /// <inheritdoc />
         public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)           => 2;
         /// <inheritdoc />
         public int ValidateAndGetLength(sbyte value, NpgsqlParameter? parameter)          => 2;
         /// <inheritdoc />
-        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)          => 2;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)         => 2;
-        /// <inheritdoc />
         public int ValidateAndGetLength(decimal value, NpgsqlParameter? parameter)        => 2;
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)
+        {
+            _ = checked((short)value);
+            return 2;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)
+        {
+            _ = checked((short)value);
+            return 2;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)
+        {
+            _ = checked((short)value);
+            return 2;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)
+        {
+            _ = checked((short)value);
+            return 2;
+        }
 
         /// <inheritdoc />
         public override void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteInt16(value);
         /// <inheritdoc />
-        public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)            => buf.WriteInt16(checked((short)value));
+        public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)            => buf.WriteInt16((short)value);
         /// <inheritdoc />
-        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)           => buf.WriteInt16(checked((short)value));
+        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)           => buf.WriteInt16((short)value);
         /// <inheritdoc />
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)           => buf.WriteInt16(value);
         /// <inheritdoc />
@@ -86,9 +106,9 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt16((short)value);
         /// <inheritdoc />
-        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt16(checked((short)value));
+        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt16((short)value);
         /// <inheritdoc />
-        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)          => buf.WriteInt16(checked((short)value));
+        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)          => buf.WriteInt16((short)value);
 
         #endregion Write
     }

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int32Handler.cs
@@ -58,28 +58,43 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)        => 4;
         /// <inheritdoc />
-        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)         => 4;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)        => 4;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)       => 4;
+        public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)         => 4;
         /// <inheritdoc />
         public int ValidateAndGetLength(decimal value, NpgsqlParameter? parameter)      => 4;
+
         /// <inheritdoc />
-        public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)         => 4;
+        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)
+        {
+            _ = checked((int)value);
+            return 4;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)
+        {
+            _ = checked((int)value);
+            return 4;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)
+        {
+            _ = checked((int)value);
+            return 4;
+        }
 
         /// <inheritdoc />
         public override void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteInt32(value);
         /// <inheritdoc />
         public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt32(value);
         /// <inheritdoc />
-        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt32(checked((int)value));
+        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt32((int)value);
         /// <inheritdoc />
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt32(value);
         /// <inheritdoc />
-        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt32(checked((int)value));
+        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt32((int)value);
         /// <inheritdoc />
-        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)       => buf.WriteInt32(checked((int)value));
+        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)       => buf.WriteInt32((int)value);
         /// <inheritdoc />
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)      => buf.WriteInt32((int)value);
 

--- a/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
+++ b/src/Npgsql/TypeHandlers/NumericHandlers/Int64Handler.cs
@@ -56,17 +56,27 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public override int ValidateAndGetLength(long value, NpgsqlParameter? parameter) => 8;
         /// <inheritdoc />
-        public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)         => 8;
-        /// <inheritdoc />
         public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)           => 8;
         /// <inheritdoc />
-        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)         => 8;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)        => 8;
-        /// <inheritdoc />
-        public int ValidateAndGetLength(decimal value, NpgsqlParameter? parameter)       => 8;
+        public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)         => 8;
         /// <inheritdoc />
         public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)          => 8;
+        /// <inheritdoc />
+        public int ValidateAndGetLength(decimal value, NpgsqlParameter? parameter)       => 8;
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)
+        {
+            _ = checked((long)value);
+            return 8;
+        }
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter)
+        {
+            _ = checked((long)value);
+            return 8;
+        }
 
         /// <inheritdoc />
         public override void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => buf.WriteInt64(value);
@@ -77,9 +87,9 @@ namespace Npgsql.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)          => buf.WriteInt64(value);
         /// <inheritdoc />
-        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt64(checked((long)value));
+        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)         => buf.WriteInt64((long)value);
         /// <inheritdoc />
-        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt64(checked((long)value));
+        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)        => buf.WriteInt64((long)value);
         /// <inheritdoc />
         public void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)       => buf.WriteInt64((long)value);
 

--- a/test/Npgsql.Tests/Types/NumericTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTypeTests.cs
@@ -244,21 +244,19 @@ namespace Npgsql.Tests.Types
         [TestCase(NpgsqlDbType.Integer, 1D + int.MaxValue)]
         [TestCase(NpgsqlDbType.Bigint, 1F + long.MaxValue)]
         [TestCase(NpgsqlDbType.Bigint, 1D + long.MaxValue)]
+        [TestCase(NpgsqlDbType.InternalChar, 1 + byte.MaxValue)]
         public void WriteOverflow(NpgsqlDbType type, object value)
         {
-            using (var conn = OpenConnection())
-            using (var cmd = new NpgsqlCommand("SELECT @p1", conn))
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT @p1", conn);
+
+            var p1 = new NpgsqlParameter("p1", type)
             {
-                var p1 = new NpgsqlParameter("p1", type)
-                {
-                    Value = value
-                };
-                cmd.Parameters.Add(p1);
-                Assert.Throws<OverflowException>(() =>
-                {
-                    using (var reader = cmd.ExecuteReader()) { }
-                });
-            }
+                Value = value
+            };
+            cmd.Parameters.Add(p1);
+            Assert.Throws<OverflowException>(() => cmd.ExecuteScalar());
+            Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
         }
 
         static IEnumerable<TestCaseData> ReadOverflowTestCases


### PR DESCRIPTION
We did checked arithmetic when casting down numeric types for writing, but during writing. Do this during validation instead, to avoid breaking the connection.