### PR TITLE
Remove IsParameterLoggingEnabled (#3060)

### DIFF
--- a/src/Npgsql/Logging/NpgsqlLogManager.cs
+++ b/src/Npgsql/Logging/NpgsqlLogManager.cs
@@ -26,12 +26,6 @@ namespace Npgsql.Logging
             }
         }
 
-        /// <summary>
-        /// Determines whether parameter contents will be logged alongside SQL statements - this may reveal sensitive information.
-        /// Defaults to false.
-        /// </summary>
-        public static bool IsParameterLoggingEnabled { get; set; }
-
         static INpgsqlLoggingProvider? _provider;
         static bool _providerRetrieved;
 

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1399,7 +1399,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             {
                 sb.Append("\t").AppendLine(s.SQL);
                 var p = s.InputParameters;
-                if (p.Count > 0 && (NpgsqlLogManager.IsParameterLoggingEnabled || connector.Settings.LogParameters))
+                if (p.Count > 0 && connector.Settings.LogParameters)
                 {
                     sb.Append('\t').Append("Parameters:");
                     for (var i = 0; i < p.Count; i++)

--- a/test/Npgsql.Tests/Support/LoggingSetupFixture.cs
+++ b/test/Npgsql.Tests/Support/LoggingSetupFixture.cs
@@ -32,6 +32,5 @@ public class LoggingSetupFixture
         LogManager.Configuration = config;
 
         NpgsqlLogManager.Provider = new NLogLoggingProvider();
-        NpgsqlLogManager.IsParameterLoggingEnabled = true;
     }
 }

--- a/test/Npgsql.Tests/TestBase.cs
+++ b/test/Npgsql.Tests/TestBase.cs
@@ -12,7 +12,7 @@ namespace Npgsql.Tests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+        const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;LogParameters=true";
 
         /// <summary>
         /// The connection string that will be used when opening the connection to the tests database.


### PR DESCRIPTION
NpgsqlLogManager.IsParameterLoggingEnabled duplicates connectionstring property `LogParameters`.
For the 5.x branch lets remove IsParameterLoggingEnabled.

See issue https://github.com/npgsql/npgsql/issues/3060

As this is a breaking change I would suggest that this change is not back ported into the 4.X branch. 