### PR TITLE
Obsolete provider specific date time types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/npgsql/npgsql</PackageProjectUrl>
     <PackageIcon>postgresql.png</PackageIcon>
+    <DefineConstants>LegacyProviderSpecificDateTimeTypes</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.NodaTime/DateHandler.cs
+++ b/src/Npgsql.NodaTime/DateHandler.cs
@@ -19,7 +19,12 @@ namespace Npgsql.NodaTime
         }
     }
 
-    sealed class DateHandler : NpgsqlSimpleTypeHandler<LocalDate>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<NpgsqlDate>
+    sealed class DateHandler : NpgsqlSimpleTypeHandler<LocalDate>, INpgsqlSimpleTypeHandler<DateTime>
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
+        , INpgsqlSimpleTypeHandler<NpgsqlDate>
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
     {
         /// <summary>
         /// Whether to convert positive and negative infinity values to Instant.{Max,Min}Value when
@@ -71,6 +76,8 @@ namespace Npgsql.NodaTime
             buf.WriteInt32(totalDaysSinceEra - 730119);
         }
 
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         NpgsqlDate INpgsqlSimpleTypeHandler<NpgsqlDate>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
             => _bclHandler.Read<NpgsqlDate>(buf, len, fieldDescription);
 
@@ -79,6 +86,8 @@ namespace Npgsql.NodaTime
 
         void INpgsqlSimpleTypeHandler<NpgsqlDate>.Write(NpgsqlDate value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
             => _bclHandler.Write(value, buf, parameter);
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
 
         DateTime INpgsqlSimpleTypeHandler<DateTime>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
             => _bclHandler.Read<DateTime>(buf, len, fieldDescription);

--- a/src/Npgsql.NodaTime/IntervalHandler.cs
+++ b/src/Npgsql.NodaTime/IntervalHandler.cs
@@ -19,7 +19,12 @@ namespace Npgsql.NodaTime
                 : throw new NotSupportedException($"The deprecated floating-point date/time format is not supported by {nameof(Npgsql)}.");
     }
 
-    sealed class IntervalHandler : NpgsqlSimpleTypeHandler<Period>, INpgsqlSimpleTypeHandler<NpgsqlTimeSpan>, INpgsqlSimpleTypeHandler<TimeSpan>
+    sealed class IntervalHandler : NpgsqlSimpleTypeHandler<Period>, INpgsqlSimpleTypeHandler<TimeSpan>
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
+        , INpgsqlSimpleTypeHandler<NpgsqlTimeSpan>
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
     {
         readonly BclIntervalHandler _bclHandler;
 
@@ -60,6 +65,8 @@ namespace Npgsql.NodaTime
             buf.WriteInt32(value.Years * 12 + value.Months); // months
         }
 
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         NpgsqlTimeSpan INpgsqlSimpleTypeHandler<NpgsqlTimeSpan>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
             => _bclHandler.Read<NpgsqlTimeSpan>(buf, len, fieldDescription);
 
@@ -68,6 +75,8 @@ namespace Npgsql.NodaTime
 
         void INpgsqlSimpleTypeHandler<NpgsqlTimeSpan>.Write(NpgsqlTimeSpan value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
             => _bclHandler.Write(value, buf, parameter);
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
 
         TimeSpan INpgsqlSimpleTypeHandler<TimeSpan>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
             => _bclHandler.Read<TimeSpan>(buf, len, fieldDescription);

--- a/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
@@ -40,7 +40,13 @@ namespace Npgsql
                     PgTypeName = "date",
                     NpgsqlDbType = NpgsqlDbType.Date,
                     DbTypes = new[] { DbType.Date },
-                    ClrTypes = new[] { typeof(LocalDate),  typeof(NpgsqlDate) },
+                    ClrTypes = new[] { typeof(LocalDate)
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
+                        ,  typeof(NpgsqlDate)
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
+                    },
                     TypeHandlerFactory = new DateHandlerFactory()
                 }.Build())
                 .AddMapping(new NpgsqlTypeMappingBuilder
@@ -62,7 +68,13 @@ namespace Npgsql
                 {
                     PgTypeName = "interval",
                     NpgsqlDbType = NpgsqlDbType.Interval,
-                    ClrTypes = new[] { typeof(Period), typeof(TimeSpan), typeof(NpgsqlTimeSpan) },
+                    ClrTypes = new[] { typeof(Period), typeof(TimeSpan)
+#if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
+                        , typeof(NpgsqlTimeSpan)
+#pragma warning restore 618
+#endif // LegacyProviderSpecificDateTimeTypes
+                    },
                     TypeHandlerFactory = new IntervalHandlerFactory()
                 }.Build());
     }

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -974,6 +974,19 @@ namespace Npgsql
         public override DateTime GetDateTime(int ordinal) => GetFieldValue<DateTime>(ordinal);
 
         /// <summary>
+        /// Gets the value of the specified column as a TimeSpan,
+        /// </summary>
+        /// <remarks>
+        /// PostgreSQL's interval type has has a resolution of 1 microsecond and ranges from
+        /// -178000000 to 178000000 years, while .NET's TimeSpan has a resolution of 100 nanoseconds
+        /// and ranges from roughly -29247 to 29247 years.
+        /// See http://www.postgresql.org/docs/current/static/datatype-datetime.html
+        /// </remarks>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <returns>The value of the specified column.</returns>
+        public TimeSpan GetTimeSpan(int ordinal) => GetFieldValue<TimeSpan>(ordinal);
+
+        /// <summary>
         /// Gets the value of the specified column as an instance of <see cref="string"/>.
         /// </summary>
         /// <param name="ordinal">The zero-based column ordinal.</param>
@@ -1036,6 +1049,8 @@ namespace Npgsql
 
         #region Provider-specific simple type getters
 
+#if LegacyProviderSpecificDateTimeTypes
+
         /// <summary>
         /// Gets the value of the specified column as an <see cref="NpgsqlDate"/>,
         /// Npgsql's provider-specific type for dates.
@@ -1050,19 +1065,6 @@ namespace Npgsql
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
         public NpgsqlDate GetDate(int ordinal) => GetFieldValue<NpgsqlDate>(ordinal);
-
-        /// <summary>
-        /// Gets the value of the specified column as a TimeSpan,
-        /// </summary>
-        /// <remarks>
-        /// PostgreSQL's interval type has has a resolution of 1 microsecond and ranges from
-        /// -178000000 to 178000000 years, while .NET's TimeSpan has a resolution of 100 nanoseconds
-        /// and ranges from roughly -29247 to 29247 years.
-        /// See http://www.postgresql.org/docs/current/static/datatype-datetime.html
-        /// </remarks>
-        /// <param name="ordinal">The zero-based column ordinal.</param>
-        /// <returns>The value of the specified column.</returns>
-        public TimeSpan GetTimeSpan(int ordinal) => GetFieldValue<TimeSpan>(ordinal);
 
         /// <summary>
         /// Gets the value of the specified column as an <see cref="NpgsqlTimeSpan"/>,
@@ -1097,6 +1099,8 @@ namespace Npgsql
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
         public NpgsqlDateTime GetTimeStamp(int ordinal) => GetFieldValue<NpgsqlDateTime>(ordinal);
+
+#endif // LegacyProviderSpecificDateTimeTypes
 
         #endregion
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1064,7 +1064,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlDate GetDate(int ordinal) => GetFieldValue<NpgsqlDate>(ordinal);
+#pragma warning restore 618
 
         /// <summary>
         /// Gets the value of the specified column as an <see cref="NpgsqlTimeSpan"/>,
@@ -1081,7 +1083,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlTimeSpan GetInterval(int ordinal) => GetFieldValue<NpgsqlTimeSpan>(ordinal);
+#pragma warning restore 618
 
         /// <summary>
         /// Gets the value of the specified column as an <see cref="NpgsqlDateTime"/>,
@@ -1098,7 +1102,9 @@ namespace Npgsql
         /// </remarks>
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The value of the specified column.</returns>
+#pragma warning disable 618
         public NpgsqlDateTime GetTimeStamp(int ordinal) => GetFieldValue<NpgsqlDateTime>(ordinal);
+#pragma warning restore 618
 
 #endif // LegacyProviderSpecificDateTimeTypes
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
@@ -1,3 +1,4 @@
+#if LegacyProviderSpecificDateTimeTypes
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -461,3 +462,4 @@ namespace NpgsqlTypes
         }
     }
 }
+#endif // LegacyProviderSpecificDateTimeTypes

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
@@ -11,6 +11,9 @@ using JetBrains.Annotations;
 namespace NpgsqlTypes
 {
     [Serializable]
+    [Obsolete("This type will be removed/replaced in the next release. Please use the System.DateTime"
+              + " type or the LocalDate type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/3108 and describe your issues.")]
     public readonly struct NpgsqlDate : IEquatable<NpgsqlDate>, IComparable<NpgsqlDate>, IComparable,
         IComparer<NpgsqlDate>, IComparer
     {

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if LegacyProviderSpecificDateTimeTypes
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Npgsql.Util;
@@ -476,3 +477,4 @@ namespace NpgsqlTypes
         }
     }
 }
+#endif // LegacyProviderSpecificDateTimeTypes

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDateTime.cs
@@ -15,6 +15,9 @@ namespace NpgsqlTypes
     /// while PostgreSQL's timestamps store values from 4713BC to 5874897AD with 1-microsecond precision.
     /// </summary>
     [Serializable]
+    [Obsolete("This type will be removed/replaced in the next release. Please use the System.DateTime"
+              + " type or the Instant type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/3108 and describe your issues.")]
     public readonly struct NpgsqlDateTime : IEquatable<NpgsqlDateTime>, IComparable<NpgsqlDateTime>, IComparable,
         IComparer<NpgsqlDateTime>, IComparer
     {

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if LegacyProviderSpecificDateTimeTypes
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -903,3 +904,4 @@ namespace NpgsqlTypes
         #endregion
     }
 }
+#endif // LegacyProviderSpecificDateTimeTypes

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTimeSpan.cs
@@ -33,6 +33,9 @@ namespace NpgsqlTypes
     /// <seealso cref="JustifyMonths"/>
     /// <seealso cref="Canonicalize()"/>
     [Serializable]
+    [Obsolete("This type will be removed/replaced in the next release. Please use the System.TimeSpan"
+              + " type or the Period type from NodaTime. If you can't, please comment "
+              + "at https://github.com/npgsql/npgsql/issues/3108 and describe your issues.")]
     public readonly struct NpgsqlTimeSpan : IComparable, IComparer, IEquatable<NpgsqlTimeSpan>, IComparable<NpgsqlTimeSpan>,
                                    IComparer<NpgsqlTimeSpan>
     {

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/DateHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/DateHandler.cs
@@ -21,7 +21,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// </remarks>
     [TypeMapping("date", NpgsqlDbType.Date, DbType.Date
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         , typeof(NpgsqlDate)
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
         )]
     public class DateHandlerFactory : NpgsqlTypeHandlerFactory<DateTime>
@@ -43,7 +45,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// </remarks>
     public class DateHandler :
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDate>
+#pragma warning restore 618
 #else
         NpgsqlSimpleTypeHandler<DateTime>
 #endif // LegacyProviderSpecificDateTimeTypes
@@ -94,6 +98,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         }
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <remarks>
         /// Copied wholesale from Postgresql backend/utils/adt/datetime.c:j2date
         /// </remarks>
@@ -108,6 +113,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 _            => new NpgsqlDate(binDate + 730119)
             };
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         #endregion Read
@@ -118,8 +124,10 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         public override int ValidateAndGetLength(DateTime value, NpgsqlParameter? parameter) => 4;
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         public override int ValidateAndGetLength(NpgsqlDate value, NpgsqlParameter? parameter) => 4;
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         /// <inheritdoc />
@@ -139,6 +147,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         }
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         public override void Write(NpgsqlDate value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
         {
@@ -149,6 +158,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             else
                 buf.WriteInt32(value.DaysSinceEra - 730119);
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         #endregion Write

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
@@ -19,7 +19,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// </remarks>
     [TypeMapping("interval", NpgsqlDbType.Interval, new[] { typeof(TimeSpan)
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         , typeof(NpgsqlTimeSpan)
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
     })]
     public class IntervalHandlerFactory : NpgsqlTypeHandlerFactory<TimeSpan>
@@ -43,7 +45,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// </remarks>
     public class IntervalHandler :
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         NpgsqlSimpleTypeHandlerWithPsv<TimeSpan, NpgsqlTimeSpan>
+#pragma warning restore 618
 #else
         NpgsqlSimpleTypeHandler<TimeSpan>
 #endif // LegacyProviderSpecificDateTimeTypes
@@ -63,6 +67,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         }
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         protected override NpgsqlTimeSpan ReadPsv(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
         {
@@ -71,12 +76,14 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             var month = buf.ReadInt32();
             return new NpgsqlTimeSpan(month, day, ticks * 10);
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         /// <inheritdoc />
         public override int ValidateAndGetLength(TimeSpan value, NpgsqlParameter? parameter) => 16;
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         public override int ValidateAndGetLength(NpgsqlTimeSpan value, NpgsqlParameter? parameter) => 16;
 
@@ -87,6 +94,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             buf.WriteInt32(value.Days);
             buf.WriteInt32(value.Months);
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
@@ -22,7 +22,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     [TypeMapping("timestamp without time zone", NpgsqlDbType.Timestamp, new[] { DbType.DateTime, DbType.DateTime2 }, new[]
     {
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         typeof(NpgsqlDateTime),
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
         typeof(DateTime)
     }, DbType.DateTime)]
@@ -47,7 +49,9 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
     /// </remarks>
     public class TimestampHandler :
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>
+#pragma warning restore 618
 #else
         NpgsqlSimpleTypeHandler<DateTime>
 #endif // LegacyProviderSpecificDateTimeTypes
@@ -94,6 +98,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         }
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         protected override NpgsqlDateTime ReadPsv(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
         {
@@ -129,6 +134,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 return new NpgsqlDateTime(new NpgsqlDate(date), new TimeSpan(time));
             }
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         #endregion Read
@@ -139,6 +145,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         public override int ValidateAndGetLength(DateTime value, NpgsqlParameter? parameter) => 8;
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         public override int ValidateAndGetLength(NpgsqlDateTime value, NpgsqlParameter? parameter) => 8;
 
@@ -170,6 +177,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
                 buf.WriteInt64(-(uSecsDate - uSecsTime));
             }
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -53,9 +53,11 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
             => base.Read(buf, len, fieldDescription).ToLocalTime();
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         protected override NpgsqlDateTime ReadPsv(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => base.ReadPsv(buf, len, fieldDescription).ToLocalTime();
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         DateTimeOffset INpgsqlSimpleTypeHandler<DateTimeOffset>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
@@ -88,6 +90,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
         public int ValidateAndGetLength(DateTimeOffset value, NpgsqlParameter? parameter) => 8;
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         /// <inheritdoc />
         public override void Write(NpgsqlDateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
         {
@@ -105,6 +108,7 @@ namespace Npgsql.TypeHandlers.DateTimeHandlers
 
             base.Write(value, buf, parameter);
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -11,8 +11,8 @@ namespace Npgsql.TypeHandling
     /// <summary>
     /// A simple type handler that supports a provider-specific value in addition to its default value.
     /// This is necessary mainly in cases where the CLR type cannot represent the full range of the
-    /// PostgreSQL type, and a custom CLR type is needed (e.g. <see cref="DateTime"/> and
-    /// <see cref="NpgsqlDateTime"/>). The provider-specific type <typeparamref name="TPsv"/> will be returned
+    /// PostgreSQL type, and a custom CLR type is needed.
+    /// The provider-specific type <typeparamref name="TPsv"/> will be returned
     /// from calls to <see cref="DbDataReader.GetProviderSpecificValue"/>.
     /// </summary>
     /// <typeparam name="TDefault">

--- a/test/Npgsql.PluginTests/NodaTimeTests.cs
+++ b/test/Npgsql.PluginTests/NodaTimeTests.cs
@@ -78,7 +78,9 @@ namespace Npgsql.PluginTests
                         Assert.That(() => reader.GetFieldValue<ZonedDateTime>(i), Throws.TypeOf<InvalidCastException>());
                         Assert.That(() => reader.GetDateTime(i), Is.EqualTo(localDateTime.ToDateTimeUnspecified()));
                         Assert.That(() => reader.GetFieldValue<DateTime>(i), Is.EqualTo(localDateTime.ToDateTimeUnspecified()));
+#if LegacyProviderSpecificDateTimeTypes
                         Assert.That(() => reader.GetDate(i), Throws.TypeOf<InvalidCastException>());
+#endif // LegacyProviderSpecificDateTimeTypes
                     }
                 }
             }
@@ -179,7 +181,9 @@ namespace Npgsql.PluginTests
                         Assert.That(reader.GetFieldValue<DateTimeOffset>(i), Is.EqualTo(dateTimeOffset));
                         Assert.That(() => reader.GetFieldValue<LocalDateTime>(i), Throws.TypeOf<InvalidCastException>());
                         Assert.That(() => reader.GetDateTime(i), Throws.TypeOf<InvalidCastException>());
+#if LegacyProviderSpecificDateTimeTypes
                         Assert.That(() => reader.GetDate(i), Throws.TypeOf<InvalidCastException>());
+#endif // LegacyProviderSpecificDateTimeTypes
                     }
                 }
             }
@@ -230,6 +234,9 @@ namespace Npgsql.PluginTests
                     Assert.That(reader.GetValue(0), Is.EqualTo(localDate));
                     Assert.That(() => reader.GetDateTime(0), Is.EqualTo(dateTime));
                     Assert.That(() => reader.GetDate(0), Is.EqualTo(new NpgsqlDate(localDate.Year, localDate.Month, localDate.Day)));
+#if LegacyProviderSpecificDateTimeTypes
+                    Assert.That(() => reader.GetDate(0), Throws.TypeOf<InvalidCastException>());
+#endif // LegacyProviderSpecificDateTimeTypes
                     Assert.That(reader.GetFieldValue<LocalDate>(2), Is.EqualTo(new LocalDate(-5, 3, 3)));
                     Assert.That(reader.GetFieldValue<DateTime>(3), Is.EqualTo(dateTime));
                     Assert.That(reader.GetDateTime(4), Is.EqualTo(dateTime));

--- a/test/Npgsql.PluginTests/NodaTimeTests.cs
+++ b/test/Npgsql.PluginTests/NodaTimeTests.cs
@@ -233,9 +233,10 @@ namespace Npgsql.PluginTests
                     Assert.That(reader.GetFieldValue<LocalDate>(0), Is.EqualTo(localDate));
                     Assert.That(reader.GetValue(0), Is.EqualTo(localDate));
                     Assert.That(() => reader.GetDateTime(0), Is.EqualTo(dateTime));
-                    Assert.That(() => reader.GetDate(0), Is.EqualTo(new NpgsqlDate(localDate.Year, localDate.Month, localDate.Day)));
 #if LegacyProviderSpecificDateTimeTypes
-                    Assert.That(() => reader.GetDate(0), Throws.TypeOf<InvalidCastException>());
+#pragma warning disable 618
+                    Assert.That(() => reader.GetDate(0), Is.EqualTo(new NpgsqlDate(localDate.Year, localDate.Month, localDate.Day)));
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
                     Assert.That(reader.GetFieldValue<LocalDate>(2), Is.EqualTo(new LocalDate(-5, 3, 3)));
                     Assert.That(reader.GetFieldValue<DateTime>(3), Is.EqualTo(dateTime));

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -558,7 +558,9 @@ INSERT INTO {table} (name) VALUES ('Text with '' single quote');");
                 var values = new object[4];
                 Assert.That(dr.GetProviderSpecificValues(values), Is.EqualTo(3));
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
                     Assert.That(values, Is.EqualTo(new object?[] { "hello", 1, new NpgsqlDate(2014, 1, 1), null }));
+#pragma warning restore 618
 #else
                 Assert.That(values, Is.EqualTo(new object?[] { "hello", 1, new DateTime(2014, 1, 1), null }));
 #endif // LegacyProviderSpecificDateTimeTypes

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -326,15 +326,19 @@ namespace Npgsql.Tests.Types
             using var cmd = new NpgsqlCommand(@"SELECT '{ ""2014-01-04"", ""2014-01-08"" }'::DATE[]", conn);
             var expectedRegular = new[] { new DateTime(2014, 1, 4), new DateTime(2014, 1, 8) };
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var expectedPsv = new[] { new NpgsqlDate(2014, 1, 4), new NpgsqlDate(2014, 1, 8) };
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
             await using var reader = await cmd.ExecuteReaderAsync();
             reader.Read();
             Assert.That(reader.GetValue(0), Is.EqualTo(expectedRegular));
             Assert.That(reader.GetFieldValue<DateTime[]>(0), Is.EqualTo(expectedRegular));
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedPsv));
             Assert.That(reader.GetFieldValue<NpgsqlDate[]>(0), Is.EqualTo(expectedPsv));
+#pragma warning restore 618
 #else
             Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedRegular));
 #endif // LegacyProviderSpecificDateTimeTypes

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -23,7 +23,9 @@ namespace Npgsql.Tests.Types
             await using var conn = await OpenConnectionAsync();
             var dateTime = new DateTime(2002, 3, 4, 0, 0, 0, 0, DateTimeKind.Unspecified);
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var npgsqlDate = new NpgsqlDate(dateTime);
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
             using var cmd = new NpgsqlCommand("SELECT @p1::date, @p2::date", conn);
@@ -55,10 +57,12 @@ namespace Npgsql.Tests.Types
 
                 // Provider-specific type (NpgsqlDate)
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
                 Assert.That(reader.GetDate(i), Is.EqualTo(npgsqlDate));
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDate)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDate));
                 Assert.That(reader.GetFieldValue<NpgsqlDate>(i), Is.EqualTo(npgsqlDate));
+#pragma warning restore 618
 #else
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTime));
@@ -81,11 +85,13 @@ namespace Npgsql.Tests.Types
             await using var reader = await cmd.ExecuteReaderAsync();
             reader.Read();
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var npgsqlDate = NpgsqlDate.Parse(value);
             Assert.That(reader.GetDate(0), Is.EqualTo(npgsqlDate));
             Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(NpgsqlDate)));
             Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(npgsqlDate));
             Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(npgsqlDate));
+#pragma warning restore 618
 #else
             Assert.That(() => reader.GetProviderSpecificValue(0), Throws.Exception.TypeOf<InvalidCastException>());
             Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
@@ -103,8 +109,10 @@ namespace Npgsql.Tests.Types
             await using var reader = await cmd.ExecuteReaderAsync();
             reader.Read();
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(NpgsqlDate.Infinity));
             Assert.That(reader.GetFieldValue<NpgsqlDate>(1), Is.EqualTo(NpgsqlDate.NegativeInfinity));
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
             Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
             Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
@@ -220,7 +228,9 @@ namespace Npgsql.Tests.Types
         {
             await using var conn = await OpenConnectionAsync();
 #if LegacyProviderSpecificDateTimeTypes
-                var npgsqlDateTime = new NpgsqlDateTime(dateTime.Ticks);
+#pragma warning disable 618
+            var npgsqlDateTime = new NpgsqlDateTime(dateTime.Ticks);
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
             using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6::timestamp", conn);
@@ -265,10 +275,12 @@ namespace Npgsql.Tests.Types
 
                 // Provider-specific type (NpgsqlTimeStamp)
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
                 Assert.That(reader.GetTimeStamp(i), Is.EqualTo(npgsqlDateTime));
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDateTime));
                 Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(npgsqlDateTime));
+#pragma warning restore 618
 #else
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTime));
@@ -290,9 +302,11 @@ namespace Npgsql.Tests.Types
         {
             await using var conn = await OpenConnectionAsync();
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var npgsqlDateTime = NpgsqlDateTime.Parse(value);
             using var cmd = new NpgsqlCommand("SELECT @p", conn);
             cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = npgsqlDateTime });
+#pragma warning restore 618
 #else
             using var cmd = new NpgsqlCommand("SELECT @p::timestamp", conn);
             cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
@@ -319,8 +333,10 @@ namespace Npgsql.Tests.Types
             await using var reader = await cmd.ExecuteReaderAsync();
             reader.Read();
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             Assert.That(reader.GetFieldValue<NpgsqlDateTime>(0), Is.EqualTo(NpgsqlDateTime.Infinity));
             Assert.That(reader.GetFieldValue<NpgsqlDateTime>(1), Is.EqualTo(NpgsqlDateTime.NegativeInfinity));
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
             Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
             Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
@@ -343,6 +359,7 @@ namespace Npgsql.Tests.Types
             var dateTimeUnspecified = new DateTime(dateTimeUtc.Ticks, DateTimeKind.Unspecified);
 
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var nDateTimeUtc = new NpgsqlDateTime(dateTimeUtc);
             var nDateTimeLocal = nDateTimeUtc.ToLocalTime();
             var nDateTimeUnspecified = new NpgsqlDateTime(nDateTimeUtc.Ticks, DateTimeKind.Unspecified);
@@ -350,6 +367,7 @@ namespace Npgsql.Tests.Types
             Assert.AreEqual(nDateTimeUtc, nDateTimeLocal.ToUniversalTime());
             Assert.AreEqual(nDateTimeUtc, new NpgsqlDateTime(nDateTimeLocal.Ticks, DateTimeKind.Unspecified).ToUniversalTime());
             Assert.AreEqual(nDateTimeLocal, nDateTimeUnspecified.ToLocalTime());
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
             var dateTimeOffset = new DateTimeOffset(dateTimeLocal);
@@ -383,10 +401,12 @@ namespace Npgsql.Tests.Types
 
                 // Provider-specific type (NpgsqlDateTime)
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
                 Assert.That(reader.GetTimeStamp(i), Is.EqualTo(nDateTimeLocal));
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(nDateTimeLocal));
                 Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(nDateTimeLocal));
+#pragma warning restore 618
 #else
                 Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
                 Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTimeLocal));
@@ -409,7 +429,9 @@ namespace Npgsql.Tests.Types
             await using var conn = await OpenConnectionAsync();
             var expectedTimeSpan = new TimeSpan(1, 2, 3, 4, 5);
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             var expectedNpgsqlInterval = new NpgsqlTimeSpan(1, 2, 3, 4, 5);
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
             using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
@@ -444,10 +466,12 @@ namespace Npgsql.Tests.Types
 
             // Provider-specific type (NpgsqlInterval)
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
             Assert.That(reader.GetInterval(0), Is.EqualTo(expectedNpgsqlInterval));
             Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(NpgsqlTimeSpan)));
             Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedNpgsqlInterval));
             Assert.That(reader.GetFieldValue<NpgsqlTimeSpan>(0), Is.EqualTo(expectedNpgsqlInterval));
+#pragma warning restore 618
 #else
             Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(TimeSpan)));
             Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedTimeSpan));

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -20,83 +20,94 @@ namespace Npgsql.Tests.Types
         [Test]
         public async Task Date()
         {
-            using (var conn = await OpenConnectionAsync())
+            await using var conn = await OpenConnectionAsync();
+            var dateTime = new DateTime(2002, 3, 4, 0, 0, 0, 0, DateTimeKind.Unspecified);
+#if LegacyProviderSpecificDateTimeTypes
+            var npgsqlDate = new NpgsqlDate(dateTime);
+#endif // LegacyProviderSpecificDateTimeTypes
+
+            using var cmd = new NpgsqlCommand("SELECT @p1::date, @p2::date", conn);
+#if LegacyProviderSpecificDateTimeTypes
+            cmd.CommandText += ", @p3";
+#endif // LegacyProviderSpecificDateTimeTypes
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Text) {Value = dateTime.ToString("yyyy-MM-dd")};
+            cmd.Parameters.Add(p1);
+            //Assert.That(p1.DbType, Is.EqualTo(DbType.Date));
+            var p2 = new NpgsqlParameter("p2", NpgsqlDbType.Text) {Value = dateTime.ToString("yyyy-MM-dd")};
+            cmd.Parameters.Add(p2);
+#if LegacyProviderSpecificDateTimeTypes
+            var p3 = new NpgsqlParameter {ParameterName = "p3", Value = npgsqlDate};
+            Assert.That(p3.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Date));
+            Assert.That(p3.DbType, Is.EqualTo(DbType.Date));
+            cmd.Parameters.Add(p3);
+#endif // LegacyProviderSpecificDateTimeTypes
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+
+            for (var i = 0; i < cmd.Parameters.Count; i++)
             {
-                var dateTime = new DateTime(2002, 3, 4, 0, 0, 0, 0, DateTimeKind.Unspecified);
-                var npgsqlDate = new NpgsqlDate(dateTime);
+                // Regular type (DateTime)
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTime));
+                Assert.That(reader.GetFieldValue<DateTime>(i), Is.EqualTo(dateTime));
+                Assert.That(reader[i], Is.EqualTo(dateTime));
+                Assert.That(reader.GetValue(i), Is.EqualTo(dateTime));
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
-                {
-                    var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Date) {Value = npgsqlDate};
-                    var p2 = new NpgsqlParameter {ParameterName = "p2", Value = npgsqlDate};
-                    Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Date));
-                    Assert.That(p2.DbType, Is.EqualTo(DbType.Date));
-                    cmd.Parameters.Add(p1);
-                    cmd.Parameters.Add(p2);
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        reader.Read();
-
-                        for (var i = 0; i < cmd.Parameters.Count; i++)
-                        {
-                            // Regular type (DateTime)
-                            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
-                            Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTime));
-                            Assert.That(reader.GetFieldValue<DateTime>(i), Is.EqualTo(dateTime));
-                            Assert.That(reader[i], Is.EqualTo(dateTime));
-                            Assert.That(reader.GetValue(i), Is.EqualTo(dateTime));
-
-                            // Provider-specific type (NpgsqlDate)
-                            Assert.That(reader.GetDate(i), Is.EqualTo(npgsqlDate));
-                            Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDate)));
-                            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDate));
-                            Assert.That(reader.GetFieldValue<NpgsqlDate>(i), Is.EqualTo(npgsqlDate));
-                        }
-                    }
-                }
+                // Provider-specific type (NpgsqlDate)
+#if LegacyProviderSpecificDateTimeTypes
+                Assert.That(reader.GetDate(i), Is.EqualTo(npgsqlDate));
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDate)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDate));
+                Assert.That(reader.GetFieldValue<NpgsqlDate>(i), Is.EqualTo(npgsqlDate));
+#else
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTime));
+#endif // LegacyProviderSpecificDateTimeTypes
             }
         }
 
         static readonly TestCaseData[] DateSpecialCases = {
-            new TestCaseData(NpgsqlDate.Infinity).SetName(nameof(DateSpecial) + "Infinity"),
-            new TestCaseData(NpgsqlDate.NegativeInfinity).SetName(nameof(DateSpecial) + "NegativeInfinity"),
-            new TestCaseData(new NpgsqlDate(-5, 3, 3)).SetName(nameof(DateSpecial) +"BC"),
+            new TestCaseData("-infinity").SetName(nameof(DateSpecial) + "NegativeInfinity"),
+            new TestCaseData("infinity").SetName(nameof(DateSpecial) + "Infinity"),
+            new TestCaseData("0005-03-03 BC").SetName(nameof(DateSpecial) +"BC"),
         };
 
         [Test, TestCaseSource(nameof(DateSpecialCases))]
-        public async Task DateSpecial(NpgsqlDate value)
+        public async Task DateSpecial(string value)
         {
-            using (var conn = await OpenConnectionAsync())
-            using (var cmd = new NpgsqlCommand("SELECT @p", conn)) {
-                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
-                using (var reader = await cmd.ExecuteReaderAsync()) {
-                    reader.Read();
-                    Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(value));
-                    Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
-                }
-                Assert.That(await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
-            }
+            await using var conn = await OpenConnectionAsync();
+            using var cmd = new NpgsqlCommand("SELECT @p::date", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+#if LegacyProviderSpecificDateTimeTypes
+            var npgsqlDate = NpgsqlDate.Parse(value);
+            Assert.That(reader.GetDate(0), Is.EqualTo(npgsqlDate));
+            Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(NpgsqlDate)));
+            Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(npgsqlDate));
+            Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(npgsqlDate));
+#else
+            Assert.That(() => reader.GetProviderSpecificValue(0), Throws.Exception.TypeOf<InvalidCastException>());
+            Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
+#endif // LegacyProviderSpecificDateTimeTypes
         }
 
         [Test, Description("Makes sure that when ConvertInfinityDateTime is true, infinity values are properly converted")]
         public async Task DateConvertInfinity()
         {
-            using (var conn = new NpgsqlConnection(ConnectionString + ";ConvertInfinityDateTime=true"))
-            {
-                conn.Open();
-
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn)) {
-                    cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Date, DateTime.MaxValue);
-                    cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Date, DateTime.MinValue);
-                    using (var reader = await cmd.ExecuteReaderAsync()) {
-                        reader.Read();
-                        Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(NpgsqlDate.Infinity));
-                        Assert.That(reader.GetFieldValue<NpgsqlDate>(1), Is.EqualTo(NpgsqlDate.NegativeInfinity));
-                        Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
-                        Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
-                    }
-                }
-            }
+            await using var conn = await OpenConnectionAsync(new NpgsqlConnectionStringBuilder(ConnectionString)
+                { ConvertInfinityDateTime = true });
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
+            cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Date, DateTime.MaxValue);
+            cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Date, DateTime.MinValue);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+#if LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetFieldValue<NpgsqlDate>(0), Is.EqualTo(NpgsqlDate.Infinity));
+            Assert.That(reader.GetFieldValue<NpgsqlDate>(1), Is.EqualTo(NpgsqlDate.NegativeInfinity));
+#endif // LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
+            Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
         }
 
         #endregion
@@ -197,107 +208,122 @@ namespace Npgsql.Tests.Types
         #region Timestamp
 
         static readonly TestCaseData[] TimeStampCases = {
+            new TestCaseData(DateTime.MinValue).SetName(nameof(Timestamp) + "DateTime.MinValue"),
             new TestCaseData(new DateTime(1998, 4, 12, 13, 26, 38)).SetName(nameof(Timestamp) + "Pre2000"),
             new TestCaseData(new DateTime(2015, 1, 27, 8, 45, 12, 345)).SetName(nameof(Timestamp) + "Post2000"),
             new TestCaseData(new DateTime(2013, 7, 25)).SetName(nameof(Timestamp) + "DateOnly"),
+            new TestCaseData(new DateTime(DateTime.MaxValue.Ticks - 9)).SetName(nameof(Timestamp) + "DateTime.MaxValue (rounded)"),
         };
 
         [Test, TestCaseSource(nameof(TimeStampCases))]
         public async Task Timestamp(DateTime dateTime)
         {
-            using (var conn = await OpenConnectionAsync())
-            {
+            await using var conn = await OpenConnectionAsync();
+#if LegacyProviderSpecificDateTimeTypes
                 var npgsqlDateTime = new NpgsqlDateTime(dateTime.Ticks);
+#endif // LegacyProviderSpecificDateTimeTypes
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6", conn))
-                {
-                    var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Timestamp);
-                    var p2 = new NpgsqlParameter("p2", DbType.DateTime);
-                    var p3 = new NpgsqlParameter("p3", DbType.DateTime2);
-                    var p4 = new NpgsqlParameter { ParameterName = "p4", Value = npgsqlDateTime };
-                    var p5 = new NpgsqlParameter { ParameterName = "p5", Value = dateTime };
-                    var p6 = new NpgsqlParameter<DateTime> { ParameterName = "p6", TypedValue = dateTime };
-                    Assert.That(p4.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
-                    Assert.That(p4.DbType, Is.EqualTo(DbType.DateTime));
-                    Assert.That(p5.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
-                    Assert.That(p5.DbType, Is.EqualTo(DbType.DateTime));
-                    cmd.Parameters.Add(p1);
-                    cmd.Parameters.Add(p2);
-                    cmd.Parameters.Add(p3);
-                    cmd.Parameters.Add(p4);
-                    cmd.Parameters.Add(p5);
-                    cmd.Parameters.Add(p6);
-                    p1.Value = p2.Value = p3.Value = npgsqlDateTime;
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        reader.Read();
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6::timestamp", conn);
+#if LegacyProviderSpecificDateTimeTypes
+            cmd.CommandText += ", @p7";
+#endif // LegacyProviderSpecificDateTimeTypes
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Timestamp);
+            var p2 = new NpgsqlParameter("p2", DbType.DateTime);
+            var p3 = new NpgsqlParameter("p3", DbType.DateTime2);
+            var p4 = new NpgsqlParameter { ParameterName = "p4", Value = dateTime };
+            Assert.That(p4.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
+            Assert.That(p4.DbType, Is.EqualTo(DbType.DateTime));
+            var p5 = new NpgsqlParameter<DateTime> { ParameterName = "p5", TypedValue = dateTime };
+            var p6 = new NpgsqlParameter("p6", NpgsqlDbType.Text){Value = dateTime.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFF")};
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            cmd.Parameters.Add(p3);
+            cmd.Parameters.Add(p4);
+            cmd.Parameters.Add(p5);
+            cmd.Parameters.Add(p6);
+#if LegacyProviderSpecificDateTimeTypes
+            var p7 = new NpgsqlParameter { ParameterName = "p7", Value = npgsqlDateTime };
+            Assert.That(p7.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Timestamp));
+            Assert.That(p7.DbType, Is.EqualTo(DbType.DateTime));
+            cmd.Parameters.Add(p7);
+            p1.Value = p2.Value = p3.Value = npgsqlDateTime;
+#else
+            p1.Value = p2.Value = p3.Value = dateTime;
+#endif // LegacyProviderSpecificDateTimeTypes
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
 
-                        for (var i = 0; i < cmd.Parameters.Count; i++)
-                        {
-                            // Regular type (DateTime)
-                            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
-                            Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTime));
-                            Assert.That(reader.GetDateTime(i).Kind, Is.EqualTo(DateTimeKind.Unspecified));
-                            Assert.That(reader.GetFieldValue<DateTime>(i), Is.EqualTo(dateTime));
-                            Assert.That(reader[i], Is.EqualTo(dateTime));
-                            Assert.That(reader.GetValue(i), Is.EqualTo(dateTime));
+            for (var i = 0; i < cmd.Parameters.Count; i++)
+            {
+                // Regular type (DateTime)
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTime));
+                Assert.That(reader.GetDateTime(i).Kind, Is.EqualTo(DateTimeKind.Unspecified));
+                Assert.That(reader.GetFieldValue<DateTime>(i), Is.EqualTo(dateTime));
+                Assert.That(reader[i], Is.EqualTo(dateTime));
+                Assert.That(reader.GetValue(i), Is.EqualTo(dateTime));
 
-                            // Provider-specific type (NpgsqlTimeStamp)
-                            Assert.That(reader.GetTimeStamp(i), Is.EqualTo(npgsqlDateTime));
-                            Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
-                            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDateTime));
-                            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(npgsqlDateTime));
+                // Provider-specific type (NpgsqlTimeStamp)
+#if LegacyProviderSpecificDateTimeTypes
+                Assert.That(reader.GetTimeStamp(i), Is.EqualTo(npgsqlDateTime));
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(npgsqlDateTime));
+                Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(npgsqlDateTime));
+#else
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTime));
+#endif // LegacyProviderSpecificDateTimeTypes
 
-                            // DateTimeOffset
-                            Assert.That(() => reader.GetFieldValue<DateTimeOffset>(i), Throws.Exception.TypeOf<InvalidCastException>());
-                        }
-                    }
-                }
+                // DateTimeOffset
+                Assert.That(() => reader.GetFieldValue<DateTimeOffset>(i), Throws.Exception.TypeOf<InvalidCastException>());
             }
         }
 
         static readonly TestCaseData[] TimeStampSpecialCases = {
-            new TestCaseData(NpgsqlDateTime.Infinity).SetName(nameof(TimeStampSpecial) + "Infinity"),
-            new TestCaseData(NpgsqlDateTime.NegativeInfinity).SetName(nameof(TimeStampSpecial) + "NegativeInfinity"),
-            new TestCaseData(new NpgsqlDateTime(-5, 3, 3, 1, 0, 0)).SetName(nameof(TimeStampSpecial) + "BC"),
+            new TestCaseData("-infinity").SetName(nameof(TimeStampSpecial) + "NegativeInfinity"),
+            new TestCaseData("infinity").SetName(nameof(TimeStampSpecial) + "Infinity"),
+            new TestCaseData("0005-03-03 01:00:00 BC").SetName(nameof(TimeStampSpecial) +"BC"),
         };
 
         [Test, TestCaseSource(nameof(TimeStampSpecialCases))]
-        public async Task TimeStampSpecial(NpgsqlDateTime value)
+        public async Task TimeStampSpecial(string value)
         {
-            using (var conn = await OpenConnectionAsync())
-            using (var cmd = new NpgsqlCommand("SELECT @p", conn)) {
-                cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
-                using (var reader = await cmd.ExecuteReaderAsync()) {
-                    reader.Read();
-                    Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(value));
-                    Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
-                }
-                Assert.That(await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
-            }
+            await using var conn = await OpenConnectionAsync();
+#if LegacyProviderSpecificDateTimeTypes
+            var npgsqlDateTime = NpgsqlDateTime.Parse(value);
+            using var cmd = new NpgsqlCommand("SELECT @p", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = npgsqlDateTime });
+#else
+            using var cmd = new NpgsqlCommand("SELECT @p::timestamp", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = value });
+#endif // LegacyProviderSpecificDateTimeTypes
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+#if LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(npgsqlDateTime));
+            Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
+#else
+            Assert.That(() => reader.GetProviderSpecificValue(0), Throws.Exception.TypeOf<InvalidCastException>());
+            Assert.That(() => reader.GetDateTime(0), Throws.Exception.TypeOf<InvalidCastException>());
+#endif // LegacyProviderSpecificDateTimeTypes
         }
 
         [Test, Description("Makes sure that when ConvertInfinityDateTime is true, infinity values are properly converted")]
         public async Task TimeStampConvertInfinity()
         {
-            using (var conn = new NpgsqlConnection(ConnectionString + ";ConvertInfinityDateTime=true"))
-            {
-                conn.Open();
-
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn))
-                {
-                    cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Timestamp, DateTime.MaxValue);
-                    cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Timestamp, DateTime.MinValue);
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        reader.Read();
-                        Assert.That(reader.GetFieldValue<NpgsqlDateTime>(0), Is.EqualTo(NpgsqlDateTime.Infinity));
-                        Assert.That(reader.GetFieldValue<NpgsqlDateTime>(1), Is.EqualTo(NpgsqlDateTime.NegativeInfinity));
-                        Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
-                        Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
-                    }
-                }
-            }
+            await using var conn = await OpenConnectionAsync(new NpgsqlConnectionStringBuilder(ConnectionString)
+                { ConvertInfinityDateTime = true });
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
+            cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Timestamp, DateTime.MaxValue);
+            cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Timestamp, DateTime.MinValue);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+#if LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(0), Is.EqualTo(NpgsqlDateTime.Infinity));
+            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(1), Is.EqualTo(NpgsqlDateTime.NegativeInfinity));
+#endif // LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetDateTime(0), Is.EqualTo(DateTime.MaxValue));
+            Assert.That(reader.GetDateTime(1), Is.EqualTo(DateTime.MinValue));
         }
 
         #endregion
@@ -307,64 +333,70 @@ namespace Npgsql.Tests.Types
         [Test]
         public async Task TimestampTz()
         {
-            using (var conn = await OpenConnectionAsync())
+            await using var conn = await OpenConnectionAsync();
+            var tzOffset = TimeZoneInfo.Local.BaseUtcOffset;
+            if (tzOffset == TimeSpan.Zero)
+                Assert.Ignore("Test cannot run when machine timezone is UTC");
+
+            var dateTimeUtc = new DateTime(2015, 6, 27, 8, 45, 12, 345, DateTimeKind.Utc);
+            var dateTimeLocal = dateTimeUtc.ToLocalTime();
+            var dateTimeUnspecified = new DateTime(dateTimeUtc.Ticks, DateTimeKind.Unspecified);
+
+#if LegacyProviderSpecificDateTimeTypes
+            var nDateTimeUtc = new NpgsqlDateTime(dateTimeUtc);
+            var nDateTimeLocal = nDateTimeUtc.ToLocalTime();
+            var nDateTimeUnspecified = new NpgsqlDateTime(nDateTimeUtc.Ticks, DateTimeKind.Unspecified);
+
+            Assert.AreEqual(nDateTimeUtc, nDateTimeLocal.ToUniversalTime());
+            Assert.AreEqual(nDateTimeUtc, new NpgsqlDateTime(nDateTimeLocal.Ticks, DateTimeKind.Unspecified).ToUniversalTime());
+            Assert.AreEqual(nDateTimeLocal, nDateTimeUnspecified.ToLocalTime());
+#endif // LegacyProviderSpecificDateTimeTypes
+
+            var dateTimeOffset = new DateTimeOffset(dateTimeLocal);
+
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn);
+#if LegacyProviderSpecificDateTimeTypes
+            cmd.CommandText += ", @p5, @p6, @p7";
+#endif // LegacyProviderSpecificDateTimeTypes
+            cmd.Parameters.AddWithValue("p1", NpgsqlDbType.TimestampTz, dateTimeUtc);
+            cmd.Parameters.AddWithValue("p2", NpgsqlDbType.TimestampTz, dateTimeLocal);
+            cmd.Parameters.AddWithValue("p3", NpgsqlDbType.TimestampTz, dateTimeUnspecified);
+            cmd.Parameters.AddWithValue("p4", dateTimeOffset);
+            Assert.That(cmd.Parameters["p4"].NpgsqlDbType, Is.EqualTo(NpgsqlDbType.TimestampTz));
+#if LegacyProviderSpecificDateTimeTypes
+            cmd.Parameters.AddWithValue("p5", NpgsqlDbType.TimestampTz, nDateTimeUtc);
+            cmd.Parameters.AddWithValue("p6", NpgsqlDbType.TimestampTz, nDateTimeLocal);
+            cmd.Parameters.AddWithValue("p7", NpgsqlDbType.TimestampTz, nDateTimeUnspecified);
+#endif // LegacyProviderSpecificDateTimeTypes
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+
+            for (var i = 0; i < cmd.Parameters.Count; i++)
             {
-                var tzOffset = TimeZoneInfo.Local.BaseUtcOffset;
-                if (tzOffset == TimeSpan.Zero)
-                    Assert.Ignore("Test cannot run when machine timezone is UTC");
+                // Regular type (DateTime)
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTimeLocal));
+                Assert.That(reader.GetFieldValue<DateTime>(i).Kind, Is.EqualTo(DateTimeKind.Local));
+                Assert.That(reader[i], Is.EqualTo(dateTimeLocal));
+                Assert.That(reader.GetValue(i), Is.EqualTo(dateTimeLocal));
 
-                var dateTimeUtc = new DateTime(2015, 6, 27, 8, 45, 12, 345, DateTimeKind.Utc);
-                var dateTimeLocal = dateTimeUtc.ToLocalTime();
-                var dateTimeUnspecified = new DateTime(dateTimeUtc.Ticks, DateTimeKind.Unspecified);
+                // Provider-specific type (NpgsqlDateTime)
+#if LegacyProviderSpecificDateTimeTypes
+                Assert.That(reader.GetTimeStamp(i), Is.EqualTo(nDateTimeLocal));
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(nDateTimeLocal));
+                Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(nDateTimeLocal));
+#else
+                Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(DateTime)));
+                Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(dateTimeLocal));
+#endif // LegacyProviderSpecificDateTimeTypes
 
-                var nDateTimeUtc = new NpgsqlDateTime(dateTimeUtc);
-                var nDateTimeLocal = nDateTimeUtc.ToLocalTime();
-                var nDateTimeUnspecified = new NpgsqlDateTime(nDateTimeUtc.Ticks, DateTimeKind.Unspecified);
-
-                //var dateTimeOffset = new DateTimeOffset(dateTimeLocal, dateTimeLocal - dateTimeUtc);
-                var dateTimeOffset = new DateTimeOffset(dateTimeLocal);
-
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4, @p5, @p6, @p7", conn))
-                {
-                    cmd.Parameters.AddWithValue("p1", NpgsqlDbType.TimestampTz, dateTimeUtc);
-                    cmd.Parameters.AddWithValue("p2", NpgsqlDbType.TimestampTz, dateTimeLocal);
-                    cmd.Parameters.AddWithValue("p3", NpgsqlDbType.TimestampTz, dateTimeUnspecified);
-                    cmd.Parameters.AddWithValue("p4", NpgsqlDbType.TimestampTz, nDateTimeUtc);
-                    cmd.Parameters.AddWithValue("p5", NpgsqlDbType.TimestampTz, nDateTimeLocal);
-                    cmd.Parameters.AddWithValue("p6", NpgsqlDbType.TimestampTz, nDateTimeUnspecified);
-                    cmd.Parameters.AddWithValue("p7", dateTimeOffset);
-                    Assert.That(cmd.Parameters["p7"].NpgsqlDbType, Is.EqualTo(NpgsqlDbType.TimestampTz));
-
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        reader.Read();
-
-                        for (var i = 0; i < cmd.Parameters.Count; i++)
-                        {
-                            // Regular type (DateTime)
-                            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(DateTime)));
-                            Assert.That(reader.GetDateTime(i), Is.EqualTo(dateTimeLocal));
-                            Assert.That(reader.GetFieldValue<DateTime>(i).Kind, Is.EqualTo(DateTimeKind.Local));
-                            Assert.That(reader[i], Is.EqualTo(dateTimeLocal));
-                            Assert.That(reader.GetValue(i), Is.EqualTo(dateTimeLocal));
-
-                            // Provider-specific type (NpgsqlDateTime)
-                            Assert.That(reader.GetTimeStamp(i), Is.EqualTo(nDateTimeLocal));
-                            Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(NpgsqlDateTime)));
-                            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(nDateTimeLocal));
-                            Assert.That(reader.GetFieldValue<NpgsqlDateTime>(i), Is.EqualTo(nDateTimeLocal));
-
-                            // DateTimeOffset
-                            Assert.That(reader.GetFieldValue<DateTimeOffset>(i), Is.EqualTo(dateTimeOffset));
-                            var x = reader.GetFieldValue<DateTimeOffset>(i);
-                        }
-                    }
-                }
-
-                Assert.AreEqual(nDateTimeUtc, nDateTimeLocal.ToUniversalTime());
-                Assert.AreEqual(nDateTimeUtc, new NpgsqlDateTime(nDateTimeLocal.Ticks, DateTimeKind.Unspecified).ToUniversalTime());
-                Assert.AreEqual(nDateTimeLocal, nDateTimeUnspecified.ToLocalTime());
+                // DateTimeOffset
+                Assert.That(reader.GetFieldValue<DateTimeOffset>(i), Is.EqualTo(dateTimeOffset));
+                var x = reader.GetFieldValue<DateTimeOffset>(i);
             }
+
         }
 
         #endregion
@@ -374,44 +406,52 @@ namespace Npgsql.Tests.Types
         [Test]
         public async Task Interval()
         {
-            using (var conn = await OpenConnectionAsync())
-            {
-                var expectedNpgsqlInterval = new NpgsqlTimeSpan(1, 2, 3, 4, 5);
-                var expectedTimeSpan = new TimeSpan(1, 2, 3, 4, 5);
+            await using var conn = await OpenConnectionAsync();
+            var expectedTimeSpan = new TimeSpan(1, 2, 3, 4, 5);
+#if LegacyProviderSpecificDateTimeTypes
+            var expectedNpgsqlInterval = new NpgsqlTimeSpan(1, 2, 3, 4, 5);
+#endif // LegacyProviderSpecificDateTimeTypes
 
-                using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn))
-                {
-                    var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Interval);
-                    var p2 = new NpgsqlParameter("p2", expectedTimeSpan);
-                    var p3 = new NpgsqlParameter("p3", expectedNpgsqlInterval);
-                    Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Interval));
-                    Assert.That(p2.DbType, Is.EqualTo(DbType.Object));
-                    Assert.That(p3.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Interval));
-                    Assert.That(p3.DbType, Is.EqualTo(DbType.Object));
-                    cmd.Parameters.Add(p1);
-                    cmd.Parameters.Add(p2);
-                    cmd.Parameters.Add(p3);
-                    p1.Value = expectedNpgsqlInterval;
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
+#if LegacyProviderSpecificDateTimeTypes
+            cmd.CommandText += ", @p3";
+#endif // LegacyProviderSpecificDateTimeTypes
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Interval);
+            var p2 = new NpgsqlParameter("p2", expectedTimeSpan);
+            Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Interval));
+            Assert.That(p2.DbType, Is.EqualTo(DbType.Object));
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+#if LegacyProviderSpecificDateTimeTypes
+            var p3 = new NpgsqlParameter("p3", expectedNpgsqlInterval);
+            Assert.That(p3.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Interval));
+            Assert.That(p3.DbType, Is.EqualTo(DbType.Object));
+            cmd.Parameters.Add(p3);
+            p1.Value = expectedNpgsqlInterval;
+#else
+            p1.Value = expectedTimeSpan;
+#endif // LegacyProviderSpecificDateTimeTypes
 
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        reader.Read();
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
 
-                        // Regular type (TimeSpan)
-                        Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(TimeSpan)));
-                        Assert.That(reader.GetTimeSpan(0), Is.EqualTo(expectedTimeSpan));
-                        Assert.That(reader.GetFieldValue<TimeSpan>(0), Is.EqualTo(expectedTimeSpan));
-                        Assert.That(reader[0], Is.EqualTo(expectedTimeSpan));
-                        Assert.That(reader.GetValue(0), Is.EqualTo(expectedTimeSpan));
+            // Regular type (TimeSpan)
+            Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(TimeSpan)));
+            Assert.That(reader.GetTimeSpan(0), Is.EqualTo(expectedTimeSpan));
+            Assert.That(reader.GetFieldValue<TimeSpan>(0), Is.EqualTo(expectedTimeSpan));
+            Assert.That(reader[0], Is.EqualTo(expectedTimeSpan));
+            Assert.That(reader.GetValue(0), Is.EqualTo(expectedTimeSpan));
 
-                        // Provider-specific type (NpgsqlInterval)
-                        Assert.That(reader.GetInterval(0), Is.EqualTo(expectedNpgsqlInterval));
-                        Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(NpgsqlTimeSpan)));
-                        Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedNpgsqlInterval));
-                        Assert.That(reader.GetFieldValue<NpgsqlTimeSpan>(0), Is.EqualTo(expectedNpgsqlInterval));
-                    }
-                }
-            }
+            // Provider-specific type (NpgsqlInterval)
+#if LegacyProviderSpecificDateTimeTypes
+            Assert.That(reader.GetInterval(0), Is.EqualTo(expectedNpgsqlInterval));
+            Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(NpgsqlTimeSpan)));
+            Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedNpgsqlInterval));
+            Assert.That(reader.GetFieldValue<NpgsqlTimeSpan>(0), Is.EqualTo(expectedNpgsqlInterval));
+#else
+            Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(TimeSpan)));
+            Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expectedTimeSpan));
+#endif // LegacyProviderSpecificDateTimeTypes
         }
 
         #endregion

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -14,6 +14,7 @@ namespace Npgsql.Tests
     public class TypesTests
     {
 #if LegacyProviderSpecificDateTimeTypes
+#pragma warning disable 618
         [Test]
         public void NpgsqlIntervalParse()
         {
@@ -400,6 +401,7 @@ namespace Npgsql.Tests
             Assert.That(new NpgsqlDateTime(2020, 2, 1, 0, 0, 0).AddMonths(1).Add(new NpgsqlTimeSpan(1, 0, 0)),
                 Is.EqualTo(new NpgsqlDateTime(2020, 3, 31, 0, 0, 0)));
         }
+#pragma warning restore 618
 #endif // LegacyProviderSpecificDateTimeTypes
 
         [Test]

--- a/test/Npgsql.Tests/TypesTests.cs
+++ b/test/Npgsql.Tests/TypesTests.cs
@@ -13,6 +13,7 @@ namespace Npgsql.Tests
     [TestFixture]
     public class TypesTests
     {
+#if LegacyProviderSpecificDateTimeTypes
         [Test]
         public void NpgsqlIntervalParse()
         {
@@ -399,6 +400,7 @@ namespace Npgsql.Tests
             Assert.That(new NpgsqlDateTime(2020, 2, 1, 0, 0, 0).AddMonths(1).Add(new NpgsqlTimeSpan(1, 0, 0)),
                 Is.EqualTo(new NpgsqlDateTime(2020, 3, 31, 0, 0, 0)));
         }
+#endif // LegacyProviderSpecificDateTimeTypes
 
         [Test]
         public void TsVector()


### PR DESCRIPTION
This pull request is a more holistic approach to obsolete `NpgsqlDate`, `NpgsqlDateTime` and `NpgsqlTimeSpan` than https://github.com/npgsql/npgsql/pull/2984 which it replaces and continues.

It

- Marks `NpgsqlDate`, `NpgsqlDateTime` and `NpgsqlTimeSpan` with the `Obsolete` attribute pointing users to https://github.com/npgsql/npgsql/issues/3108 which is a new issue for discussing requirements for a possible replacement (see https://github.com/npgsql/npgsql/pull/2984#discussion_r431627808).
- conditionally removes any internal use and external APIs concerning those types by introducing the `LegacyProviderSpecificDateTimeTypes` conditional compilation flag
- removes internal code that passes through `NpgsqlDateTime` as a temporary structure when reading regular `DateTime` values (see https://github.com/npgsql/npgsql/pull/2984#pullrequestreview-419835448)
- takes a more compromised approach regarding the use of `#pragma disabled warning 618`