### PR TITLE
Partial fix #2763: On a fresh DbConnection, NpgsqlConnection.DataSource should be an empty string

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -371,6 +371,8 @@ namespace Npgsql
         /// <summary>
         /// Gets the string identifying the database server (host and port)
         /// </summary>
+        /// <value>The name of the database server (host and port). The default value
+        /// is the empty string.</value>
         public override string DataSource => Settings.DataSourceCached;
 
         /// <summary>

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -371,8 +371,8 @@ namespace Npgsql
         /// <summary>
         /// Gets the string identifying the database server (host and port)
         /// </summary>
-        /// <value>The name of the database server (host and port). The default value
-        /// is the empty string.</value>
+        /// <value>The name of the database server (host and port). If a Unix-domain socket
+        /// connection is available, then this is returned. The default value is the empty string.</value>
         public override string DataSource => Settings.DataSourceCached;
 
         /// <summary>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -40,7 +41,18 @@ namespace Npgsql
         /// </summary>
         string? _dataSourceCached;
 
-        internal string DataSourceCached => _dataSourceCached ??= (_host is null ? string.Empty : $"tcp://{_host}:{_port}");
+        internal string DataSourceCached
+        {
+            get
+            {
+                if (!(_host is null))
+                {
+                    _dataSourceCached ??= Path.IsPathRooted(_host) ? Path.Combine(_host, $".s.PGSQL.{_port}") : $"tcp://{_host}:{_port}";
+                }
+
+                return _dataSourceCached ??= string.Empty;
+            }
+        }
 
         #endregion
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -40,7 +40,7 @@ namespace Npgsql
         /// </summary>
         string? _dataSourceCached;
 
-        internal string DataSourceCached => _dataSourceCached ??= $"tcp://{_host}:{_port}";
+        internal string DataSourceCached => _dataSourceCached ??= (_host is null ? string.Empty : $"tcp://{_host}:{_port}");
 
         #endregion
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -594,6 +594,18 @@ namespace Npgsql.Tests
                 Assert.That(conn.DataSource, Is.EqualTo($"tcp://{conn.Host}:{conn.Port}"));
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2763")]
+        public void DataSourceDefault()
+        {
+            using (var conn = new NpgsqlConnection())
+            {
+                Assert.That(conn.DataSource, Is.EqualTo(string.Empty));
+
+                conn.ConnectionString = ConnectionString;
+                Assert.That(conn.DataSource, Is.EqualTo($"tcp://{conn.Host}:{conn.Port}"));
+            }
+        }
+
         [Test]
         public void SetConnectionString()
         {

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -566,6 +566,7 @@ namespace Npgsql.Tests
             {
                 using var conn = OpenConnection(csb);
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
+                Assert.That(conn.DataSource, Is.EqualTo(Path.Combine(csb.Host, $".s.PGSQL.{port}")));
             }
             catch (PostgresException e) when (e.SqlState.StartsWith("28"))
             {


### PR DESCRIPTION
Hi @Roji, hope you don't mind but would like to start contributing to Npgsql and have made applied a partial fix to this bug. Please review the changes and let me know if there is anything I may have missed.
I haven't addressed the Unix domain socket functionality in this PR as I'm not very clear on what the requirement is?

Fixes #2763.