### PR TITLE
Fix auto-preparation batching bug

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.5.20279.10"
+    "version": "5.0.100-preview.7.20366.6",
+    "rollForward": "major",
+    "allowPrerelease": "true"
   }
 }

--- a/src/Npgsql/PreparedStatement.cs
+++ b/src/Npgsql/PreparedStatement.cs
@@ -9,6 +9,7 @@ namespace Npgsql
     /// Internally represents a statement has been prepared, is in the process of being prepared, or is a
     /// candidate for preparation (i.e. awaiting further usages).
     /// </summary>
+    [DebuggerDisplay("{Name} ({State}): {Sql}")]
     class PreparedStatement
     {
         readonly PreparedStatementManager _manager;

--- a/test/Npgsql.Tests/AutoPrepareTests.cs
+++ b/test/Npgsql.Tests/AutoPrepareTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NpgsqlTypes;
 using NUnit.Framework;
 
@@ -369,6 +371,24 @@ namespace Npgsql.Tests
                 Assert.That(reader.GetName(0), Is.EqualTo("foo"));
 
             conn.UnprepareAll();
+        }
+
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3106")]
+        public async Task DontAutoPrepareMoreThanMaxStatementsInBatch()
+        {
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                MaxAutoPrepare = 50,
+            };
+
+            await using var connection = new NpgsqlConnection(builder.ToString());
+            await connection.OpenAsync();
+            for (var i = 0; i < 10; i++)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = string.Join("", Enumerable.Range(0, 100).Select(n => $"SELECT {n};"));
+                await command.ExecuteNonQueryAsync();
+            }
         }
 
         // Exclude some internal Npgsql queries which include pg_type as well as the count statement itself

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -450,7 +450,7 @@ namespace Npgsql.Tests
             string newTimezone;
             using (var conn1 = await OpenConnectionAsync())
             {
-                newTimezone = (string)await conn1.ExecuteScalarAsync("SHOW TIMEZONE") == "Africa/Bamako"
+                newTimezone = (string?)await conn1.ExecuteScalarAsync("SHOW TIMEZONE") == "Africa/Bamako"
                     ? "Africa/Lagos"
                     : "Africa/Bamako";
             }
@@ -469,7 +469,7 @@ namespace Npgsql.Tests
             string newTimezone;
             using (var conn = await OpenConnectionAsync())
             {
-                newTimezone = (string)await conn.ExecuteScalarAsync("SHOW TIMEZONE") == "Africa/Bamako"
+                newTimezone = (string?)await conn.ExecuteScalarAsync("SHOW TIMEZONE") == "Africa/Bamako"
                     ? "Africa/Lagos"
                     : "Africa/Bamako";
             }

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -335,7 +335,7 @@ namespace Npgsql.Tests
                 return await cmd.ExecuteNonQueryAsync();
         }
 
-        public static async Task<object> ExecuteScalarAsync(this NpgsqlConnection conn, string sql, NpgsqlTransaction? tx = null)
+        public static async Task<object?> ExecuteScalarAsync(this NpgsqlConnection conn, string sql, NpgsqlTransaction? tx = null)
         {
             var cmd = tx == null ? new NpgsqlCommand(sql, conn) : new NpgsqlCommand(sql, conn, tx);
             using (cmd)

--- a/test/Npgsql.Tests/Types/ByteaTests.cs
+++ b/test/Npgsql.Tests/Types/ByteaTests.cs
@@ -105,7 +105,7 @@ namespace Npgsql.Tests.Types
                 var expected = new byte[0];
                 cmd.Parameters.Add("val", NpgsqlDbType.Bytea);
                 cmd.Parameters["val"].Value = expected;
-                var result = (byte[])await cmd.ExecuteScalarAsync();
+                var result = (byte[]?)await cmd.ExecuteScalarAsync();
                 Assert.That(result, Is.EqualTo(expected));
             }
         }
@@ -162,8 +162,8 @@ namespace Npgsql.Tests.Types
                 var bytes = new byte[] { 1, 2, 3, 4, 5, 34, 39, 48, 49, 50, 51, 52, 92, 127, 128, 255, 254, 253, 252, 251 };
                 var inVal = new[] { bytes, bytes };
                 cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Bytea | NpgsqlDbType.Array, inVal);
-                var retVal = (byte[][])await cmd.ExecuteScalarAsync();
-                Assert.AreEqual(inVal.Length, retVal.Length);
+                var retVal = (byte[][]?)await cmd.ExecuteScalarAsync();
+                Assert.AreEqual(inVal.Length, retVal!.Length);
                 Assert.AreEqual(inVal[0], retVal[0]);
                 Assert.AreEqual(inVal[1], retVal[1]);
             }
@@ -201,8 +201,8 @@ namespace Npgsql.Tests.Types
             {
                 byte[] toStore = { 0, 1, 255, 254 };
                 cmd.Parameters.AddWithValue("@bytes", toStore);
-                var result = (byte[])await cmd.ExecuteScalarAsync();
-                Assert.AreEqual(toStore, result);
+                var result = (byte[]?)await cmd.ExecuteScalarAsync();
+                Assert.AreEqual(toStore, result!);
             }
         }
 
@@ -222,29 +222,29 @@ namespace Npgsql.Tests.Types
                     // Big value, should go through "direct buffer"
                     var segment = new ArraySegment<byte>(arr, 17, 18000);
                     cmd.Parameters.Add(new NpgsqlParameter("bytearr", DbType.Binary) {Value = segment});
-                    var returned = (byte[]) await cmd.ExecuteScalarAsync();
-                    Assert.That(segment.SequenceEqual(returned));
+                    var returned = (byte[]?)await cmd.ExecuteScalarAsync();
+                    Assert.That(segment.SequenceEqual(returned!));
 
                     cmd.Parameters[0].Size = 17000;
-                    returned = (byte[]) await cmd.ExecuteScalarAsync();
-                    Assert.That(returned.SequenceEqual(new ArraySegment<byte>(segment.Array!, segment.Offset, 17000)));
+                    returned = (byte[]?)await cmd.ExecuteScalarAsync();
+                    Assert.That(returned!.SequenceEqual(new ArraySegment<byte>(segment.Array!, segment.Offset, 17000)));
 
                     // Small value, should be written normally through the NpgsqlBuffer
                     segment = new ArraySegment<byte>(arr, 6, 10);
                     cmd.Parameters[0].Value = segment;
-                    returned = (byte[]) await cmd.ExecuteScalarAsync();
-                    Assert.That(segment.SequenceEqual(returned));
+                    returned = (byte[]?)await cmd.ExecuteScalarAsync();
+                    Assert.That(segment.SequenceEqual(returned!));
 
                     cmd.Parameters[0].Size = 2;
-                    returned = (byte[]) await cmd.ExecuteScalarAsync();
-                    Assert.That(returned.SequenceEqual(new ArraySegment<byte>(segment.Array!, segment.Offset, 2)));
+                    returned = (byte[]?)await cmd.ExecuteScalarAsync();
+                    Assert.That(returned!.SequenceEqual(new ArraySegment<byte>(segment.Array!, segment.Offset, 2)));
                 }
 
                 using (var cmd = new NpgsqlCommand("select :bytearr", conn))
                 {
                     var segment = new ArraySegment<byte>(new byte[] {1, 2, 3}, 1, 2);
                     cmd.Parameters.AddWithValue("bytearr", segment);
-                    Assert.That(segment.SequenceEqual((byte[]) await cmd.ExecuteScalarAsync()));
+                    Assert.That(segment.SequenceEqual((byte[])(await cmd.ExecuteScalarAsync())!));
                 }
             }
         }

--- a/test/Npgsql.Tests/Types/FullTextSearchTests.cs
+++ b/test/Npgsql.Tests/Types/FullTextSearchTests.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Tests.Types
                 cmd.CommandText = "Select :p";
                 cmd.Parameters.AddWithValue("p", inputVec);
                 var outputVec = await cmd.ExecuteScalarAsync();
-                Assert.AreEqual(inputVec.ToString(), outputVec.ToString());
+                Assert.AreEqual(inputVec.ToString(), outputVec!.ToString());
             }
         }
 
@@ -35,7 +35,7 @@ namespace Npgsql.Tests.Types
                 cmd.CommandText = "Select :p";
                 cmd.Parameters.AddWithValue("p", query);
                 var output = await cmd.ExecuteScalarAsync();
-                Assert.AreEqual(query.ToString(), output.ToString());
+                Assert.AreEqual(query.ToString(), output!.ToString());
             }
         }
 

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -395,17 +395,17 @@ namespace Npgsql.Tests.Types
             {
                 var expectedValue = 8.99m;
                 command.Parameters.Add("moneyvalue", NpgsqlDbType.Money).Value = expectedValue;
-                var result = (decimal)await command.ExecuteScalarAsync();
+                var result = (decimal?)await command.ExecuteScalarAsync();
                 Assert.AreEqual(expectedValue, result);
 
                 expectedValue = 100m;
                 command.Parameters[0].Value = expectedValue;
-                result = (decimal)await command.ExecuteScalarAsync();
+                result = (decimal?)await command.ExecuteScalarAsync();
                 Assert.AreEqual(expectedValue, result);
 
                 expectedValue = 72.25m;
                 command.Parameters[0].Value = expectedValue;
-                result = (decimal)await command.ExecuteScalarAsync();
+                result = (decimal?)await command.ExecuteScalarAsync();
                 Assert.AreEqual(expectedValue, result);
             }
         }
@@ -433,7 +433,7 @@ CREATE TABLE {table} (
 
                 command = new NpgsqlCommand($"SELECT person_uuid::uuid FROM {table} LIMIT 1", conn);
                 var result = await command.ExecuteScalarAsync();
-                Assert.AreEqual(typeof(Guid), result.GetType());
+                Assert.AreEqual(typeof(Guid), result!.GetType());
             }
         }
 

--- a/test/Npgsql.Tests/Types/MoneyTests.cs
+++ b/test/Npgsql.Tests/Types/MoneyTests.cs
@@ -29,7 +29,7 @@ namespace Npgsql.Tests.Types
             using (var cmd = new NpgsqlCommand("SELECT " + query, conn))
             {
                 Assert.That(
-                    decimal.GetBits((decimal)await cmd.ExecuteScalarAsync()),
+                    decimal.GetBits((decimal)(await cmd.ExecuteScalarAsync())!),
                     Is.EqualTo(decimal.GetBits(expected)));
             }
         }

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -66,7 +66,7 @@ namespace Npgsql.Tests.Types
             using (var cmd = new NpgsqlCommand("SELECT " + query, conn))
             {
                 Assert.That(
-                    decimal.GetBits((decimal)await cmd.ExecuteScalarAsync()),
+                    decimal.GetBits((decimal)(await cmd.ExecuteScalarAsync())!),
                     Is.EqualTo(decimal.GetBits(expected)));
             }
         }


### PR DESCRIPTION
When there are more auto-preparable statements in a batch than the maximum allowed, later statements would replace earlier ones, leading to issues.
    
Fixes #3106
