### PR TITLE
Fix issue #2846 Setting NpgsqlDbType for arrays with CommandBuilder GetUpdateCommand

### DIFF
--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -227,15 +227,7 @@ ORDER BY attnum";
         {
             var typeMapper = _connection.Connector!.TypeMapper;
 
-            if (typeMapper.Mappings.TryGetValue(column.PostgresType.Name, out var mapping))
-                column.NpgsqlDbType = mapping.NpgsqlDbType;
-            else if (
-                column.PostgresType.Name.Contains(".") &&
-                typeMapper.Mappings.TryGetValue(column.PostgresType.Name.Split('.')[1], out mapping)
-            ) {
-                column.NpgsqlDbType = mapping.NpgsqlDbType;
-            }
-
+            column.NpgsqlDbType = typeMapper.GetTypeInfoByOid(column.TypeOID).npgsqlDbType;
             column.DataType = typeMapper.TryGetByOID(column.TypeOID, out var handler)
                 ? handler.GetFieldType()
                 : null;


### PR DESCRIPTION
I've had a look at this issue and have found that this was occurring because the parameter being generated for the array data type column by the GetUpdateCommand had it's NpgsqlDbType set to NpgsqlDbType.Unknown. 

This was causing an issue in the NpgsqlParameter classes internal ResolveHandler method as it was returning an UnknownTypeHandler (instead of an ArrayTypeHandler). Note that the correct handler would be returned if typeMapper.GetByClrType(_value.GetType()) was called but this code could never be reached as _npgsqlDbType.HasValue was true.

After a bit of digging I found that the NpgsqlDbType was not being set for data type Arrays in the DbColumnSchemaGenerator class (this meant that it was set to NpgsqlDbType.Unknown as this is the default value for the NpgsqlDbType property of the NpgsqlParameter). 

I've made a fix which I think is correct in the ColumnPostConfig method when setting the value of the column.NpgsqlDbType. I was a little reluctant to replace some of the original code but after investigating and testing, I thought it was a little redundant to keep it (please let me know if I was wrong and I'll fix it up)

I've also added some extra array data type columns to the CommandBuilderTests.GetUpdateCommandInfersParametersWithNpgsqDbType test and a new test for the specific issue.

Kind Regards,
Warren Chan
Fujitsu Australia

