### PR TITLE
Obsolete NpgsqlDate, NpgsqlDateTime and NpgsqlTimeSpan

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1023,7 +1023,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlDate GetDate(int ordinal) => GetFieldValue<NpgsqlDate>(ordinal);
+#pragma warning restore 618
 
         /// <summary>
         /// Gets the value of the specified column as a TimeSpan,
@@ -1053,7 +1055,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlTimeSpan GetInterval(int ordinal) => GetFieldValue<NpgsqlTimeSpan>(ordinal);
+#pragma warning restore 618
 
         /// <summary>
         /// Gets the value of the specified column as an <see cref="NpgsqlDateTime"/>,
@@ -1070,7 +1074,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlDateTime GetTimeStamp(int ordinal) => GetFieldValue<NpgsqlDateTime>(ordinal);
+#pragma warning restore 618
 
         #endregion
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
@@ -10,6 +10,9 @@ using JetBrains.Annotations;
 namespace NpgsqlTypes
 {
     [Serializable]
+    [Obsolete("This type will be removed from the next release. Please use the System.DateTime"
+              + " type or the Instant type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/2009 and describe your issues.")]
     public readonly struct NpgsqlDate : IEquatable<NpgsqlDate>, IComparable<NpgsqlDate>, IComparable,
         IComparer<NpgsqlDate>, IComparer
     {

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -14,6 +14,9 @@ namespace NpgsqlTypes
     /// while PostgreSQL's timestamps store values from 4713BC to 5874897AD with 1-microsecond precision.
     /// </summary>
     [Serializable]
+    [Obsolete("This type will be removed from the next release. Please use the System.DateTime"
+              + " type or the Instant type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/2009 and describe your issues.")]
     public readonly struct NpgsqlDateTime : IEquatable<NpgsqlDateTime>, IComparable<NpgsqlDateTime>, IComparable,
         IComparer<NpgsqlDateTime>, IComparer
     {

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
@@ -32,6 +32,9 @@ namespace NpgsqlTypes
     /// <seealso cref="JustifyMonths"/>
     /// <seealso cref="Canonicalize()"/>
     [Serializable]
+    [Obsolete("This type will be removed from the next release. Please use the System.DateTime"
+              + " type or the Instant type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/2009 and describe your issues.")]
     public readonly struct NpgsqlTimeSpan : IComparable, IComparer, IEquatable<NpgsqlTimeSpan>, IComparable<NpgsqlTimeSpan>,
                                    IComparer<NpgsqlTimeSpan>
     {

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/DateHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/DateHandler.cs
@@ -5,6 +5,7 @@ using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+#pragma warning disable 618
 
 namespace Npgsql.TypeHandlers.DateTimeHandlers
 {

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
@@ -4,6 +4,7 @@ using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+#pragma warning disable 618
 
 namespace Npgsql.TypeHandlers.DateTimeHandlers
 {

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
@@ -5,6 +5,7 @@ using System.Data;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
+#pragma warning disable 618
 
 namespace Npgsql.TypeHandlers.DateTimeHandlers
 {

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -5,6 +5,7 @@ using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+#pragma warning disable 618
 
 namespace Npgsql.TypeHandlers.DateTimeHandlers
 {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -538,7 +538,9 @@ namespace Npgsql.Tests
                     dr.Read();
                     var values = new object[4];
                     Assert.That(dr.GetProviderSpecificValues(values), Is.EqualTo(3));
+#pragma warning disable 618
                     Assert.That(values, Is.EqualTo(new object?[] { "hello", 1, new NpgsqlDate(2014, 1, 1), null }));
+#pragma warning restore 618
                 }
                 using (var dr = command.ExecuteReader(Behavior))
                 {

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -315,6 +315,7 @@ namespace Npgsql.Tests.Types
             }
         }
 
+#pragma warning disable 618
         [Test, Description("Reads a one-dimensional array dates, both as DateTime and as the provider-specific NpgsqlDate")]
         public void ReadProviderSpecificType()
         {
@@ -333,6 +334,7 @@ namespace Npgsql.Tests.Types
                 }
             }
         }
+#pragma warning restore 618
 
         [Test, Description("Reads an one-dimensional array with lower bound != 0")]
         public void ReadNonZeroLowerBounded()

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Linq;
 using NpgsqlTypes;
 using NUnit.Framework;
+#pragma warning disable 618
 
 namespace Npgsql.Tests.Types
 {

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Npgsql.Util;
 using NpgsqlTypes;
 using NUnit.Framework;
+#pragma warning disable 618
 
 namespace Npgsql.Tests
 {


### PR DESCRIPTION
Closes #2009

In the files where the use of the NpgsqlTypes in question is abundant I went full bore and #pragma disabled warning 618 for the whole file to avoid having to sprinkle it over the whole file.

If you consider this to invasive/dangerous (It might suppress other Obsolete warnings too) I'll change this to a line by line approach or some compromise between the two approaches as you like.