### PR TITLE
Scram channel binding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,15 @@ jobs:
           export PGDATA=/etc/postgresql/${{ matrix.pg_major }}/main
           sudo sed -i 's/#ssl = off/ssl = on/' $PGDATA/postgresql.conf
           sudo sed -i 's/#max_prepared_transactions = 0/max_prepared_transactions = 10/' $PGDATA/postgresql.conf
+          sudo sed -i 's/#password_encryption = md5/password_encryption = scram-sha-256/' $PGDATA/postgresql.conf
           # Disable trust authentication, requiring MD5 passwords - some tests must fail if a password isn't provided.
           sudo sh -c "echo 'local all all trust' > $PGDATA/pg_hba.conf"
+          sudo sh -c "echo 'host all npgsql_tests_scram all scram-sha-256' >> $PGDATA/pg_hba.conf"
           sudo sh -c "echo 'host all all all md5' >> $PGDATA/pg_hba.conf"
           sudo pg_ctlcluster ${{ matrix.pg_major }} main restart
+          
+          # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
+          sudo -u postgres psql -c "CREATE USER npgsql_tests_scram SUPERUSER PASSWORD 'npgsql_tests_scram'"
 
       - name: Start PostgreSQL ${{ matrix.pg_major }} (Windows)
         if: startsWith(matrix.os, 'windows')
@@ -105,9 +110,17 @@ jobs:
           pgsql/bin/psql -U postgres -c "CREATE EXTENSION postgis" npgsql_tests
           pgsql/bin/psql -U postgres -c "CREATE EXTENSION hstore" npgsql_tests
           pgsql/bin/psql -U postgres -c "CREATE EXTENSION citext" npgsql_tests
+          
+          # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
+          sed -i "s|#password_encryption = md5|password_encryption = scram-sha-256|" pgsql/PGDATA/postgresql.conf
+          
+          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10 -c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' restart
+          
+          pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_scram SUPERUSER LOGIN PASSWORD 'npgsql_tests_scram'"
 
           # Disable trust authentication, requiring MD5 passwords - some tests must fail if a password isn't provided.
-          echo "host all all all md5" > pgsql/PGDATA/pg_hba.conf
+          echo "host all npgsql_tests_scram all scram-sha-256" > pgsql/PGDATA/pg_hba.conf
+          echo "host all all all md5" >> pgsql/PGDATA/pg_hba.conf
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -895,6 +895,16 @@ namespace Npgsql
         internal bool IsSecure => CheckOpenAndRunInTemporaryScope(c => c.IsSecure);
 
         /// <summary>
+        /// Returns whether SCRAM-SHA256 is being user for the connection
+        /// </summary>
+        internal bool IsScram => CheckOpenAndRunInTemporaryScope(c => c.IsScram);
+
+        /// <summary>
+        /// Returns whether SCRAM-SHA256-PLUS is being user for the connection
+        /// </summary>
+        internal bool IsScramPlus => CheckOpenAndRunInTemporaryScope(c => c.IsScramPlus);
+
+        /// <summary>
         /// Selects the local Secure Sockets Layer (SSL) certificate used for authentication.
         /// </summary>
         /// <remarks>

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -129,7 +129,10 @@ namespace Npgsql
             if (!successfulBind && supportsSha256)
             {
                 mechanism = "SCRAM-SHA-256";
-                cbindFlag = "y";
+                // We can get here if PostgreSQL supports only SCRAM-SHA-256 or there was an error while binding to SCRAM-SHA-256-PLUS
+                // So, we set 'n' (client does not support binding) if there was an error while binding
+                // or 'y' (client supports but server doesn't) in other case
+                cbindFlag = supportsSha256Plus ? "n" : "y";
                 cbind = "biws";
                 successfulBind = true;
             }

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -122,6 +122,7 @@ namespace Npgsql
                         var cbindBytes = cbindFlagBytes.Concat(certificateHash).ToArray();
                         cbind = Convert.ToBase64String(cbindBytes);
                         successfulBind = true;
+                        IsScramPlus = true;
                     }
                 }
             }
@@ -135,6 +136,7 @@ namespace Npgsql
                 cbindFlag = supportsSha256Plus ? "n" : "y";
                 cbind = supportsSha256Plus ? "biws" : "eSws";
                 successfulBind = true;
+                IsScram = true;
             }
 
             if (!successfulBind)

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -95,17 +95,17 @@ namespace Npgsql
                 // Checking for hashing algorithms
                 HashAlgorithm? hashAlgorithm = null;
                 var algorithmName = remoteCertificate.SignatureAlgorithm.FriendlyName;
-                if (algorithmName.IndexOf("sha1", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    algorithmName.IndexOf("md5", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    algorithmName.IndexOf("sha256", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (algorithmName.StartsWith("sha1", StringComparison.OrdinalIgnoreCase) ||
+                    algorithmName.StartsWith("md5", StringComparison.OrdinalIgnoreCase) ||
+                    algorithmName.StartsWith("sha256", StringComparison.OrdinalIgnoreCase))
                 {
                     hashAlgorithm = SHA256.Create();
                 }
-                else if (algorithmName.IndexOf("sha384", StringComparison.OrdinalIgnoreCase) >= 0)
+                else if (algorithmName.StartsWith("sha384", StringComparison.OrdinalIgnoreCase))
                 {
                     hashAlgorithm = SHA384.Create();
                 }
-                else if (algorithmName.IndexOf("sha512", StringComparison.OrdinalIgnoreCase) >= 0)
+                else if (algorithmName.StartsWith("sha512", StringComparison.OrdinalIgnoreCase))
                 {
                     hashAlgorithm = SHA512.Create();
                 }
@@ -116,14 +116,12 @@ namespace Npgsql
 
                 if (hashAlgorithm != null)
                 {
-                    using (hashAlgorithm)
-                    {
-                        var certificateHash = hashAlgorithm.ComputeHash(remoteCertificate.GetRawCertData());
-                        var cbindBytes = cbindFlagBytes.Concat(certificateHash).ToArray();
-                        cbind = Convert.ToBase64String(cbindBytes);
-                        successfulBind = true;
-                        IsScramPlus = true;
-                    }
+                    using var _ = hashAlgorithm;
+                    var certificateHash = hashAlgorithm.ComputeHash(remoteCertificate.GetRawCertData());
+                    var cbindBytes = cbindFlagBytes.Concat(certificateHash).ToArray();
+                    cbind = Convert.ToBase64String(cbindBytes);
+                    successfulBind = true;
+                    IsScramPlus = true;
                 }
             }
 

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -133,7 +133,7 @@ namespace Npgsql
                 // So, we set 'n' (client does not support binding) if there was an error while binding
                 // or 'y' (client supports but server doesn't) in other case
                 cbindFlag = supportsSha256Plus ? "n" : "y";
-                cbind = "biws";
+                cbind = supportsSha256Plus ? "biws" : "eSws";
                 successfulBind = true;
             }
 

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -80,13 +80,7 @@ namespace Npgsql
             string cbindFlag;
             string cbind;
 
-            if (supportsSha256)
-            {
-                mechanism = "SCRAM-SHA-256";
-                cbindFlag = "y";
-                cbind = "biws";
-            }
-            else
+            if (supportsSha256Plus)
             {
                 // RFC 5929
                 mechanism = "SCRAM-SHA-256-PLUS";
@@ -115,6 +109,12 @@ namespace Npgsql
                     //TODO
                     throw new NotImplementedException("Support for other signature algorithms is not yet implemented");
                 }
+            }
+            else
+            {
+                mechanism = "SCRAM-SHA-256";
+                cbindFlag = "y";
+                cbind = "biws";
             }
 
             var passwd = GetPassword(username) ??

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1315,6 +1315,16 @@ namespace Npgsql
         /// </summary>
         internal bool IsSecure { get; private set; }
 
+        /// <summary>
+        /// Returns whether SCRAM-SHA256 is being user for the connection
+        /// </summary>
+        internal bool IsScram { get; private set; }
+
+        /// <summary>
+        /// Returns whether SCRAM-SHA256-PLUS is being user for the connection
+        /// </summary>
+        internal bool IsScramPlus { get; private set; }
+
 #pragma warning disable CA1801 // Review unused parameters
         static bool DefaultUserCertificateValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
             => sslPolicyErrors == SslPolicyErrors.None;

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -147,10 +147,8 @@ namespace Npgsql.Tests
                 {
                     conn.Open();
                 }
-                catch (Exception e)
+                catch (Exception e) when (!TestUtil.IsOnBuildServer)
                 {
-                    if (TestUtil.IsOnBuildServer)
-                        throw;
                     Console.WriteLine(e);
                     Assert.Ignore("Integrated security (GSS/SSPI) doesn't seem to be set up");
                 }

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -147,8 +147,10 @@ namespace Npgsql.Tests
                 {
                     conn.Open();
                 }
-                catch (Exception e) when (!TestUtil.IsOnBuildServer)
+                catch (Exception e)
                 {
+                    if (TestUtil.IsOnBuildServer)
+                        throw;
                     Console.WriteLine(e);
                     Assert.Ignore("Integrated security (GSS/SSPI) doesn't seem to be set up");
                 }
@@ -197,10 +199,8 @@ namespace Npgsql.Tests
                     Assert.That(conn.IsScramPlus, Is.True);
                 }
             }
-            catch (Exception e)
+            catch (Exception e) when (!TestUtil.IsOnBuildServer)
             {
-                if (TestUtil.IsOnBuildServer)
-                    throw;
                 Console.WriteLine(e);
                 Assert.Ignore("scram-sha-256-plus doesn't seem to be set up");
             }


### PR DESCRIPTION
#1922
From what I've read, it should be mostly done (there is missing support for hashing algorithms other than `sha1` and `md5`), so any commentary is appreciated.

Relevant documentation:
[RFC 5929](https://tools.ietf.org/html/rfc5929#section-4) - `tls-server-end-point` channel binding.
[RFC 5802](https://tools.ietf.org/html/rfc5802#section-6) - SCRAM channel binding.
[read_client_first_message()](https://doxygen.postgresql.org/auth-scram_8c.html#a2505d1b5a3a5fd1ac5b02e67a534e6db) - how PostgreSQL reads first SCRAM message.
[read_client_final_message()](https://doxygen.postgresql.org/auth-scram_8c.html#ac4462cf008e89ef52b43a23a964c8783) - how PostgreSQL reads last SCRAM message.
[PostgreSQL SASL-SCRAM documentation](https://www.postgresql.org/docs/current/sasl-authentication.html#SASL-SCRAM-SHA-256) - short description of SASL-SCRAM protocol.