### PR TITLE
Label tree support

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -513,6 +513,18 @@ namespace NpgsqlTypes
         /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
         Ltree = 61,    // Extension type
 
+        /// <summary>
+        /// The PostgreSQL lquery type for PostgreSQL extension ltree
+        /// </summary>
+        /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+        Lquery = 62,    // Extension type
+
+        /// <summary>
+        /// The PostgreSQL ltxtquery type for PostgreSQL extension ltree
+        /// </summary>
+        /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+        Ltxtquery = 63,    // Extension type
+
         #endregion
 
     }

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -501,9 +501,20 @@ namespace NpgsqlTypes
         /// <summary>
         /// The geography (geodetic) type for PostgreSQL spatial extension PostGIS.
         /// </summary>
-        Geography = 55     // Extension type
+        Geography = 55,    // Extension type
 
         #endregion
+
+        #region Ltree
+
+        /// <summary>
+        /// The PostgreSQL ltree type, each value is a label path "a.label.tree.value", forming a tree in a set.
+        /// </summary>
+        /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+        Ltree = 61,    // Extension type
+
+        #endregion
+
     }
 
     /// <summary>

--- a/src/Npgsql/TypeHandlers/LqueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/LqueryHandler.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+using Npgsql.TypeMapping;
+using NpgsqlTypes;
+
+namespace Npgsql.TypeHandlers
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    [TypeMapping("lquery", NpgsqlDbType.Lquery)]
+    class LqueryHandlerFactory : NpgsqlTypeHandlerFactory<string>
+    {
+        public override NpgsqlTypeHandler<string> Create(PostgresType postgresType, NpgsqlConnection conn)
+            => new LqueryHandler(postgresType, conn);
+    }
+
+    /// <summary>
+    /// Lquery binary encoding is a simple UTF8 string, but prepended with a version number.
+    /// </summary>
+    public class LqueryHandler : TextHandler
+    {
+        /// <summary>
+        /// Prepended to the string in the wire encoding
+        /// </summary>
+        const byte LqueryProtocolVersion = 1;
+
+        internal override bool PreferTextWrite => false;
+
+        protected internal LqueryHandler(PostgresType postgresType, NpgsqlConnection connection)
+            : base(postgresType, connection) {}
+
+        #region Write
+
+        public override int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(char[] value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(ArraySegment<char> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(char[] value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        #endregion
+
+        #region Read
+
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            await buf.Ensure(1, async);
+            var version = buf.ReadByte();
+            if (version != LqueryProtocolVersion)
+                throw new NotSupportedException($"Don't know how to decode lquery with wire format {version}, your connection is now broken");
+
+            return await base.Read(buf, len - 1, async, fieldDescription);
+        }
+
+        #endregion
+
+        public override TextReader GetTextReader(Stream stream)
+        {
+            var version = stream.ReadByte();
+            if (version != LqueryProtocolVersion)
+                throw new NpgsqlException($"Don't know how to decode lquery with wire format {version}, your connection is now broken");
+
+            return base.GetTextReader(stream);
+        }
+    }
+}

--- a/src/Npgsql/TypeHandlers/LtreeHandler.cs
+++ b/src/Npgsql/TypeHandlers/LtreeHandler.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+using Npgsql.TypeMapping;
+using NpgsqlTypes;
+
+namespace Npgsql.TypeHandlers
+{
+    #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    [TypeMapping("ltree", NpgsqlDbType.Ltree)]
+    class LtreeHandlerFactory : NpgsqlTypeHandlerFactory<string>
+    {
+        public override NpgsqlTypeHandler<string> Create(PostgresType postgresType, NpgsqlConnection conn)
+            => new LtreeHandler(postgresType, conn);
+    }
+
+    /// <summary>
+    /// Ltree binary encoding is a simple UTF8 string, but prepended with a version number.
+    /// </summary>
+    public class LtreeHandler : TextHandler
+    {
+        /// <summary>
+        /// Prepended to the string in the wire encoding
+        /// </summary>
+        const byte LtreeProtocolVersion = 1;
+
+        internal override bool PreferTextWrite => false;
+
+        protected internal LtreeHandler(PostgresType postgresType, NpgsqlConnection connection)
+            : base(postgresType, connection) {}
+
+        #region Write
+
+        public override int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(char[] value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(ArraySegment<char> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtreeProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(char[] value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtreeProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtreeProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        #endregion
+
+        #region Read
+
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            await buf.Ensure(1, async);
+            var version = buf.ReadByte();
+            if (version != LtreeProtocolVersion)
+                throw new NotSupportedException($"Don't know how to decode ltree with wire format {version}, your connection is now broken");
+
+            return await base.Read(buf, len - 1, async, fieldDescription);
+        }
+
+        #endregion
+
+        public override TextReader GetTextReader(Stream stream)
+        {
+            var version = stream.ReadByte();
+            if (version != LtreeProtocolVersion)
+                throw new NpgsqlException($"Don't know how to decode ltree with wire format {version}, your connection is now broken");
+
+            return base.GetTextReader(stream);
+        }
+    }
+}

--- a/src/Npgsql/TypeHandlers/LtxtqueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/LtxtqueryHandler.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Data;
+using System.IO;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+using Npgsql.TypeMapping;
+using NpgsqlTypes;
+
+namespace Npgsql.TypeHandlers
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    [TypeMapping("ltxtquery", NpgsqlDbType.Ltxtquery)]
+    class LtxtqueryHandlerFactory : NpgsqlTypeHandlerFactory<string>
+    {
+        public override NpgsqlTypeHandler<string> Create(PostgresType postgresType, NpgsqlConnection conn)
+            => new LtxtqueryHandler(postgresType, conn);
+    }
+
+    /// <summary>
+    /// Ltxtquery binary encoding is a simple UTF8 string, but prepended with a version number.
+    /// </summary>
+    public class LtxtqueryHandler : TextHandler
+    {
+        /// <summary>
+        /// Prepended to the string in the wire encoding
+        /// </summary>
+        const byte LtxtqueryProtocolVersion = 1;
+
+        internal override bool PreferTextWrite => false;
+
+        protected internal LtxtqueryHandler(PostgresType postgresType, NpgsqlConnection connection)
+            : base(postgresType, connection) {}
+
+        #region Write
+
+        public override int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(char[] value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override int ValidateAndGetLength(ArraySegment<char> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get() + 1;
+
+            // Add one byte for the prepended version number
+            return base.ValidateAndGetLength(value, ref lengthCache, parameter) + 1;
+        }
+
+        public override async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtxtqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(char[] value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtxtqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        public override async Task Write(ArraySegment<char> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async);
+            buf.WriteByte(LtxtqueryProtocolVersion);
+            await base.Write(value, buf, lengthCache, parameter, async);
+        }
+
+        #endregion
+
+        #region Read
+
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            await buf.Ensure(1, async);
+            var version = buf.ReadByte();
+            if (version != LtxtqueryProtocolVersion)
+                throw new NotSupportedException($"Don't know how to decode ltxtquery with wire format {version}, your connection is now broken");
+
+            return await base.Read(buf, len - 1, async, fieldDescription);
+        }
+
+        #endregion
+
+        public override TextReader GetTextReader(Stream stream)
+        {
+            var version = stream.ReadByte();
+            if (version != LtxtqueryProtocolVersion)
+                throw new NpgsqlException($"Don't know how to decode ltxtquery with wire format {version}, your connection is now broken");
+
+            return base.GetTextReader(stream);
+        }
+    }
+}


### PR DESCRIPTION
https://www.postgresql.org/docs/13/release-13.html
> Add support for binary I/O of ltree, lquery, and ltxtquery types (Nino Floris)


As ltree now supports binary protocol in beta 1 of pg 13 I thought it time to dig up this branch :)
It implements the wire format (one byte for version, binary string afterwards) and maps this to a string. We may want to parse it into segments for IEnumerable<string>/string[] support. 

I'm not sure what's with all the regions so I just followed the trend here.