### PR TITLE
Fixes invalid update command generated when using select query with aliases

### DIFF
--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -139,10 +139,10 @@ ORDER BY attnum";
             // Fill in whatever info we have from the RowDescription itself
             for (var i = 0; i < fields.Count; i++)
             {
-                NpgsqlDbColumn column;
+                var column = result[i];
                 var field = fields[i];
 
-                if (result[i] == null)
+                if (column == null)
                 {
                     column = SetUpNonColumnField(field);
                     column.ColumnOrdinal = i;
@@ -150,13 +150,10 @@ ORDER BY attnum";
                     populatedColumns++;
                 }
 
-                Debug.Assert(result != null);
                 var fieldName = field.Name.StartsWith("?column?") ? null : field.Name;
 
-#pragma warning disable CS8602 // Dereference of a possibly null reference.
-                result[i].BaseColumnName ??= fieldName;
-                result[i].ColumnName = fieldName;
-#pragma warning restore CS8602
+                column.BaseColumnName ??= fieldName;
+                column.ColumnName = fieldName;
             }
 
             if (populatedColumns != fields.Count)

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -150,8 +150,13 @@ ORDER BY attnum";
                     populatedColumns++;
                 }
 
-                result[i]!.BaseColumnName ??= field.Name.StartsWith("?column?") ? null : field.Name;
-                result[i]!.ColumnName = field.Name.StartsWith("?column?") ? null : field.Name;
+                Debug.Assert(result != null);
+                var fieldName = field.Name.StartsWith("?column?") ? null : field.Name;
+
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+                result[i].BaseColumnName ??= fieldName;
+                result[i].ColumnName = fieldName;
+#pragma warning restore CS8602
             }
 
             if (populatedColumns != fields.Count)

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -150,7 +150,8 @@ ORDER BY attnum";
                     populatedColumns++;
                 }
 
-                result[i]!.ColumnName = result[i]!.BaseColumnName = field.Name.StartsWith("?column?") ? null : field.Name;
+                result[i]!.BaseColumnName ??= field.Name.StartsWith("?column?") ? null : field.Name;
+                result[i]!.ColumnName = field.Name.StartsWith("?column?") ? null : field.Name;
             }
 
             if (populatedColumns != fields.Count)
@@ -171,6 +172,7 @@ ORDER BY attnum";
                 BaseSchemaName = reader.GetString(reader.GetOrdinal("nspname")),
                 BaseServerName = _connection.Host!,
                 BaseTableName = reader.GetString(reader.GetOrdinal("relname")),
+                BaseColumnName = reader.GetString(reader.GetOrdinal("attname")),
                 ColumnOrdinal = reader.GetInt32(reader.GetOrdinal("attnum")) - 1,
                 ColumnAttributeNumber = (short)(reader.GetInt16(reader.GetOrdinal("attnum")) - 1),
                 IsKey = reader.GetBoolean(reader.GetOrdinal("isprimarykey")),

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -843,7 +843,6 @@ $$ LANGUAGE SQL;
                 Assert.That(dt.Rows[1]["ColumnName"].ToString(), Is.EqualTo("descralias"));
                 Assert.That(dt.Rows[2]["BaseColumnName"].ToString(), Is.EqualTo("data"));
                 Assert.That(dt.Rows[2]["ColumnName"].ToString(), Is.EqualTo("dataalias"));
-
             }
         }
     }

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -816,34 +816,23 @@ $$ LANGUAGE SQL;
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/2560")]
         public void GetUpdateCommandWithColumnAliases()
         {
-            using (var conn = OpenConnection())
-            {
-                conn.ExecuteNonQuery(@"
-                    CREATE TABLE pg_temp.test (
-                        Cod varchar(5) NOT NULL,
-                        Descr varchar(40),
-                        Data date,
-                        CONSTRAINT PK_test_Cod PRIMARY KEY (Cod)
-                    );
-                ");
-                var cmd = new NpgsqlCommand("SELECT Cod as CodAlias, Descr as DescrAlias, Data as DataAlias FROM test", conn);
+            using var conn = OpenConnection();
 
-                var daDataAdapter = new NpgsqlDataAdapter(cmd);
-                var cbCommandBuilder = new NpgsqlCommandBuilder(daDataAdapter);
-                daDataAdapter.UpdateCommand = cbCommandBuilder.GetUpdateCommand();
-                Assert.True(daDataAdapter.UpdateCommand.CommandText.Contains("SET \"cod\" = @p1, \"descr\" = @p2, \"data\" = @p3 WHERE ((\"cod\" = @p4) AND ((@p5 = 1 AND \"descr\" IS NULL) OR (\"descr\" = @p6)) AND ((@p7 = 1 AND \"data\" IS NULL) OR (\"data\" = @p8)))"));
+            conn.ExecuteNonQuery(@"
+                CREATE TEMP TABLE data (
+                    Cod varchar(5) NOT NULL,
+                    Descr varchar(40),
+                    Data date,
+                    CONSTRAINT PK_test_Cod PRIMARY KEY (Cod)
+                );
+            ");
 
-                // specify command behaviour of SchemaOnly | KeyInfo for datareader in order for column meta data to be retrieved
-                var dr = cmd.ExecuteReader(CommandBehavior.SchemaOnly|CommandBehavior.KeyInfo);
-                var dt = dr.GetSchemaTable();
+            using var cmd = new NpgsqlCommand("SELECT Cod as CodAlias, Descr as DescrAlias, Data as DataAlias FROM data", conn);
+            using var daDataAdapter = new NpgsqlDataAdapter(cmd);
+            using var cbCommandBuilder = new NpgsqlCommandBuilder(daDataAdapter);
 
-                Assert.That(dt.Rows[0]["BaseColumnName"].ToString(), Is.EqualTo("cod"));
-                Assert.That(dt.Rows[0]["ColumnName"].ToString(), Is.EqualTo("codalias"));
-                Assert.That(dt.Rows[1]["BaseColumnName"].ToString(), Is.EqualTo("descr"));
-                Assert.That(dt.Rows[1]["ColumnName"].ToString(), Is.EqualTo("descralias"));
-                Assert.That(dt.Rows[2]["BaseColumnName"].ToString(), Is.EqualTo("data"));
-                Assert.That(dt.Rows[2]["ColumnName"].ToString(), Is.EqualTo("dataalias"));
-            }
+            daDataAdapter.UpdateCommand = cbCommandBuilder.GetUpdateCommand();
+            Assert.True(daDataAdapter.UpdateCommand.CommandText.Contains("SET \"cod\" = @p1, \"descr\" = @p2, \"data\" = @p3 WHERE ((\"cod\" = @p4) AND ((@p5 = 1 AND \"descr\" IS NULL) OR (\"descr\" = @p6)) AND ((@p7 = 1 AND \"data\" IS NULL) OR (\"data\" = @p8)))"));
         }
     }
 }

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -831,7 +831,7 @@ $$ LANGUAGE SQL;
                 var daDataAdapter = new NpgsqlDataAdapter(cmd);
                 var cbCommandBuilder = new NpgsqlCommandBuilder(daDataAdapter);
                 daDataAdapter.UpdateCommand = cbCommandBuilder.GetUpdateCommand();
-                Assert.That(daDataAdapter.UpdateCommand.CommandText, Is.EqualTo("UPDATE \"npgsql_tests\".\"pg_temp_3\".\"test\" SET \"cod\" = @p1, \"descr\" = @p2, \"data\" = @p3 WHERE ((\"cod\" = @p4) AND ((@p5 = 1 AND \"descr\" IS NULL) OR (\"descr\" = @p6)) AND ((@p7 = 1 AND \"data\" IS NULL) OR (\"data\" = @p8)))"));
+                Assert.True(daDataAdapter.UpdateCommand.CommandText.Contains("SET \"cod\" = @p1, \"descr\" = @p2, \"data\" = @p3 WHERE ((\"cod\" = @p4) AND ((@p5 = 1 AND \"descr\" IS NULL) OR (\"descr\" = @p6)) AND ((@p7 = 1 AND \"data\" IS NULL) OR (\"data\" = @p8)))"));
 
                 // specify command behaviour of SchemaOnly | KeyInfo for datareader in order for column meta data to be retrieved
                 var dr = cmd.ExecuteReader(CommandBehavior.SchemaOnly|CommandBehavior.KeyInfo);

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -70,6 +70,33 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public void BaseColumnNameWithColumnAliases()
+        {
+            using var conn = OpenConnection();
+
+            conn.ExecuteNonQuery(@"
+                CREATE TEMP TABLE data (
+                    Cod varchar(5) NOT NULL,
+                    Descr varchar(40),
+                    Date date,
+                    CONSTRAINT PK_test_Cod PRIMARY KEY (Cod)
+                );
+            ");
+
+            var cmd = new NpgsqlCommand("SELECT Cod as CodAlias, Descr as DescrAlias, Date FROM data", conn);
+
+            using var dr = cmd.ExecuteReader(CommandBehavior.SchemaOnly | CommandBehavior.KeyInfo);
+            var cols = dr.GetColumnSchema();
+
+            Assert.That(cols[0].BaseColumnName, Is.EqualTo("cod"));
+            Assert.That(cols[0].ColumnName.ToString(), Is.EqualTo("codalias"));
+            Assert.That(cols[1].BaseColumnName.ToString(), Is.EqualTo("descr"));
+            Assert.That(cols[1].ColumnName.ToString(), Is.EqualTo("descralias"));
+            Assert.That(cols[2].BaseColumnName.ToString(), Is.EqualTo("date"));
+            Assert.That(cols[2].ColumnName.ToString(), Is.EqualTo("date"));
+        }
+
+        [Test]
         public void BaseSchemaName()
         {
             using (var conn = OpenConnection())

--- a/test/Npgsql.Tests/ReaderOldSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderOldSchemaTests.cs
@@ -217,5 +217,32 @@ namespace Npgsql.Tests
                 }
             }
         }
+
+        [Test]
+        public void BaseColumnName()
+        {
+            using var conn = OpenConnection();
+
+            conn.ExecuteNonQuery(@"
+                CREATE TEMP TABLE data (
+                    Cod varchar(5) NOT NULL,
+                    Descr varchar(40),
+                    Date date,
+                    CONSTRAINT PK_test_Cod PRIMARY KEY (Cod)
+                );
+            ");
+
+            var cmd = new NpgsqlCommand("SELECT Cod as CodAlias, Descr as DescrAlias, Date FROM data", conn);
+
+            using var dr = cmd.ExecuteReader(CommandBehavior.SchemaOnly | CommandBehavior.KeyInfo);
+            var dt = dr.GetSchemaTable();
+
+            Assert.That(dt.Rows[0]["BaseColumnName"].ToString(), Is.EqualTo("cod"));
+            Assert.That(dt.Rows[0]["ColumnName"].ToString(), Is.EqualTo("codalias"));
+            Assert.That(dt.Rows[1]["BaseColumnName"].ToString(), Is.EqualTo("descr"));
+            Assert.That(dt.Rows[1]["ColumnName"].ToString(), Is.EqualTo("descralias"));
+            Assert.That(dt.Rows[2]["BaseColumnName"].ToString(), Is.EqualTo("date"));
+            Assert.That(dt.Rows[2]["ColumnName"].ToString(), Is.EqualTo("date"));
+        }
     }
 }


### PR DESCRIPTION
Looking into this issue I found that the notes for the Microsoft  ODBC command builder mention that the base column names is what is used to generate the statements and if set to the alias column names this would be used incorrectly.
https://docs.microsoft.com/en-us/dotnet/api/system.data.odbc.odbccommandbuilder?view=dotnet-plat-ext-3.1#remarks

I've fixed this and set the BaseColumnName correctly (I think). Please review and let me know if there are any issues with the fix or the test.

Kind Regards,
Warren Chan
Fujitsu Australia