### PR TITLE
Allow setting runtime configuration parameters in the StartupMessage

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1162,13 +1162,13 @@ namespace Npgsql
 
         string? _options;
 
-        internal Dictionary<string,string> OptionsDictionary { get; } = new Dictionary<string, string>();
+        internal Dictionary<string,string> ParsedOptions { get; } = new Dictionary<string, string>();
 
         void ParseOptions(string? str)
         {
             if (str == null)
             {
-                OptionsDictionary.Clear();
+                ParsedOptions.Clear();
             }
             else
             {
@@ -1177,7 +1177,7 @@ namespace Npgsql
                 {
                     var key = ParseKey(str, ref pos);
                     var value = ParseValue(str, ref pos);
-                    OptionsDictionary[key] = value;
+                    ParsedOptions[key] = value;
                 }
             }
         }

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1141,6 +1141,24 @@ namespace Npgsql
         }
         bool _loadTableComposites;
 
+        /// <summary>
+        /// Set PostgreSQL configuration parameter default values for the connection.
+        /// </summary>
+        [Category("Advanced")]
+        [Description("Set PostgreSQL configuration parameter default values for the connection.")]
+        [DisplayName("Options")]
+        [NpgsqlConnectionStringProperty]
+        public string? Options
+        {
+            get => _options;
+            set
+            {
+                _options = value;
+                SetValue(nameof(Options), value);
+            }
+        }
+        string? _options;
+
         #endregion
 
         #region Properties - Compatibility

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -429,31 +429,9 @@ namespace Npgsql
 
         void WriteStartupMessage(string username)
         {
-            Dictionary<string, string> startupParams;
-
-            if (Settings.OptionsDictionary.Count > 0)
-            {
-                startupParams = new Dictionary<string, string>(Settings.OptionsDictionary);
-            }
-            else
-            {
-                startupParams = new Dictionary<string, string>();
-
-                var options = PostgresEnvironment.Options?.Length > 0
-                    ? PostgresEnvironment.Options
-                    : null;
-
-                if (options != null)
-                {
-                    var pos = 0;
-                    while (pos < options.Length)
-                    {
-                        var key = NpgsqlConnectionStringBuilder.ParseKey(options, ref pos);
-                        var value = NpgsqlConnectionStringBuilder.ParseValue(options, ref pos);
-                        startupParams[key] = value;
-                    }
-                }
-            }
+            var startupParams = Settings.ParsedOptions.Count > 0
+                ? new Dictionary<string, string>(Settings.ParsedOptions)
+                : new Dictionary<string, string>(PostgresEnvironment.ParsedOptions);
 
             startupParams["user"] = username;
             startupParams["client_encoding"] =

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -429,14 +429,37 @@ namespace Npgsql
 
         void WriteStartupMessage(string username)
         {
-            var startupParams = new Dictionary<string, string>
+            Dictionary<string, string> startupParams;
+
+            if (Settings.OptionsDictionary.Count > 0)
             {
-                ["user"] = username,
-                ["client_encoding"] =
-                    Settings.ClientEncoding ??
-                    PostgresEnvironment.ClientEncoding ??
-                    "UTF8"
-            };
+                startupParams = new Dictionary<string, string>(Settings.OptionsDictionary);
+            }
+            else
+            {
+                startupParams = new Dictionary<string, string>();
+
+                var options = PostgresEnvironment.Options?.Length > 0
+                    ? PostgresEnvironment.Options
+                    : null;
+
+                if (options != null)
+                {
+                    var pos = 0;
+                    while (pos < options.Length)
+                    {
+                        var key = NpgsqlConnectionStringBuilder.ParseKey(options, ref pos);
+                        var value = NpgsqlConnectionStringBuilder.ParseValue(options, ref pos);
+                        startupParams[key] = value;
+                    }
+                }
+            }
+
+            startupParams["user"] = username;
+            startupParams["client_encoding"] =
+                Settings.ClientEncoding ??
+                PostgresEnvironment.ClientEncoding ??
+                "UTF8";
 
             startupParams["database"] = Settings.Database!;
 
@@ -450,72 +473,7 @@ namespace Npgsql
             if (timezone != null)
                 startupParams["TimeZone"] = timezone;
 
-            var options = Settings.Options?.Length > 0
-                ? Settings.Options
-                : PostgresEnvironment.Options?.Length > 0
-                    ? PostgresEnvironment.Options
-                    : null;
-
-            if (options != null)
-            {
-                var pos = 0;
-                while (pos < options.Length)
-                {
-                    var key = ParseKey(options, ref pos);
-                    var value = ParseValue(options, ref pos);
-                    startupParams[key] = value;
-                }
-            }
-
             WriteStartup(startupParams);
-        }
-
-        static string ParseKey(string str, ref int pos)
-        {
-            var start = pos;
-            for (;pos < str.Length; pos++)
-            {
-                if (str[pos] == '=')
-                {
-                    var key = str.Substring(start, pos - start);
-                    pos++;
-                    return key.Length > 0
-                        ? key
-                        : throw new FormatException(
-                            $"Invalid syntax for connection string parameter '{nameof(NpgsqlConnectionStringBuilder.Options)}': Missing key.");
-                }
-            }
-            throw new FormatException($"Invalid syntax for connection string parameter '{nameof(NpgsqlConnectionStringBuilder.Options)}': Missing '='.");
-        }
-
-        static string ParseValue(string str, ref int pos)
-        {
-            var escaped = false;
-            var value = new StringBuilder();
-            for (;pos < str.Length; pos++)
-            {
-                if (escaped)
-                    escaped = false;
-                else if(str[pos] == ' ')
-                {
-                    pos++;
-                    for (; pos < str.Length && str[pos] == ' '; pos++)
-                    {
-                    }
-
-                    break;
-                }
-                else if (str[pos] == '\\')
-                {
-                    escaped = true;
-                    continue;
-                }
-                value.Append(str[pos]);
-            }
-            return value.Length  > 0
-                ? value.ToString()
-                : throw new FormatException(
-                    $"Invalid syntax for connection string parameter '{nameof(NpgsqlConnectionStringBuilder.Options)}': Missing value.");
         }
 
         string GetUsername()

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -25,39 +25,24 @@ namespace Npgsql
 
         public static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
 
-        public static Dictionary<string, string> ParsedOptions
+        public static Dictionary<string, string> ParsedOptions => ParseOptions(Options);
+
+        static Dictionary<string, string> ParseOptions(string? options)
         {
-            get
-            {
-                if (_optionsCache == Options)
-                    return ParsedOptionsCache;
+            var parsedOptions = new Dictionary<string, string>();
 
-                _optionsCache = Options;
-                ParseOptions();
-                return ParsedOptionsCache;
-            }
-        }
-
-        static readonly Dictionary<string, string> ParsedOptionsCache = new Dictionary<string, string>();
-
-        static string? _optionsCache;
-
-        static void ParseOptions()
-        {
-            if (_optionsCache == null)
-            {
-                ParsedOptions.Clear();
-            }
-            else
+            if (options != null)
             {
                 var pos = 0;
-                while (pos < _optionsCache.Length)
+                while (pos < options.Length)
                 {
-                    var key = NpgsqlConnectionStringBuilder.ParseKey(_optionsCache, ref pos);
-                    var value = NpgsqlConnectionStringBuilder.ParseValue(_optionsCache, ref pos);
-                    ParsedOptions[key] = value;
+                    var key = NpgsqlConnectionStringBuilder.ParseKey(options, ref pos);
+                    var value = NpgsqlConnectionStringBuilder.ParseValue(options, ref pos);
+                    parsedOptions[key] = value;
                 }
             }
+
+            return parsedOptions;
         }
 
         static string? GetDefaultFilePath(string fileName) =>

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -22,6 +22,8 @@ namespace Npgsql
 
         public static string? TimeZone => Environment.GetEnvironmentVariable("PGTZ");
 
+        public static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
+
         static string? GetDefaultFilePath(string fileName) =>
             Environment.GetEnvironmentVariable(PGUtil.IsWindows ? "APPDATA" : "HOME") is string appData
                 ? Path.Combine(appData, "postgresql", fileName)

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1371,16 +1371,12 @@ namespace Npgsql.Tests
         [NonParallelizable]
         public void Connect_OptionsFromEnvironment_Succeeds()
         {
-            var builder = new NpgsqlConnectionStringBuilder(ConnectionString)
+            using (TestUtil.SetEnvironmentVariable("PGOPTIONS", "default_transaction_isolation=serializable  default_transaction_deferrable=on application_name=My\\ Famous\\\\App"))
             {
-                Pooling = false,
-                Options = "default_transaction_isolation=serializable  default_transaction_deferrable=on application_name=My\\ Famous\\\\App"
-            };
-
-            using (TestUtil.SetEnvironmentVariable("PGOPTIONS", builder.Options))
-            {
-                builder.Options = null;
-                using var conn = OpenConnection(builder);
+                using var conn = OpenConnection(new NpgsqlConnectionStringBuilder(ConnectionString)
+                {
+                    Pooling = false
+                });
                 Assert.That(conn.ExecuteScalar("SHOW default_transaction_isolation;"), Is.EqualTo("serializable"));
                 Assert.That(conn.ExecuteScalar("SHOW default_transaction_deferrable;"), Is.EqualTo("on"));
                 Assert.That(conn.ExecuteScalar("SHOW application_name;"), Is.EqualTo("My Famous\\App"));


### PR DESCRIPTION
This works either via the `Options` connection string parameter or via
the `PGOPTIONS` environment variable.

As discussed in #2938

There are two remaining tasks:

1. Decide about precedence of parameters set via `Options` vs parameters set directly in the connection string (e. g. "Application Name=App1;Options=application_name=App2").

   In the current implementation the parameters set via `Options` have precedence so the above example would end up with:

   ``` sql
   SHOW application_name;
   
   App2
   ```

2. Documentation
I will add this to the documentation once we've agreed that this is how we want this feature  to be implemented.
