### PR TITLE
Implement connection lifetime

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -801,6 +801,28 @@ namespace Npgsql
         }
         int _connectionPruningInterval;
 
+        /// <summary>
+        /// The total maximum lifetime of connections (in seconds). Connections which have exceeded this value will be
+        /// destroyed instead of returned from the pool. This is useful in clustered configurations to force load
+        /// balancing between a running server and a server just brought online.
+        /// </summary>
+        /// <value>The time (in seconds) to wait, or 0 to to make connections last indefinitely (the default).</value>
+        [Category("Pooling")]
+        [Description("The total maximum lifetime of connections (in seconds).")]
+        [DisplayName("Connection Lifetime")]
+        [NpgsqlConnectionStringProperty("Load Balance Timeout")]
+        [DefaultValue(0)]
+        public int ConnectionLifetime
+        {
+            get => _connectionLifetime;
+            set
+            {
+                _connectionLifetime = value;
+                SetValue(nameof(ConnectionLifetime), value);
+            }
+        }
+        int _connectionLifetime;
+
         #endregion
 
         #region Properties - Timeouts
@@ -1354,20 +1376,6 @@ namespace Npgsql
         #endregion
 
         #region Properties - Obsolete
-
-        /// <summary>
-        /// Obsolete, see https://www.npgsql.org/doc/release-notes/3.1.html
-        /// </summary>
-        [Category("Obsolete")]
-        [Description("Obsolete, see https://www.npgsql.org/doc/release-notes/3.1.html")]
-        [DisplayName("Connection Lifetime")]
-        [NpgsqlConnectionStringProperty]
-        [Obsolete("The ConnectionLifeTime parameter is no longer supported")]
-        public int ConnectionLifeTime
-        {
-            get => 0;
-            set => throw new NotSupportedException("The ConnectionLifeTime parameter is no longer supported. Please see https://www.npgsql.org/doc/release-notes/3.1.html");
-        }
 
         /// <summary>
         /// Obsolete, see https://www.npgsql.org/doc/release-notes/3.1.html

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -210,12 +210,13 @@ namespace Npgsql
 
         bool _sendResetOnClose;
 
-        /// <summary>
-        /// If pooled, the pool index on which this connector will be returned to the pool.
-        /// </summary>
-        internal int PoolIndex { get; set; } = int.MaxValue;
-
         ConnectorPool? _pool;
+
+        /// <summary>
+        /// Contains the UTC timestamp when this connector was opened, used to implement
+        /// <see cref="NpgsqlConnectionStringBuilder.ConnectionLifetime"/>.
+        /// </summary>
+        internal DateTime OpenTimestamp { get; private set; }
 
         internal int ClearCounter { get; set; }
 
@@ -439,6 +440,7 @@ namespace Npgsql
                     GenerateResetMessage();
                 }
 
+                OpenTimestamp = DateTime.UtcNow;
                 Log.Trace($"Opened connection to {Host}:{Port}");
 
                 if (Settings.Multiplexing)


### PR DESCRIPTION
Builds on previous work by @FlorianRainer in #2068.

Some notes:

* Unlike #2068, this introduces the lifetime check whenever an idle connector is returned from the pool. Experiments as part of multiplexing have shown there to be negligible perf impact from a single branch, so it's better to introduce a fully reliable mechanism than an approximate, pruning-based one.
* As noted in https://github.com/npgsql/npgsql/pull/2068/files#r218738279, I've named the connection string parameter "Connection Lifetime" with the synonym "Load Balance Timeout" to match [the SqlClient naming](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=netframework-4.7.2).

Closes #1810