### PR TITLE
Add two missing nullability annotations

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -131,7 +131,7 @@ namespace Npgsql
         /// Initializes a new instance of <see cref="NpgsqlConnection"/> with the given connection string.
         /// </summary>
         /// <param name="connectionString">The connection used to open the PostgreSQL database.</param>
-        public NpgsqlConnection(string connectionString) : this()
+        public NpgsqlConnection(string? connectionString) : this()
             => ConnectionString = connectionString;
 
         /// <summary>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -66,7 +66,7 @@ namespace Npgsql
         /// <summary>
         /// Initializes a new instance of the NpgsqlConnectionStringBuilder class and sets its <see cref="DbConnectionStringBuilder.ConnectionString"/>.
         /// </summary>
-        public NpgsqlConnectionStringBuilder(string connectionString)
+        public NpgsqlConnectionStringBuilder(string? connectionString)
         {
             Init();
             ConnectionString = connectionString;


### PR DESCRIPTION
1. NpgsqlConnection constructor
2. NpgsqlConnectionStringBuilder constructor


The annotation is consistent with all our other annotations (e. g. NpgsqlCommand constructor) and the annotations @roji did for ADO.NET, yet I don't like it.

See:
https://twitter.com/BrarPiening/status/1304689157013475333?s=20