### PR TITLE
Set columnName to PostgreSQL field name when column name not available

### DIFF
--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -150,10 +150,8 @@ ORDER BY attnum";
                     populatedColumns++;
                 }
 
-                var fieldName = field.Name.StartsWith("?column?") ? null : field.Name;
-
-                column.BaseColumnName ??= fieldName;
-                column.ColumnName = fieldName;
+                column.BaseColumnName ??= field.Name.StartsWith("?column?") ? null : field.Name;
+                column.ColumnName = field.Name;
             }
 
             if (populatedColumns != fields.Count)

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -163,7 +163,7 @@ namespace Npgsql.Tests
                     var columns = reader.GetColumnSchema();
                     Assert.That(columns[0].ColumnName, Is.EqualTo("foo"));
                     Assert.That(columns[1].ColumnName, Is.EqualTo("bar"));
-                    Assert.That(columns[2].ColumnName, Is.Null);
+                    Assert.That(columns[2].ColumnName, Is.EqualTo("?column?"));
                     Assert.That(columns[3].ColumnName, Is.EqualTo("varchar"));
                 }
             }

--- a/test/Npgsql.Tests/ReaderOldSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderOldSchemaTests.cs
@@ -195,7 +195,7 @@ CREATE OR REPLACE VIEW {view} (id, int2) AS SELECT id, int2 + int2 AS int2 FROM 
                 var query = $@"
 SELECT 1 AS some_column;
 UPDATE {table} SET name='yo' WHERE 1=0;
-SELECT 1 AS some_other_column";
+SELECT 1 AS some_other_column, 2";
 
                 using (var cmd = new NpgsqlCommand(query, conn))
                 {
@@ -210,6 +210,7 @@ SELECT 1 AS some_other_column";
                         Assert.That(reader.Read(), Is.False);
                         t = reader.GetSchemaTable();
                         Assert.That(t.Rows[0]["ColumnName"], Is.EqualTo("some_other_column"));
+                        Assert.That(t.Rows[1]["ColumnName"], Is.EqualTo("?column?"));
                         Assert.That(reader.NextResult(), Is.False);
                     }
 


### PR DESCRIPTION
Fixes #3044 

Sets the Column Name to the field.Name regardless of whether it contains "?column?". This is the same behavior as psql and aligns with [the docs](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcolumn.columnname?view=netframework-4.8#System_Data_Common_DbColumn_ColumnName).

I've also left the BaseColumnName as null when no appropriate field name is available in order to keep the behavior as [documented](https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbcolumn.basecolumnname?view=netframework-4.8)