### PR TITLE
Fix hang-up while disposing RawCopyExport

### DIFF
--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -174,9 +174,16 @@ namespace Npgsql
 
             if (_leftToReadInDataMsg == 0)
             {
-                // We've consumed the current DataMessage (or haven't yet received the first),
-                // read the next message
-                var msg = await _connector.ReadMessage(async);
+                IBackendMessage msg;
+                try {
+                    // We've consumed the current DataMessage (or haven't yet received the first),
+                    // read the next message
+                    msg = await _connector.ReadMessage(async);
+                } catch {
+                    Cleanup();
+                    throw;
+                }
+
                 switch (msg.Code) {
                 case BackendMessageCode.CopyData:
                     _leftToReadInDataMsg = ((CopyDataMessage)msg).Length;

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -175,11 +175,14 @@ namespace Npgsql
             if (_leftToReadInDataMsg == 0)
             {
                 IBackendMessage msg;
-                try {
+                try
+                {
                     // We've consumed the current DataMessage (or haven't yet received the first),
                     // read the next message
                     msg = await _connector.ReadMessage(async);
-                } catch {
+                }
+                catch
+                {
                     Cleanup();
                     throw;
                 }

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1216,5 +1216,27 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
                 conn.ExecuteNonQuery("DROP TABLE IF EXISTS bug_2849");
             }
         }
+
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2371")]
+        public void NullReferenceExceptionInBeginTextExport()
+        {
+            using var conn = OpenConnection();
+            try
+            {
+                using var transaction = conn.BeginTransaction();
+                var command = conn.CreateCommand();
+                command.CommandText = "CREATE OR REPLACE FUNCTION f_test() RETURNS TABLE (i INT) AS $$ BEGIN RETURN QUERY SELECT s.a FROM pg_stat_activity p; end; $$ LANGUAGE plpgsql;";
+                command.ExecuteNonQuery();
+                using var reader = conn.BeginTextExport("copy (select * FROM f_test())  TO STDOUT WITH (format csv)");
+                Assert.That(() => reader.ReadLine(), Throws.Exception
+                    .TypeOf<PostgresException>()
+                    .With.Property(nameof(PostgresException.SqlState)).EqualTo("42P01")
+                );
+            }
+            finally
+            {
+                conn.ExecuteNonQuery("DROP FUNCTION IF EXISTS f_test()");
+            }
+        }
     }
 }


### PR DESCRIPTION
When the first read message fails with an exception, the stream can be immediately closed.

Fixes #2371.