### PR TITLE
System.Text.Json mapper

### DIFF
--- a/src/Npgsql.SystemJson/JsonHandler.cs
+++ b/src/Npgsql.SystemJson/JsonHandler.cs
@@ -1,0 +1,71 @@
+﻿using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Npgsql.SystemJson
+{
+    public class JsonHandlerFactory : NpgsqlTypeHandlerFactory<string>
+    {
+        private readonly JsonSerializerOptions _settings;
+
+        public JsonHandlerFactory(JsonSerializerOptions settings = null)
+            => _settings = settings ?? new JsonSerializerOptions();
+
+        public override NpgsqlTypeHandler<string> Create(PostgresType postgresType, NpgsqlConnection conn)
+            => new JsonHandler(postgresType, conn, _settings);
+    }
+
+    internal class JsonHandler : TypeHandlers.TextHandler
+    {
+        private readonly JsonSerializerOptions _settings;
+
+        public JsonHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerOptions settings)
+            : base(postgresType, connection) => _settings = settings;
+
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        {
+            var s = await base.Read<string>(buf, len, async, fieldDescription);
+            if (typeof(T) == typeof(string))
+                return (T)(object)s;
+
+            return JsonSerializer.Deserialize<T>(s, _settings);
+        }
+
+        protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+            => typeof(T2) == typeof(string)
+                ? base.ValidateAndGetLength(value, ref lengthCache, parameter)
+                : ValidateObjectAndGetLength(value, ref lengthCache, parameter);
+
+        protected override Task WriteWithLength<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+            => typeof(T2) == typeof(string)
+                ? base.WriteWithLength(value, buf, lengthCache, parameter, async)
+                : WriteObjectWithLength(value, buf, lengthCache, parameter, async);
+
+        protected override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        {
+            if (!(value is string s))
+            {
+                s = JsonSerializer.Serialize(value, _settings);
+                if (parameter != null)
+                    parameter.ConvertedValue = s;
+            }
+            return base.ValidateAndGetLength(s, ref lengthCache, parameter);
+        }
+
+        protected override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+        {
+            if (value is DBNull)
+                return base.WriteObjectWithLength(DBNull.Value, buf, lengthCache, parameter, async);
+
+            if (parameter?.ConvertedValue != null)
+                value = parameter.ConvertedValue;
+            var s = value as string ?? JsonSerializer.Serialize(value, _settings);
+            return base.WriteObjectWithLength(s, buf, lengthCache, parameter, async);
+        }
+    }
+}

--- a/src/Npgsql.SystemJson/JsonbHandler.cs
+++ b/src/Npgsql.SystemJson/JsonbHandler.cs
@@ -1,0 +1,94 @@
+﻿using Npgsql.BackendMessages;
+using Npgsql.PostgresTypes;
+using Npgsql.TypeHandling;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Npgsql.SystemJson
+{
+    public class JsonbHandlerFactory : NpgsqlTypeHandlerFactory<string>
+    {
+        private readonly JsonSerializerOptions _settings;
+
+        public JsonbHandlerFactory(JsonSerializerOptions settings = null)
+            => _settings = settings ?? new JsonSerializerOptions();
+
+        public override NpgsqlTypeHandler<string> Create(PostgresType postgresType, NpgsqlConnection conn)
+            => new JsonbHandler(postgresType, conn, _settings);
+    }
+
+    internal class JsonbHandler : TypeHandlers.JsonHandler
+    {
+        private readonly JsonSerializerOptions _settings;
+
+        public JsonbHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerOptions settings)
+            : base(postgresType, connection, isJsonb: true) => _settings = settings;
+
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        {
+            if (typeof(T) == typeof(string) ||
+                typeof(T) == typeof(char[]) ||
+                typeof(T) == typeof(ArraySegment<char>) ||
+                typeof(T) == typeof(char) ||
+                typeof(T) == typeof(byte[]))
+            {
+                return await base.Read<T>(buf, len, async, fieldDescription);
+            }
+
+            return JsonSerializer.Deserialize<T>(await base.Read<string>(buf, len, async, fieldDescription), _settings);
+        }
+
+        protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+            => typeof(T2) == typeof(string)
+                ? base.ValidateAndGetLength(value, ref lengthCache, parameter)
+                : ValidateObjectAndGetLength(value, ref lengthCache, parameter);
+
+        protected override Task WriteWithLength<T2>(T2 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+            => typeof(T2) == typeof(string)
+                ? base.WriteWithLength(value, buf, lengthCache, parameter, async)
+                : WriteObjectWithLength(value, buf, lengthCache, parameter, async);
+
+        protected override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
+        {
+            switch (value)
+            {
+                case string _:
+                case char[] _:
+                case ArraySegment<char> _:
+                case char _:
+                case byte[] _:
+                    return base.ValidateObjectAndGetLength(value, ref lengthCache, parameter);
+                default:
+                    var serialized = JsonSerializer.Serialize(value, _settings);
+                    if (parameter != null)
+                        parameter.ConvertedValue = serialized;
+                    return base.ValidateObjectAndGetLength(serialized, ref lengthCache, parameter);
+            }
+        }
+
+        protected override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async)
+        {
+            if (value is DBNull)
+                return base.WriteObjectWithLength(DBNull.Value, buf, lengthCache, parameter, async);
+
+            switch (value)
+            {
+                case string _:
+                case char[] _:
+                case ArraySegment<char> _:
+                case char _:
+                case byte[] _:
+                    return base.WriteObjectWithLength(value, buf, lengthCache, parameter, async);
+                default:
+                    // User POCO, read serialized representation from the validation phase
+                    var serialized = parameter?.ConvertedValue != null
+                        ? (string)parameter.ConvertedValue
+                        : JsonSerializer.Serialize(value, _settings);
+                    return base.WriteObjectWithLength(serialized, buf, lengthCache, parameter, async);
+            }
+        }
+    }
+}

--- a/src/Npgsql.SystemJson/Npgsql.SystemJson.csproj
+++ b/src/Npgsql.SystemJson/Npgsql.SystemJson.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Authors>Yorick de Wid</Authors>
+    <Description>System.Text.Json plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
+    <PackageTags>npgsql postgresql json jsonb postgres ado ado.net database sql</PackageTags>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">net461;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Npgsql\Npgsql.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Npgsql.SystemJson/NpgsqlSystemJsonExtensions.cs
+++ b/src/Npgsql.SystemJson/NpgsqlSystemJsonExtensions.cs
@@ -1,0 +1,47 @@
+﻿using Npgsql.SystemJson;
+using Npgsql.TypeMapping;
+using NpgsqlTypes;
+using System;
+using System.Text.Json;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Extension allowing adding the System.Text.Json plugin to an Npgsql type mapper.
+    /// </summary>
+    public static class NpgsqlSystemJsonExtensions
+    {
+        /// <summary>
+        /// Sets up System.Text.Json mappings for the PostgreSQL json and jsonb types.
+        /// </summary>
+        /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
+        /// <param name="jsonbClrTypes">A list of CLR types to map to PostgreSQL jsonb (no need to specify NpgsqlDbType.Jsonb)</param>
+        /// <param name="jsonClrTypes">A list of CLR types to map to PostgreSQL json (no need to specify NpgsqlDbType.Json)</param>
+        /// <param name="settings">Optional settings to customize JSON serialization</param>
+        public static INpgsqlTypeMapper UseSystemJson(
+            this INpgsqlTypeMapper mapper,
+            Type[] jsonbClrTypes = null,
+            Type[] jsonClrTypes = null,
+            JsonSerializerOptions settings = null
+        )
+        {
+            mapper.AddMapping(new NpgsqlTypeMappingBuilder
+            {
+                PgTypeName = "jsonb",
+                NpgsqlDbType = NpgsqlDbType.Jsonb,
+                ClrTypes = jsonbClrTypes,
+                TypeHandlerFactory = new JsonbHandlerFactory(settings)
+            }.Build());
+
+            mapper.AddMapping(new NpgsqlTypeMappingBuilder
+            {
+                PgTypeName = "json",
+                NpgsqlDbType = NpgsqlDbType.Json,
+                ClrTypes = jsonClrTypes,
+                TypeHandlerFactory = new JsonHandlerFactory(settings)
+            }.Build());
+
+            return mapper;
+        }
+    }
+}


### PR DESCRIPTION
This mapper plugin integrates .NET Core 3.0+ ```System.Text.Json``` JSON serializer as an alternative to Json.NET. Future applications might be less depend on `Newtonsoft.Json`.

- Plugin based on `Npgsql.Json.NET`.
- When accepted, I'll add testcases in this PR.