### PR TITLE
Fixed reading by reader previous query messages

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1296,7 +1296,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                         throw;
                     }
-                    
                 }
             }
             catch

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1037,8 +1037,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             using var reader = await ExecuteReader(CommandBehavior.Default, async, cancellationToken);
             while (async ? await reader.NextResultAsync(cancellationToken) : reader.NextResult()) ;
 
-            reader.Close();
-
             return reader.RecordsAffected;
         }
 

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -297,7 +297,7 @@ namespace Npgsql
         int _state;
 
         /// <summary>
-        /// The current state of the command
+        /// Gets the current state of the connector
         /// </summary>
         internal CommandState State
         {
@@ -1145,8 +1145,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 {
                     connector.StartUserAction(ConnectorState.Executing, this, CancellationToken.None);
 
-                    Task? sendTask = null;
-
                     try
                     {
                         ValidateParameters(connector.TypeMapper);
@@ -1224,30 +1222,34 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         // to prevents a dependency on the thread pool (which would also trigger deadlocks).
                         // The WriteBuffer notifies this command when the first buffer flush occurs, so that the
                         // send functions can switch to the special async mode when needed.
-                        sendTask = NonMultiplexingWriteWrapper(connector, async, CancellationToken.None);
+                        var sendTask = NonMultiplexingWriteWrapper(connector, async, CancellationToken.None);
 
                         // The following is a hack. It raises an exception if one was thrown in the first phases
                         // of the send (i.e. in parts of the send that executed synchronously). Exceptions may
                         // still happen later and aren't properly handled. See #1323.
                         if (sendTask.IsFaulted)
                             sendTask.GetAwaiter().GetResult();
+
+                        // TODO: DRY the following with multiplexing, but be careful with the cancellation registration...
+                        var reader = connector.DataReader;
+                        reader.Init(this, behavior, _statements, sendTask);
+                        connector.CurrentReader = reader;
+                        if (async)
+                            await reader.NextResultAsync(cancellationToken);
+                        else
+                            reader.NextResult();
+
+                        return reader;
                     }
                     catch
                     {
+                        var reader = connector.CurrentReader;
+                        if (reader != null)
+                            await reader.Cleanup(async);
+
                         conn.Connector?.EndUserAction();
                         throw;
                     }
-
-                    // TODO: DRY the following with multiplexing, but be careful with the cancellation registration...
-                    var reader = connector.DataReader;
-                    reader.Init(this, behavior, _statements, sendTask);
-                    connector.CurrentReader = reader;
-                    if (async)
-                        await reader.NextResultAsync(cancellationToken);
-                    else
-                        reader.NextResult();
-
-                    return reader;
                 }
                 else
                 {
@@ -1261,36 +1263,43 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             "Synchronous command execution is not supported when multiplexing is on");
                     }
 
-                    ValidateParameters(conn.Pool!.MultiplexingTypeMapper!);
-                    ProcessRawQuery();
+                    try
+                    {
+                        ValidateParameters(conn.Pool!.MultiplexingTypeMapper!);
+                        ProcessRawQuery();
 
-                    State = CommandState.InProgress;
+                        State = CommandState.InProgress;
 
-                    // TODO: Experiment: do we want to wait on *writing* here, or on *reading*?
-                    // Previous behavior was to wait on reading, which throw the exception from ExecuteReader (and not from
-                    // the first read). But waiting on writing would allow us to do sync writing and async reading.
-                    ExecutionCompletion.Reset();
-                    await conn.Pool!.MultiplexCommandWriter!.WriteAsync(this, cancellationToken);
-                    connector = await new ValueTask<NpgsqlConnector>(ExecutionCompletion, ExecutionCompletion.Version);
-                    // TODO: Overload of StartBindingScope?
-                    conn.Connector = connector;
-                    connector.Connection = conn;
-                    conn.ConnectorBindingScope = ConnectorBindingScope.Reader;
+                        // TODO: Experiment: do we want to wait on *writing* here, or on *reading*?
+                        // Previous behavior was to wait on reading, which throw the exception from ExecuteReader (and not from
+                        // the first read). But waiting on writing would allow us to do sync writing and async reading.
+                        ExecutionCompletion.Reset();
+                        await conn.Pool!.MultiplexCommandWriter!.WriteAsync(this, cancellationToken);
+                        connector = await new ValueTask<NpgsqlConnector>(ExecutionCompletion, ExecutionCompletion.Version);
+                        // TODO: Overload of StartBindingScope?
+                        conn.Connector = connector;
+                        connector.Connection = conn;
+                        conn.ConnectorBindingScope = ConnectorBindingScope.Reader;
 
-                    var reader = connector.DataReader;
-                    reader.Init(this, behavior, _statements);
-                    connector.CurrentReader = reader;
-                    await reader.NextResultAsync(cancellationToken);
+                        var reader = connector.DataReader;
+                        reader.Init(this, behavior, _statements);
+                        connector.CurrentReader = reader;
+                        await reader.NextResultAsync(cancellationToken);
 
-                    return reader;
+                        return reader;
+                    }
+                    catch
+                    {
+                        var reader = connector?.CurrentReader;
+                        if (reader != null)
+                            await reader.Cleanup(async);
+
+                        throw;
+                    }
                 }
             }
             catch
             {
-                var reader = conn.Connector?.CurrentReader;
-                if (reader != null)
-                    await reader.Cleanup(async);
-
                 State = CommandState.Idle;
 
                 // Reader disposal contains logic for closing the connection if CommandBehavior.CloseConnection is

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -297,7 +297,7 @@ namespace Npgsql
         int _state;
 
         /// <summary>
-        /// Gets the current state of the connector
+        /// The current state of the command
         /// </summary>
         internal CommandState State
         {
@@ -1143,6 +1143,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 {
                     connector.StartUserAction(ConnectorState.Executing, this, CancellationToken.None);
 
+                    Task? sendTask = null;
+
                     try
                     {
                         ValidateParameters(connector.TypeMapper);
@@ -1220,34 +1222,30 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         // to prevents a dependency on the thread pool (which would also trigger deadlocks).
                         // The WriteBuffer notifies this command when the first buffer flush occurs, so that the
                         // send functions can switch to the special async mode when needed.
-                        var sendTask = NonMultiplexingWriteWrapper(connector, async, CancellationToken.None);
+                        sendTask = NonMultiplexingWriteWrapper(connector, async, CancellationToken.None);
 
                         // The following is a hack. It raises an exception if one was thrown in the first phases
                         // of the send (i.e. in parts of the send that executed synchronously). Exceptions may
                         // still happen later and aren't properly handled. See #1323.
                         if (sendTask.IsFaulted)
                             sendTask.GetAwaiter().GetResult();
-
-                        // TODO: DRY the following with multiplexing, but be careful with the cancellation registration...
-                        var reader = connector.DataReader;
-                        reader.Init(this, behavior, _statements, sendTask);
-                        connector.CurrentReader = reader;
-                        if (async)
-                            await reader.NextResultAsync(cancellationToken);
-                        else
-                            reader.NextResult();
-
-                        return reader;
                     }
                     catch
                     {
-                        var reader = connector.CurrentReader;
-                        if (reader != null)
-                            await reader.Cleanup(async);
-
                         conn.Connector?.EndUserAction();
                         throw;
                     }
+
+                    // TODO: DRY the following with multiplexing, but be careful with the cancellation registration...
+                    var reader = connector.DataReader;
+                    reader.Init(this, behavior, _statements, sendTask);
+                    connector.CurrentReader = reader;
+                    if (async)
+                        await reader.NextResultAsync(cancellationToken);
+                    else
+                        reader.NextResult();
+
+                    return reader;
                 }
                 else
                 {
@@ -1261,43 +1259,36 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             "Synchronous command execution is not supported when multiplexing is on");
                     }
 
-                    try
-                    {
-                        ValidateParameters(conn.Pool!.MultiplexingTypeMapper!);
-                        ProcessRawQuery();
+                    ValidateParameters(conn.Pool!.MultiplexingTypeMapper!);
+                    ProcessRawQuery();
 
-                        State = CommandState.InProgress;
+                    State = CommandState.InProgress;
 
-                        // TODO: Experiment: do we want to wait on *writing* here, or on *reading*?
-                        // Previous behavior was to wait on reading, which throw the exception from ExecuteReader (and not from
-                        // the first read). But waiting on writing would allow us to do sync writing and async reading.
-                        ExecutionCompletion.Reset();
-                        await conn.Pool!.MultiplexCommandWriter!.WriteAsync(this, cancellationToken);
-                        connector = await new ValueTask<NpgsqlConnector>(ExecutionCompletion, ExecutionCompletion.Version);
-                        // TODO: Overload of StartBindingScope?
-                        conn.Connector = connector;
-                        connector.Connection = conn;
-                        conn.ConnectorBindingScope = ConnectorBindingScope.Reader;
+                    // TODO: Experiment: do we want to wait on *writing* here, or on *reading*?
+                    // Previous behavior was to wait on reading, which throw the exception from ExecuteReader (and not from
+                    // the first read). But waiting on writing would allow us to do sync writing and async reading.
+                    ExecutionCompletion.Reset();
+                    await conn.Pool!.MultiplexCommandWriter!.WriteAsync(this, cancellationToken);
+                    connector = await new ValueTask<NpgsqlConnector>(ExecutionCompletion, ExecutionCompletion.Version);
+                    // TODO: Overload of StartBindingScope?
+                    conn.Connector = connector;
+                    connector.Connection = conn;
+                    conn.ConnectorBindingScope = ConnectorBindingScope.Reader;
 
-                        var reader = connector.DataReader;
-                        reader.Init(this, behavior, _statements);
-                        connector.CurrentReader = reader;
-                        await reader.NextResultAsync(cancellationToken);
+                    var reader = connector.DataReader;
+                    reader.Init(this, behavior, _statements);
+                    connector.CurrentReader = reader;
+                    await reader.NextResultAsync(cancellationToken);
 
-                        return reader;
-                    }
-                    catch
-                    {
-                        var reader = connector?.CurrentReader;
-                        if (reader != null)
-                            await reader.Cleanup(async);
-
-                        throw;
-                    }
+                    return reader;
                 }
             }
-            catch
+            catch (Exception e)
             {
+                var reader = conn.Connector?.CurrentReader;
+                if (!(e is NpgsqlOperationInProgressException) && reader != null)
+                    await reader.Cleanup(async);
+
                 State = CommandState.Idle;
 
                 // Reader disposal contains logic for closing the connection if CommandBehavior.CloseConnection is

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1217,8 +1217,8 @@ namespace Npgsql
                 catch (PostgresException e)
                 {
                     // In case if reader is not null, it will do cleanup (and call EndUserAction) while catching the exception
-                    if (CurrentReader is null)
-                        EndUserAction();
+                    if (connector.CurrentReader is null)
+                        connector.EndUserAction();
 
                     if (e.SqlState == PostgresErrorCodes.QueryCanceled && connector.PostgresCancellationPerformed)
                     {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -278,7 +278,7 @@ namespace Npgsql
 
         #endregion
 
-        internal NpgsqlDataReader DataReader { get; }
+        internal NpgsqlDataReader DataReader { get; set; }
 
         #region Constructors
 
@@ -1216,15 +1216,9 @@ namespace Npgsql
                 }
                 catch (PostgresException e)
                 {
-                    if (connector.CurrentReader != null)
-                    {
-                        // The reader cleanup will call EndUserAction
-                        await connector.CurrentReader.Cleanup(async);
-                    }
-                    else
-                    {
-                        connector.EndUserAction();
-                    }
+                    // In case if reader is not null, it will do cleanup (and call EndUserAction) while catching the exception
+                    if (CurrentReader is null)
+                        EndUserAction();
 
                     if (e.SqlState == PostgresErrorCodes.QueryCanceled && connector.PostgresCancellationPerformed)
                     {
@@ -1606,7 +1600,7 @@ namespace Npgsql
             var copyOperation = CurrentCopyOperation;
 
             if (reader != null)
-                await reader.Close(connectionClosing: true, async);
+                await reader.Close(connectionClosing: true, async, isDisposing: false);
             else if (copyOperation != null)
             {
                 // TODO: There's probably a race condition as the COPY operation may finish on its own during the next few lines
@@ -1887,6 +1881,8 @@ namespace Npgsql
                 }
             }
 
+            DataReader.UnbindIfNecessary();
+            
             if (endBindingScope)
             {
                 // Connection is null if a connection enlisted in a TransactionScope was closed before the

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1216,7 +1216,7 @@ namespace Npgsql
                 }
                 catch (PostgresException e)
                 {
-                    // In case if reader is not null, it will do cleanup (and call EndUserAction) while catching the exception
+                    // TODO: move it up the stack, like #3126 did (relevant for non-command-execution scenarios, like COPY)
                     if (connector.CurrentReader is null)
                         connector.EndUserAction();
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -33,7 +33,7 @@ namespace Npgsql
 #pragma warning restore CA1010
     {
         internal NpgsqlCommand Command { get; private set; } = default!;
-        internal NpgsqlConnector Connector { get; private set; }
+        internal NpgsqlConnector Connector { get; }
         NpgsqlConnection _connection = default!;
 
         /// <summary>
@@ -2152,10 +2152,7 @@ namespace Npgsql
             // We have to unbind the reader from the connector, otherwise there could be a concurency issues
             // See #3126 and #3290
             if (!_isDisposed && !Connector.IsBroken)
-            {
                 Connector.DataReader = new NpgsqlDataReader(Connector);
-                Connector = null!;
-            }
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -259,7 +259,7 @@ namespace Npgsql
                     throw new ArgumentOutOfRangeException();
                 }
 
-                var msg2 = await ReadMessage(async, CancellationToken.None);
+                var msg2 = await ReadMessage(async);
                 ProcessMessage(msg2);
                 return msg2.Code == BackendMessageCode.DataRow;
             }

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -282,7 +282,7 @@ namespace Npgsql.Tests
             Assert.That(() => cmd.ExecuteNonQuery(), Throws
                 .TypeOf<OperationCanceledException>()
                 .With.InnerException.TypeOf<PostgresException>()
-                .With.InnerException.Property(nameof(PostgresException.SqlState)).EqualTo("57014")
+                .With.InnerException.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled)
             );
 
             await cancelTask;
@@ -302,7 +302,7 @@ namespace Npgsql.Tests
 
             var exception = Assert.ThrowsAsync<OperationCanceledException>(async () => await t);
             Assert.That(exception.InnerException,
-                Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
+                Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled));
             Assert.That(exception.CancellationToken, Is.EqualTo(cancellationSource.Token));
 
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1722,10 +1722,10 @@ LANGUAGE plpgsql VOLATILE";
 
                 var exception = Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
                 Assert.That(exception.InnerException,
-                    Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
+                    Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled));
                 Assert.That(exception.CancellationToken, Is.EqualTo(cancellationSource.Token));
 
-                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
+                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open | ConnectionState.Fetching));
             }
 
             await pgMock.WriteScalarResponseAndFlush(1);
@@ -1774,10 +1774,10 @@ LANGUAGE plpgsql VOLATILE";
 
                 var exception = Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
                 Assert.That(exception.InnerException,
-                    Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
+                    Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled));
                 Assert.That(exception.CancellationToken, Is.EqualTo(cancellationSource.Token));
 
-                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
+                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open | ConnectionState.Fetching));
             }
 
             await pgMock.WriteScalarResponseAndFlush(1);

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -175,7 +175,7 @@ namespace Npgsql.Tests
                 Assert.That(async () => await cmd.ExecuteNonQueryAsync(cts), Throws.Exception
                     .TypeOf<OperationCanceledException>()
                     .With.InnerException.TypeOf<PostgresException>()
-                    .With.InnerException.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
+                    .With.InnerException.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled));
             }
         }
 

--- a/test/Npgsql.Tests/SystemTransactionTests.cs
+++ b/test/Npgsql.Tests/SystemTransactionTests.cs
@@ -263,7 +263,7 @@ namespace Npgsql.Tests
                     Assert.That(() => CreateSleepCommand(conn, 5).ExecuteNonQuery(),
                         Throws.Exception.TypeOf<PostgresException>()
                             .With.Property(nameof(PostgresException.SqlState))
-                            .EqualTo("57014"));
+                            .EqualTo(PostgresErrorCodes.QueryCanceled));
 
                 }
             }


### PR DESCRIPTION
Closes #2913
Closes #3289
Closes #2964

The idea is to move reader cleanup from a connector to the reader.