### PR TITLE
Added an option to suppress exception details

### DIFF
--- a/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
+++ b/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
@@ -58,7 +58,7 @@ namespace Npgsql.BackendMessages
                     break;
                 case ErrorFieldTypeCode.Detail:
                     detail = buf.ReadNullTerminatedStringRelaxed();
-                    if(suppressDetailInPostgressError && string.IsNullOrEmpty(detail) == false)
+                    if(suppressDetailInPostgressError && !string.IsNullOrEmpty(detail))
                     {
                         detail = "Detail suppressed as SuppressDetailInPostgressError is enabled";
                     }

--- a/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
+++ b/src/Npgsql/BackendMessages/ErrorOrNoticeMessage.cs
@@ -28,7 +28,7 @@ namespace Npgsql.BackendMessages
         static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(ErrorOrNoticeMessage));
 
         // ReSharper disable once FunctionComplexityOverflow
-        internal static ErrorOrNoticeMessage Load(NpgsqlReadBuffer buf)
+        internal static ErrorOrNoticeMessage Load(NpgsqlReadBuffer buf, bool suppressDetailInPostgressError)
         {
             (string? severity, string? invariantSeverity, string? code, string? message, string? detail, string? hint) = (null, null, null, null, null, null);
             var (position, internalPosition) = (0, 0);
@@ -58,6 +58,10 @@ namespace Npgsql.BackendMessages
                     break;
                 case ErrorFieldTypeCode.Detail:
                     detail = buf.ReadNullTerminatedStringRelaxed();
+                    if(suppressDetailInPostgressError && string.IsNullOrEmpty(detail) == false)
+                    {
+                        detail = "Detail suppressed as SuppressDetailInPostgressError is enabled";
+                    }
                     break;
                 case ErrorFieldTypeCode.Hint:
                     hint = buf.ReadNullTerminatedStringRelaxed();

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1181,7 +1181,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     State = CommandState.InProgress;
 
                     if (Log.IsEnabled(NpgsqlLogLevel.Debug))
-                        LogCommand(connector.Id);
+                        LogCommand(connector.Id, connector.Settings.ExcludeParametersFromLogs);
                     NpgsqlEventSource.Log.CommandStart(CommandText);
                     Task sendTask;
 
@@ -1307,7 +1307,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 rowDescription[i].FormatCode = (UnknownResultTypeList == null || !isFirst ? AllResultTypesAreUnknown : UnknownResultTypeList[i]) ? FormatCode.Text : FormatCode.Binary;
         }
 
-        void LogCommand(int connectorId)
+        void LogCommand(int connectorId, bool excludeParametersFromLogs)
         {
             var sb = new StringBuilder();
             sb.AppendLine("Executing statement(s):");
@@ -1315,7 +1315,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             {
                 sb.Append("\t").AppendLine(s.SQL);
                 var p = s.InputParameters;
-                if (NpgsqlLogManager.IsParameterLoggingEnabled && p.Count > 0)
+                if (NpgsqlLogManager.IsParameterLoggingEnabled && p.Count > 0 && excludeParametersFromLogs == false)
                 {
                     sb.Append('\t').Append("Parameters:");
                     for (var i = 0; i < p.Count; i++)

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -653,6 +653,25 @@ namespace Npgsql
         }
         bool _persistSecurityInfo;
 
+        /// <summary>
+        /// Gets or sets a Boolean value that indicates if the Postgres DETAIL field is included in raised exceptions.
+        /// </summary>
+        [Category("Security")]
+        [Description("When enabled, removes the Postgres DETAIL property from raised exceptions. This DETAIL message can contain user data that should not be included in logs or displayed to users.")]
+        [DisplayName("Suppress Detailed Exceptions")]
+        [NpgsqlConnectionStringProperty]
+        public bool SuppressDetailedExceptions
+        {
+            get => _suppressDetailedExceptions;
+            set
+            {
+                _suppressDetailedExceptions = value;
+                SetValue(nameof(SuppressDetailedExceptions), value);
+            }
+        }
+        bool _suppressDetailedExceptions;
+
+
         #endregion
 
         #region Properties - Pooling

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -654,6 +654,24 @@ namespace Npgsql
         bool _persistSecurityInfo;
 
         /// <summary>
+        /// Gets or sets a Boolean value that indicates if NpgsqlCommand parameters should be included (false) or suppressed (true) within logging.
+        /// </summary>
+        [Category("Security")]
+        [Description("When enabled prevents logging of command parameter values.")]
+        [DisplayName("Exclude Parameters From Logs")]
+        [NpgsqlConnectionStringProperty]
+        public bool ExcludeParametersFromLogs
+        {
+            get => _excludeParametersFromLogs;
+            set
+            {
+                _excludeParametersFromLogs = value;
+                SetValue(nameof(ExcludeParametersFromLogs), value);
+            }
+        }
+        bool _excludeParametersFromLogs;
+
+        /// <summary>
         /// Gets or sets a Boolean value that indicates if the Postgres DETAIL field is included in raised exceptions.
         /// </summary>
         [Category("Security")]

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -902,7 +902,7 @@ namespace Npgsql
 
                             // An ErrorResponse is (almost) always followed by a ReadyForQuery. Save the error
                             // and throw it as an exception when the ReadyForQuery is received (next).
-                            error = PostgresException.Load(ReadBuffer);
+                            error = PostgresException.Load(ReadBuffer, Settings.SuppressDetailedExceptions);
 
                             if (State == ConnectorState.Connecting)
                             {
@@ -996,7 +996,7 @@ namespace Npgsql
                     ReadParameterStatus(buf.GetNullTerminatedBytes(), buf.GetNullTerminatedBytes());
                     return null;
                 case BackendMessageCode.NoticeResponse:
-                    var notice = PostgresNotice.Load(buf);
+                    var notice = PostgresNotice.Load(buf, Settings.SuppressDetailedExceptions);
                     Log.Debug($"Received notice: {notice.MessageText}", Id);
                     Connection?.OnNotice(notice);
                     return null;

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -94,8 +94,8 @@ namespace Npgsql
                 msg.Where, msg.SchemaName, msg.TableName, msg.ColumnName, msg.DataTypeName,
                 msg.ConstraintName, msg.File, msg.Line, msg.Routine) {}
 
-        internal static PostgresException Load(NpgsqlReadBuffer buf)
-            => new PostgresException(ErrorOrNoticeMessage.Load(buf));
+        internal static PostgresException Load(NpgsqlReadBuffer buf, bool suppressDetailInPostgressError)
+            => new PostgresException(ErrorOrNoticeMessage.Load(buf, suppressDetailInPostgressError));
 
         internal PostgresException(SerializationInfo info, StreamingContext context)
             : base(info, context)

--- a/src/Npgsql/PostgresNotice.cs
+++ b/src/Npgsql/PostgresNotice.cs
@@ -210,8 +210,8 @@ namespace Npgsql
                 msg.Where, msg.SchemaName, msg.TableName, msg.ColumnName, msg.DataTypeName,
                 msg.ConstraintName, msg.File, msg.Line, msg.Routine) {}
 
-        internal static PostgresNotice Load(NpgsqlReadBuffer buf)
-            => new PostgresNotice(ErrorOrNoticeMessage.Load(buf));
+        internal static PostgresNotice Load(NpgsqlReadBuffer buf, bool suppressDetailInPostgressError)
+            => new PostgresNotice(ErrorOrNoticeMessage.Load(buf, suppressDetailInPostgressError));
     }
 
     /// <summary>

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -19,7 +19,7 @@ namespace Npgsql.Tests
                 conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF-8'");
                 conn.ExecuteNonQuery(@"
                      CREATE OR REPLACE FUNCTION pg_temp.emit_exception() RETURNS VOID AS
-                        'BEGIN RAISE EXCEPTION ''testexception'' USING ERRCODE = ''12345''; END;'
+                        'BEGIN RAISE EXCEPTION ''testexception'' USING ERRCODE = ''12345'', DETAIL = ''testdetail''; END;'
                      LANGUAGE 'plpgsql';
                 ");
 
@@ -38,6 +38,7 @@ namespace Npgsql.Tests
                 Assert.That(ex.Severity, Is.EqualTo("ERROR"));
                 Assert.That(ex.InvariantSeverity, Is.EqualTo("ERROR"));
                 Assert.That(ex.SqlState, Is.EqualTo("12345"));
+                Assert.That(ex.Detail, Is.EqualTo("testdetail"));
                 Assert.That(ex.Position, Is.EqualTo(0));
 
                 var data = ex.Data;
@@ -50,6 +51,40 @@ namespace Npgsql.Tests
                 Assert.That(exString, Contains.Substring(nameof(PostgresException.SqlState) + ": 12345"));
 
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1), "Connection in bad state after an exception");
+            }
+        }
+
+        [Test, Description("Ensures DETAIL is not present in PostgresExceptions when SuppressDetailedExceptions is enabled.")]
+        public void DetailsAreRemoved()
+        {
+            using (var conn = OpenConnection(ConnectionString + ";SuppressDetailedExceptions=true"))
+            {
+                // Make sure messages are in English
+                conn.ExecuteNonQuery(@"SET lc_messages='en_US.UTF-8'");
+                conn.ExecuteNonQuery(@"
+                     CREATE OR REPLACE FUNCTION pg_temp.emit_exception() RETURNS VOID AS
+                        'BEGIN RAISE EXCEPTION ''testexception'' USING DETAIL = ''testdetail''; END;'
+                     LANGUAGE 'plpgsql';
+                ");
+
+                PostgresException ex = null!;
+                try
+                {
+                    conn.ExecuteNonQuery("SELECT pg_temp.emit_exception()");
+                    Assert.Fail("No exception was thrown");
+                }
+                catch (PostgresException e)
+                {
+                    ex = e;
+                }
+
+                Assert.That(ex.Detail, Is.EqualTo("Detail suppressed as SuppressDetailInPostgressError is enabled"));
+
+                var data = ex.Data;
+                Assert.That(data[nameof(PostgresException.Detail)], Is.EqualTo("Detail suppressed as SuppressDetailInPostgressError is enabled"));
+
+                var exString = ex.ToString();
+                Assert.That(exString, Does.Not.Contain("testdetail"));
             }
         }
 


### PR DESCRIPTION
As per comments in the Issue, this PR deals with both PostgresException.Details and the logging of command parameters.

This is related to PR https://github.com/npgsql/npgsql/pull/3008 which does the same for the 3.X branch. 