### PR TITLE
Remove logging from NpgsqlFactory

### DIFF
--- a/src/Npgsql/NpgsqlFactory.cs
+++ b/src/Npgsql/NpgsqlFactory.cs
@@ -11,8 +11,6 @@ namespace Npgsql
     [Serializable]
     public sealed class NpgsqlFactory : DbProviderFactory, IServiceProvider
     {
-        static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlFactory));
-
         /// <summary>
         /// Gets an instance of the <see cref="NpgsqlFactory"/>.
         /// This can be used to retrieve strongly typed data objects.
@@ -93,8 +91,7 @@ namespace Npgsql
             Assembly npgsqlEfAssembly;
             try {
                 npgsqlEfAssembly = Assembly.Load(new AssemblyName(assemblyName.FullName));
-            } catch (Exception e) {
-                Log.Debug("A service request was made for System.Data.Common.DbProviderServices, but the EntityFramework5.Npgsql assemby could not be loaded.", e);
+            } catch {
                 return null;
             }
 


### PR DESCRIPTION
It isn't used for anything interesting, and can cause premature setting of the log manager.

Fixes #3018