### PR TITLE
Never use NoSynchronizationContextScope in async methods

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1593,15 +1593,19 @@ namespace Npgsql
         /// <param name="ordinal">The zero-based column to be retrieved.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns><b>true</b> if the specified column value is equivalent to <see cref="DBNull"/> otherwise <b>false</b>.</returns>
-        public override async Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             CheckRowAndGetField(ordinal);
 
             if (!_isSequential)
-                return IsDBNull(ordinal);
+                return IsDBNull(ordinal) ? PGUtil.TrueTask : PGUtil.FalseTask;
 
             using (NoSynchronizationContextScope.Enter())
+                return IsDBNullAsyncInternal();
+
+            // ReSharper disable once InconsistentNaming
+            async Task<bool> IsDBNullAsyncInternal()
             {
                 await SeekToColumn(ordinal, true);
                 return ColumnLen == -1;

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -157,9 +157,7 @@ namespace Npgsql
             async ValueTask WriteAsyncInternal()
             {
                 if (buffer.Length == 0)
-                {
                     return;
-                }
 
                 if (buffer.Length <= _writeBuf.WriteSpaceLeft)
                 {

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -142,9 +142,9 @@ namespace Npgsql
         }
 
 #if !NET461 && !NETSTANDARD2_0
-        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
 #else
-        public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
 #endif
         {
             CheckDisposed();
@@ -152,8 +152,14 @@ namespace Npgsql
                 throw new InvalidOperationException("Stream not open for writing");
             cancellationToken.ThrowIfCancellationRequested();
             using (NoSynchronizationContextScope.Enter())
+                return WriteAsyncInternal();
+
+            async ValueTask WriteAsyncInternal()
             {
-                if (buffer.Length == 0) { return; }
+                if (buffer.Length == 0)
+                {
+                    return;
+                }
 
                 if (buffer.Length <= _writeBuf.WriteSpaceLeft)
                 {
@@ -233,9 +239,9 @@ namespace Npgsql
         }
 
 #if !NET461 && !NETSTANDARD2_0
-        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
 #else
-        public async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
 #endif
         {
             CheckDisposed();
@@ -243,6 +249,9 @@ namespace Npgsql
                 throw new InvalidOperationException("Stream not open for reading");
             cancellationToken.ThrowIfCancellationRequested();
             using (NoSynchronizationContextScope.Enter())
+                return ReadAsyncInternal();
+
+            async ValueTask<int> ReadAsyncInternal()
             {
                 var count = await ReadCore(buffer.Length, true);
                 if (count > 0)


### PR DESCRIPTION
Only in sync wrappers, otherwise the sync context leaks out as the method completes synchronously.

Example:

```c#
public async Task Foo() {
    using (NoSynchronizationContextScope.Enter()) {
        await something();
    }
}

var t = Foo();
// Our SynchronizationContext.Current now has the NoSynchronizationContextScope instance set by Npgsql - not good.
// Instead, we only set NoSynchronizationContextScope in non-async wrappers.
```

As an aside, we may be able to get rid of this for 5.0, and just use ConfigureAwait(false) like any other library (with an analyzer to enforce it). There was a good reason why I went down this path in the first place, but it may not be so relevant after multiplexing.

@manandre @YohDeadfall @Brar