### PR TITLE
Stream contract gathering and enforcement

### DIFF
--- a/src/Npgsql/AsyncExtensions.cs
+++ b/src/Npgsql/AsyncExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Npgsql
+{
+    static class AsyncExtensions
+    {
+        public static IAsyncResult AsApm<T>(this Task<T> task,
+                                            AsyncCallback callback,
+                                            object? state)
+        {
+            if (task == null)
+                throw new ArgumentNullException("task");
+
+            var tcs = new TaskCompletionSource<T>(state);
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception!.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+
+                callback?.Invoke(tcs.Task);
+            }, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        public static IAsyncResult AsApm(this Task task,
+                                            AsyncCallback callback,
+                                            object? state)
+        {
+            if (task == null)
+                throw new ArgumentNullException("task");
+
+            var tcs = new TaskCompletionSource<object?>(state);
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception!.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(null!);
+
+                callback?.Invoke(tcs.Task);
+            }, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        public static async ValueTask Then(this ValueTask task, Action next)
+        {
+            await task;
+            next();
+        }
+    }
+}

--- a/src/Npgsql/AsyncExtensions.cs
+++ b/src/Npgsql/AsyncExtensions.cs
@@ -5,13 +5,8 @@ namespace Npgsql
 {
     static class AsyncExtensions
     {
-        public static IAsyncResult AsApm<T>(this Task<T> task,
-                                            AsyncCallback callback,
-                                            object? state)
+        public static IAsyncResult AsApm<T>(this Task<T> task, AsyncCallback callback, object? state)
         {
-            if (task == null)
-                throw new ArgumentNullException("task");
-
             var tcs = new TaskCompletionSource<T>(state);
             task.ContinueWith(t =>
             {
@@ -23,17 +18,12 @@ namespace Npgsql
                     tcs.TrySetResult(t.Result);
 
                 callback?.Invoke(tcs.Task);
-            }, TaskScheduler.Default);
+            });
             return tcs.Task;
         }
 
-        public static IAsyncResult AsApm(this Task task,
-                                            AsyncCallback callback,
-                                            object? state)
+        public static IAsyncResult AsApm(this Task task, AsyncCallback callback, object? state)
         {
-            if (task == null)
-                throw new ArgumentNullException("task");
-
             var tcs = new TaskCompletionSource<object?>(state);
             task.ContinueWith(t =>
             {

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -271,7 +271,7 @@ namespace Npgsql
                 _connector = connector;
             }
 
-            internal protected override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            private protected override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
                 if (_leftToWrite == 0)
                 {
@@ -298,7 +298,7 @@ namespace Npgsql
                 _leftToWrite -= count;
             }
 
-            internal protected override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            private protected override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
                 if (_leftToRead == 0)
                 {
@@ -327,7 +327,7 @@ namespace Npgsql
                 return count;
             }
 
-            internal protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
+            private protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
         }
 
         class AuthenticationCompleteException : Exception { }

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -258,7 +258,7 @@ namespace Npgsql
         /// <remarks>
         /// See https://referencesource.microsoft.com/#System/net/System/Net/_StreamFramer.cs,16417e735f0e9530,references
         /// </remarks>
-        class GSSPasswordMessageStream : Stream
+        class GSSPasswordMessageStream : NpgsqlStream
         {
             readonly NpgsqlConnector _connector;
             int _leftToWrite;
@@ -266,17 +266,12 @@ namespace Npgsql
             byte[]? _readBuf;
 
             internal GSSPasswordMessageStream(NpgsqlConnector connector)
+                : base(canRead: true, canWrite: true)
             {
                 _connector = connector;
             }
 
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-                => Write(buffer, offset, count, true);
-
-            public override void Write(byte[] buffer, int offset, int count)
-                => Write(buffer, offset, count, false).GetAwaiter().GetResult();
-
-            async Task Write(byte[] buffer, int offset, int count, bool async)
+            internal protected override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
                 if (_leftToWrite == 0)
                 {
@@ -303,13 +298,7 @@ namespace Npgsql
                 _leftToWrite -= count;
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-                => Read(buffer, offset, count, true);
-
-            public override int Read(byte[] buffer, int offset, int count)
-                => Read(buffer, offset, count, false).GetAwaiter().GetResult();
-
-            async Task<int> Read(byte[] buffer, int offset, int count, bool async)
+            internal protected override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
                 if (_leftToRead == 0)
                 {
@@ -338,21 +327,7 @@ namespace Npgsql
                 return count;
             }
 
-            public override void Flush() { }
-
-            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-            public override void SetLength(long value) => throw new NotSupportedException();
-
-            public override bool CanRead => true;
-            public override bool CanWrite => true;
-            public override bool CanSeek => false;
-            public override long Length => throw new NotSupportedException();
-
-            public override long Position
-            {
-                get => throw new NotSupportedException();
-                set => throw new NotSupportedException();
-            }
+            internal protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
         }
 
         class AuthenticationCompleteException : Exception { }

--- a/src/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/src/Npgsql/NpgsqlLargeObjectStream.cs
@@ -50,8 +50,7 @@ namespace Npgsql
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => base.ReadAsync(buffer, offset, count, cancellationToken);
 
-        /// <inheritdoc />
-        internal protected override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+        private protected override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
         {
             var chunkCount = Math.Min(count, _manager.MaxTransferBlockSize);
             var read = 0;
@@ -88,8 +87,7 @@ namespace Npgsql
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => base.WriteAsync(buffer, offset, count, cancellationToken);
 
-        /// <inheritdoc />
-        internal protected override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+        private protected override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
         {
             var totalWritten = 0;
 
@@ -151,8 +149,7 @@ namespace Npgsql
         public override Task<long> GetLengthAsync(CancellationToken cancellationToken = default)
             => base.GetLengthAsync(cancellationToken);
 
-        /// <inheritdoc />
-        internal protected override async Task<long> GetLengthAsync(CancellationToken cancellationToken, bool async)
+        private protected override async Task<long> GetLengthAsync(CancellationToken cancellationToken, bool async)
         {
             var old = _pos;
             var retval = await SeekAsync(0, SeekOrigin.End, default, async);
@@ -179,8 +176,7 @@ namespace Npgsql
         public override Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken = default)
             => base.SeekAsync(offset, origin, cancellationToken);
 
-        /// <inheritdoc />
-        internal protected override async Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken, bool async)
+        private protected override async Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken, bool async)
         {
             if (!Has64BitSupport && offset != (int)offset)
                 throw new ArgumentOutOfRangeException(nameof(offset), "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
@@ -193,7 +189,7 @@ namespace Npgsql
         /// <summary>
         /// Does nothing.
         /// </summary>
-        internal protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
+        private protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
 
         /// <summary>
         /// Truncates or enlarges the large object to the given size. If enlarging, the large object is extended with null bytes.
@@ -212,8 +208,7 @@ namespace Npgsql
         public override Task SetLengthAsync(long value, CancellationToken cancellationToken)
             => base.SetLengthAsync(value, cancellationToken);
 
-        /// <inheritdoc />
-        internal protected override async Task SetLengthAsync(long value, CancellationToken cancellationToken, bool async)
+        private protected override async Task SetLengthAsync(long value, CancellationToken cancellationToken, bool async)
         {
             if (!Has64BitSupport && value != (int)value)
                 throw new ArgumentOutOfRangeException(nameof(value), "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
@@ -224,8 +219,7 @@ namespace Npgsql
                 await _manager.ExecuteFunction<int>("lo_truncate", async, _fd, (int)value);
         }
 
-        /// <inheritdoc />
-        internal protected override async ValueTask DisposeAsync(bool async)
+        private protected override async ValueTask DisposeAsync(bool async)
         {
             if (async)
                 await _manager.ExecuteFunction<int>("lo_close", false, _fd);

--- a/src/Npgsql/NpgsqlSpanStream.cs
+++ b/src/Npgsql/NpgsqlSpanStream.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract class NpgsqlSpanStream : NpgsqlStream
+    {
+        #region Constructor
+
+        /// <inheritdoc />
+        internal protected NpgsqlSpanStream(bool canRead = false, bool canSeek = false, bool canWrite = false)
+            : base(canRead, canSeek, canWrite)
+        { }
+
+        #endregion
+
+        #region Read
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanRead();
+            return Read(new Span<byte>(buffer, offset, count));
+        }
+
+        /// <inheritdoc />
+#if !NET461 && !NETSTANDARD2_0
+        public override int Read(Span<byte> span)
+#else
+        public virtual int Read(Span<byte> span)
+#endif
+            => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanRead();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        }
+
+        /// <inheritdoc />
+#if !NET461 && !NETSTANDARD2_0
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+#else
+        public virtual ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+#endif
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Write
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanWrite();
+            Write(new ReadOnlySpan<byte>(buffer, offset, count));
+        }
+
+        /// <inheritdoc />
+#if !NET461 && !NETSTANDARD2_0
+        public override void Write(ReadOnlySpan<byte> buffer)
+#else
+        public virtual void Write(ReadOnlySpan<byte> buffer)
+#endif
+            => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanWrite();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return WriteAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        }
+
+        /// <inheritdoc />
+#if !NET461 && !NETSTANDARD2_0
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+#else
+        public virtual ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+#endif
+            => throw new NotImplementedException();
+
+        #endregion
+    }
+}

--- a/src/Npgsql/NpgsqlStream.cs
+++ b/src/Npgsql/NpgsqlStream.cs
@@ -1,0 +1,329 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract class NpgsqlStream : Stream
+    {
+        #region Constructor
+        /// <inheritdoc />
+        internal protected NpgsqlStream(bool canRead = false, bool canSeek = false, bool canWrite = false)
+        {
+            _canRead = canRead;
+            _canSeek = canSeek;
+            _canWrite = canWrite;
+        }
+        #endregion
+
+        #region Read
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanRead();
+            return ReadAsync(buffer, offset, count, default, false).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanRead();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return ReadAsync(buffer, offset, count, cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Write
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanWrite();
+            WriteAsync(buffer, offset, count, default, false).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateArguments(buffer, offset, count);
+            CheckCanWrite();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return WriteAsync(buffer, offset, count, cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Flush
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            CheckCanWrite();
+            FlushAsync(default, false).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            CheckCanWrite();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return FlushAsync(cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task FlushAsync(CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Length
+
+        /// <inheritdoc />
+        public override long Length
+        {
+            get
+            {
+                CheckCanSeek();
+                return GetLengthAsync(default, false).GetAwaiter().GetResult();
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual Task<long> GetLengthAsync(CancellationToken cancellationToken)
+        {
+            CheckCanSeek();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<long>(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return GetLengthAsync(cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task<long> GetLengthAsync(CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region SetLength
+
+        /// <inheritdoc />
+        public override void SetLength(long value)
+        {
+            ValidateArguments(value);
+            CheckCanSeek();
+            CheckCanWrite();
+            SetLengthAsync(value, default, false).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public virtual Task SetLengthAsync(long value, CancellationToken cancellationToken)
+        {
+            ValidateArguments(value);
+            CheckCanSeek();
+            CheckCanWrite();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return SetLengthAsync(value, cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task SetLengthAsync(long value, CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Seek
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            ValidateArguments(origin);
+            CheckCanSeek();
+            return SeekAsync(offset, origin, default, false).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc />
+        public virtual Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken)
+        {
+            ValidateArguments(origin);
+            CheckCanSeek();
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<long>(cancellationToken);
+            using (NoSynchronizationContextScope.Enter())
+                return SeekAsync(offset, origin, cancellationToken, true);
+        }
+
+        /// <inheritdoc />
+        internal protected virtual Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken, bool async)
+            => throw new NotImplementedException();
+
+        #endregion
+
+        #region Dispose
+
+        /// <inheritdoc />
+        internal protected bool IsDisposed { get; protected set; }
+
+        /// <inheritdoc />
+        internal protected virtual void CheckDisposed()
+        {
+            if (IsDisposed)
+                throw new ObjectDisposedException(GetType().FullName, "Object disposed");
+        }
+
+        /// <inheritdoc />
+        protected sealed override void Dispose(bool disposing)
+        {
+            if (IsDisposed || !disposing)
+                return;
+
+            DisposeAsync(false).GetAwaiter().GetResult();
+
+            IsDisposed = true;
+        }
+
+        /// <inheritdoc />
+#if !NET461 && !NETSTANDARD2_0
+        public override ValueTask DisposeAsync()
+#else
+        public ValueTask DisposeAsync()
+#endif
+        {
+            if (IsDisposed)
+                return default;
+
+            using (NoSynchronizationContextScope.Enter())
+                return DisposeAsync(true).Then(() =>
+                    IsDisposed = true
+                );
+        }
+
+        /// <inheritdoc />
+        internal protected virtual ValueTask DisposeAsync(bool async) => default;
+
+        #endregion
+
+        #region APM
+
+        /// <inheritdoc />
+        public sealed override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
+            => ReadAsync(buffer, offset, count).AsApm(callback, state);
+
+        /// <inheritdoc />
+        public sealed override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object? state)
+            => WriteAsync(buffer, offset, count).AsApm(callback, state);
+
+        /// <inheritdoc />
+        public sealed override int EndRead(IAsyncResult asyncResult)
+            => ((Task<int>)asyncResult).GetAwaiter().GetResult();
+
+        /// <inheritdoc />
+        public sealed override void EndWrite(IAsyncResult asyncResult)
+            => ((Task)asyncResult).GetAwaiter().GetResult();
+
+        #endregion
+
+        #region Capabilities
+
+        /// <inheritdoc />
+        internal protected /*readonly*/ bool _canRead;
+        /// <inheritdoc />
+        internal protected /*readonly*/ bool _canSeek;
+        /// <inheritdoc />
+        internal protected /*readonly*/ bool _canWrite;
+        /// <inheritdoc />
+        public override bool CanRead => _canRead && !IsDisposed;
+        /// <inheritdoc />
+        public override bool CanSeek => _canSeek && !IsDisposed;
+        /// <inheritdoc />
+        public override bool CanWrite => _canWrite && !IsDisposed;
+
+        /// <inheritdoc />
+        internal protected virtual void CheckCanRead()
+        {
+            if (!_canRead)
+                throw new NotSupportedException("Stream does not support reading.");
+            CheckDisposed();
+        }
+
+        /// <inheritdoc />
+        internal protected virtual void CheckCanSeek()
+        {
+            if (!_canSeek)
+                throw new NotSupportedException("Stream does not support seeking.");
+            CheckDisposed();
+        }
+
+        /// <inheritdoc />
+        internal protected virtual void CheckCanWrite()
+        {
+            if (!_canWrite)
+                throw new NotSupportedException("Stream does not support writing.");
+            CheckDisposed();
+        }
+
+        #endregion
+
+        #region Position
+
+        /// <inheritdoc />
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        #endregion
+
+        #region Input validation
+
+        /// <inheritdoc />
+        internal protected static void ValidateArguments(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0)
+                throw new ArgumentNullException(nameof(offset));
+            if (count < 0)
+                throw new ArgumentNullException(nameof(count));
+            if (buffer.Length - offset < count)
+                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+        }
+
+        /// <inheritdoc />
+        internal protected static void ValidateArguments(SeekOrigin origin)
+        {
+            if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
+                throw new ArgumentException("Invalid origin");
+        }
+
+        /// <inheritdoc />
+        internal protected static void ValidateArguments(long value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        #endregion
+    }
+}

--- a/src/Npgsql/NpgsqlStream.cs
+++ b/src/Npgsql/NpgsqlStream.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 namespace Npgsql
 {
     /// <summary>
-    /// 
+    /// Abstract class providing implementation of the <see cref="System.IO.Stream">Stream</see> contract
+    /// based on implementation of the async methods
     /// </summary>
     public abstract class NpgsqlStream : Stream
     {
         #region Constructor
-        /// <inheritdoc />
-        internal protected NpgsqlStream(bool canRead = false, bool canSeek = false, bool canWrite = false)
+        internal NpgsqlStream(bool canRead = false, bool canSeek = false, bool canWrite = false)
         {
             _canRead = canRead;
             _canSeek = canSeek;
@@ -27,7 +27,7 @@ namespace Npgsql
         {
             ValidateArguments(buffer, offset, count);
             CheckCanRead();
-            return ReadAsync(buffer, offset, count, default, false).GetAwaiter().GetResult();
+            return ReadAsync(buffer, offset, count, cancellationToken: default, async: false).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />
@@ -38,12 +38,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled<int>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return ReadAsync(buffer, offset, count, cancellationToken, true);
+                return ReadAsync(buffer, offset, count, cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -54,7 +53,7 @@ namespace Npgsql
         {
             ValidateArguments(buffer, offset, count);
             CheckCanWrite();
-            WriteAsync(buffer, offset, count, default, false).GetAwaiter().GetResult();
+            WriteAsync(buffer, offset, count, cancellationToken: default, async: false).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />
@@ -65,12 +64,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return WriteAsync(buffer, offset, count, cancellationToken, true);
+                return WriteAsync(buffer, offset, count, cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -80,7 +78,7 @@ namespace Npgsql
         public override void Flush()
         {
             CheckCanWrite();
-            FlushAsync(default, false).GetAwaiter().GetResult();
+            FlushAsync(cancellationToken: default, async: false).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />
@@ -90,12 +88,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return FlushAsync(cancellationToken, true);
+                return FlushAsync(cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task FlushAsync(CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task FlushAsync(CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -107,7 +104,7 @@ namespace Npgsql
             get
             {
                 CheckCanSeek();
-                return GetLengthAsync(default, false).GetAwaiter().GetResult();
+                return GetLengthAsync(cancellationToken: default, async: false).GetAwaiter().GetResult();
             }
         }
 
@@ -118,12 +115,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled<long>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return GetLengthAsync(cancellationToken, true);
+                return GetLengthAsync(cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task<long> GetLengthAsync(CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task<long> GetLengthAsync(CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -135,7 +131,7 @@ namespace Npgsql
             ValidateArguments(value);
             CheckCanSeek();
             CheckCanWrite();
-            SetLengthAsync(value, default, false).GetAwaiter().GetResult();
+            SetLengthAsync(value, cancellationToken: default, async: false).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />
@@ -147,12 +143,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return SetLengthAsync(value, cancellationToken, true);
+                return SetLengthAsync(value, cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task SetLengthAsync(long value, CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task SetLengthAsync(long value, CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -163,7 +158,7 @@ namespace Npgsql
         {
             ValidateArguments(origin);
             CheckCanSeek();
-            return SeekAsync(offset, origin, default, false).GetAwaiter().GetResult();
+            return SeekAsync(offset, origin, cancellationToken: default, async: false).GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />
@@ -174,12 +169,11 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled<long>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return SeekAsync(offset, origin, cancellationToken, true);
+                return SeekAsync(offset, origin, cancellationToken, async: true);
         }
 
-        /// <inheritdoc />
-        internal protected virtual Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken, bool async)
-            => throw new NotImplementedException();
+        private protected virtual Task<long> SeekAsync(long offset, SeekOrigin origin, CancellationToken cancellationToken, bool async)
+            => throw new NotSupportedException();
 
         #endregion
 
@@ -188,8 +182,7 @@ namespace Npgsql
         /// <inheritdoc />
         internal protected bool IsDisposed { get; protected set; }
 
-        /// <inheritdoc />
-        internal protected virtual void CheckDisposed()
+        private protected virtual void CheckDisposed()
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(GetType().FullName, "Object disposed");
@@ -201,7 +194,7 @@ namespace Npgsql
             if (IsDisposed || !disposing)
                 return;
 
-            DisposeAsync(false).GetAwaiter().GetResult();
+            DisposeAsync(async: false).GetAwaiter().GetResult();
 
             IsDisposed = true;
         }
@@ -217,13 +210,12 @@ namespace Npgsql
                 return default;
 
             using (NoSynchronizationContextScope.Enter())
-                return DisposeAsync(true).Then(() =>
+                return DisposeAsync(async: true).Then(() =>
                     IsDisposed = true
                 );
         }
 
-        /// <inheritdoc />
-        internal protected virtual ValueTask DisposeAsync(bool async) => default;
+        private protected virtual ValueTask DisposeAsync(bool async) => default;
 
         #endregion
 
@@ -239,22 +231,26 @@ namespace Npgsql
 
         /// <inheritdoc />
         public sealed override int EndRead(IAsyncResult asyncResult)
-            => ((Task<int>)asyncResult).GetAwaiter().GetResult();
+        {
+            ValidateArguments(asyncResult);
+            return ((Task<int>)asyncResult).GetAwaiter().GetResult();
+        }
 
         /// <inheritdoc />
         public sealed override void EndWrite(IAsyncResult asyncResult)
-            => ((Task)asyncResult).GetAwaiter().GetResult();
+        {
+            ValidateArguments(asyncResult);
+            ((Task)asyncResult).GetAwaiter().GetResult();
+        }
 
         #endregion
 
         #region Capabilities
 
-        /// <inheritdoc />
-        internal protected /*readonly*/ bool _canRead;
-        /// <inheritdoc />
-        internal protected /*readonly*/ bool _canSeek;
-        /// <inheritdoc />
-        internal protected /*readonly*/ bool _canWrite;
+        private protected bool _canRead;
+        private protected bool _canSeek;
+        private protected bool _canWrite;
+
         /// <inheritdoc />
         public override bool CanRead => _canRead && !IsDisposed;
         /// <inheritdoc />
@@ -262,24 +258,21 @@ namespace Npgsql
         /// <inheritdoc />
         public override bool CanWrite => _canWrite && !IsDisposed;
 
-        /// <inheritdoc />
-        internal protected virtual void CheckCanRead()
+        private protected virtual void CheckCanRead()
         {
             if (!_canRead)
                 throw new NotSupportedException("Stream does not support reading.");
             CheckDisposed();
         }
 
-        /// <inheritdoc />
-        internal protected virtual void CheckCanSeek()
+        private protected virtual void CheckCanSeek()
         {
             if (!_canSeek)
                 throw new NotSupportedException("Stream does not support seeking.");
             CheckDisposed();
         }
 
-        /// <inheritdoc />
-        internal protected virtual void CheckCanWrite()
+        private protected virtual void CheckCanWrite()
         {
             if (!_canWrite)
                 throw new NotSupportedException("Stream does not support writing.");
@@ -291,14 +284,13 @@ namespace Npgsql
         #region Position
 
         /// <inheritdoc />
-        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 
         #endregion
 
         #region Input validation
 
-        /// <inheritdoc />
-        internal protected static void ValidateArguments(byte[] buffer, int offset, int count)
+        private protected static void ValidateArguments(byte[] buffer, int offset, int count)
         {
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
@@ -310,18 +302,22 @@ namespace Npgsql
                 throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
         }
 
-        /// <inheritdoc />
-        internal protected static void ValidateArguments(SeekOrigin origin)
+        private protected static void ValidateArguments(SeekOrigin origin)
         {
             if (origin < SeekOrigin.Begin || origin > SeekOrigin.End)
                 throw new ArgumentException("Invalid origin");
         }
 
-        /// <inheritdoc />
-        internal protected static void ValidateArguments(long value)
+        private protected static void ValidateArguments(long value)
         {
             if (value < 0)
                 throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        private protected static void ValidateArguments(IAsyncResult asyncResult)
+        {
+            if (asyncResult == null)
+                throw new ArgumentNullException(nameof(asyncResult));
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
@@ -7,77 +7,22 @@ namespace Npgsql
 {
     public sealed partial class NpgsqlWriteBuffer
     {
-        sealed class ParameterStream : Stream
+        sealed class ParameterStream : NpgsqlStream
         {
             readonly NpgsqlWriteBuffer _buf;
-            bool _disposed;
 
             internal ParameterStream(NpgsqlWriteBuffer buf)
+                : base(canWrite: true)
                 => _buf = buf;
 
             internal void Init()
-                => _disposed = false;
+                => IsDisposed = false;
 
-            public override bool CanRead => false;
+            internal protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
 
-            public override bool CanWrite => true;
-
-            public override bool CanSeek => false;
-
-            public override long Length => throw new NotSupportedException();
-
-            public override void SetLength(long value)
-                => throw new NotSupportedException();
-
-            public override long Position
+            /// <inheritdoc />
+            internal protected override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
-                get => throw new NotSupportedException();
-                set => throw new NotSupportedException();
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-                => throw new NotSupportedException();
-
-            public override void Flush()
-                => CheckDisposed();
-
-            public override Task FlushAsync(CancellationToken cancellationToken)
-            {
-                CheckDisposed();
-                return cancellationToken.IsCancellationRequested
-                    ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-                => throw new NotSupportedException();
-
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-                => throw new NotSupportedException();
-
-            public override void Write(byte[] buffer, int offset, int count)
-                => Write(buffer, offset, count, CancellationToken.None, false);
-
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                using (NoSynchronizationContextScope.Enter())
-                    return Write(buffer, offset, count, cancellationToken, true);
-            }
-
-            Task Write(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
-            {
-                CheckDisposed();
-
-                if (buffer == null)
-                    throw new ArgumentNullException(nameof(buffer));
-                if (offset < 0)
-                    throw new ArgumentNullException(nameof(offset));
-                if (count < 0)
-                    throw new ArgumentNullException(nameof(count));
-                if (buffer.Length - offset < count)
-                    throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
-                if (cancellationToken.IsCancellationRequested)
-                    return Task.FromCanceled(cancellationToken);
-
                 while (count > 0)
                 {
                     var left = _buf.WriteSpaceLeft;
@@ -109,15 +54,6 @@ namespace Npgsql
                     count -= slice;
                 }
             }
-
-            void CheckDisposed()
-            {
-                if (_disposed)
-                    throw new ObjectDisposedException(null);
-            }
-
-            protected override void Dispose(bool disposing)
-                => _disposed = true;
         }
     }
 }

--- a/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.Stream.cs
@@ -18,10 +18,9 @@ namespace Npgsql
             internal void Init()
                 => IsDisposed = false;
 
-            internal protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
+            private protected override Task FlushAsync(CancellationToken cancellationToken, bool async) => Task.CompletedTask;
 
-            /// <inheritdoc />
-            internal protected override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
+            private protected override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool async)
             {
                 while (count > 0)
                 {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1138,8 +1138,12 @@ LANGUAGE plpgsql VOLATILE";
 
                     using (var stream = await streamGetter(reader, 0))
                     {
-                        Assert.That(stream.CanSeek, Is.EqualTo(Behavior == CommandBehavior.Default));
-                        Assert.That(stream.Length, Is.EqualTo(expected.Length));
+                        Assert.That(stream.CanSeek, Is.EqualTo(!IsSequential));
+                        if (IsSequential)
+                            Assert.That(() => stream.Length, Throws.Exception.TypeOf<NotSupportedException>(), "Stream does not support seeking.");
+                        else
+                            Assert.That(stream.Length, Is.EqualTo(expected.Length));
+
                         stream.Read(actual, 0, 2);
                         Assert.That(actual[0], Is.EqualTo(expected[0]));
                         Assert.That(actual[1], Is.EqualTo(expected[1]));


### PR DESCRIPTION
The Npgsql library currently contains 5 implementations of the `System.IO.Stream` contract:
- [NpgsqlConnector.GSSPasswordMessageStream](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlConnector.Auth.cs#L261)
- [NpgsqlLargeObjectStream](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlLargeObjectStream.cs#L12)
- [NpgsqlRawCopyStream](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlRawCopyStream.cs#L21)
- [NpgsqlReadBuffer.ColumnStream](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlReadBuffer.Stream.cs#L11)
- [NpgsqlWriteBuffer.ParameterStream](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlWriteBuffer.Stream.cs#L10)

Each of these implementations takes care of:
- Input validation
- Capability checks (`CanRead`, `CanWrite`, `CanSeek`)
- Disposal check
- Cancellation token handling
- Throwing exception for not supported abstract methods
- Methods signature adaptation depending on targeted framework (`#if !NET461 && !NETSTANDARD2_0`)
- Sync-over-async pattern
- `NoSynchronizationContextScope` pattern

what can hinder the readability of the effective reading/writing specific operations of the stream, or can even introduce dumb (duplication?) mistake, like [here](https://github.com/npgsql/npgsql/blob/6f61b495b23c6f9cca8700fa65f05c2d3ae39672/src/Npgsql/NpgsqlWriteBuffer.Stream.cs#L58).

So, I propose to introduce the `NpgsqlStream` (and `NpgsqlSpanStream`) abstract classes in order to regroup these responsibilities into one dedicated place.

I have executed some performance tests on the `NpgsqlRawCopyStream` class via `BeginTextExport`/`BeginTextImport` and they do not report any negative impact (tolerance= 1%) due to the additional inheritance.