### PR TITLE
Fix NpgsqlDateTime.Add when adding NpgsqlTimeSpan

### DIFF
--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -308,14 +308,14 @@ namespace NpgsqlTypes
         #region Arithmetic
 
         /// <summary>
-        /// Returns a new <see cref="NpgsqlDateTime"/> that adds the value of the specified TimeSpan to the value of this instance.
+        /// Returns a new <see cref="NpgsqlDateTime"/> that adds the value of the specified <see cref="NpgsqlTimeSpan"/> to the value of this instance.
         /// </summary>
-        /// <param name="value">A positive or negative time interval.</param>
+        /// <param name="value">An NpgsqlTimeSpan interval.</param>
         /// <returns>An object whose value is the sum of the date and time represented by this instance and the time interval represented by value.</returns>
-        public NpgsqlDateTime Add(in NpgsqlTimeSpan value) { return AddTicks(value.Ticks); }
+        public NpgsqlDateTime Add(in NpgsqlTimeSpan value) => AddTicks(value.UnjustifyInterval().TotalTicks);
 
         /// <summary>
-        /// Returns a new <see cref="NpgsqlDateTime"/> that adds the value of the specified <see cref="NpgsqlTimeSpan"/> to the value of this instance.
+        /// Returns a new <see cref="NpgsqlDateTime"/> that adds the value of the specified TimeSpan to the value of this instance.
         /// </summary>
         /// <param name="value">A positive or negative time interval.</param>
         /// <returns>An object whose value is the sum of the date and time represented by this instance and the time interval represented by value.</returns>

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -381,6 +381,25 @@ namespace Npgsql.Tests
             Assert.AreEqual(dateForTestMonths.AddMonths(-13), new NpgsqlDate(2008, 2, 29));
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3019")]
+        public void NpgsqlDateTimeMath()
+        {
+            // Note* NpgsqlTimespan treats 1 month as 30 days
+            Assert.That(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0).Add(new NpgsqlTimeSpan(1, 2, 0)),
+                Is.EqualTo(new NpgsqlDateTime(2020, 2, 2, 0, 0, 0)));
+            Assert.That(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0).Add(new NpgsqlTimeSpan(0, -1, 0)),
+                Is.EqualTo(new NpgsqlDateTime(2019, 12, 31, 0, 0, 0)));
+            Assert.That(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0).Add(new NpgsqlTimeSpan(0, 0, 0)),
+                Is.EqualTo(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0)));
+            Assert.That(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0).Add(new NpgsqlTimeSpan(0, 0, 10000000)),
+                Is.EqualTo(new NpgsqlDateTime(2020, 1, 1, 0, 0, 1)));
+            Assert.That(new NpgsqlDateTime(2020, 1, 1, 0, 0, 0).Subtract(new NpgsqlTimeSpan(1, 1, 0)),
+                Is.EqualTo(new NpgsqlDateTime(2019, 12, 1, 0, 0, 0)));
+            // Add 1 month = 2020-03-01 then add 30 days (1 month in npgsqlTimespan = 30 days) = 2020-03-31
+            Assert.That(new NpgsqlDateTime(2020, 2, 1, 0, 0, 0).AddMonths(1).Add(new NpgsqlTimeSpan(1, 0, 0)),
+                Is.EqualTo(new NpgsqlDateTime(2020, 3, 31, 0, 0, 0)));
+        }
+
         [Test]
         public void TsVector()
         {


### PR DESCRIPTION
Fix for Npgsql #3019; Previously, the NpgsqlDateTime.Add with NpgsqlTimeSpan was adding NpgsqlTimeSpan.Ticks to the DateTime, which was incorrect as the Ticks property only returns the ticks in a day and ignores the number of days and months held.

In order to count months and days in the NpgsqlTimeSpan, we need to call TotalTicks after calling UnjustifyInterval (see summary notes for NpgsqlTimeSpan.Ticks)

Also  note that 1 month in NpgsqlTimeSpan is the equivalent of 30 days (see summary notes for NpgsqlTimeSpan constant DaysPerMonth)