### PR TITLE
Fixed pruning of connections and idlecount in ConnectorPool is now kept in sync with correct amount

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -514,7 +514,7 @@ namespace Npgsql
             }
 
             while (toPrune > 0 &&
-                   pool._numConnectors <= pool._min &&
+                   pool._numConnectors > pool._min &&
                    pool._idleConnectorReader.TryRead(out var connector) &&
                    connector != null)
             {

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -262,7 +262,7 @@ namespace Npgsql.Tests
                 var sleepInterval = connectionPruningIntervalMs + paddingMs;
                 var total = 0;
 
-                for (var i = 0; i < samples; i++)
+                for (var i = 0; i < samples - 1; i++)
                 {
                     total += sleepInterval;
                     Thread.Sleep(sleepInterval);
@@ -358,7 +358,9 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public void ClearPool()
+        [TestCase(1)]
+        [TestCase(2)]
+        public void ClearPool(int iterations)
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
@@ -366,13 +368,16 @@ namespace Npgsql.Tests
             }.ToString();
 
             NpgsqlConnection conn;
-            using (conn = OpenConnection(connString)) {}
-            // Now have one connection in the pool
-            Assert.True(PoolManager.TryGetValue(connString, out var pool));
-            AssertPoolState(pool, open: 1, idle: 1);
+            for (var i = 0; i < iterations; i++)
+            {
+                using (conn = OpenConnection(connString)) { }
+                // Now have one connection in the pool
+                Assert.True(PoolManager.TryGetValue(connString, out var pool));
+                AssertPoolState(pool, open: 1, idle: 1);
 
-            NpgsqlConnection.ClearPool(conn);
-            AssertPoolState(pool, open: 0, idle: 0);
+                NpgsqlConnection.ClearPool(conn);
+                AssertPoolState(pool, open: 0, idle: 0);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Hello 

During some testing and investigations together with my colleague @ErazerBrecht we noticed that pruning of connections wasn't working. When fixing the pruning we noticed something funky was happening with the _idleCount in the ConnectorPool.
This had impact on the pruning and ClearPool logic. 

The amount in the _idleCount field wasn't correct after the first iteration of pruning or clearing. We fixed this by moving the decrement of the _idleCount after the check if the connector is null in the CheckIdleConnector method. Connectors that are null are not used (not idle) so the count should not get decremented. 
We extended the ClearPool test so it can run multiple iterations and verify this issue.

We fixed the pruning logic and the PruneIdleConnectors tests as well. The tests are still slow and timing based but maybe consider activating these tests as it would have shown pruning wasn't working. 

Looking forward to the feedback from you guys 👍 