### PR TITLE
Support -c as part of the PGOPTIONS environment variable

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1293,6 +1293,9 @@ namespace Npgsql
 
         internal static string ParseKey(string str, ref int pos)
         {
+            if (str.StartsWith("-c "))
+                pos += 3;
+
             var start = pos;
             for (; pos < str.Length; pos++)
             {

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -713,11 +713,13 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public async Task SetOptions()
+        [TestCase("default_transaction_isolation=serializable default_transaction_deferrable=on foo.bar=My\\ Famous\\\\Thing")]
+        [TestCase("-c default_transaction_isolation=serializable -c default_transaction_deferrable=on -c foo.bar=My\\ Famous\\\\Thing")]
+        public async Task SetOptions(string options)
         {
             using var _ = CreateTempPool(new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                Options = "default_transaction_isolation=serializable  default_transaction_deferrable=on foo.bar=My\\ Famous\\\\Thing"
+                Options = options
             }, out var connectionString);
 
             using var conn = await OpenConnectionAsync(connectionString);
@@ -1347,9 +1349,11 @@ CREATE TABLE record ()");
 
         [Test]
         [NonParallelizable]
-        public async Task Connect_OptionsFromEnvironment_Succeeds()
+        [TestCase("default_transaction_isolation=serializable default_transaction_deferrable=on foo.bar=My\\ Famous\\\\Thing")]
+        [TestCase("-c default_transaction_isolation=serializable -c default_transaction_deferrable=on -c foo.bar=My\\ Famous\\\\Thing")]
+        public async Task Connect_OptionsFromEnvironment_Succeeds(string pgOptions)
         {
-            using (SetEnvironmentVariable("PGOPTIONS", "default_transaction_isolation=serializable  default_transaction_deferrable=on foo.bar=My\\ Famous\\\\Thing"))
+            using (SetEnvironmentVariable("PGOPTIONS", pgOptions))
             {
                 using var _ = CreateTempPool(ConnectionString, out var connectionString);
                 using var conn = await OpenConnectionAsync(connectionString);


### PR DESCRIPTION
This also works for the Options connection string parameter
and is mainly for compatibility with other PostgreSQL applications
that use PGOPTIONS and expect the -c to be there.
In Npgsql you can omit it if you want.

Closes #3102