### PR TITLE
Fix benchmarks for netcoreapp5.0

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,8 +26,8 @@
     <PackageReference Update="AdoNet.Specification.Tests" Version="2.0.0-alpha3" />
 
     <!-- Benchmarks -->
-    <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Microsoft.Data.SqlClient" Version="1.0.19249.1" />
-    <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.5" />
+    <PackageReference Update="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
   </ItemGroup>
 </Project>

--- a/test/Npgsql.Benchmarks/CommandExecuteBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/CommandExecuteBenchmarks.cs
@@ -56,7 +56,7 @@ namespace Npgsql.Benchmarks
         {
             public Config()
             {
-                Add(StatisticColumn.OperationsPerSecond);
+                AddColumn(StatisticColumn.OperationsPerSecond);
             }
         }
     }

--- a/test/Npgsql.Benchmarks/Commit.cs
+++ b/test/Npgsql.Benchmarks/Commit.cs
@@ -30,7 +30,7 @@ namespace Npgsql.Benchmarks
         {
             public Config()
             {
-                Add(StatisticColumn.OperationsPerSecond);
+                AddColumn(StatisticColumn.OperationsPerSecond);
             }
         }
     }

--- a/test/Npgsql.Benchmarks/ConnectionCreationBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/ConnectionCreationBenchmarks.cs
@@ -23,7 +23,7 @@ namespace Npgsql.Benchmarks
         {
             public Config()
             {
-                Add(StatisticColumn.OperationsPerSecond);
+                AddColumn(StatisticColumn.OperationsPerSecond);
             }
         }
     }

--- a/test/Npgsql.Benchmarks/ConnectionOpenCloseBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/ConnectionOpenCloseBenchmarks.cs
@@ -169,7 +169,7 @@ namespace Npgsql.Benchmarks
         {
             public Config()
             {
-                Add(StatisticColumn.OperationsPerSecond);
+                AddColumn(StatisticColumn.OperationsPerSecond);
             }
         }
     }

--- a/test/Npgsql.Benchmarks/GetFieldValue.cs
+++ b/test/Npgsql.Benchmarks/GetFieldValue.cs
@@ -33,7 +33,7 @@ namespace Npgsql.Benchmarks
 
         class Config : ManualConfig
         {
-            public Config() => Add(StatisticColumn.OperationsPerSecond);
+            public Config() => AddColumn(StatisticColumn.OperationsPerSecond);
         }
     }
 }

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -20,8 +20,8 @@ namespace Npgsql.Benchmarks.TypeHandlers
         {
             public Config()
             {
-                Add(StatisticColumn.OperationsPerSecond);
-                Add(MemoryDiagnoser.Default);
+                AddColumn(StatisticColumn.OperationsPerSecond);
+                AddDiagnoser(MemoryDiagnoser.Default);
             }
         }
 


### PR DESCRIPTION
When trying to run the benchmarks with `Microsoft.NETCore.App 5.0.0-preview.5.20278.1`, they would fail with the following stacktrace
```
Unhandled exception. System.NotSupportedException: Unknown .NET Framework
   at BenchmarkDotNet.Portability.RuntimeInformation.GetCurrentRuntime()
   at BenchmarkDotNet.Characteristics.Resolver.<>c__DisplayClass1_0`1.<Register>b__0(CharacteristicObject obj)
   at BenchmarkDotNet.Characteristics.Resolver.Resolve[T](CharacteristicObject obj, Characteristic`1 characteristic)
   at BenchmarkDotNet.Characteristics.CompositeResolver.Resolve[T](CharacteristicObject obj, Characteristic`1 characteristic)
   at BenchmarkDotNet.Characteristics.CharacteristicObject.ResolveValue[T](Characteristic`1 characteristic, IResolver resolver)
   at BenchmarkDotNet.Toolchains.ToolchainExtensions.GetToolchain(Job job)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.<>c__DisplayClass12_0.<GetSupportedBenchmarks>b__2(BenchmarkCase benchmark)
   at System.Linq.Enumerable.WhereArrayIterator`1.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.<>c__DisplayClass12_0.<GetSupportedBenchmarks>b__0(BenchmarkRunInfo info)
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.GetSupportedBenchmarks(BenchmarkRunInfo[] benchmarkRunInfos, ILogger logger, IResolver resolver)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo[] benchmarkRunInfos)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
   at Npgsql.Benchmarks.Program.Main(String[] args) in C:\Users\Chris\src\npgsql\test\Npgsql.Benchmarks\Program.cs:line 8
```

This is due to the verison of BenchmarkDotNet being used not supporting the .NET Core 5 -> .NET 5 rebrand (see https://github.com/dotnet/BenchmarkDotNet/pull/1399)

This PR:
 - bumps BenchmarkDotNet to the latest stable version at time of writing (0.12.1) which includes support for runtime detection post-rebrand
 - fixes up the build post-package-upgrade by replacing usages of now-obsolete methods with their new equivalents

The benchmarks can now be run on post-rebrand .NET 5 runtimes.