### PR TITLE
Added UnprepareAsync

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -683,11 +683,11 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 foreach (var statement in _statements)
                     if (statement.PreparedStatement?.State == PreparedState.BeingUnprepared)
                     {
-                        Expect<CloseCompletedMessage>(async ? await connector.ReadMessage(true) : connector.ReadMessage(), connector);
+                        Expect<CloseCompletedMessage>(await connector.ReadMessage(async), connector);
                         statement.PreparedStatement.CompleteUnprepare();
                         statement.PreparedStatement = null;
                     }
-                Expect<ReadyForQueryMessage>(async ? await connector.ReadMessage(true) : connector.ReadMessage(), connector);
+                Expect<ReadyForQueryMessage>(await connector.ReadMessage(async), connector);
                 if (async)
                     await sendTask;
                 else

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -654,6 +654,23 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// automatically prepared statements.
         /// </summary>
         public void Unprepare()
+            => Unprepare(false).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Unprepares a command, closing server-side statements associated with it.
+        /// Note that this only affects commands explicitly prepared with <see cref="Prepare()"/>, not
+        /// automatically prepared statements.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        public Task UnprepareAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return Unprepare(true);
+        }
+
+        async Task Unprepare(bool async)
         {
             if (_statements.All(s => !s.IsPrepared))
                 return;
@@ -662,16 +679,19 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             Log.Debug("Closing command's prepared statements", connector.Id);
             using (connector.StartUserAction())
             {
-                var sendTask = SendClose(connector, false);
+                var sendTask = SendClose(connector, async);
                 foreach (var statement in _statements)
                     if (statement.PreparedStatement?.State == PreparedState.BeingUnprepared)
                     {
-                        Expect<CloseCompletedMessage>(connector.ReadMessage(), connector);
+                        Expect<CloseCompletedMessage>(async ? await connector.ReadMessage(true) : connector.ReadMessage(), connector);
                         statement.PreparedStatement.CompleteUnprepare();
                         statement.PreparedStatement = null;
                     }
-                Expect<ReadyForQueryMessage>(connector.ReadMessage(), connector);
-                sendTask.GetAwaiter().GetResult();
+                Expect<ReadyForQueryMessage>(async ? await connector.ReadMessage(true) : connector.ReadMessage(), connector);
+                if (async)
+                    await sendTask;
+                else
+                    sendTask.GetAwaiter().GetResult();
             }
         }
 

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -71,6 +71,24 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public async Task UnprepareAsync()
+        {
+            using (var conn = OpenConnectionAndUnprepare())
+            {
+                AssertNumPreparedStatements(conn, 0);
+                using (var cmd = new NpgsqlCommand("SELECT 1", conn))
+                {
+                    await cmd.PrepareAsync();
+                    AssertNumPreparedStatements(conn, 1);
+                    await cmd.UnprepareAsync();
+                    AssertNumPreparedStatements(conn, 0);
+                    Assert.That(cmd.IsPrepared, Is.False);
+                    Assert.That(cmd.ExecuteScalar(), Is.EqualTo(1));
+                }
+            }
+        }
+
+        [Test]
         public void Parameters()
         {
             using (var conn = OpenConnectionAndUnprepare())

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -52,7 +52,7 @@ namespace Npgsql.Tests
             }
         }
 
-                [Test]
+        [Test]
         public void Unprepare()
             => Unprepare(false).GetAwaiter().GetResult();
 

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -52,35 +52,33 @@ namespace Npgsql.Tests
             }
         }
 
-        [Test]
+                [Test]
         public void Unprepare()
-        {
-            using (var conn = OpenConnectionAndUnprepare())
-            {
-                AssertNumPreparedStatements(conn, 0);
-                using (var cmd = new NpgsqlCommand("SELECT 1", conn))
-                {
-                    cmd.Prepare();
-                    AssertNumPreparedStatements(conn, 1);
-                    cmd.Unprepare();
-                    AssertNumPreparedStatements(conn, 0);
-                    Assert.That(cmd.IsPrepared, Is.False);
-                    Assert.That(cmd.ExecuteScalar(), Is.EqualTo(1));
-                }
-            }
-        }
+            => Unprepare(false).GetAwaiter().GetResult();
 
         [Test]
-        public async Task UnprepareAsync()
+        public Task UnprepareAsync()
+            => Unprepare(true);
+
+        private async Task Unprepare(bool async)
         {
             using (var conn = OpenConnectionAndUnprepare())
             {
                 AssertNumPreparedStatements(conn, 0);
                 using (var cmd = new NpgsqlCommand("SELECT 1", conn))
                 {
-                    await cmd.PrepareAsync();
+                    if(async)
+                        await cmd.PrepareAsync();
+                    else
+                        cmd.Prepare();
+
                     AssertNumPreparedStatements(conn, 1);
-                    await cmd.UnprepareAsync();
+
+                    if (async)
+                        await cmd.UnprepareAsync();
+                    else
+                        cmd.Unprepare();
+
                     AssertNumPreparedStatements(conn, 0);
                     Assert.That(cmd.IsPrepared, Is.False);
                     Assert.That(cmd.ExecuteScalar(), Is.EqualTo(1));


### PR DESCRIPTION
Basically allows for async Unpreperation of `NpgsqlCommand`s as mentioned in #2943.

I hope this matches the general guidelines for this repository. I tried to reproduce the pattern the best I could from what I could gather from the surrounding methods.