### PR TITLE
Issue2501 Postgres returns inserted data in exception if insert fails

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1117,7 +1117,7 @@ namespace Npgsql
             foreach (var s in _statements)
                 sb.AppendLine().Append("\t").Append(s.SQL);
 
-            if (NpgsqlLogManager.IsParameterLoggingEnabled && Parameters.Any())
+            if (NpgsqlLogManager.IsParameterLoggingEnabled && Parameters.Any() && Connection.Connector.Settings.ExcludeParametersFromLogs == false )
             {
                 sb.AppendLine().AppendLine("Parameters:");
                 for (var i = 0; i < Parameters.Count; i++)

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -628,6 +628,24 @@ namespace Npgsql
         }
         bool _persistSecurityInfo;
 
+        /// <summary>
+        /// Gets or sets a Boolean value that indicates if the Postgres DETAIL field is included in raised exceptions.
+        /// </summary>
+        /// [Category("Security")]
+        [Description("When enabled prevents excludes the Postgres DETAIL response from raised exceptions. This DETAIL message often contains user data that may be sensative.")]
+        [DisplayName("Suppress Postgres Error Detail")]
+        [NpgsqlConnectionStringProperty]
+        public bool SuppressDetailInPostgressError
+        {
+            get => _suppressDetailInPostgressError;
+            set
+            {
+                _suppressDetailInPostgressError = value;
+                SetValue(nameof(SuppressDetailInPostgressError), value);
+            }
+        }
+        bool _suppressDetailInPostgressError;
+
         #endregion
 
         #region Properties - Pooling

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -629,7 +629,7 @@ namespace Npgsql
         bool _persistSecurityInfo;
 
         /// <summary>
-        /// Gets or sets a Boolean value that indicates if NpgsqlCommand parameters should be included (false) or excluded (true) within logging.
+        /// Gets or sets a Boolean value that indicates if NpgsqlCommand parameters should be included (false) or suppressed (true) within logging.
         /// </summary>
         [Category("Security")]
         [Description("When enabled prevents logging of command parameter values.")]
@@ -649,20 +649,20 @@ namespace Npgsql
         /// <summary>
         /// Gets or sets a Boolean value that indicates if the Postgres DETAIL field is included in raised exceptions.
         /// </summary>
-        /// [Category("Security")]
-        [Description("When enabled prevents excludes the Postgres DETAIL response from raised exceptions. This DETAIL message often contains user data that may be sensative.")]
-        [DisplayName("Suppress Postgres Error Detail")]
+        [Category("Security")]
+        [Description("When enabled, removes the Postgres DETAIL property from raised exceptions. This DETAIL message can contain user data that should not be included in logs or displayed to users.")]
+        [DisplayName("Suppress Detailed Exceptions")]
         [NpgsqlConnectionStringProperty]
-        public bool SuppressDetailInPostgressError
+        public bool SuppressDetailedExceptions
         {
-            get => _suppressDetailInPostgressError;
+            get => _suppressDetailedExceptions;
             set
             {
-                _suppressDetailInPostgressError = value;
-                SetValue(nameof(SuppressDetailInPostgressError), value);
+                _suppressDetailedExceptions = value;
+                SetValue(nameof(SuppressDetailedExceptions), value);
             }
         }
-        bool _suppressDetailInPostgressError;
+        bool _suppressDetailedExceptions;
 
         #endregion
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -629,6 +629,24 @@ namespace Npgsql
         bool _persistSecurityInfo;
 
         /// <summary>
+        /// Gets or sets a Boolean value that indicates if NpgsqlCommand parameters should be included (false) or excluded (true) within logging.
+        /// </summary>
+        [Category("Security")]
+        [Description("When enabled prevents logging of command parameter values.")]
+        [DisplayName("Exclude Parameters From Logs")]
+        [NpgsqlConnectionStringProperty]
+        public bool ExcludeParametersFromLogs
+        {
+            get => _excludeParametersFromLogs;
+            set
+            {
+                _excludeParametersFromLogs = value;
+                SetValue(nameof(ExcludeParametersFromLogs), value);
+            }
+        }
+        bool _excludeParametersFromLogs;
+
+        /// <summary>
         /// Gets or sets a Boolean value that indicates if the Postgres DETAIL field is included in raised exceptions.
         /// </summary>
         /// [Category("Security")]

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -935,7 +935,7 @@ namespace Npgsql
 
                     // An ErrorResponse is (almost) always followed by a ReadyForQuery. Save the error
                     // and throw it as an exception when the ReadyForQuery is received (next).
-                    error = new PostgresException(ReadBuffer);
+                    error = new PostgresException(ReadBuffer, Settings);
 
                     if (State == ConnectorState.Connecting) {
                         // During the startup/authentication phase, an ErrorResponse isn't followed by

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -935,7 +935,7 @@ namespace Npgsql
 
                     // An ErrorResponse is (almost) always followed by a ReadyForQuery. Save the error
                     // and throw it as an exception when the ReadyForQuery is received (next).
-                    error = new PostgresException(ReadBuffer, Settings);
+                    error = new PostgresException(ReadBuffer, Settings.SuppressDetailedExceptions);
 
                     if (State == ConnectorState.Connecting) {
                         // During the startup/authentication phase, an ErrorResponse isn't followed by

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -208,13 +208,16 @@ namespace Npgsql
         /// </summary>
         public PostgresException() {}
 
-        internal PostgresException(ReadBuffer buf)
+        internal PostgresException(ReadBuffer buf, NpgsqlConnectionStringBuilder settings)
         {
             var msg = new ErrorOrNoticeMessage(buf);
             Severity = msg.Severity;
             SqlState = msg.Code;
             MessageText = msg.Message;
-            Detail = msg.Detail;
+            if(settings.SuppressDetailInPostgressError == false)
+            {
+                Detail = msg.Detail;
+            }
             Hint = msg.Hint;
             Position = msg.Position;
             InternalPosition = msg.InternalPosition;

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -208,16 +208,14 @@ namespace Npgsql
         /// </summary>
         public PostgresException() {}
 
-        internal PostgresException(ReadBuffer buf, NpgsqlConnectionStringBuilder settings)
+        internal PostgresException(ReadBuffer buf, bool suppressDetailInPostgressError)
         {
             var msg = new ErrorOrNoticeMessage(buf);
             Severity = msg.Severity;
             SqlState = msg.Code;
             MessageText = msg.Message;
-            if(settings.SuppressDetailInPostgressError == false)
-            {
-                Detail = msg.Detail;
-            }
+            Detail = suppressDetailInPostgressError && string.IsNullOrEmpty(msg.Detail) == false ?
+                "Detail suppressed as SuppressDetailInPostgressError is enabled" : msg.Detail;
             Hint = msg.Hint;
             Position = msg.Position;
             InternalPosition = msg.InternalPosition;


### PR DESCRIPTION
As per comments in the Issue, this PR deals with both `PostgresException.Details` and the logging of command parameters. 

If this approach gains approval I will apply the same change to the `dev` branch. Given the major version bump in the `dev` branch we could consider removing or deprecating `NpgsqlLogManager.IsParameterLoggingEnabled` I would not do that on the 3.X branch. 