### PR TITLE
Support setting of TCP keepalive parameters on non-Windows operating systems

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -965,12 +965,12 @@ namespace Npgsql
         bool _tcpKeepAlive;
 
         /// <summary>
-        /// The number of milliseconds of connection inactivity before a TCP keepalive query is sent.
+        /// The number of seconds of connection inactivity before a TCP keepalive query is sent.
         /// Use of this option is discouraged, use <see cref="KeepAlive"/> instead if possible.
         /// Set to 0 (the default) to disable. Supported only on Windows.
         /// </summary>
         [Category("Advanced")]
-        [Description("The number of milliseconds of connection inactivity before a TCP keepalive query is sent.")]
+        [Description("The number of seconds of connection inactivity before a TCP keepalive query is sent.")]
         [DisplayName("TCP Keepalive Time")]
         [NpgsqlConnectionStringProperty]
         public int TcpKeepAliveTime
@@ -988,12 +988,12 @@ namespace Npgsql
         int _tcpKeepAliveTime;
 
         /// <summary>
-        /// The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
+        /// The interval, in seconds, between when successive keep-alive packets are sent if no acknowledgement is received.
         /// Defaults to the value of <see cref="TcpKeepAliveTime"/>. <see cref="TcpKeepAliveTime"/> must be non-zero as well.
         /// Supported only on Windows.
         /// </summary>
         [Category("Advanced")]
-        [Description("The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.")]
+        [Description("The interval, in seconds, between when successive keep-alive packets are sent if no acknowledgement is received.")]
         [DisplayName("TCP Keepalive Interval")]
         [NpgsqlConnectionStringProperty]
         public int TcpKeepAliveInterval

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -965,7 +965,7 @@ namespace Npgsql
         bool _tcpKeepAlive;
 
         /// <summary>
-        /// The number of seconds of connection inactivity before a TCP keepalive query is sent.
+        /// The number of milliseconds of connection inactivity before a TCP keepalive query is sent.
         /// Use of this option is discouraged, use <see cref="KeepAlive"/> instead if possible.
         /// Set to 0 (the default) to disable. Supported only on Windows.
         /// </summary>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -967,7 +967,7 @@ namespace Npgsql
         /// <summary>
         /// The number of seconds of connection inactivity before a TCP keepalive query is sent.
         /// Use of this option is discouraged, use <see cref="KeepAlive"/> instead if possible.
-        /// Set to 0 (the default) to disable. Supported only on Windows.
+        /// Set to 0 (the default) to disable.
         /// </summary>
         [Category("Advanced")]
         [Description("The number of seconds of connection inactivity before a TCP keepalive query is sent.")]
@@ -990,7 +990,6 @@ namespace Npgsql
         /// <summary>
         /// The interval, in seconds, between when successive keep-alive packets are sent if no acknowledgement is received.
         /// Defaults to the value of <see cref="TcpKeepAliveTime"/>. <see cref="TcpKeepAliveTime"/> must be non-zero as well.
-        /// Supported only on Windows.
         /// </summary>
         [Category("Advanced")]
         [Description("The interval, in seconds, between when successive keep-alive packets are sent if no acknowledgement is received.")]

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -842,12 +842,17 @@ namespace Npgsql
                         "Npgsql management of TCP keepalive is supported only on Windows. " +
                         "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
 
+                SetTcpKeepaliveSocketOptionsWindows(socket, timeMilliseconds, intervalMilliseconds);
+            }
+
+            void SetTcpKeepaliveSocketOptionsWindows(Socket socket, int keepAliveTimeMilliseconds, int keepAliveIntervalMilliseconds)
+            {
                 // For the following see https://msdn.microsoft.com/en-us/library/dd877220.aspx
                 var uintSize = Marshal.SizeOf(typeof(uint));
                 var inOptionValues = new byte[uintSize * 3];
                 BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
-                BitConverter.GetBytes((uint)timeMilliseconds).CopyTo(inOptionValues, uintSize);
-                BitConverter.GetBytes((uint)intervalMilliseconds).CopyTo(inOptionValues, uintSize * 2);
+                BitConverter.GetBytes((uint)keepAliveTimeMilliseconds).CopyTo(inOptionValues, uintSize);
+                BitConverter.GetBytes((uint)keepAliveIntervalMilliseconds).CopyTo(inOptionValues, uintSize * 2);
                 var result = socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
                 if (result != 0)
                     throw new NpgsqlException($"Got non-zero value when trying to set TCP keepalive: {result}");

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -840,7 +840,7 @@ namespace Npgsql
 #if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
                 if (!PGUtil.IsWindows)
                     throw new PlatformNotSupportedException(
-                        "Npgsql management of TCP keepalive is supported only on Windows. " +
+                        "Npgsql management of TCP keepalive is supported only on Windows, unless targeting .NET Core 3.0 and above " +
                         "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
 
                 SetTcpKeepaliveSocketOptionsWindows(socket, timeMilliseconds, intervalMilliseconds);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -832,8 +832,8 @@ namespace Npgsql
                 throw new ArgumentException("If TcpKeepAliveInterval is defined, TcpKeepAliveTime must be defined as well");
             if (Settings.TcpKeepAliveTime > 0)
             {
-                var time = Settings.TcpKeepAliveTime;
-                var interval = Settings.TcpKeepAliveInterval > 0
+                var timeMilliseconds = Settings.TcpKeepAliveTime;
+                var intervalMilliseconds = Settings.TcpKeepAliveInterval > 0
                     ? Settings.TcpKeepAliveInterval
                     : Settings.TcpKeepAliveTime;
 
@@ -846,8 +846,8 @@ namespace Npgsql
                 var uintSize = Marshal.SizeOf(typeof(uint));
                 var inOptionValues = new byte[uintSize * 3];
                 BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
-                BitConverter.GetBytes((uint)time).CopyTo(inOptionValues, uintSize);
-                BitConverter.GetBytes((uint)interval).CopyTo(inOptionValues, uintSize * 2);
+                BitConverter.GetBytes((uint)timeMilliseconds).CopyTo(inOptionValues, uintSize);
+                BitConverter.GetBytes((uint)intervalMilliseconds).CopyTo(inOptionValues, uintSize * 2);
                 var result = socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
                 if (result != 0)
                     throw new NpgsqlException($"Got non-zero value when trying to set TCP keepalive: {result}");

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -837,24 +837,31 @@ namespace Npgsql
                     ? Settings.TcpKeepAliveInterval
                     : Settings.TcpKeepAliveTime;
 
-#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
-                if (!PGUtil.IsWindows)
-                    throw new PlatformNotSupportedException(
-                        "Npgsql management of TCP keepalive is supported only on Windows, unless targeting .NET Core 3.0 and above " +
-                        "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
 
-                SetTcpKeepaliveSocketOptionsWindows(socket, timeMilliseconds, intervalMilliseconds);
-#else
                 if (PGUtil.IsWindows)
                 {
                     // Historically, we only supported setting TCP keepalive parameters on Windows, which
                     // allows those parameters to be set with millisecond granularity, so continue using
                     // the "old" (IOControl) way of setting these options if running on Windows to keep
                     // backward compatibility
-                    SetTcpKeepaliveSocketOptionsWindows(socket, timeMilliseconds, intervalMilliseconds);
+
+                    // For the following see https://msdn.microsoft.com/en-us/library/dd877220.aspx
+                    var uintSize = Marshal.SizeOf(typeof(uint));
+                    var inOptionValues = new byte[uintSize * 3];
+                    BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
+                    BitConverter.GetBytes((uint)timeMilliseconds).CopyTo(inOptionValues, uintSize);
+                    BitConverter.GetBytes((uint)intervalMilliseconds).CopyTo(inOptionValues, uintSize * 2);
+                    var result = socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
+                    if (result != 0)
+                        throw new NpgsqlException($"Got non-zero value when trying to set TCP keepalive: {result}");
                 }
                 else
                 {
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
+                    throw new PlatformNotSupportedException(
+                        "Npgsql management of TCP keepalive is supported only on Windows, unless targeting .NET Core 3.0 and above " +
+                        "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
+#else
                     // This API for setting TCP keepalive parameters uses seconds, rather than milliseconds
                     // Round parameters up to the nearest second
                     var timeSeconds = Convert.ToInt32(Math.Ceiling(timeMilliseconds / 1000.0));
@@ -863,21 +870,8 @@ namespace Npgsql
                     socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                     socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, timeSeconds);
                     socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, intervalSeconds);
-                }
 #endif
-            }
-
-            void SetTcpKeepaliveSocketOptionsWindows(Socket socket, int keepAliveTimeMilliseconds, int keepAliveIntervalMilliseconds)
-            {
-                // For the following see https://msdn.microsoft.com/en-us/library/dd877220.aspx
-                var uintSize = Marshal.SizeOf(typeof(uint));
-                var inOptionValues = new byte[uintSize * 3];
-                BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
-                BitConverter.GetBytes((uint)keepAliveTimeMilliseconds).CopyTo(inOptionValues, uintSize);
-                BitConverter.GetBytes((uint)keepAliveIntervalMilliseconds).CopyTo(inOptionValues, uintSize * 2);
-                var result = socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
-                if (result != 0)
-                    throw new NpgsqlException($"Got non-zero value when trying to set TCP keepalive: {result}");
+                }
             }
         }
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -832,15 +832,15 @@ namespace Npgsql
                 throw new ArgumentException("If TcpKeepAliveInterval is defined, TcpKeepAliveTime must be defined as well");
             if (Settings.TcpKeepAliveTime > 0)
             {
-                if (!PGUtil.IsWindows)
-                    throw new PlatformNotSupportedException(
-                        "Npgsql management of TCP keepalive is supported only on Windows. " +
-                        "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
-
                 var time = Settings.TcpKeepAliveTime;
                 var interval = Settings.TcpKeepAliveInterval > 0
                     ? Settings.TcpKeepAliveInterval
                     : Settings.TcpKeepAliveTime;
+
+                if (!PGUtil.IsWindows)
+                    throw new PlatformNotSupportedException(
+                        "Npgsql management of TCP keepalive is supported only on Windows. " +
+                        "TCP keepalives can still be used on other systems but are enabled via the TcpKeepAlive option or configured globally for the machine, see the relevant docs.");
 
                 // For the following see https://msdn.microsoft.com/en-us/library/dd877220.aspx
                 var uintSize = Marshal.SizeOf(typeof(uint));

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1288,7 +1288,7 @@ CREATE TABLE record ()");
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                TcpKeepAliveTime = 2000
+                TcpKeepAliveTime = 2
             };
             using (await OpenConnectionAsync(csb))
                 Thread.Sleep(Timeout.Infinite);


### PR DESCRIPTION
.NET Core 3.0 and above supports the ability to set TCP keepalive time, interval, and retry count parameters on operating systems other than Windows - https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.socketoptionname?view=netcore-3.0

This PR:
 - ~fixes the units in the summary for the `TcpKeepAliveTime` connection string parameter (it said seconds, whereas the documentation and actual use are milliseconds)~
 - **breaking change** switches the TCP keepalive parameters over from milliseconds to seconds, since maintaining millisecond granularity only for Windows was not worth the additional complexity of introducing additional behaviour (e.g. rounding up to the nearest second) for the newly supported platforms (see https://github.com/npgsql/npgsql/pull/3037#discussion_r446568721)
 - introduces support for the `TcpKeepAliveTime` and `TcpKeepAliveInterval` settings on non-Windows platforms when targeting netcoreapp3.0 and "above"
 - updates the exception message when running on a non-Windows platform to point out that targeting .NET Core 3.0 and "above" would allow it

~Best reviewed commit by commit.~

I'm not particularly well versed in multi-targeting, so let me know if this is way off base here!

~Big caveat time:~
~The new API for setting these options takes values in seconds, rather than milliseconds. The approach I've taken is:~
 - ~on Windows, set these options the old way to avoid changing the behaviour for existing users who may rely on sub-second/non-integral second precision, regardless of netcore vs net framework~
 - ~on non-Windows, round the (millisecond) values provided by the user *up* to the nearest whole second~

~I'm not sure if this rounding behaviour is something that's acceptable? Is it acceptable if it is documented (since this behaviour is entirely new, as it will only be for non-Windows, which didn't support this at all until now)? This difference in behaviour on different platforms feels yucky, but it feels like a better option than changing behaviour for existing users of this feature.~

Another caveat:
This doesn't cover the case where a user is running the netcore3.0 DLL under mono, which I don't think supports these options in the most recent release - should that be special cased with a `Type.GetType("Mono.Runtime") != null` and throw a PlatformNotSupportedException too? (What if they add support in the future?) 

_Edit: mono throws `SocketException: Protocol option not supported` when you try to set the option_

Also, I wasn't sure if changing that exception message was the right thing to do?

Currently the documentation for these two settings say that they are supported Windows only, I don't know how you folks track documentation updates - is there something additional that should be added to this PR that serves as a reminder at release time ("supported only on Windows before Npgsql vX.Y.Z, values rounded up to whole seconds on non-Windows platforms")

Sorry about needing a bit more guidance than I'd like with this one!

