### PR TITLE
Optimized and made AOT friendly composite mappings

### DIFF
--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -135,7 +135,7 @@ namespace Npgsql.TypeMapping
         /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
         /// an exception will be raised.
         /// </remarks>
-        /// <param name="compType">The .NET type to be mapped.</param>
+        /// <param name="clrType">The .NET type to be mapped.</param>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding composite type in the database.
         /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
@@ -146,14 +146,14 @@ namespace Npgsql.TypeMapping
         /// </param>
         [NotNull]
         INpgsqlTypeMapper MapComposite(
-            Type compType,
+            Type clrType,
             string? pgName = null,
             INpgsqlNameTranslator? nameTranslator = null);
 
         /// <summary>
         /// Removes an existing composite mapping.
         /// </summary>
-        /// <param name="compType">The .NET type to be unmapped.</param>
+        /// <param name="clrType">The .NET type to be unmapped.</param>
         /// <param name="pgName">
         /// A PostgreSQL type name for the corresponding composite type in the database.
         /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
@@ -163,7 +163,7 @@ namespace Npgsql.TypeMapping
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         bool UnmapComposite(
-            Type compType,
+            Type clrType,
             string? pgName = null,
             INpgsqlNameTranslator? nameTranslator = null);
 

--- a/src/Npgsql/TypeMapping/TypeMapperBase.cs
+++ b/src/Npgsql/TypeMapping/TypeMapperBase.cs
@@ -82,9 +82,9 @@ namespace Npgsql.TypeMapping
         public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             => MapComposite(pgName, nameTranslator, typeof(T), t => new CompositeTypeHandlerFactory<T>(t));
 
-        public INpgsqlTypeMapper MapComposite(Type compType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-            => MapComposite(pgName, nameTranslator, compType, t => (NpgsqlTypeHandlerFactory)
-                Activator.CreateInstance(typeof(CompositeTypeHandlerFactory<>).MakeGenericType(compType), t)!);
+        public INpgsqlTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+            => MapComposite(pgName, nameTranslator, clrType, t => (NpgsqlTypeHandlerFactory)
+                Activator.CreateInstance(typeof(CompositeTypeHandlerFactory<>).MakeGenericType(clrType), t)!);
 
         INpgsqlTypeMapper MapComposite(string? pgName, INpgsqlNameTranslator? nameTranslator, Type type, Func<INpgsqlNameTranslator, NpgsqlTypeHandlerFactory> factory)
         {
@@ -107,13 +107,13 @@ namespace Npgsql.TypeMapping
         public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             => UnmapComposite(typeof(T), pgName, nameTranslator);
 
-        public bool UnmapComposite(Type compType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+        public bool UnmapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         {
             if (pgName != null && string.IsNullOrWhiteSpace(pgName))
                 throw new ArgumentException("pgName can't be empty.", nameof(pgName));
 
             nameTranslator ??= DefaultNameTranslator;
-            pgName ??= GetPgName(compType, nameTranslator);
+            pgName ??= GetPgName(clrType, nameTranslator);
 
             return RemoveMapping(pgName);
         }
@@ -124,9 +124,9 @@ namespace Npgsql.TypeMapping
 
         // TODO: why does ReSharper think `GetCustomAttribute<T>` is non-nullable?
         // ReSharper disable once ConstantConditionalAccessQualifier ConstantNullCoalescingCondition
-        static string GetPgName(Type compType, INpgsqlNameTranslator nameTranslator)
-            => compType.GetCustomAttribute<PgNameAttribute>()?.PgName
-               ?? nameTranslator.TranslateTypeName(compType.Name);
+        static string GetPgName(Type clrType, INpgsqlNameTranslator nameTranslator)
+            => clrType.GetCustomAttribute<PgNameAttribute>()?.PgName
+               ?? nameTranslator.TranslateTypeName(clrType.Name);
 
         #endregion Misc
     }


### PR DESCRIPTION
When you're okay with C# 9 we will eliminate delegate allocations here.