### PR TITLE
Passing the cancellation token to the ReadBuffer

### DIFF
--- a/src/Npgsql.GeoJSON/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/GeoJSONHandler.cs
@@ -126,39 +126,39 @@ namespace Npgsql.GeoJSON
         #region Read
 
         public override ValueTask<GeoJSONObject> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (Point)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (Point)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (LineString)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (LineString)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (Polygon)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (Polygon)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiPoint)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (MultiPoint)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiLineString)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (MultiLineString)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiPolygon)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (MultiPolygon)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (GeometryCollection)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (GeometryCollection)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<IGeoJSONObject> INpgsqlTypeHandler<IGeoJSONObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<IGeometryObject> INpgsqlTypeHandler<IGeometryObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (IGeometryObject)await ReadGeometry(buf, async, cancellationToken: cancellationToken);
+            => (IGeometryObject)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<GeoJSONObject> ReadGeometry(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken = default)
         {
             var boundingBox = BoundingBox ? new BoundingBoxBuilder() : null;
-            var geometry = await ReadGeometryCore(buf, async, boundingBox, cancellationToken: cancellationToken);
+            var geometry = await ReadGeometryCore(buf, async, boundingBox, cancellationToken);
 
             geometry.BoundingBoxes = boundingBox?.Build();
             return geometry;
@@ -166,7 +166,7 @@ namespace Npgsql.GeoJSON
 
         async ValueTask<GeoJSONObject> ReadGeometryCore(NpgsqlReadBuffer buf, bool async, BoundingBoxBuilder? boundingBox, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(SizeOfHeader, async, cancellationToken: cancellationToken);
+            await buf.Ensure(SizeOfHeader, async, cancellationToken);
             var littleEndian = buf.ReadByte() > 0;
             var type = (EwkbGeometryType)buf.ReadUInt32(littleEndian);
 
@@ -175,7 +175,7 @@ namespace Npgsql.GeoJSON
 
             if (HasSrid(type))
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 crs = GetCrs(buf.ReadInt32(littleEndian));
             }
 
@@ -183,7 +183,7 @@ namespace Npgsql.GeoJSON
             {
             case EwkbGeometryType.Point:
                 {
-                    await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
                     var position = ReadPosition(buf, type, littleEndian);
                     boundingBox?.Accumulate(position);
                     geometry = new Point(position);
@@ -192,11 +192,11 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.LineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var coordinates = new Position[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < coordinates.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                        await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         coordinates[i] = position;
@@ -207,14 +207,14 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.Polygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -227,12 +227,12 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPoint:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var points = new Point[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < points.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async, cancellationToken: cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async, cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         points[i] = new Point(position);
@@ -243,16 +243,16 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiLineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken: cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken);
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -265,19 +265,19 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPolygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var polygons = new Polygon[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < polygons.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken: cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken);
                         var lines = new LineString[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < lines.Length; ++j)
                         {
                             var coordinates = new Position[buf.ReadInt32(littleEndian)];
                             for (var k = 0; k < coordinates.Length; ++k)
                             {
-                                await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                                await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
                                 var position = ReadPosition(buf, type, littleEndian);
                                 boundingBox?.Accumulate(position);
                                 coordinates[k] = position;
@@ -292,10 +292,10 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.GeometryCollection:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken);
                     var elements = new IGeometryObject[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < elements.Length; ++i)
-                        elements[i] = (IGeometryObject)await ReadGeometryCore(buf, async, boundingBox, cancellationToken: cancellationToken);
+                        elements[i] = (IGeometryObject)await ReadGeometryCore(buf, async, boundingBox, cancellationToken);
                     geometry = new GeometryCollection(elements);
                     break;
                 }

--- a/src/Npgsql.GeoJSON/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/GeoJSONHandler.cs
@@ -125,34 +125,34 @@ namespace Npgsql.GeoJSON
 
         #region Read
 
-        public override ValueTask<GeoJSONObject> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override ValueTask<GeoJSONObject> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (Point)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (LineString)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (Polygon)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (MultiPoint)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (MultiLineString)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (MultiPolygon)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (GeometryCollection)await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<IGeoJSONObject> INpgsqlTypeHandler<IGeoJSONObject>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<IGeoJSONObject> INpgsqlTypeHandler<IGeoJSONObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => await ReadGeometry(buf, async, cancellationToken);
 
-        async ValueTask<IGeometryObject> INpgsqlTypeHandler<IGeometryObject>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<IGeometryObject> INpgsqlTypeHandler<IGeometryObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => (IGeometryObject)await ReadGeometry(buf, async, cancellationToken);
 
         async ValueTask<GeoJSONObject> ReadGeometry(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken)
@@ -166,7 +166,7 @@ namespace Npgsql.GeoJSON
 
         async ValueTask<GeoJSONObject> ReadGeometryCore(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken, BoundingBoxBuilder? boundingBox)
         {
-            await buf.Ensure(SizeOfHeader, async, cancellationToken);
+            await buf.Ensure(SizeOfHeader, async, cancellationToken: cancellationToken);
             var littleEndian = buf.ReadByte() > 0;
             var type = (EwkbGeometryType)buf.ReadUInt32(littleEndian);
 
@@ -175,7 +175,7 @@ namespace Npgsql.GeoJSON
 
             if (HasSrid(type))
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 crs = GetCrs(buf.ReadInt32(littleEndian));
             }
 
@@ -183,7 +183,7 @@ namespace Npgsql.GeoJSON
             {
             case EwkbGeometryType.Point:
                 {
-                    await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                    await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
                     var position = ReadPosition(buf, type, littleEndian);
                     boundingBox?.Accumulate(position);
                     geometry = new Point(position);
@@ -192,11 +192,11 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.LineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var coordinates = new Position[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < coordinates.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                        await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         coordinates[i] = position;
@@ -207,14 +207,14 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.Polygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -227,12 +227,12 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPoint:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var points = new Point[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < points.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async, cancellationToken: cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         points[i] = new Point(position);
@@ -243,16 +243,16 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiLineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken: cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -265,19 +265,19 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPolygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var polygons = new Polygon[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < polygons.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken: cancellationToken);
+                        await buf.Skip(SizeOfHeader, async, cancellationToken: cancellationToken);
                         var lines = new LineString[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < lines.Length; ++j)
                         {
                             var coordinates = new Position[buf.ReadInt32(littleEndian)];
                             for (var k = 0; k < coordinates.Length; ++k)
                             {
-                                await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                                await buf.Ensure(SizeOfPoint(type), async, cancellationToken: cancellationToken);
                                 var position = ReadPosition(buf, type, littleEndian);
                                 boundingBox?.Accumulate(position);
                                 coordinates[k] = position;
@@ -292,7 +292,7 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.GeometryCollection:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async, cancellationToken: cancellationToken);
                     var elements = new IGeometryObject[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < elements.Length; ++i)
                         elements[i] = (IGeometryObject)await ReadGeometryCore(buf, async, cancellationToken, boundingBox);

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Npgsql.BackendMessages;
@@ -27,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             if (typeof(T) == typeof(string) ||
                 typeof(T) == typeof(char[]) ||
@@ -35,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char) ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription);
+                return await base.Read<T>(buf, len, async, cancellationToken, fieldDescription);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, cancellationToken, fieldDescription), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -28,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             if (typeof(T) == typeof(string) ||
                 typeof(T) == typeof(char[]) ||
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char) ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, cancellationToken, fieldDescription);
+                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, cancellationToken, fieldDescription), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken: cancellationToken), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char) ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken: cancellationToken), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/JsonbHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Npgsql.BackendMessages;
@@ -27,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonbHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection, isJsonb: true) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             if (typeof(T) == typeof(string)             ||
                 typeof(T) == typeof(char[])             ||
@@ -35,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription);
+                return await base.Read<T>(buf, len, async, cancellationToken, fieldDescription);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, cancellationToken, fieldDescription), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/JsonbHandler.cs
@@ -28,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonbHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection, isJsonb: true) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             if (typeof(T) == typeof(string)             ||
                 typeof(T) == typeof(char[])             ||
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, cancellationToken, fieldDescription);
+                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, cancellationToken, fieldDescription), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken: cancellationToken), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/JsonbHandler.cs
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken: cancellationToken), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
@@ -25,16 +25,16 @@ namespace Npgsql.LegacyPostgis
 
         #region Read
 
-        public override async ValueTask<PostgisGeometry> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<PostgisGeometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(5, async, cancellationToken);
+            await buf.Ensure(5, async, cancellationToken: cancellationToken);
             var le = buf.ReadByte() != 0;
             var id = buf.ReadUInt32(le);
 
             var srid = 0u;
             if ((id & (uint)EwkbModifiers.HasSRID) != 0)
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 srid = buf.ReadUInt32(le);
             }
 
@@ -48,16 +48,16 @@ namespace Npgsql.LegacyPostgis
             switch (id)
             {
             case WkbIdentifier.Point:
-                await buf.Ensure(16, async, cancellationToken);
+                await buf.Ensure(16, async, cancellationToken: cancellationToken);
                 return new PostgisPoint(buf.ReadDouble(le), buf.ReadDouble(le));
 
             case WkbIdentifier.LineString:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
-                    await buf.Ensure(16, async, cancellationToken);
+                    await buf.Ensure(16, async, cancellationToken: cancellationToken);
                     points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisLineString(points);
@@ -65,16 +65,16 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.Polygon:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
-                    await buf.Ensure(4, async, cancellationToken);
+                    await buf.Ensure(4, async, cancellationToken: cancellationToken);
                     rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
-                        await buf.Ensure(16, async, cancellationToken);
+                        await buf.Ensure(16, async, cancellationToken: cancellationToken);
                         rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
@@ -83,12 +83,12 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiPoint:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
-                    await buf.Ensure(21, async, cancellationToken);
-                    await buf.Skip(5, async, cancellationToken);
+                    await buf.Ensure(21, async, cancellationToken: cancellationToken);
+                    await buf.Skip(5, async, cancellationToken: cancellationToken);
                     points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisMultiPoint(points);
@@ -96,17 +96,17 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiLineString:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
-                    await buf.Ensure(9, async, cancellationToken);
-                    await buf.Skip(5, async, cancellationToken);
+                    await buf.Ensure(9, async, cancellationToken: cancellationToken);
+                    await buf.Skip(5, async, cancellationToken: cancellationToken);
                     rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
-                        await buf.Ensure(16, async, cancellationToken);
+                        await buf.Ensure(16, async, cancellationToken: cancellationToken);
                         rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
@@ -115,21 +115,21 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiPolygon:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var pols = new Coordinate2D[buf.ReadInt32(le)][][];
 
                 for (var ipol = 0; ipol < pols.Length; ipol++)
                 {
-                    await buf.Ensure(9, async, cancellationToken);
-                    await buf.Skip(5, async, cancellationToken);
+                    await buf.Ensure(9, async, cancellationToken: cancellationToken);
+                    await buf.Skip(5, async, cancellationToken: cancellationToken);
                     pols[ipol] = new Coordinate2D[buf.ReadInt32(le)][];
                     for (var irng = 0; irng < pols[ipol].Length; irng++)
                     {
-                        await buf.Ensure(4, async, cancellationToken);
+                        await buf.Ensure(4, async, cancellationToken: cancellationToken);
                         pols[ipol][irng] = new Coordinate2D[buf.ReadInt32(le)];
                         for (var ipts = 0; ipts < pols[ipol][irng].Length; ipts++)
                         {
-                            await buf.Ensure(16, async, cancellationToken);
+                            await buf.Ensure(16, async, cancellationToken: cancellationToken);
                             pols[ipol][irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                         }
                     }
@@ -139,12 +139,12 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.GeometryCollection:
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async, cancellationToken: cancellationToken);
                 var g = new PostgisGeometry[buf.ReadInt32(le)];
 
                 for (var i = 0; i < g.Length; i++)
                 {
-                    await buf.Ensure(5, async, cancellationToken);
+                    await buf.Ensure(5, async, cancellationToken: cancellationToken);
                     var elemLe = buf.ReadByte() != 0;
                     var elemId = (WkbIdentifier)(buf.ReadUInt32(le) & 7);
 
@@ -162,20 +162,20 @@ namespace Npgsql.LegacyPostgis
 
         #region Read concrete types
 
-        async ValueTask<PostgisPoint> INpgsqlTypeHandler<PostgisPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisPoint)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisMultiPoint> INpgsqlTypeHandler<PostgisMultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisMultiPoint)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisLineString> INpgsqlTypeHandler<PostgisLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisLineString)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisMultiLineString> INpgsqlTypeHandler<PostgisMultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisMultiLineString)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisPolygon> INpgsqlTypeHandler<PostgisPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisPolygon)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisMultiPolygon> INpgsqlTypeHandler<PostgisMultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisMultiPolygon)await Read(buf, len, async, cancellationToken, fieldDescription);
-        async ValueTask<PostgisGeometryCollection> INpgsqlTypeHandler<PostgisGeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (PostgisGeometryCollection)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<PostgisPoint> INpgsqlTypeHandler<PostgisPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisMultiPoint> INpgsqlTypeHandler<PostgisMultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisMultiPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisLineString> INpgsqlTypeHandler<PostgisLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisMultiLineString> INpgsqlTypeHandler<PostgisMultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisMultiLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisPolygon> INpgsqlTypeHandler<PostgisPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisMultiPolygon> INpgsqlTypeHandler<PostgisMultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisMultiPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+        async ValueTask<PostgisGeometryCollection> INpgsqlTypeHandler<PostgisGeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+            => (PostgisGeometryCollection)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         #endregion
 

--- a/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
@@ -38,12 +38,12 @@ namespace Npgsql.LegacyPostgis
                 srid = buf.ReadUInt32(le);
             }
 
-            var geom = await DoRead(buf, (WkbIdentifier)(id & 7), le, async, cancellationToken);
+            var geom = await DoRead(buf, (WkbIdentifier) (id & 7), le, async, cancellationToken: cancellationToken);
             geom.SRID = srid;
             return geom;
         }
 
-        async ValueTask<PostgisGeometry> DoRead(NpgsqlReadBuffer buf, WkbIdentifier id, bool le, bool async, CancellationToken cancellationToken)
+        async ValueTask<PostgisGeometry> DoRead(NpgsqlReadBuffer buf, WkbIdentifier id, bool le, bool async, CancellationToken cancellationToken = default)
         {
             switch (id)
             {
@@ -148,7 +148,7 @@ namespace Npgsql.LegacyPostgis
                     var elemLe = buf.ReadByte() != 0;
                     var elemId = (WkbIdentifier)(buf.ReadUInt32(le) & 7);
 
-                    g[i] = await DoRead(buf, elemId, elemLe, async, cancellationToken);
+                    g[i] = await DoRead(buf, elemId, elemLe, async, cancellationToken: cancellationToken);
                 }
                 return new PostgisGeometryCollection(g);
             }
@@ -162,19 +162,19 @@ namespace Npgsql.LegacyPostgis
 
         #region Read concrete types
 
-        async ValueTask<PostgisPoint> INpgsqlTypeHandler<PostgisPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisPoint> INpgsqlTypeHandler<PostgisPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisMultiPoint> INpgsqlTypeHandler<PostgisMultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisMultiPoint> INpgsqlTypeHandler<PostgisMultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisMultiPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisLineString> INpgsqlTypeHandler<PostgisLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisLineString> INpgsqlTypeHandler<PostgisLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisMultiLineString> INpgsqlTypeHandler<PostgisMultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisMultiLineString> INpgsqlTypeHandler<PostgisMultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisMultiLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisPolygon> INpgsqlTypeHandler<PostgisPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisPolygon> INpgsqlTypeHandler<PostgisPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisMultiPolygon> INpgsqlTypeHandler<PostgisMultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisMultiPolygon> INpgsqlTypeHandler<PostgisMultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisMultiPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
-        async ValueTask<PostgisGeometryCollection> INpgsqlTypeHandler<PostgisGeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        async ValueTask<PostgisGeometryCollection> INpgsqlTypeHandler<PostgisGeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => (PostgisGeometryCollection)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         #endregion

--- a/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
@@ -38,7 +38,7 @@ namespace Npgsql.LegacyPostgis
                 srid = buf.ReadUInt32(le);
             }
 
-            var geom = await DoRead(buf, (WkbIdentifier) (id & 7), le, async, cancellationToken: cancellationToken);
+            var geom = await DoRead(buf, (WkbIdentifier)(id & 7), le, async, cancellationToken);
             geom.SRID = srid;
             return geom;
         }
@@ -148,7 +148,7 @@ namespace Npgsql.LegacyPostgis
                     var elemLe = buf.ReadByte() != 0;
                     var elemId = (WkbIdentifier)(buf.ReadUInt32(le) & 7);
 
-                    g[i] = await DoRead(buf, elemId, elemLe, async, cancellationToken: cancellationToken);
+                    g[i] = await DoRead(buf, elemId, elemLe, async, cancellationToken);
                 }
                 return new PostgisGeometryCollection(g);
             }

--- a/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/LegacyPostgisHandler.cs
@@ -27,14 +27,14 @@ namespace Npgsql.LegacyPostgis
 
         public override async ValueTask<PostgisGeometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(5, async, cancellationToken: cancellationToken);
+            await buf.Ensure(5, async, cancellationToken);
             var le = buf.ReadByte() != 0;
             var id = buf.ReadUInt32(le);
 
             var srid = 0u;
             if ((id & (uint)EwkbModifiers.HasSRID) != 0)
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 srid = buf.ReadUInt32(le);
             }
 
@@ -48,16 +48,16 @@ namespace Npgsql.LegacyPostgis
             switch (id)
             {
             case WkbIdentifier.Point:
-                await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                await buf.Ensure(16, async, cancellationToken);
                 return new PostgisPoint(buf.ReadDouble(le), buf.ReadDouble(le));
 
             case WkbIdentifier.LineString:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
-                    await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(16, async, cancellationToken);
                     points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisLineString(points);
@@ -65,16 +65,16 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.Polygon:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
-                    await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(4, async, cancellationToken);
                     rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
-                        await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(16, async, cancellationToken);
                         rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
@@ -83,12 +83,12 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiPoint:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var points = new Coordinate2D[buf.ReadInt32(le)];
                 for (var ipts = 0; ipts < points.Length; ipts++)
                 {
-                    await buf.Ensure(21, async, cancellationToken: cancellationToken);
-                    await buf.Skip(5, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(21, async, cancellationToken);
+                    await buf.Skip(5, async, cancellationToken);
                     points[ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                 }
                 return new PostgisMultiPoint(points);
@@ -96,17 +96,17 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiLineString:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var rings = new Coordinate2D[buf.ReadInt32(le)][];
 
                 for (var irng = 0; irng < rings.Length; irng++)
                 {
-                    await buf.Ensure(9, async, cancellationToken: cancellationToken);
-                    await buf.Skip(5, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(9, async, cancellationToken);
+                    await buf.Skip(5, async, cancellationToken);
                     rings[irng] = new Coordinate2D[buf.ReadInt32(le)];
                     for (var ipts = 0; ipts < rings[irng].Length; ipts++)
                     {
-                        await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(16, async, cancellationToken);
                         rings[irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                     }
                 }
@@ -115,21 +115,21 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.MultiPolygon:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var pols = new Coordinate2D[buf.ReadInt32(le)][][];
 
                 for (var ipol = 0; ipol < pols.Length; ipol++)
                 {
-                    await buf.Ensure(9, async, cancellationToken: cancellationToken);
-                    await buf.Skip(5, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(9, async, cancellationToken);
+                    await buf.Skip(5, async, cancellationToken);
                     pols[ipol] = new Coordinate2D[buf.ReadInt32(le)][];
                     for (var irng = 0; irng < pols[ipol].Length; irng++)
                     {
-                        await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                        await buf.Ensure(4, async, cancellationToken);
                         pols[ipol][irng] = new Coordinate2D[buf.ReadInt32(le)];
                         for (var ipts = 0; ipts < pols[ipol][irng].Length; ipts++)
                         {
-                            await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                            await buf.Ensure(16, async, cancellationToken);
                             pols[ipol][irng][ipts] = new Coordinate2D(buf.ReadDouble(le), buf.ReadDouble(le));
                         }
                     }
@@ -139,12 +139,12 @@ namespace Npgsql.LegacyPostgis
 
             case WkbIdentifier.GeometryCollection:
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var g = new PostgisGeometry[buf.ReadInt32(le)];
 
                 for (var i = 0; i < g.Length; i++)
                 {
-                    await buf.Ensure(5, async, cancellationToken: cancellationToken);
+                    await buf.Ensure(5, async, cancellationToken);
                     var elemLe = buf.ReadByte() != 0;
                     var elemId = (WkbIdentifier)(buf.ReadUInt32(le) & 7);
 
@@ -163,19 +163,19 @@ namespace Npgsql.LegacyPostgis
         #region Read concrete types
 
         async ValueTask<PostgisPoint> INpgsqlTypeHandler<PostgisPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisPoint)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisMultiPoint> INpgsqlTypeHandler<PostgisMultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisMultiPoint)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisMultiPoint)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisLineString> INpgsqlTypeHandler<PostgisLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisLineString)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisMultiLineString> INpgsqlTypeHandler<PostgisMultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisMultiLineString)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisMultiLineString)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisPolygon> INpgsqlTypeHandler<PostgisPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisPolygon)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisMultiPolygon> INpgsqlTypeHandler<PostgisMultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisMultiPolygon)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisMultiPolygon)await Read(buf, len, async, fieldDescription, cancellationToken);
         async ValueTask<PostgisGeometryCollection> INpgsqlTypeHandler<PostgisGeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (PostgisGeometryCollection)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (PostgisGeometryCollection)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         #endregion
 

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
@@ -33,28 +34,28 @@ namespace Npgsql.NetTopologySuite
 
         #region Read
 
-        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
             => ReadCore<Geometry>(buf, len);
 
-        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<Point>(buf, len);
 
-        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<LineString>(buf, len);
 
-        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<Polygon>(buf, len);
 
-        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<MultiPoint>(buf, len);
 
-        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<MultiLineString>(buf, len);
 
-        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<MultiPolygon>(buf, len);
 
-        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => ReadCore<GeometryCollection>(buf, len);
 
         ValueTask<T> ReadCore<T>(NpgsqlReadBuffer buf, int len)

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -34,28 +34,28 @@ namespace Npgsql.NetTopologySuite
 
         #region Read
 
-        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => ReadCore<Geometry>(buf, len);
 
-        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<Point>(buf, len);
 
-        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<LineString>(buf, len);
 
-        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<Polygon>(buf, len);
 
-        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<MultiPoint>(buf, len);
 
-        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<MultiLineString>(buf, len);
 
-        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<MultiPolygon>(buf, len);
 
-        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             => ReadCore<GeometryCollection>(buf, len);
 
         ValueTask<T> ReadCore<T>(NpgsqlReadBuffer buf, int len)

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -37,25 +37,25 @@ namespace Npgsql.NetTopologySuite
         public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => ReadCore<Geometry>(buf, len);
 
-        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<Point>(buf, len);
 
-        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<LineString>(buf, len);
 
-        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<Polygon>(buf, len);
 
-        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<MultiPoint>(buf, len);
 
-        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<MultiLineString>(buf, len);
 
-        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<MultiPolygon>(buf, len);
 
-        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => ReadCore<GeometryCollection>(buf, len);
 
         ValueTask<T> ReadCore<T>(NpgsqlReadBuffer buf, int len)

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -106,7 +106,7 @@ namespace Npgsql
         /// The number of columns in the row. -1 if there are no further rows.
         /// Note: This will currently be the same value for all rows, but this may change in the future.
         /// </returns>
-        public int StartRow() => StartRow(false).GetAwaiter().GetResult();
+        public int StartRow() => StartRow(false, default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Starts reading a single row, must be invoked before reading any columns.
@@ -117,13 +117,11 @@ namespace Npgsql
         /// </returns>
         public ValueTask<int> StartRowAsync(CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
             using (NoSynchronizationContextScope.Enter())
-                return StartRow(true);
+                return StartRow(true, cancellationToken);
         }
 
-        async ValueTask<int> StartRow(bool async)
+        async ValueTask<int> StartRow(bool async, CancellationToken cancellationToken)
         {
             CheckDisposed();
             if (_isConsumed)
@@ -133,20 +131,20 @@ namespace Npgsql
             // Otherwise we need to read in a new CopyData row (the docs specify that there's a CopyData
             // message per row).
             if (_column == NumColumns)
-                _leftToReadInDataMsg = Expect<CopyDataMessage>(await _connector.ReadMessage(async), _connector).Length;
+                _leftToReadInDataMsg = Expect<CopyDataMessage>(await _connector.ReadMessage(async, cancellationToken), _connector).Length;
             else if (_column != -1)
                 throw new InvalidOperationException("Already in the middle of a row");
 
-            await _buf.Ensure(2, async);
+            await _buf.Ensure(2, async, cancellationToken);
             _leftToReadInDataMsg -= 2;
 
             var numColumns = _buf.ReadInt16();
             if (numColumns == -1)
             {
                 Debug.Assert(_leftToReadInDataMsg == 0);
-                Expect<CopyDoneMessage>(await _connector.ReadMessage(async), _connector);
-                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async), _connector);
+                Expect<CopyDoneMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
+                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
                 _column = -1;
                 _isConsumed = true;
                 return -1;
@@ -168,7 +166,7 @@ namespace Npgsql
         /// specify the type.
         /// </typeparam>
         /// <returns>The value of the column</returns>
-        public T Read<T>() => Read<T>(false).GetAwaiter().GetResult();
+        public T Read<T>() => Read<T>(false, default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Reads the current column, returns its value and moves ahead to the next column.
@@ -182,13 +180,11 @@ namespace Npgsql
         /// <returns>The value of the column</returns>
         public ValueTask<T> ReadAsync<T>(CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
             using (NoSynchronizationContextScope.Enter())
-                return Read<T>(true);
+                return Read<T>(true, cancellationToken);
         }
 
-        ValueTask<T> Read<T>(bool async)
+        ValueTask<T> Read<T>(bool async, CancellationToken cancellationToken)
         {
             CheckDisposed();
             if (_column == -1 || _column == NumColumns)
@@ -199,7 +195,7 @@ namespace Npgsql
             if (handler == null)
                 handler = _typeHandlerCache[_column] = _typeMapper.GetByClrType(type);
 
-            return DoRead<T>(handler, async);
+            return DoRead<T>(handler, async, cancellationToken);
         }
 
         /// <summary>
@@ -215,7 +211,7 @@ namespace Npgsql
         /// </param>
         /// <typeparam name="T">The .NET type of the column to be read.</typeparam>
         /// <returns>The value of the column</returns>
-        public T Read<T>(NpgsqlDbType type) => Read<T>(type, false).GetAwaiter().GetResult();
+        public T Read<T>(NpgsqlDbType type) => Read<T>(type, false, default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Reads the current column, returns its value according to <paramref name="type"/> and
@@ -233,13 +229,11 @@ namespace Npgsql
         /// <returns>The value of the column</returns>
         public ValueTask<T> ReadAsync<T>(NpgsqlDbType type, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
             using (NoSynchronizationContextScope.Enter())
-                return Read<T>(type, true);
+                return Read<T>(type, true, cancellationToken);
         }
 
-        ValueTask<T> Read<T>(NpgsqlDbType type, bool async)
+        ValueTask<T> Read<T>(NpgsqlDbType type, bool async, CancellationToken cancellationToken)
         {
             CheckDisposed();
             if (_column == -1 || _column == NumColumns)
@@ -249,14 +243,14 @@ namespace Npgsql
             if (handler == null)
                 handler = _typeHandlerCache[_column] = _typeMapper.GetByNpgsqlDbType(type);
 
-            return DoRead<T>(handler, async);
+            return DoRead<T>(handler, async, cancellationToken);
         }
 
-        async ValueTask<T> DoRead<T>(NpgsqlTypeHandler handler, bool async)
+        async ValueTask<T> DoRead<T>(NpgsqlTypeHandler handler, bool async, CancellationToken cancellationToken)
         {
             try
             {
-                await ReadColumnLenIfNeeded(async);
+                await ReadColumnLenIfNeeded(async, cancellationToken);
 
                 if (_columnLen == -1)
                 {
@@ -272,10 +266,10 @@ namespace Npgsql
                 var result = NullableHandler<T>.Exists
                     ? _columnLen <= _buf.ReadBytesLeft
                         ? NullableHandler<T>.Read(handler, _buf, _columnLen)
-                        : await NullableHandler<T>.ReadAsync(handler, _buf, _columnLen, async)
+                        : await NullableHandler<T>.ReadAsync(handler, _buf, _columnLen, async, cancellationToken)
                     : _columnLen <= _buf.ReadBytesLeft
                         ? handler.Read<T>(_buf, _columnLen)
-                        : await handler.Read<T>(_buf, _columnLen, async);
+                        : await handler.Read<T>(_buf, _columnLen, async, cancellationToken);
 
                 _leftToReadInDataMsg -= _columnLen;
                 _columnLen = int.MinValue;   // Mark that the (next) column length hasn't been read yet
@@ -297,7 +291,7 @@ namespace Npgsql
         {
             get
             {
-                ReadColumnLenIfNeeded(false).GetAwaiter().GetResult();
+                ReadColumnLenIfNeeded(false, default).GetAwaiter().GetResult();
                 return _columnLen == -1;
             }
         }
@@ -305,7 +299,7 @@ namespace Npgsql
         /// <summary>
         /// Skips the current column without interpreting its value.
         /// </summary>
-        public void Skip() => Skip(false).GetAwaiter().GetResult();
+        public void Skip() => Skip(false, default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Skips the current column without interpreting its value.
@@ -315,14 +309,14 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Skip(true);
+                return Skip(true, cancellationToken);
         }
 
-        async Task Skip(bool async)
+        async Task Skip(bool async, CancellationToken cancellationToken)
         {
-            await ReadColumnLenIfNeeded(async);
+            await ReadColumnLenIfNeeded(async, cancellationToken);
             if (_columnLen != -1)
-                await _buf.Skip(_columnLen, async);
+                await _buf.Skip(_columnLen, async, cancellationToken);
 
             _columnLen = int.MinValue;
             _column++;
@@ -332,11 +326,11 @@ namespace Npgsql
 
         #region Utilities
 
-        async Task ReadColumnLenIfNeeded(bool async)
+        async Task ReadColumnLenIfNeeded(bool async, CancellationToken cancellationToken)
         {
             if (_columnLen == int.MinValue)
             {
-                await _buf.Ensure(4, async);
+                await _buf.Ensure(4, async, cancellationToken);
                 _columnLen = _buf.ReadInt32();
                 _leftToReadInDataMsg -= 4;
             }
@@ -383,8 +377,9 @@ namespace Npgsql
                 _buf.Skip(_leftToReadInDataMsg);
                 // Read to the end
                 _connector.SkipUntil(BackendMessageCode.CopyDone);
-                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async), _connector);
+                // We intentionally do not pass a CancellationToken since we don't want to cancel cleanup
+                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, default), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, default), _connector);
             }
 
             var connector = _connector;

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -297,7 +297,7 @@ namespace Npgsql
         {
             get
             {
-                ReadColumnLenIfNeeded(false, default).GetAwaiter().GetResult();
+                ReadColumnLenIfNeeded(false).GetAwaiter().GetResult();
                 return _columnLen == -1;
             }
         }

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -266,7 +266,7 @@ namespace Npgsql
                 var result = NullableHandler<T>.Exists
                     ? _columnLen <= _buf.ReadBytesLeft
                         ? NullableHandler<T>.Read(handler, _buf, _columnLen)
-                        : await NullableHandler<T>.ReadAsync(handler, _buf, _columnLen, async, cancellationToken)
+                        : await NullableHandler<T>.ReadAsync(handler, _buf, _columnLen, async, cancellationToken: cancellationToken)
                     : _columnLen <= _buf.ReadBytesLeft
                         ? handler.Read<T>(_buf, _columnLen)
                         : await handler.Read<T>(_buf, _columnLen, async, cancellationToken: cancellationToken);

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -135,7 +135,7 @@ namespace Npgsql
             else if (_column != -1)
                 throw new InvalidOperationException("Already in the middle of a row");
 
-            await _buf.Ensure(2, async, cancellationToken: cancellationToken);
+            await _buf.Ensure(2, async, cancellationToken);
             _leftToReadInDataMsg -= 2;
 
             var numColumns = _buf.ReadInt16();
@@ -316,7 +316,7 @@ namespace Npgsql
         {
             await ReadColumnLenIfNeeded(async, cancellationToken);
             if (_columnLen != -1)
-                await _buf.Skip(_columnLen, async, cancellationToken: cancellationToken);
+                await _buf.Skip(_columnLen, async, cancellationToken);
 
             _columnLen = int.MinValue;
             _column++;
@@ -330,7 +330,7 @@ namespace Npgsql
         {
             if (_columnLen == int.MinValue)
             {
-                await _buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await _buf.Ensure(4, async, cancellationToken);
                 _columnLen = _buf.ReadInt32();
                 _leftToReadInDataMsg -= 4;
             }

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -408,8 +408,8 @@ namespace Npgsql
                 _buf.EndCopyMode();
                 await _connector.WriteCopyDone(async);
                 await _connector.Flush(async);
-                var cmdComplete = Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
+                var cmdComplete = Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
                 _state = ImporterState.Committed;
                 return cmdComplete.Rows;
             }
@@ -447,7 +447,7 @@ namespace Npgsql
             await _connector.Flush(async);
             try
             {
-                var msg = await _connector.ReadMessage(async, cancellationToken);
+                var msg = await _connector.ReadMessage(async, cancellationToken: cancellationToken);
                 // The CopyFail should immediately trigger an exception from the read above.
                 throw _connector.Break(
                     new NpgsqlException("Expected ErrorResponse when cancelling COPY but got: " + msg.Code));

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -537,7 +537,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// Creates a server-side prepared statement on the PostgreSQL server.
         /// This will make repeated future executions of this command much faster.
         /// </summary>
-        public override void Prepare() => Prepare(false, default).GetAwaiter().GetResult();
+        public override void Prepare() => Prepare(false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Creates a server-side prepared statement on the PostgreSQL server.
@@ -550,11 +550,13 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         public Task PrepareAsync(CancellationToken cancellationToken = default)
 #endif
         {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Prepare(true, cancellationToken);
         }
 
-        Task Prepare(bool async, CancellationToken cancellationToken)
+        Task Prepare(bool async, CancellationToken cancellationToken = default)
         {
             var connection = CheckAndGetConnection();
             if (connection.Settings.Multiplexing)
@@ -609,14 +611,14 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         {
                             if (pStatement.StatementBeingReplaced != null)
                             {
-                                Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                                Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken), connector);
                                 pStatement.StatementBeingReplaced.CompleteUnprepare();
                                 pStatement.StatementBeingReplaced = null;
                             }
 
-                            Expect<ParseCompleteMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
-                            Expect<ParameterDescriptionMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
-                            var msg = await connector.ReadMessage(async, cancellationToken: cancellationToken);
+                            Expect<ParseCompleteMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                            Expect<ParameterDescriptionMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                            var msg = await connector.ReadMessage(async, cancellationToken);
                             switch (msg.Code)
                             {
                             case BackendMessageCode.RowDescription:
@@ -655,7 +657,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         }
                     }
 
-                    Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                    Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken), connector);
 
                     if (async)
                         await sendTask;
@@ -671,7 +673,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// automatically prepared statements.
         /// </summary>
         public void Unprepare()
-            => Unprepare(false, default).GetAwaiter().GetResult();
+            => Unprepare(false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Unprepares a command, closing server-side statements associated with it.
@@ -681,11 +683,13 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task UnprepareAsync(CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled<int>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Unprepare(true, cancellationToken);
         }
 
-        async Task Unprepare(bool async, CancellationToken cancellationToken)
+        async Task Unprepare(bool async, CancellationToken cancellationToken = default)
         {
             var connection = CheckAndGetConnection();
             if (connection.Settings.Multiplexing)
@@ -702,11 +706,11 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 foreach (var statement in _statements)
                     if (statement.PreparedStatement?.State == PreparedState.BeingUnprepared)
                     {
-                        Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                        Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken), connector);
                         statement.PreparedStatement.CompleteUnprepare();
                         statement.PreparedStatement = null;
                     }
-                Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken), connector);
                 if (async)
                     await sendTask;
                 else

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -609,14 +609,14 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         {
                             if (pStatement.StatementBeingReplaced != null)
                             {
-                                Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                                Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
                                 pStatement.StatementBeingReplaced.CompleteUnprepare();
                                 pStatement.StatementBeingReplaced = null;
                             }
 
-                            Expect<ParseCompleteMessage>(await connector.ReadMessage(async, cancellationToken), connector);
-                            Expect<ParameterDescriptionMessage>(await connector.ReadMessage(async, cancellationToken), connector);
-                            var msg = await connector.ReadMessage(async, cancellationToken);
+                            Expect<ParseCompleteMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                            Expect<ParameterDescriptionMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
+                            var msg = await connector.ReadMessage(async, cancellationToken: cancellationToken);
                             switch (msg.Code)
                             {
                             case BackendMessageCode.RowDescription:
@@ -655,7 +655,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         }
                     }
 
-                    Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                    Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
 
                     if (async)
                         await sendTask;
@@ -702,11 +702,11 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 foreach (var statement in _statements)
                     if (statement.PreparedStatement?.State == PreparedState.BeingUnprepared)
                     {
-                        Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                        Expect<CloseCompletedMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
                         statement.PreparedStatement.CompleteUnprepare();
                         statement.PreparedStatement = null;
                     }
-                Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken), connector);
+                Expect<ReadyForQueryMessage>(await connector.ReadMessage(async, cancellationToken: cancellationToken), connector);
                 if (async)
                     await sendTask;
                 else

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -673,7 +673,7 @@ namespace Npgsql
         /// Releases the connection. If the connection is pooled, it will be returned to the pool and made available for re-use.
         /// If it is non-pooled, the physical connection will be closed.
         /// </summary>
-        public override void Close() => Close(false, default);
+        public override void Close() => Close(async: false);
 
         /// <summary>
         /// Releases the connection. If the connection is pooled, it will be returned to the pool and made available for re-use.
@@ -686,10 +686,10 @@ namespace Npgsql
 #endif
         {
             using (NoSynchronizationContextScope.Enter())
-                return Close(true, default);
+                return Close(async: true);
         }
 
-        internal Task Close(bool async, CancellationToken cancellationToken)
+        internal Task Close(bool async, CancellationToken cancellationToken = default)
         {
             // Even though NpgsqlConnection isn't thread safe we'll make sure this part is.
             // Because we really don't want double returns to the pool.
@@ -823,9 +823,7 @@ namespace Npgsql
         {
             if (_disposed)
                 return;
-
             await CloseAsync();
-
             _disposed = true;
         }
 
@@ -1388,7 +1386,7 @@ namespace Npgsql
             CheckReady();
 
             Log.Debug("Starting to wait asynchronously...", Connector!.Id);
-            return Connector!.WaitAsync(cancellationToken: cancellationToken);
+            return Connector!.WaitAsync(cancellationToken);
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -823,11 +823,9 @@ namespace Npgsql
         {
             if (_disposed)
                 return;
-#if !NET461 && !NETSTANDARD2_0
+
             await CloseAsync();
-#else
-            await CloseAsync();
-#endif
+
             _disposed = true;
         }
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1388,7 +1388,7 @@ namespace Npgsql
             CheckReady();
 
             Log.Debug("Starting to wait asynchronously...", Connector!.Id);
-            return Connector!.WaitAsync(cancellationToken);
+            return Connector!.WaitAsync(cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -17,11 +17,11 @@ namespace Npgsql
 {
     partial class NpgsqlConnector
     {
-        async Task Authenticate(string username, NpgsqlTimeout timeout, bool async)
+        async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         {
             Log.Trace("Authenticating...", Id);
 
-            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
+            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
             timeout.Check();
             switch (msg.AuthRequestType)
             {
@@ -29,15 +29,15 @@ namespace Npgsql
                 return;
 
             case AuthenticationRequestType.AuthenticationCleartextPassword:
-                await AuthenticateCleartext(username, async);
+                await AuthenticateCleartext(username, async, cancellationToken);
                 return;
 
             case AuthenticationRequestType.AuthenticationMD5Password:
-                await AuthenticateMD5(username, ((AuthenticationMD5PasswordMessage)msg).Salt, async);
+                await AuthenticateMD5(username, ((AuthenticationMD5PasswordMessage)msg).Salt, async, cancellationToken);
                 return;
 
             case AuthenticationRequestType.AuthenticationSASL:
-                await AuthenticateSASL(((AuthenticationSASLMessage)msg).Mechanisms, username, async);
+                await AuthenticateSASL(((AuthenticationSASLMessage)msg).Mechanisms, username, async, cancellationToken);
                 return;
 
             case AuthenticationRequestType.AuthenticationGSS:
@@ -53,7 +53,7 @@ namespace Npgsql
             }
         }
 
-        async Task AuthenticateCleartext(string username, bool async)
+        async Task AuthenticateCleartext(string username, bool async, CancellationToken cancellationToken)
         {
             var passwd = GetPassword(username);
             if (passwd == null)
@@ -64,10 +64,10 @@ namespace Npgsql
 
             await WritePassword(encoded, async);
             await Flush(async);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
         }
 
-        async Task AuthenticateSASL(List<string> mechanisms, string username, bool async)
+        async Task AuthenticateSASL(List<string> mechanisms, string username, bool async, CancellationToken cancellationToken)
         {
             // At the time of writing PostgreSQL only supports SCRAM-SHA-256 and SCRAM-SHA-256-PLUS
             var supportsSha256 = mechanisms.Contains("SCRAM-SHA-256");
@@ -164,7 +164,7 @@ namespace Npgsql
             await WriteSASLInitialResponse(mechanism, PGUtil.UTF8Encoding.GetBytes($"{cbindFlag},,n=*,r={clientNonce}"), async);
             await Flush(async);
 
-            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async), this);
+            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async, cancellationToken), this);
             if (saslContinueMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLContinue)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
             var firstServerMsg = AuthenticationSCRAMServerFirstMessage.Load(saslContinueMsg.Payload);
@@ -197,7 +197,7 @@ namespace Npgsql
             await WriteSASLResponse(Encoding.UTF8.GetBytes(messageStr), async);
             await Flush(async);
 
-            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async), this);
+            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async, cancellationToken), this);
             if (saslFinalServerMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLFinal)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
 
@@ -205,7 +205,7 @@ namespace Npgsql
             if (scramFinalServerMsg.ServerSignature != Convert.ToBase64String(serverSignature))
                 throw new NpgsqlException("[SCRAM] Unable to verify server signature");
 
-            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
+            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
             if (okMsg.AuthRequestType != AuthenticationRequestType.AuthenticationOk)
                 throw new NpgsqlException("[SASL] Expected AuthenticationOK message");
 
@@ -253,7 +253,7 @@ namespace Npgsql
             }
         }
 
-        async Task AuthenticateMD5(string username, byte[] salt, bool async)
+        async Task AuthenticateMD5(string username, byte[] salt, bool async, CancellationToken cancellationToken)
         {
             var passwd = GetPassword(username);
             if (passwd == null)
@@ -297,7 +297,7 @@ namespace Npgsql
 
             await WritePassword(result, async);
             await Flush(async);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
         }
 
         async Task AuthenticateGSS(bool async)
@@ -386,16 +386,16 @@ namespace Npgsql
             }
 
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-                => Read(buffer, offset, count, true);
+                => Read(buffer, offset, count, true, cancellationToken);
 
             public override int Read(byte[] buffer, int offset, int count)
-                => Read(buffer, offset, count, false).GetAwaiter().GetResult();
+                => Read(buffer, offset, count, false, default).GetAwaiter().GetResult();
 
-            async Task<int> Read(byte[] buffer, int offset, int count, bool async)
+            async Task<int> Read(byte[] buffer, int offset, int count, bool async, CancellationToken cancellationToken)
             {
                 if (_leftToRead == 0)
                 {
-                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async), _connector);
+                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
                     if (response.AuthRequestType == AuthenticationRequestType.AuthenticationOk)
                         throw new AuthenticationCompleteException();
                     var gssMsg = response as AuthenticationGSSContinueMessage;

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -21,7 +21,7 @@ namespace Npgsql
         {
             Log.Trace("Authenticating...", Id);
 
-            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
+            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
             timeout.Check();
             switch (msg.AuthRequestType)
             {
@@ -64,7 +64,7 @@ namespace Npgsql
 
             await WritePassword(encoded, async);
             await Flush(async);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
         }
 
         async Task AuthenticateSASL(List<string> mechanisms, string username, bool async, CancellationToken cancellationToken)
@@ -164,7 +164,7 @@ namespace Npgsql
             await WriteSASLInitialResponse(mechanism, PGUtil.UTF8Encoding.GetBytes($"{cbindFlag},,n=*,r={clientNonce}"), async);
             await Flush(async);
 
-            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async, cancellationToken), this);
+            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
             if (saslContinueMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLContinue)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
             var firstServerMsg = AuthenticationSCRAMServerFirstMessage.Load(saslContinueMsg.Payload);
@@ -197,7 +197,7 @@ namespace Npgsql
             await WriteSASLResponse(Encoding.UTF8.GetBytes(messageStr), async);
             await Flush(async);
 
-            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async, cancellationToken), this);
+            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
             if (saslFinalServerMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLFinal)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
 
@@ -205,7 +205,7 @@ namespace Npgsql
             if (scramFinalServerMsg.ServerSignature != Convert.ToBase64String(serverSignature))
                 throw new NpgsqlException("[SCRAM] Unable to verify server signature");
 
-            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
+            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
             if (okMsg.AuthRequestType != AuthenticationRequestType.AuthenticationOk)
                 throw new NpgsqlException("[SASL] Expected AuthenticationOK message");
 
@@ -297,7 +297,7 @@ namespace Npgsql
 
             await WritePassword(result, async);
             await Flush(async);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken: cancellationToken), this);
         }
 
         async Task AuthenticateGSS(bool async)
@@ -395,7 +395,7 @@ namespace Npgsql
             {
                 if (_leftToRead == 0)
                 {
-                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
+                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
                     if (response.AuthRequestType == AuthenticationRequestType.AuthenticationOk)
                         throw new AuthenticationCompleteException();
                     var gssMsg = response as AuthenticationGSSContinueMessage;

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -592,7 +592,7 @@ namespace Npgsql
                     WriteSslRequest();
                     await Flush(async);
 
-                    await ReadBuffer.Ensure(1, async, cancellationToken: cancellationToken);
+                    await ReadBuffer.Ensure(1, async, cancellationToken);
                     var response = (char)ReadBuffer.ReadByte();
                     timeout.Check();
 
@@ -887,7 +887,7 @@ namespace Npgsql
                     {
                         commandsRead++;
 
-                        await ReadBuffer.Ensure(5, true, cancellationToken: default);
+                        await ReadBuffer.Ensure(5, true, default);
 
                         // We have a resultset for the command - hand back control to the command (which will
                         // return it to the user)
@@ -1060,7 +1060,7 @@ namespace Npgsql
                     {
                         try
                         {
-                            await ReadBuffer.Ensure(5, async, cancellationToken: cancellationToken);
+                            await ReadBuffer.Ensure(5, async, cancellationToken);
                             messageCode = (BackendMessageCode) ReadBuffer.ReadByte();
                             PGUtil.ValidateBackendMessageCode(messageCode);
                             len = ReadBuffer.ReadInt32() - 4; // Transmitted length includes itself
@@ -1071,7 +1071,7 @@ namespace Npgsql
                             {
                                 if (dataRowLoadingMode2 == DataRowLoadingMode.Skip)
                                 {
-                                    await ReadBuffer.Skip(len, async, cancellationToken: cancellationToken);
+                                    await ReadBuffer.Skip(len, async, cancellationToken);
                                     continue;
                                 }
                             }
@@ -1089,7 +1089,7 @@ namespace Npgsql
                                     ReadBuffer = oversizeBuffer;
                                 }
 
-                                await ReadBuffer.Ensure(len, async, cancellationToken: cancellationToken);
+                                await ReadBuffer.Ensure(len, async, cancellationToken);
                             }
 
                             var msg = ParseServerMessage(ReadBuffer, messageCode, len, isReadingPrependedMessage);
@@ -2063,7 +2063,7 @@ namespace Npgsql
                                     break;
                                 case BackendMessageCode.DataRow:
                                     // DataRow is usually consumed by a reader, here we have to skip it manually.
-                                    await ReadBuffer.Skip(((DataRowMessage) msg).Length, true, cancellationToken: cancellationToken);
+                                    await ReadBuffer.Skip(((DataRowMessage) msg).Length, true, cancellationToken);
                                     expectedMessageCode = BackendMessageCode.CompletedResponse;
                                     break;
                                 case BackendMessageCode.CompletedResponse:

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1456,7 +1456,7 @@ namespace Npgsql
             var copyOperation = CurrentCopyOperation;
 
             if (reader != null)
-                await reader.Close(connectionClosing: true, async, cancellationToken);
+                await reader.Close(connectionClosing: true, async);
             else if (copyOperation != null)
             {
                 // TODO: There's probably a race condition as the COPY operation may finish on its own during the next few lines

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -278,7 +278,7 @@ namespace Npgsql
                 if (msg.Code == BackendMessageCode.DataRow)
                 {
                     // Make sure that the datarow's column count is already buffered
-                    await Connector.ReadBuffer.Ensure(2, async, cancellationToken: cancellationToken);
+                    await Connector.ReadBuffer.Ensure(2, async, cancellationToken);
                     return msg;
                 }
                 return msg;
@@ -1415,7 +1415,7 @@ namespace Npgsql
                     var writtenBytes = Buffer.ReadPosition - position;
                     var remainingBytes = ColumnLen - writtenBytes;
                     if (remainingBytes > 0)
-                        Buffer.Skip(remainingBytes, false, cancellationToken: default).GetAwaiter().GetResult();
+                        Buffer.Skip(remainingBytes, false, default).GetAwaiter().GetResult();
                 }
                 throw;
             }
@@ -1466,7 +1466,7 @@ namespace Npgsql
                     var writtenBytes = Buffer.ReadPosition - position;
                     var remainingBytes = ColumnLen - writtenBytes;
                     if (remainingBytes > 0)
-                        await Buffer.Skip(remainingBytes, async, cancellationToken: cancellationToken);
+                        await Buffer.Skip(remainingBytes, async, cancellationToken);
                 }
                 throw;
             }
@@ -1514,7 +1514,7 @@ namespace Npgsql
                     var writtenBytes = Buffer.ReadPosition - position;
                     var remainingBytes = ColumnLen - writtenBytes;
                     if (remainingBytes > 0)
-                        Buffer.Skip(remainingBytes, false, cancellationToken: default).GetAwaiter().GetResult();
+                        Buffer.Skip(remainingBytes, false, default).GetAwaiter().GetResult();
                 }
                 throw;
             }
@@ -1570,7 +1570,7 @@ namespace Npgsql
                     var writtenBytes = Buffer.ReadPosition - position;
                     var remainingBytes = ColumnLen - writtenBytes;
                     if (remainingBytes > 0)
-                        Buffer.Skip(remainingBytes, false, cancellationToken: default).GetAwaiter().GetResult();
+                        Buffer.Skip(remainingBytes, false, default).GetAwaiter().GetResult();
                 }
                 throw;
             }
@@ -1882,18 +1882,18 @@ namespace Npgsql
             // TODO: Simplify by better initializing _columnLen/_posInColumn
             var remainingInColumn = ColumnLen == -1 ? 0 : ColumnLen - PosInColumn;
             if (remainingInColumn > 0)
-                await Buffer.Skip(remainingInColumn, async, cancellationToken: cancellationToken);
+                await Buffer.Skip(remainingInColumn, async, cancellationToken);
 
             // Skip over unwanted fields
             for (; _column < column - 1; _column++)
             {
-                await Buffer.Ensure(4, async, cancellationToken: cancellationToken);
+                await Buffer.Ensure(4, async, cancellationToken);
                 var len = Buffer.ReadInt32();
                 if (len != -1)
-                    await Buffer.Skip(len, async, cancellationToken: cancellationToken);
+                    await Buffer.Skip(len, async, cancellationToken);
             }
 
-            await Buffer.Ensure(4, async, cancellationToken: cancellationToken);
+            await Buffer.Ensure(4, async, cancellationToken);
             ColumnLen = Buffer.ReadInt32();
             PosInColumn = 0;
             _column = column;
@@ -1923,7 +1923,7 @@ namespace Npgsql
 
                 if (posInColumn2 > PosInColumn)
                 {
-                    await Buffer.Skip(posInColumn2 - PosInColumn, async2, cancellationToken: cancellationToken);
+                    await Buffer.Skip(posInColumn2 - PosInColumn, async2, cancellationToken);
                     PosInColumn = posInColumn2;
                 }
             }
@@ -1956,15 +1956,15 @@ namespace Npgsql
                 // Skip to end of column if needed
                 var remainingInColumn = ColumnLen == -1 ? 0 : ColumnLen - PosInColumn;
                 if (remainingInColumn > 0)
-                    await Buffer.Skip(remainingInColumn, async2, cancellationToken: cancellationToken);
+                    await Buffer.Skip(remainingInColumn, async2, cancellationToken);
 
                 // Skip over the remaining columns in the row
                 for (; _column < _numColumns - 1; _column++)
                 {
-                    await Buffer.Ensure(4, async2, cancellationToken: cancellationToken);
+                    await Buffer.Ensure(4, async2, cancellationToken);
                     var len = Buffer.ReadInt32();
                     if (len != -1)
-                        await Buffer.Skip(len, async2, cancellationToken: cancellationToken);
+                        await Buffer.Skip(len, async2, cancellationToken);
                 }
             }
         }

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1560,7 +1560,7 @@ namespace Npgsql
             try
             {
                 return _isSequential
-                    ? fieldDescription.Handler.ReadPsvAsObject(Buffer, ColumnLen, false, default, fieldDescription).GetAwaiter().GetResult()
+                    ? fieldDescription.Handler.ReadPsvAsObject(Buffer, ColumnLen, false, fieldDescription, cancellationToken: default).GetAwaiter().GetResult()
                     : fieldDescription.Handler.ReadPsvAsObject(Buffer, ColumnLen, fieldDescription);
             }
             catch

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -828,7 +828,7 @@ namespace Npgsql
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.
         /// </summary>
-        public override void Close() => Close(connectionClosing: false, async: true, cancellationToken: default).GetAwaiter().GetResult();
+        public override void Close() => Close(connectionClosing: false, async: false, cancellationToken: default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1450,7 +1450,7 @@ namespace Npgsql
                 return NullableHandler<T>.Exists
                     ? ColumnLen <= Buffer.ReadBytesLeft
                         ? NullableHandler<T>.Read(field.Handler, Buffer, ColumnLen, field)
-                        : await NullableHandler<T>.ReadAsync(field.Handler, Buffer, ColumnLen, async, cancellationToken, field)
+                        : await NullableHandler<T>.ReadAsync(field.Handler, Buffer, ColumnLen, async, field, cancellationToken: cancellationToken)
                     : typeof(T) == typeof(object)
                         ? ColumnLen <= Buffer.ReadBytesLeft
                             ? (T)field.Handler.ReadAsObject(Buffer, ColumnLen, field)

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -827,13 +827,13 @@ namespace Npgsql
 #endif
         {
             using (NoSynchronizationContextScope.Enter())
-                return new ValueTask(Close(connectionClosing: false, async: true, cancellationToken: default));
+                return new ValueTask(Close(connectionClosing: false, async: true));
         }
 
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.
         /// </summary>
-        public override void Close() => Close(connectionClosing: false, async: false, cancellationToken: default).GetAwaiter().GetResult();
+        public override void Close() => Close(connectionClosing: false, async: false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.
@@ -843,9 +843,9 @@ namespace Npgsql
 #else
         public Task CloseAsync()
 #endif
-            => Close(connectionClosing: false, async: true, cancellationToken: default);
+            => Close(connectionClosing: false, async: true);
 
-        internal async Task Close(bool connectionClosing, bool async, CancellationToken cancellationToken = default)
+        internal async Task Close(bool connectionClosing, bool async)
         {
             if (State == ReaderState.Closed)
                 return;
@@ -857,7 +857,7 @@ namespace Npgsql
             case ConnectorState.Executing:
             case ConnectorState.Connecting:
                 if (State != ReaderState.Consumed)
-                    await Consume(async, cancellationToken);
+                    await Consume(async);
                 break;
             case ConnectorState.Closed:
             case ConnectorState.Broken:
@@ -1330,7 +1330,7 @@ namespace Npgsql
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The returned object.</returns>
         public override TextReader GetTextReader(int ordinal)
-            => GetTextReader(ordinal, false, default).Result;
+            => GetTextReader(ordinal, false).Result;
 
         /// <summary>
         /// Retrieves data as a <see cref="TextReader"/>.

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -298,7 +298,7 @@ namespace Npgsql
             // If our buffer is empty, read in more. Otherwise return whatever is there, even if the
             // user asked for more (normal socket behavior)
             if (_readBuf.ReadBytesLeft == 0)
-                await _readBuf.ReadMore(async, cancellationToken: cancellationToken);
+                await _readBuf.ReadMore(async, cancellationToken);
 
             Debug.Assert(_readBuf.ReadBytesLeft > 0);
 
@@ -389,7 +389,7 @@ namespace Npgsql
                     {
                         if (_leftToReadInDataMsg > 0)
                         {
-                            await _readBuf.Skip(_leftToReadInDataMsg, async, cancellationToken: default);
+                            await _readBuf.Skip(_leftToReadInDataMsg, async, default);
                         }
                         _connector.SkipUntil(BackendMessageCode.ReadyForQuery);
                     }

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -270,7 +270,7 @@ namespace Npgsql
                 {
                     // We've consumed the current DataMessage (or haven't yet received the first),
                     // read the next message
-                    msg = await _connector.ReadMessage(async, cancellationToken);
+                    msg = await _connector.ReadMessage(async, cancellationToken: cancellationToken);
                 }
                 catch
                 {
@@ -284,8 +284,8 @@ namespace Npgsql
                     _leftToReadInDataMsg = ((CopyDataMessage)msg).Length;
                     break;
                 case BackendMessageCode.CopyDone:
-                    Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
-                    Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken), _connector);
+                    Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
+                    Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken: cancellationToken), _connector);
                     _isConsumed = true;
                     return 0;
                 default:
@@ -298,7 +298,7 @@ namespace Npgsql
             // If our buffer is empty, read in more. Otherwise return whatever is there, even if the
             // user asked for more (normal socket behavior)
             if (_readBuf.ReadBytesLeft == 0)
-                await _readBuf.ReadMore(async, cancellationToken);
+                await _readBuf.ReadMore(async, cancellationToken: cancellationToken);
 
             Debug.Assert(_readBuf.ReadBytesLeft > 0);
 
@@ -340,7 +340,7 @@ namespace Npgsql
                 await _connector.Flush(async);
                 try
                 {
-                    var msg = await _connector.ReadMessage(async, default);
+                    var msg = await _connector.ReadMessage(async, cancellationToken: default);
                     // The CopyFail should immediately trigger an exception from the read above.
                     throw _connector.Break(
                         new NpgsqlException("Expected ErrorResponse when cancelling COPY but got: " + msg.Code));
@@ -380,8 +380,8 @@ namespace Npgsql
                     _writeBuf.EndCopyMode();
                     await _connector.WriteCopyDone(async);
                     await _connector.Flush(async);
-                    Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, default), _connector);
-                    Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, default), _connector);
+                    Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, cancellationToken: default), _connector);
+                    Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, cancellationToken: default), _connector);
                 }
                 else
                 {
@@ -389,7 +389,7 @@ namespace Npgsql
                     {
                         if (_leftToReadInDataMsg > 0)
                         {
-                            await _readBuf.Skip(_leftToReadInDataMsg, async, default);
+                            await _readBuf.Skip(_leftToReadInDataMsg, async, cancellationToken: default);
                         }
                         _connector.SkipUntil(BackendMessageCode.ReadyForQuery);
                     }

--- a/src/Npgsql/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.Stream.cs
@@ -145,7 +145,7 @@ namespace Npgsql
             }
 
 #if !NET461 && !NETSTANDARD2_0
-            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
 #else
             public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
 #endif
@@ -161,11 +161,11 @@ namespace Npgsql
                     return new ValueTask<int>(0);
 
                 using (NoSynchronizationContextScope.Enter())
-                    return ReadLong(buffer.Slice(0, count));
+                    return ReadLong(buffer.Slice(0, count), cancellationToken);
 
-                async ValueTask<int> ReadLong(Memory<byte> buffer)
+                async ValueTask<int> ReadLong(Memory<byte> buffer, CancellationToken cancellationToken = default)
                 {
-                    var read = await _buf.ReadAsync(buffer);
+                    var read = await _buf.ReadAsync(buffer, cancellationToken);
                     _read += read;
                     return read;
                 }
@@ -197,9 +197,9 @@ namespace Npgsql
                 if (leftToSkip > 0)
                 {
                     if (async)
-                        await _buf.Skip(leftToSkip, async);
+                        await _buf.Skip(leftToSkip, async, default);
                     else
-                        _buf.Skip(leftToSkip, async).GetAwaiter().GetResult();
+                        _buf.Skip(leftToSkip, async, default).GetAwaiter().GetResult();
                 }
                 IsDisposed = true;
             }

--- a/src/Npgsql/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.Stream.cs
@@ -197,9 +197,9 @@ namespace Npgsql
                 if (leftToSkip > 0)
                 {
                     if (async)
-                        await _buf.Skip(leftToSkip, async, cancellationToken: default);
+                        await _buf.Skip(leftToSkip, async, default);
                     else
-                        _buf.Skip(leftToSkip, async, cancellationToken: default).GetAwaiter().GetResult();
+                        _buf.Skip(leftToSkip, async, default).GetAwaiter().GetResult();
                 }
                 IsDisposed = true;
             }

--- a/src/Npgsql/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.Stream.cs
@@ -122,7 +122,7 @@ namespace Npgsql
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<int>(cancellationToken);
                 using (NoSynchronizationContextScope.Enter())
-                    return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken: cancellationToken).AsTask();
+                    return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
             }
 
 #if !NET461 && !NETSTANDARD2_0
@@ -161,11 +161,11 @@ namespace Npgsql
                     return new ValueTask<int>(0);
 
                 using (NoSynchronizationContextScope.Enter())
-                    return ReadLong(buffer.Slice(0, count), cancellationToken: cancellationToken);
+                    return ReadLong(buffer.Slice(0, count), cancellationToken);
 
                 async ValueTask<int> ReadLong(Memory<byte> buffer, CancellationToken cancellationToken = default)
                 {
-                    var read = await _buf.ReadAsync(buffer, cancellationToken: cancellationToken);
+                    var read = await _buf.ReadAsync(buffer, cancellationToken);
                     _read += read;
                     return read;
                 }
@@ -197,9 +197,9 @@ namespace Npgsql
                 if (leftToSkip > 0)
                 {
                     if (async)
-                        await _buf.Skip(leftToSkip, async, default);
+                        await _buf.Skip(leftToSkip, async);
                     else
-                        _buf.Skip(leftToSkip, async, default).GetAwaiter().GetResult();
+                        _buf.Skip(leftToSkip, async).GetAwaiter().GetResult();
                 }
                 IsDisposed = true;
             }

--- a/src/Npgsql/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.Stream.cs
@@ -122,7 +122,7 @@ namespace Npgsql
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<int>(cancellationToken);
                 using (NoSynchronizationContextScope.Enter())
-                    return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+                    return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken: cancellationToken).AsTask();
             }
 
 #if !NET461 && !NETSTANDARD2_0
@@ -147,7 +147,7 @@ namespace Npgsql
 #if !NET461 && !NETSTANDARD2_0
             public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
 #else
-            public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            public ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
 #endif
             {
                 CheckDisposed();
@@ -161,11 +161,11 @@ namespace Npgsql
                     return new ValueTask<int>(0);
 
                 using (NoSynchronizationContextScope.Enter())
-                    return ReadLong(buffer.Slice(0, count), cancellationToken);
+                    return ReadLong(buffer.Slice(0, count), cancellationToken: cancellationToken);
 
                 async ValueTask<int> ReadLong(Memory<byte> buffer, CancellationToken cancellationToken = default)
                 {
-                    var read = await _buf.ReadAsync(buffer, cancellationToken);
+                    var read = await _buf.ReadAsync(buffer, cancellationToken: cancellationToken);
                     _read += read;
                     return read;
                 }
@@ -197,9 +197,9 @@ namespace Npgsql
                 if (leftToSkip > 0)
                 {
                     if (async)
-                        await _buf.Skip(leftToSkip, async, default);
+                        await _buf.Skip(leftToSkip, async, cancellationToken: default);
                     else
-                        _buf.Skip(leftToSkip, async, default).GetAwaiter().GetResult();
+                        _buf.Skip(leftToSkip, async, cancellationToken: default).GetAwaiter().GetResult();
                 }
                 IsDisposed = true;
             }

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -205,13 +205,12 @@ namespace Npgsql
                 }
                 catch (Exception e)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                        throw Connector.Break(e);
-
-                    // We have a special case when reading async notifications - a timeout may be normal
-                    // shouldn't be fatal
                     switch (e)
                     {
+                    // User requested the cancellation
+                    case OperationCanceledException _ when (cancellationToken.IsCancellationRequested):
+                        throw Connector.Break(e);
+                    // Read timeout
                     case OperationCanceledException _:
                     // Note that mono throws SocketException with the wrong error (see #1330)
                     case IOException _ when (e.InnerException as SocketException)?.SocketErrorCode ==

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -205,7 +205,8 @@ namespace Npgsql
                 }
                 catch (Exception e)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
+                    if (cancellationToken.IsCancellationRequested)
+                        throw Connector.Break(e);
 
                     // We have a special case when reading async notifications - a timeout may be normal
                     // shouldn't be fatal

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -121,7 +121,7 @@ namespace Npgsql
         {
             if (count <= ReadBytesLeft)
                 return;
-            Ensure(count, false, default).GetAwaiter().GetResult();
+            Ensure(count, false).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Npgsql
             }
         }
 
-        internal void ReadMore() => ReadMore(false, default).GetAwaiter().GetResult();
+        internal void ReadMore() => ReadMore(false).GetAwaiter().GetResult();
 
         internal Task ReadMore(bool async, CancellationToken cancellationToken = default) => Ensure(ReadBytesLeft + 1, async, cancellationToken);
 
@@ -271,7 +271,7 @@ namespace Npgsql
                     len -= Size;
                 }
                 Clear();
-                await Ensure((int) len, async, cancellationToken);
+                await Ensure((int)len, async, cancellationToken);
             }
 
             ReadPosition += (int)len;
@@ -487,7 +487,7 @@ namespace Npgsql
                 Clear();
                 try
                 {
-                    var read = await Underlying.ReadAsync(output, cancellationToken: cancellationToken);
+                    var read = await Underlying.ReadAsync(output, cancellationToken);
                     if (read == 0)
                         throw new EndOfStreamException();
                     return read;

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -121,7 +121,7 @@ namespace Npgsql
         {
             if (count <= ReadBytesLeft)
                 return;
-            Ensure(count, false, cancellationToken: default).GetAwaiter().GetResult();
+            Ensure(count, false, default).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -229,9 +229,9 @@ namespace Npgsql
             }
         }
 
-        internal void ReadMore() => ReadMore(false, cancellationToken: default).GetAwaiter().GetResult();
+        internal void ReadMore() => ReadMore(false, default).GetAwaiter().GetResult();
 
-        internal Task ReadMore(bool async, CancellationToken cancellationToken = default) => Ensure(ReadBytesLeft + 1, async, cancellationToken: cancellationToken);
+        internal Task ReadMore(bool async, CancellationToken cancellationToken = default) => Ensure(ReadBytesLeft + 1, async, cancellationToken);
 
         internal NpgsqlReadBuffer AllocateOversize(int count)
         {
@@ -267,11 +267,11 @@ namespace Npgsql
                 while (len > Size)
                 {
                     Clear();
-                    await Ensure(Size, async, cancellationToken: cancellationToken);
+                    await Ensure(Size, async, cancellationToken);
                     len -= Size;
                 }
                 Clear();
-                await Ensure((int) len, async, cancellationToken: cancellationToken);
+                await Ensure((int) len, async, cancellationToken);
             }
 
             ReadPosition += (int)len;

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -115,9 +115,9 @@ namespace Npgsql
         /// <summary>
         /// Commits the database transaction.
         /// </summary>
-        public override void Commit() => Commit(false, default).GetAwaiter().GetResult();
+        public override void Commit() => Commit(false).GetAwaiter().GetResult();
 
-        async Task Commit(bool async, CancellationToken cancellationToken)
+        async Task Commit(bool async, CancellationToken cancellationToken = default)
         {
             CheckReady();
 
@@ -154,9 +154,9 @@ namespace Npgsql
         /// <summary>
         /// Rolls back a transaction from a pending state.
         /// </summary>
-        public override void Rollback() => Rollback(false, default).GetAwaiter().GetResult();
+        public override void Rollback() => Rollback(false).GetAwaiter().GetResult();
 
-        Task Rollback(bool async, CancellationToken cancellationToken)
+        Task Rollback(bool async, CancellationToken cancellationToken = default)
         {
             CheckReady();
             return _connector.DatabaseInfo.SupportsTransactions
@@ -184,7 +184,7 @@ namespace Npgsql
 
         #region Savepoints
 
-        async Task Save(string name, bool async, CancellationToken cancellationToken)
+        async Task Save(string name, bool async, CancellationToken cancellationToken = default)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -208,9 +208,9 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
 #if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_0
-        public void Save(string name) => Save(name, false, default).GetAwaiter().GetResult();
+        public void Save(string name) => Save(name, false).GetAwaiter().GetResult();
 #else
-        public override void Save(string name) => Save(name, false, default).GetAwaiter().GetResult();
+        public override void Save(string name) => Save(name, false).GetAwaiter().GetResult();
 #endif
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Npgsql
                 return Save(name, true, cancellationToken);
         }
 
-        async Task Rollback(string name, bool async, CancellationToken cancellationToken)
+        async Task Rollback(string name, bool async, CancellationToken cancellationToken = default)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -258,7 +258,7 @@ namespace Npgsql
 #else
         public override void Rollback(string name)
 #endif
-            => Rollback(name, false, default).GetAwaiter().GetResult();
+            => Rollback(name, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Rolls back a transaction from a pending savepoint state.
@@ -277,7 +277,7 @@ namespace Npgsql
                 return Rollback(name, true, cancellationToken);
         }
 
-        async Task Release(string name, bool async, CancellationToken cancellationToken)
+        async Task Release(string name, bool async, CancellationToken cancellationToken = default)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -301,9 +301,9 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
 #if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_0
-        public void Release(string name) => Release(name, false, default).GetAwaiter().GetResult();
+        public void Release(string name) => Release(name, false).GetAwaiter().GetResult();
 #else
-        public override void Release(string name) => Release(name, false, default).GetAwaiter().GetResult();
+        public override void Release(string name) => Release(name, false).GetAwaiter().GetResult();
 #endif
 
         /// <summary>
@@ -338,7 +338,7 @@ namespace Npgsql
             if (disposing && !IsCompleted)
             {
                 // We're disposing, so no cancellation token
-                _connector.CloseOngoingOperations(async: false, default).GetAwaiter().GetResult();
+                _connector.CloseOngoingOperations(async: false).GetAwaiter().GetResult();
                 Rollback();
             }
 
@@ -369,8 +369,8 @@ namespace Npgsql
             async ValueTask DisposeAsyncInternal()
             {
                 // We're disposing, so no cancellation token
-                await _connector.CloseOngoingOperations(async: true, default);
-                await Rollback(async: true, default);
+                await _connector.CloseOngoingOperations(async: true);
+                await Rollback(async: true);
                 IsDisposed = true;
             }
         }

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -115,9 +115,9 @@ namespace Npgsql
         /// <summary>
         /// Commits the database transaction.
         /// </summary>
-        public override void Commit() => Commit(false).GetAwaiter().GetResult();
+        public override void Commit() => Commit(false, default).GetAwaiter().GetResult();
 
-        async Task Commit(bool async)
+        async Task Commit(bool async, CancellationToken cancellationToken)
         {
             CheckReady();
 
@@ -127,7 +127,7 @@ namespace Npgsql
             using (_connector.StartUserAction())
             {
                 Log.Debug("Committing transaction", _connector.Id);
-                await _connector.ExecuteInternalCommand(PregeneratedMessages.CommitTransaction, async);
+                await _connector.ExecuteInternalCommand(PregeneratedMessages.CommitTransaction, async, cancellationToken);
             }
         }
 
@@ -144,7 +144,7 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Commit(true);
+                return Commit(true, cancellationToken);
         }
 
         #endregion
@@ -154,13 +154,13 @@ namespace Npgsql
         /// <summary>
         /// Rolls back a transaction from a pending state.
         /// </summary>
-        public override void Rollback() => Rollback(false).GetAwaiter().GetResult();
+        public override void Rollback() => Rollback(false, default).GetAwaiter().GetResult();
 
-        Task Rollback(bool async)
+        Task Rollback(bool async, CancellationToken cancellationToken)
         {
             CheckReady();
             return _connector.DatabaseInfo.SupportsTransactions
-                ? _connector.Rollback(async)
+                ? _connector.Rollback(async, cancellationToken)
                 : Task.CompletedTask;
         }
 
@@ -177,14 +177,14 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Rollback(true);
+                return Rollback(true, cancellationToken);
         }
 
         #endregion
 
         #region Savepoints
 
-        async Task Save(string name, bool async)
+        async Task Save(string name, bool async, CancellationToken cancellationToken)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -199,7 +199,7 @@ namespace Npgsql
             using (_connector.StartUserAction())
             {
                 Log.Debug($"Creating savepoint {name}", _connector.Id);
-                await _connector.ExecuteInternalCommand($"SAVEPOINT {name}", async);
+                await _connector.ExecuteInternalCommand($"SAVEPOINT {name}", async, cancellationToken);
             }
         }
 
@@ -208,9 +208,9 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
 #if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_0
-        public void Save(string name) => Save(name, false).GetAwaiter().GetResult();
+        public void Save(string name) => Save(name, false, default).GetAwaiter().GetResult();
 #else
-        public override void Save(string name) => Save(name, false).GetAwaiter().GetResult();
+        public override void Save(string name) => Save(name, false, default).GetAwaiter().GetResult();
 #endif
 
         /// <summary>
@@ -227,10 +227,10 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Save(name, true);
+                return Save(name, true, cancellationToken);
         }
 
-        async Task Rollback(string name, bool async)
+        async Task Rollback(string name, bool async, CancellationToken cancellationToken)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -245,7 +245,7 @@ namespace Npgsql
             using (_connector.StartUserAction())
             {
                 Log.Debug($"Rolling back savepoint {name}", _connector.Id);
-                await _connector.ExecuteInternalCommand($"ROLLBACK TO SAVEPOINT {name}", async);
+                await _connector.ExecuteInternalCommand($"ROLLBACK TO SAVEPOINT {name}", async, cancellationToken);
             }
         }
 
@@ -258,7 +258,7 @@ namespace Npgsql
 #else
         public override void Rollback(string name)
 #endif
-            => Rollback(name, false).GetAwaiter().GetResult();
+            => Rollback(name, false, default).GetAwaiter().GetResult();
 
         /// <summary>
         /// Rolls back a transaction from a pending savepoint state.
@@ -274,10 +274,10 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Rollback(name, true);
+                return Rollback(name, true, cancellationToken);
         }
 
-        async Task Release(string name, bool async)
+        async Task Release(string name, bool async, CancellationToken cancellationToken)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -292,7 +292,7 @@ namespace Npgsql
             using (_connector.StartUserAction())
             {
                 Log.Debug($"Releasing savepoint {name}", _connector.Id);
-                await _connector.ExecuteInternalCommand($"RELEASE SAVEPOINT {name}", async);
+                await _connector.ExecuteInternalCommand($"RELEASE SAVEPOINT {name}", async, cancellationToken);
             }
         }
 
@@ -301,9 +301,9 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
 #if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_0
-        public void Release(string name) => Release(name, false).GetAwaiter().GetResult();
+        public void Release(string name) => Release(name, false, default).GetAwaiter().GetResult();
 #else
-        public override void Release(string name) => Release(name, false).GetAwaiter().GetResult();
+        public override void Release(string name) => Release(name, false, default).GetAwaiter().GetResult();
 #endif
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Npgsql
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return Release(name, true);
+                return Release(name, true, cancellationToken);
         }
 
         #endregion
@@ -337,7 +337,8 @@ namespace Npgsql
 
             if (disposing && !IsCompleted)
             {
-                _connector.CloseOngoingOperations(async: false).GetAwaiter().GetResult();
+                // We're disposing, so no cancellation token
+                _connector.CloseOngoingOperations(async: false, default).GetAwaiter().GetResult();
                 Rollback();
             }
 
@@ -367,8 +368,9 @@ namespace Npgsql
 
             async ValueTask DisposeAsyncInternal()
             {
-                await _connector.CloseOngoingOperations(async: true);
-                await Rollback(async: true);
+                // We're disposing, so no cancellation token
+                await _connector.CloseOngoingOperations(async: true, default);
+                await Rollback(async: true, default);
                 IsDisposed = true;
             }
         }

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -78,7 +78,7 @@ namespace Npgsql.TypeHandlers
         /// </summary>
         protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(12, async, cancellationToken: cancellationToken);
+            await buf.Ensure(12, async, cancellationToken);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -94,7 +94,7 @@ namespace Npgsql.TypeHandlers
 
             if (dimensions == 1)
             {
-                await buf.Ensure(8, async, cancellationToken: cancellationToken);
+                await buf.Ensure(8, async, cancellationToken);
                 var arrayLength = buf.ReadInt32();
 
                 buf.ReadInt32(); // Lower bound
@@ -107,7 +107,7 @@ namespace Npgsql.TypeHandlers
             }
 
             var dimLengths = new int[dimensions];
-            await buf.Ensure(dimensions * 8, async, cancellationToken: cancellationToken);
+            await buf.Ensure(dimensions * 8, async, cancellationToken);
 
             for (var i = 0; i < dimensions; i++)
             {
@@ -147,7 +147,7 @@ namespace Npgsql.TypeHandlers
         /// </summary>
         protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(12, async, cancellationToken: cancellationToken);
+            await buf.Ensure(12, async, cancellationToken);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -159,7 +159,7 @@ namespace Npgsql.TypeHandlers
             if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
                 throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
 
-            await buf.Ensure(8, async, cancellationToken: cancellationToken);
+            await buf.Ensure(8, async, cancellationToken);
             var length = buf.ReadInt32();
             buf.ReadInt32(); // We don't care about the lower bounds
 
@@ -494,12 +494,12 @@ namespace Npgsql.TypeHandlers
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank(), cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank(), cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async, cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async, cancellationToken);
             }
-            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken);
         }
 
         internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -56,7 +56,7 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override TRequestedArray Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TRequestedArray>(buf, len, false, fieldDescription, cancellationToken: default).GetAwaiter().GetResult();
+            => Read<TRequestedArray>(buf, len, false, fieldDescription).GetAwaiter().GetResult();
 
         /// <inheritdoc />
         protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
@@ -270,7 +270,7 @@ namespace Npgsql.TypeHandlers
             =>  await ReadArray<TElement>(buf, async, cancellationToken: cancellationToken);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadArray<TElement>(buf, false, cancellationToken: default).GetAwaiter().GetResult();
+            => ReadArray<TElement>(buf, false).GetAwaiter().GetResult();
 
         #endregion
 
@@ -503,7 +503,7 @@ namespace Npgsql.TypeHandlers
         }
 
         internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadPsvAsObject(buf, len, false, fieldDescription, cancellationToken: default).GetAwaiter().GetResult();
+            => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
 
         internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => await ReadArray<TElementPsv>(buf, async, cancellationToken: cancellationToken);

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -58,13 +59,13 @@ namespace Npgsql.TypeHandlers
             => Read<TRequestedArray>(buf, len, false, fieldDescription).GetAwaiter().GetResult();
 
         /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async);
+                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async, cancellationToken);
 
             if (ArrayTypeInfo<TRequestedArray>.IsList)
-                return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async);
+                return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async, cancellationToken);
 
             throw new InvalidCastException(fieldDescription == null
                 ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
@@ -75,9 +76,9 @@ namespace Npgsql.TypeHandlers
         /// <summary>
         /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
         /// </summary>
-        protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0)
+        protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken, int expectedDimensions = 0)
         {
-            await buf.Ensure(12, async);
+            await buf.Ensure(12, async, cancellationToken);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -93,20 +94,20 @@ namespace Npgsql.TypeHandlers
 
             if (dimensions == 1)
             {
-                await buf.Ensure(8, async);
+                await buf.Ensure(8, async, cancellationToken);
                 var arrayLength = buf.ReadInt32();
 
                 buf.ReadInt32(); // Lower bound
 
                 var oneDimensional = new TRequestedElement[arrayLength];
                 for (var i = 0; i < oneDimensional.Length; i++)
-                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
+                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken);
 
                 return oneDimensional;
             }
 
             var dimLengths = new int[dimensions];
-            await buf.Ensure(dimensions * 8, async);
+            await buf.Ensure(dimensions * 8, async, cancellationToken);
 
             for (var i = 0; i < dimensions; i++)
             {
@@ -121,7 +122,7 @@ namespace Npgsql.TypeHandlers
             var indices = new int[dimensions];
             while (true)
             {
-                var element = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
+                var element = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken);
                 result.SetValue(element, indices);
 
                 // TODO: Overly complicated/inefficient...
@@ -144,9 +145,9 @@ namespace Npgsql.TypeHandlers
         /// <summary>
         /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
         /// </summary>
-        protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
+        protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken)
         {
-            await buf.Ensure(12, async);
+            await buf.Ensure(12, async, cancellationToken);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -158,13 +159,13 @@ namespace Npgsql.TypeHandlers
             if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
                 throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
 
-            await buf.Ensure(8, async);
+            await buf.Ensure(8, async, cancellationToken);
             var length = buf.ReadInt32();
             buf.ReadInt32(); // We don't care about the lower bounds
 
             var list = new List<TRequestedElement>(length);
             for (var i = 0; i < length; i++)
-                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
+                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken));
             return list;
         }
 
@@ -191,8 +192,8 @@ namespace Npgsql.TypeHandlers
             public static readonly bool IsList;
             public static readonly Type? ElementType;
 
-            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>> ReadArrayFunc = default!;
-            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>> ReadListFunc = default!;
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<Array>> ReadArrayFunc = default!;
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<TArrayOrList>> ReadListFunc = default!;
             // ReSharper restore StaticMemberInGenericType
 
             public static bool IsArrayOrList => IsArray || IsList;
@@ -216,28 +217,29 @@ namespace Npgsql.TypeHandlers
                 var arrayHandlerParam = Expression.Parameter(typeof(ArrayHandler), "arrayHandler");
                 var bufferParam = Expression.Parameter(typeof(NpgsqlReadBuffer), "buf");
                 var asyncParam = Expression.Parameter(typeof(bool), "async");
+                var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
 
                 if (IsArray)
                 {
                     ReadArrayFunc = Expression
-                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>>>(
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<Array>>>(
                             Expression.Call(
                                 arrayHandlerParam,
                                 ReadArrayMethod.MakeGenericMethod(ElementType),
-                                bufferParam, asyncParam, Expression.Constant(type.GetArrayRank())),
-                            arrayHandlerParam, bufferParam, asyncParam)
+                                bufferParam, asyncParam, cancellationTokenParam, Expression.Constant(type.GetArrayRank())),
+                            arrayHandlerParam, bufferParam, asyncParam, cancellationTokenParam)
                         .Compile();
                 }
 
                 if (IsList)
                 {
                     ReadListFunc = Expression
-                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>>>(
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<TArrayOrList>>>(
                             Expression.Call(
                                 arrayHandlerParam,
                                 ReadListMethod.MakeGenericMethod(ElementType),
-                                bufferParam, asyncParam),
-                            arrayHandlerParam, bufferParam, asyncParam)
+                                bufferParam, asyncParam, cancellationTokenParam),
+                            arrayHandlerParam, bufferParam, asyncParam, cancellationTokenParam)
                         .Compile();
                 }
             }
@@ -264,11 +266,11 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            =>  await ReadArray<TElement>(buf, async);
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            =>  await ReadArray<TElement>(buf, async, cancellationToken);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadArray<TElement>(buf, false).GetAwaiter().GetResult();
+            => ReadArray<TElement>(buf, false, default).GetAwaiter().GetResult();
 
         #endregion
 
@@ -487,23 +489,23 @@ namespace Npgsql.TypeHandlers
         public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler)
             : base(arrayPostgresType, elementHandler) { }
 
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank());
+                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, cancellationToken, typeof(TRequestedArray).GetArrayRank());
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async);
+                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async, cancellationToken);
             }
-            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription);
+            return await base.Read<TRequestedArray>(buf, len, async, cancellationToken, fieldDescription);
         }
 
         internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
+            => ReadPsvAsObject(buf, len, false, default, fieldDescription).GetAwaiter().GetResult();
 
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => await ReadArray<TElementPsv>(buf, async);
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => await ReadArray<TElementPsv>(buf, async, cancellationToken);
     }
 }

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -56,7 +56,7 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override TRequestedArray Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TRequestedArray>(buf, len, false, fieldDescription).GetAwaiter().GetResult();
+            => Read<TRequestedArray>(buf, len, false, default, fieldDescription).GetAwaiter().GetResult();
 
         /// <inheritdoc />
         protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -286,7 +286,7 @@ namespace Npgsql.TypeHandlers
                     return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken: cancellationToken);
             }
 
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
@@ -295,7 +295,7 @@ namespace Npgsql.TypeHandlers
                     return (TRequestedArray)(object)await ReadArray<bool>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken: cancellationToken);
             }
 
             return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeHandlers
         /// <inheritdoc />
         public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numBits = buf.ReadInt32();
             var result = new BitArray(numBits);
             var bytesLeft = len - 4;  // Remove leading number of bits
@@ -83,13 +83,13 @@ namespace Npgsql.TypeHandlers
                     break;
 
                 Debug.Assert(buf.ReadBytesLeft == 0);
-                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async, cancellationToken: cancellationToken);
+                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async, cancellationToken);
             }
 
             if (bitNo < result.Length)
             {
                 var remainder = result.Length - bitNo;
-                await buf.Ensure(1, async, cancellationToken: cancellationToken);
+                await buf.Ensure(1, async, cancellationToken);
                 var lastChunk = buf.ReadByte();
                 for (var i = 7; i >= 8 - remainder; i--)
                     result[bitNo++] = (lastChunk & (1 << i)) != 0;
@@ -103,7 +103,7 @@ namespace Npgsql.TypeHandlers
             if (len > 4 + 4)
                 throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
 
-            await buf.Ensure(4 + 4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4 + 4, async, cancellationToken);
 
             var numBits = buf.ReadInt32();
             return numBits == 0
@@ -113,7 +113,7 @@ namespace Npgsql.TypeHandlers
 
         async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
         {
-            await buf.Ensure(5, async, cancellationToken: cancellationToken);
+            await buf.Ensure(5, async, cancellationToken);
             var bitLen = buf.ReadInt32();
             if (bitLen != 1)
                 throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
@@ -286,7 +286,7 @@ namespace Npgsql.TypeHandlers
                     return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken);
             }
 
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
@@ -295,10 +295,10 @@ namespace Npgsql.TypeHandlers
                     return (TRequestedArray)(object)await ReadArray<bool>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken);
             }
 
-            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken);
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -126,13 +126,13 @@ namespace Npgsql.TypeHandlers
 
         internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => fieldDescription?.TypeModifier == 1
-                ? (object)await Read<bool>(buf, len, async, fieldDescription, cancellationToken: cancellationToken)
-                : await Read<BitArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+                ? (object)await Read<bool>(buf, len, async, fieldDescription, cancellationToken)
+                : await Read<BitArray>(buf, len, async, fieldDescription, cancellationToken);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
-                ? (object)Read<bool>(buf, len, false, fieldDescription, cancellationToken: default).Result
-                : Read<BitArray>(buf, len, false, fieldDescription, cancellationToken: default).Result;
+                ? (object)Read<bool>(buf, len, false, fieldDescription).Result
+                : Read<BitArray>(buf, len, false, fieldDescription).Result;
 
         #endregion
 
@@ -302,7 +302,7 @@ namespace Npgsql.TypeHandlers
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadAsObject(buf, len, false, fieldDescription, cancellationToken: default).Result;
+            => ReadAsObject(buf, len, false, fieldDescription).Result;
 
         internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => fieldDescription?.TypeModifier == 1

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -49,9 +49,9 @@ namespace Npgsql.TypeHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var numBits = buf.ReadInt32();
             var result = new BitArray(numBits);
             var bytesLeft = len - 4;  // Remove leading number of bits
@@ -83,13 +83,13 @@ namespace Npgsql.TypeHandlers
                     break;
 
                 Debug.Assert(buf.ReadBytesLeft == 0);
-                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async, cancellationToken);
+                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async, cancellationToken: cancellationToken);
             }
 
             if (bitNo < result.Length)
             {
                 var remainder = result.Length - bitNo;
-                await buf.Ensure(1, async, cancellationToken);
+                await buf.Ensure(1, async, cancellationToken: cancellationToken);
                 var lastChunk = buf.ReadByte();
                 for (var i = 7; i >= 8 - remainder; i--)
                     result[bitNo++] = (lastChunk & (1 << i)) != 0;
@@ -98,12 +98,12 @@ namespace Npgsql.TypeHandlers
             return result;
         }
 
-        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
         {
             if (len > 4 + 4)
                 throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
 
-            await buf.Ensure(4 + 4, async, cancellationToken);
+            await buf.Ensure(4 + 4, async, cancellationToken: cancellationToken);
 
             var numBits = buf.ReadInt32();
             return numBits == 0
@@ -111,9 +111,9 @@ namespace Npgsql.TypeHandlers
                 : new BitVector32(buf.ReadInt32());
         }
 
-        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
         {
-            await buf.Ensure(5, async, cancellationToken);
+            await buf.Ensure(5, async, cancellationToken: cancellationToken);
             var bitLen = buf.ReadInt32();
             if (bitLen != 1)
                 throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
@@ -121,18 +121,18 @@ namespace Npgsql.TypeHandlers
             return (b & 128) != 0;
         }
 
-        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => fieldDescription?.TypeModifier == 1
-                ? (object)await Read<bool>(buf, len, async, cancellationToken, fieldDescription)
-                : await Read<BitArray>(buf, len, async, cancellationToken, fieldDescription);
+                ? (object)await Read<bool>(buf, len, async, fieldDescription, cancellationToken: cancellationToken)
+                : await Read<BitArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
-                ? (object)Read<bool>(buf, len, false, default, fieldDescription).Result
-                : Read<BitArray>(buf, len, false, default, fieldDescription).Result;
+                ? (object)Read<bool>(buf, len, false, fieldDescription, cancellationToken: default).Result
+                : Read<BitArray>(buf, len, false, fieldDescription, cancellationToken: default).Result;
 
         #endregion
 
@@ -278,12 +278,12 @@ namespace Npgsql.TypeHandlers
             : base(postgresType, elementHandler) {}
 
         /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
                     return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken);
@@ -292,21 +292,21 @@ namespace Npgsql.TypeHandlers
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async, cancellationToken: cancellationToken);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
                     return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken);
             }
 
-            return await base.Read<TRequestedArray>(buf, len, async, cancellationToken, fieldDescription);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadAsObject(buf, len, false, default, fieldDescription).Result;
+            => ReadAsObject(buf, len, false, fieldDescription, cancellationToken: default).Result;
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => fieldDescription?.TypeModifier == 1
-                ? await ReadArray<bool>(buf, async, cancellationToken)
-                : await ReadArray<BitArray>(buf, async, cancellationToken);
+                ? await ReadArray<bool>(buf, async, cancellationToken: cancellationToken)
+                : await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
     }
 }

--- a/src/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -42,7 +43,7 @@ namespace Npgsql.TypeHandlers
         public ByteaHandler(PostgresType postgresType) : base(postgresType) {}
 
         /// <inheritdoc />
-        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             var bytes = new byte[len];
             var pos = 0;
@@ -53,12 +54,12 @@ namespace Npgsql.TypeHandlers
                 pos += toRead;
                 if (pos == len)
                     break;
-                await buf.ReadMore(async);
+                await buf.ReadMore(async, cancellationToken);
             }
             return bytes;
         }
 
-        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing ArraySegment<byte> to PostgreSQL bytea is supported, no reading.");
 
         int ValidateAndGetLength(int bufferLen, NpgsqlParameter? parameter)
@@ -128,10 +129,10 @@ namespace Npgsql.TypeHandlers
         public Task Write(Memory<byte> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
             => Write((ReadOnlyMemory<byte>)value, buf, lengthCache, parameter, async);
 
-        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing ReadOnlyMemory<byte> to PostgreSQL bytea is supported, no reading.");
 
-        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing Memory<byte> to PostgreSQL bytea is supported, no reading.");
 #endif
     }

--- a/src/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -54,7 +54,7 @@ namespace Npgsql.TypeHandlers
                 pos += toRead;
                 if (pos == len)
                     break;
-                await buf.ReadMore(async, cancellationToken: cancellationToken);
+                await buf.ReadMore(async, cancellationToken);
             }
             return bytes;
         }

--- a/src/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -43,7 +43,7 @@ namespace Npgsql.TypeHandlers
         public ByteaHandler(PostgresType postgresType) : base(postgresType) {}
 
         /// <inheritdoc />
-        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             var bytes = new byte[len];
             var pos = 0;
@@ -54,12 +54,12 @@ namespace Npgsql.TypeHandlers
                 pos += toRead;
                 if (pos == len)
                     break;
-                await buf.ReadMore(async, cancellationToken);
+                await buf.ReadMore(async, cancellationToken: cancellationToken);
             }
             return bytes;
         }
 
-        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => throw new NotSupportedException("Only writing ArraySegment<byte> to PostgreSQL bytea is supported, no reading.");
 
         int ValidateAndGetLength(int bufferLen, NpgsqlParameter? parameter)
@@ -129,10 +129,10 @@ namespace Npgsql.TypeHandlers
         public Task Write(Memory<byte> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async)
             => Write((ReadOnlyMemory<byte>)value, buf, lengthCache, parameter, async);
 
-        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => throw new NotSupportedException("Only writing ReadOnlyMemory<byte> to PostgreSQL bytea is supported, no reading.");
 
-        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
             => throw new NotSupportedException("Only writing Memory<byte> to PostgreSQL bytea is supported, no reading.");
 #endif
     }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 
@@ -18,9 +19,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             Handlers = handlers;
         }
 
-        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async)
+        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
         {
-            await buffer.Ensure(sizeof(int), async);
+            await buffer.Ensure(sizeof(int), async, cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -28,7 +29,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var args = new object?[Handlers.Length];
             foreach (var handler in Handlers)
-                args[handler.Position] = await handler.Read(buffer, async);
+                args[handler.Position] = await handler.Read(buffer, async, cancellationToken);
 
             return (TComposite)ConstructorInfo.Invoke(args);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
@@ -21,7 +21,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
         public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
+            await buffer.Ensure(sizeof(int), async, cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
@@ -19,9 +19,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             Handlers = handlers;
         }
 
-        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -29,7 +29,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var args = new object?[Handlers.Length];
             foreach (var handler in Handlers)
-                args[handler.Position] = await handler.Read(buffer, async, cancellationToken);
+                args[handler.Position] = await handler.Read(buffer, async, cancellationToken: cancellationToken);
 
             return (TComposite)ConstructorInfo.Invoke(args);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
@@ -29,7 +29,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var args = new object?[Handlers.Length];
             foreach (var handler in Handlers)
-                args[handler.Position] = await handler.Read(buffer, async, cancellationToken: cancellationToken);
+                args[handler.Position] = await handler.Read(buffer, async, cancellationToken);
 
             return (TComposite)ConstructorInfo.Invoke(args);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 
@@ -26,9 +27,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 .Compile();
         }
 
-        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async)
+        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
         {
-            await buffer.Ensure(sizeof(int), async);
+            await buffer.Ensure(sizeof(int), async, cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -39,14 +40,14 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             foreach (var handler in Handlers)
                 switch (handler.Position)
                 {
-                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async); break;
-                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async); break;
-                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async); break;
-                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async); break;
-                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async); break;
-                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async); break;
-                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async); break;
-                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async); break;
+                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken); break;
+                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken); break;
+                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken); break;
+                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken); break;
+                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken); break;
+                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken); break;
+                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken); break;
+                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken); break;
                 }
 
             return _constructor(args);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
@@ -27,9 +27,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 .Compile();
         }
 
-        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -40,14 +40,14 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             foreach (var handler in Handlers)
                 switch (handler.Position)
                 {
-                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken); break;
-                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken); break;
-                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken); break;
-                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken); break;
-                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken); break;
-                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken); break;
-                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken); break;
-                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken); break;
+                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken: cancellationToken); break;
                 }
 
             return _constructor(args);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
@@ -40,14 +40,14 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             foreach (var handler in Handlers)
                 switch (handler.Position)
                 {
-                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken: cancellationToken); break;
-                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken: cancellationToken); break;
+                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken); break;
+                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken); break;
+                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken); break;
+                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken); break;
+                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken); break;
+                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken); break;
+                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken); break;
+                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken); break;
                 }
 
             return _constructor(args);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
@@ -29,7 +29,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
         public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
+            await buffer.Ensure(sizeof(int), async, cancellationToken);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -42,7 +42,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             async ValueTask<T> ReadUsingMemberHandlers()
             {
-                await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
+                await buffer.Ensure(sizeof(int), async, cancellationToken);
 
                 var fieldCount = buffer.ReadInt32();
                 if (fieldCount != _memberHandlers.Length)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -38,7 +38,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             return _constructorHandler is null
                 ? ReadUsingMemberHandlers()
-                : _constructorHandler.Read(buffer, async, cancellationToken: cancellationToken);
+                : _constructorHandler.Read(buffer, async, cancellationToken);
 
             async ValueTask<T> ReadUsingMemberHandlers()
             {
@@ -52,7 +52,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = new ByReference<T> { Value = _constructor() };
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken: cancellationToken);
+                        await member.Read(composite, buffer, async, cancellationToken);
 
                     return composite.Value;
                 }
@@ -60,7 +60,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = _constructor();
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken: cancellationToken);
+                        await member.Read(composite, buffer, async, cancellationToken);
 
                     return composite;
                 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -32,17 +32,17 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _nameTranslator = nameTranslator;
         }
 
-        public override ValueTask<T> Read(NpgsqlReadBuffer buffer, int length, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override ValueTask<T> Read(NpgsqlReadBuffer buffer, int length, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             Initialize();
 
             return _constructorHandler is null
                 ? ReadUsingMemberHandlers()
-                : _constructorHandler.Read(buffer, async, cancellationToken);
+                : _constructorHandler.Read(buffer, async, cancellationToken: cancellationToken);
 
             async ValueTask<T> ReadUsingMemberHandlers()
             {
-                await buffer.Ensure(sizeof(int), async, cancellationToken);
+                await buffer.Ensure(sizeof(int), async, cancellationToken: cancellationToken);
 
                 var fieldCount = buffer.ReadInt32();
                 if (fieldCount != _memberHandlers.Length)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -52,7 +52,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = new ByReference<T> { Value = _constructor() };
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken);
+                        await member.Read(composite, buffer, async, cancellationToken: cancellationToken);
 
                     return composite.Value;
                 }
@@ -60,7 +60,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = _constructor();
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken);
+                        await member.Read(composite, buffer, async, cancellationToken: cancellationToken);
 
                     return composite;
                 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 
@@ -15,9 +16,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             PostgresType = postgresType;
         }
 
-        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async);
+        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
 
-        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async);
+        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
 
         public abstract Task Write(TComposite composite, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, bool async);
 

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
@@ -16,9 +16,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             PostgresType = postgresType;
         }
 
-        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
+        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
 
-        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
+        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
 
         public abstract Task Write(TComposite composite, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, bool async);
 

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
@@ -65,7 +65,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return;
 
             var value = NullableHandler<TMember>.Exists
-                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken)
+                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken: cancellationToken)
                 : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
 
             _set(composite, value);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
@@ -55,7 +55,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);
@@ -66,7 +66,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var value = NullableHandler<TMember>.Exists
                 ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken)
-                : await _handler.Read<TMember>(buffer, length, async, cancellationToken);
+                : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
 
             _set(composite, value);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
@@ -55,7 +55,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
@@ -50,7 +50,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _handler = handler;
         }
 
-        public override async ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override async ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
@@ -71,7 +71,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _set(composite, value);
         }
 
-        public override ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
         public override async Task Write(TComposite composite, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, bool async)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
@@ -69,7 +69,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return;
 
             var value = NullableHandler<TMember>.Exists
-                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken, null)
+                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken: cancellationToken)
                 : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
 
             Set(composite, value);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
@@ -59,7 +59,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
@@ -51,10 +51,10 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _handler = handler;
         }
 
-        public override ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public override async ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override async ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
@@ -59,7 +59,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);
@@ -70,7 +70,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var value = NullableHandler<TMember>.Exists
                 ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken, null)
-                : await _handler.Read<TMember>(buffer, length, async, cancellationToken);
+                : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
 
             Set(composite, value);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.TypeHandling;
 
@@ -17,9 +18,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             Position = parameterInfo.Position;
         }
 
-        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async)
+        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
         {
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
 
             var oid = buffer.ReadUInt32();
             var length = buffer.ReadInt32();
@@ -27,10 +28,10 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return default!;
 
             return NullableHandler<T>.Exists
-                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async)
-                : await Handler.Read<T>(buffer, length, async);
+                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async, cancellationToken)
+                : await Handler.Read<T>(buffer, length, async, cancellationToken);
         }
 
-        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async);
+        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
     }
 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
@@ -20,7 +20,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
         public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
 
             var oid = buffer.ReadUInt32();
             var length = buffer.ReadInt32();

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
@@ -28,7 +28,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return default!;
 
             return NullableHandler<T>.Exists
-                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async, cancellationToken)
+                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async, cancellationToken: cancellationToken)
                 : await Handler.Read<T>(buffer, length, async, cancellationToken: cancellationToken);
         }
 

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
@@ -18,9 +18,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             Position = parameterInfo.Position;
         }
 
-        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken: cancellationToken);
 
             var oid = buffer.ReadUInt32();
             var length = buffer.ReadInt32();
@@ -29,9 +29,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             return NullableHandler<T>.Exists
                 ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async, cancellationToken)
-                : await Handler.Read<T>(buffer, length, async, cancellationToken);
+                : await Handler.Read<T>(buffer, length, async, cancellationToken: cancellationToken);
         }
 
-        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken);
+        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.TypeHandling;
 
@@ -9,9 +10,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
         public CompositeParameterHandler(NpgsqlTypeHandler handler, ParameterInfo parameterInfo)
             : base(handler, parameterInfo) { }
 
-        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async)
+        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
         {
-            var task = Read<T>(buffer, async);
+            var task = Read<T>(buffer, async, cancellationToken);
             return task.IsCompleted
                 ? new ValueTask<object?>(task.Result)
                 : AwaitTask();

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
@@ -10,9 +10,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
         public CompositeParameterHandler(NpgsqlTypeHandler handler, ParameterInfo parameterInfo)
             : base(handler, parameterInfo) { }
 
-        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken)
+        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
         {
-            var task = Read<T>(buffer, async, cancellationToken);
+            var task = Read<T>(buffer, async, cancellationToken: cancellationToken);
             return task.IsCompleted
                 ? new ValueTask<object?>(task.Result)
                 : AwaitTask();

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -44,9 +45,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async);
+            await buf.Ensure(4, async, cancellationToken);
             var numTokens = buf.ReadInt32();
             if (numTokens == 0)
                 return new NpgsqlTsQueryEmpty();
@@ -57,7 +58,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
 
             for (var tokenPos = 0; tokenPos < numTokens; tokenPos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async);
+                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken);
                 var readPos = buf.ReadPosition;
 
                 var isOper = buf.ReadByte() == 2;
@@ -119,23 +120,23 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
             }
         }
 
-        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, cancellationToken, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, cancellationToken, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryNot)await Read(buf, len, async, cancellationToken, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryAnd)await Read(buf, len, async, cancellationToken, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryOr)await Read(buf, len, async, cancellationToken, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription);
+        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, cancellationToken, fieldDescription);
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -45,9 +45,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var numTokens = buf.ReadInt32();
             if (numTokens == 0)
                 return new NpgsqlTsQueryEmpty();
@@ -58,7 +58,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
 
             for (var tokenPos = 0; tokenPos < numTokens; tokenPos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken: cancellationToken);
                 var readPos = buf.ReadPosition;
 
                 var isOper = buf.ReadByte() == 2;
@@ -120,23 +120,23 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
             }
         }
 
-        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryNot)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryAnd)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryOr)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, cancellationToken, fieldDescription);
+        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -47,7 +47,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         /// <inheritdoc />
         public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numTokens = buf.ReadInt32();
             if (numTokens == 0)
                 return new NpgsqlTsQueryEmpty();
@@ -58,7 +58,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
 
             for (var tokenPos = 0; tokenPos < numTokens; tokenPos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken: cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken);
                 var readPos = buf.ReadPosition;
 
                 var isOper = buf.ReadByte() == 2;
@@ -121,22 +121,22 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         }
 
         async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription, cancellationToken);
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -34,16 +35,16 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async);
+            await buf.Ensure(4, async, cancellationToken);
             var numLexemes = buf.ReadInt32();
             len -= 4;
 
             var lexemes = new List<NpgsqlTsVector.Lexeme>();
             for (var lexemePos = 0; lexemePos < numLexemes; lexemePos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async);
+                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken);
                 var posBefore = buf.ReadPosition;
 
                 List<NpgsqlTsVector.Lexeme.WordEntryPos>? positions = null;

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -37,14 +37,14 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         /// <inheritdoc />
         public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numLexemes = buf.ReadInt32();
             len -= 4;
 
             var lexemes = new List<NpgsqlTsVector.Lexeme>();
             for (var lexemePos = 0; lexemePos < numLexemes; lexemePos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken: cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken);
                 var posBefore = buf.ReadPosition;
 
                 List<NpgsqlTsVector.Lexeme.WordEntryPos>? positions = null;

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -35,16 +35,16 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var numLexemes = buf.ReadInt32();
             len -= 4;
 
             var lexemes = new List<NpgsqlTsVector.Lexeme>();
             for (var lexemePos = 0; lexemePos < numLexemes; lexemePos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken: cancellationToken);
                 var posBefore = buf.ReadPosition;
 
                 List<NpgsqlTsVector.Lexeme.WordEntryPos>? positions = null;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -27,9 +28,9 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(5, async);
+            await buf.Ensure(5, async, cancellationToken);
             var open = buf.ReadByte() switch
             {
                 1 => false,
@@ -41,7 +42,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
             var result = new NpgsqlPath(numPoints, open);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async);
+                await buf.Ensure(16, async, cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -30,7 +30,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         /// <inheritdoc />
         public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(5, async, cancellationToken: cancellationToken);
+            await buf.Ensure(5, async, cancellationToken);
             var open = buf.ReadByte() switch
             {
                 1 => false,
@@ -42,7 +42,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
             var result = new NpgsqlPath(numPoints, open);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                await buf.Ensure(16, async, cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -28,9 +28,9 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(5, async, cancellationToken);
+            await buf.Ensure(5, async, cancellationToken: cancellationToken);
             var open = buf.ReadByte() switch
             {
                 1 => false,
@@ -42,7 +42,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
             var result = new NpgsqlPath(numPoints, open);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken);
+                await buf.Ensure(16, async, cancellationToken: cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
@@ -26,14 +27,14 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async);
+            await buf.Ensure(4, async, cancellationToken);
             var numPoints = buf.ReadInt32();
             var result = new NpgsqlPolygon(numPoints);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async);
+                await buf.Ensure(16, async, cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -27,14 +27,14 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var numPoints = buf.ReadInt32();
             var result = new NpgsqlPolygon(numPoints);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken);
+                await buf.Ensure(16, async, cancellationToken: cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -29,12 +29,12 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         /// <inheritdoc />
         public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numPoints = buf.ReadInt32();
             var result = new NpgsqlPolygon(numPoints);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken: cancellationToken);
+                await buf.Ensure(16, async, cancellationToken);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -145,17 +145,17 @@ namespace Npgsql.TypeHandlers
         }
 
         /// <inheritdoc />
-        public override async ValueTask<Dictionary<string, string?>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null,
-            CancellationToken cancellationToken = default)
+        public override async ValueTask<Dictionary<string, string?>> Read(NpgsqlReadBuffer buf, int len, bool async,
+            FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             await buf.Ensure(4, async, cancellationToken);
             var numElements = buf.ReadInt32();
-            return await ReadInto(new Dictionary<string, string?>(numElements), numElements, buf, async, cancellationToken: cancellationToken);
+            return await ReadInto(new Dictionary<string, string?>(numElements), numElements, buf, async, cancellationToken);
         }
 
         ValueTask<IDictionary<string, string?>> INpgsqlTypeHandler<IDictionary<string, string?>>.Read(
             NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => new ValueTask<IDictionary<string, string?>>(Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken).Result);
+            => new ValueTask<IDictionary<string, string?>>(Read(buf, len, async, fieldDescription, cancellationToken).Result);
 
         #endregion
 

--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -129,12 +129,12 @@ namespace Npgsql.TypeHandlers
         {
             for (var i = 0; i < numElements; i++)
             {
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var keyLen = buf.ReadInt32();
                 Debug.Assert(keyLen != -1);
                 var key = await _textHandler.Read(buf, keyLen, async, cancellationToken: cancellationToken);
 
-                await buf.Ensure(4, async, cancellationToken: cancellationToken);
+                await buf.Ensure(4, async, cancellationToken);
                 var valueLen = buf.ReadInt32();
 
                 dictionary[key] = valueLen == -1
@@ -148,7 +148,7 @@ namespace Npgsql.TypeHandlers
         public override async ValueTask<Dictionary<string, string?>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null,
             CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numElements = buf.ReadInt32();
             return await ReadInto(new Dictionary<string, string?>(numElements), numElements, buf, async, cancellationToken: cancellationToken);
         }
@@ -175,9 +175,9 @@ namespace Npgsql.TypeHandlers
         async ValueTask<ImmutableDictionary<string, string?>> INpgsqlTypeHandler<ImmutableDictionary<string, string?>>.Read(
             NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var numElements = buf.ReadInt32();
-            return (await ReadInto(ImmutableDictionary<string, string?>.Empty.ToBuilder(), numElements, buf, async, cancellationToken: cancellationToken))
+            return (await ReadInto(ImmutableDictionary<string, string?>.Empty.ToBuilder(), numElements, buf, async, cancellationToken))
                 .ToImmutable();
         }
 

--- a/src/Npgsql/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/TypeHandlers/JsonHandler.cs
@@ -228,7 +228,7 @@ namespace Npgsql.TypeHandlers
         {
             if (_isJsonb)
             {
-                await buf.Ensure(1, async, cancellationToken: cancellationToken);
+                await buf.Ensure(1, async, cancellationToken);
                 var version = buf.ReadByte();
                 if (version != JsonbProtocolVersion)
                     throw new NotSupportedException($"Don't know how to decode JSONB with wire format {version}, your connection is now broken");
@@ -246,7 +246,7 @@ namespace Npgsql.TypeHandlers
 
             // See #2818 for possibly returning a JsonDocument directly over our internal buffer, rather
             // than deserializing to string.
-            var s = await _textHandler.Read(buf, byteLen, async, fieldDescription, cancellationToken: cancellationToken);
+            var s = await _textHandler.Read(buf, byteLen, async, fieldDescription, cancellationToken);
             return typeof(T) == typeof(JsonDocument)
                 ? (T)(object)JsonDocument.Parse(s)
                 : JsonSerializer.Deserialize<T>(s, _serializerOptions)!;

--- a/src/Npgsql/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/TypeHandlers/JsonHandler.cs
@@ -241,7 +241,7 @@ namespace Npgsql.TypeHandlers
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await _textHandler.Read<T>(buf, byteLen, async, fieldDescription, cancellationToken: cancellationToken);
+                return await _textHandler.Read<T>(buf, byteLen, async, fieldDescription, cancellationToken);
             }
 
             // See #2818 for possibly returning a JsonDocument directly over our internal buffer, rather
@@ -254,7 +254,7 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => Read<string>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => Read<string>(buf, len, async, fieldDescription, cancellationToken);
 
         /// <inheritdoc />
         public TextReader GetTextReader(Stream stream)

--- a/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -30,8 +31,8 @@ namespace Npgsql.TypeHandlers
             _wrappedHandler = (UnmappedEnumHandler)new UnmappedEnumTypeHandlerFactory(_nameTranslator).Create(PostgresType, _conn);
         }
 
-        public override ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => _wrappedHandler.Read<T>(buf, len, async, fieldDescription);
+        public override ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => _wrappedHandler.Read<T>(buf, len, async, cancellationToken, fieldDescription);
 
         public override int ValidateAndGetLength(T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => _wrappedHandler.ValidateAndGetLength(value, ref lengthCache, parameter);

--- a/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
@@ -32,7 +32,7 @@ namespace Npgsql.TypeHandlers
         }
 
         public override ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => _wrappedHandler.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => _wrappedHandler.Read<T>(buf, len, async, fieldDescription, cancellationToken);
 
         public override int ValidateAndGetLength(T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => _wrappedHandler.ValidateAndGetLength(value, ref lengthCache, parameter);

--- a/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/MappedEnumHandler.cs
@@ -31,8 +31,8 @@ namespace Npgsql.TypeHandlers
             _wrappedHandler = (UnmappedEnumHandler)new UnmappedEnumTypeHandlerFactory(_nameTranslator).Create(PostgresType, _conn);
         }
 
-        public override ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => _wrappedHandler.Read<T>(buf, len, async, cancellationToken, fieldDescription);
+        public override ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+            => _wrappedHandler.Read<T>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         public override int ValidateAndGetLength(T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => _wrappedHandler.ValidateAndGetLength(value, ref lengthCache, parameter);

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -71,12 +72,12 @@ namespace Npgsql.TypeHandlers
             => Read<TAny>(buf, len, false, default, fieldDescription).Result;
 
         /// <inheritdoc />
-        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => DoRead<TElement>(buf, len, async, fieldDescription);
+        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => DoRead<TElement>(buf, len, async, cancellationToken, fieldDescription);
 
-        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
         {
-            await buf.Ensure(1, async);
+            await buf.Ensure(1, async, cancellationToken);
 
             var flags = (RangeFlags)buf.ReadByte();
             if ((flags & RangeFlags.Empty) != 0)
@@ -86,10 +87,10 @@ namespace Npgsql.TypeHandlers
             var upperBound = default(TAny);
 
             if ((flags & RangeFlags.LowerBoundInfinite) == 0)
-                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async);
+                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken);
 
             if ((flags & RangeFlags.UpperBoundInfinite) == 0)
-                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async);
+                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken);
 
             return new NpgsqlRange<TAny>(lowerBound, upperBound, flags);
         }
@@ -209,8 +210,8 @@ namespace Npgsql.TypeHandlers
         public RangeHandler(PostgresType rangePostgresType, NpgsqlTypeHandler elementHandler)
             : base(rangePostgresType, elementHandler, new[] { typeof(NpgsqlRange<TElement1>), typeof(NpgsqlRange<TElement2>) }) {}
 
-        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => DoRead<TElement2>(buf, len, async, fieldDescription);
+        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+            => DoRead<TElement2>(buf, len, async, cancellationToken, fieldDescription);
 
         /// <inheritdoc />
         public int ValidateAndGetLength(NpgsqlRange<TElement2> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -69,11 +69,11 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TAny>(buf, len, false, fieldDescription, cancellationToken: default).Result;
+            => Read<TAny>(buf, len, false, fieldDescription).Result;
 
         /// <inheritdoc />
         public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => DoRead<TElement>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => DoRead<TElement>(buf, len, async, fieldDescription, cancellationToken);
 
         private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
         {

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -87,10 +87,10 @@ namespace Npgsql.TypeHandlers
             var upperBound = default(TAny);
 
             if ((flags & RangeFlags.LowerBoundInfinite) == 0)
-                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken);
+                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken: cancellationToken);
 
             if ((flags & RangeFlags.UpperBoundInfinite) == 0)
-                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken);
+                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken: cancellationToken);
 
             return new NpgsqlRange<TAny>(lowerBound, upperBound, flags);
         }

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -69,15 +69,15 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TAny>(buf, len, false, default, fieldDescription).Result;
+            => Read<TAny>(buf, len, false, fieldDescription, cancellationToken: default).Result;
 
         /// <inheritdoc />
-        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => DoRead<TElement>(buf, len, async, cancellationToken, fieldDescription);
+        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+            => DoRead<TElement>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
-        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async, cancellationToken: cancellationToken);
 
             var flags = (RangeFlags)buf.ReadByte();
             if ((flags & RangeFlags.Empty) != 0)
@@ -210,8 +210,8 @@ namespace Npgsql.TypeHandlers
         public RangeHandler(PostgresType rangePostgresType, NpgsqlTypeHandler elementHandler)
             : base(rangePostgresType, elementHandler, new[] { typeof(NpgsqlRange<TElement1>), typeof(NpgsqlRange<TElement2>) }) {}
 
-        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
-            => DoRead<TElement2>(buf, len, async, cancellationToken, fieldDescription);
+        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            => DoRead<TElement2>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         /// <inheritdoc />
         public int ValidateAndGetLength(NpgsqlRange<TElement2> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -68,7 +68,7 @@ namespace Npgsql.TypeHandlers
 
         /// <inheritdoc />
         public override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TAny>(buf, len, false, fieldDescription).Result;
+            => Read<TAny>(buf, len, false, default, fieldDescription).Result;
 
         /// <inheritdoc />
         public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -77,7 +77,7 @@ namespace Npgsql.TypeHandlers
 
         private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(1, async, cancellationToken: cancellationToken);
+            await buf.Ensure(1, async, cancellationToken);
 
             var flags = (RangeFlags)buf.ReadByte();
             if ((flags & RangeFlags.Empty) != 0)
@@ -211,7 +211,7 @@ namespace Npgsql.TypeHandlers
             : base(rangePostgresType, elementHandler, new[] { typeof(NpgsqlRange<TElement1>), typeof(NpgsqlRange<TElement2>) }) {}
 
         ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => DoRead<TElement2>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => DoRead<TElement2>(buf, len, async, fieldDescription, cancellationToken);
 
         /// <inheritdoc />
         public int ValidateAndGetLength(NpgsqlRange<TElement2> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/TypeHandlers/RecordHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -38,20 +39,20 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async);
+            await buf.Ensure(4, async, cancellationToken);
             var fieldCount = buf.ReadInt32();
             var result = new object[fieldCount];
 
             for (var i = 0; i < fieldCount; i++)
             {
-                await buf.Ensure(8, async);
+                await buf.Ensure(8, async, cancellationToken);
                 var typeOID = buf.ReadUInt32();
                 var fieldLen = buf.ReadInt32();
                 if (fieldLen == -1)  // Null field, simply skip it and leave at default
                     continue;
-                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async);
+                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async, cancellationToken);
             }
 
             return result;

--- a/src/Npgsql/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/TypeHandlers/RecordHandler.cs
@@ -39,20 +39,20 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var fieldCount = buf.ReadInt32();
             var result = new object[fieldCount];
 
             for (var i = 0; i < fieldCount; i++)
             {
-                await buf.Ensure(8, async, cancellationToken);
+                await buf.Ensure(8, async, cancellationToken: cancellationToken);
                 var typeOID = buf.ReadUInt32();
                 var fieldLen = buf.ReadInt32();
                 if (fieldLen == -1)  // Null field, simply skip it and leave at default
                     continue;
-                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async, cancellationToken);
+                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async, cancellationToken: cancellationToken);
             }
 
             return result;

--- a/src/Npgsql/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/TypeHandlers/RecordHandler.cs
@@ -41,13 +41,13 @@ namespace Npgsql.TypeHandlers
 
         public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var fieldCount = buf.ReadInt32();
             var result = new object[fieldCount];
 
             for (var i = 0; i < fieldCount; i++)
             {
-                await buf.Ensure(8, async, cancellationToken: cancellationToken);
+                await buf.Ensure(8, async, cancellationToken);
                 var typeOID = buf.ReadUInt32();
                 var fieldLen = buf.ReadInt32();
                 if (fieldLen == -1)  // Null field, simply skip it and leave at default

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -90,7 +90,7 @@ namespace Npgsql.TypeHandlers
                 {
                     // The string's byte representation can fit in our read buffer, read it.
                     while (buf.ReadBytesLeft < byteLen)
-                        await buf.ReadMore(async, cancellationToken: cancellationToken);
+                        await buf.ReadMore(async, cancellationToken);
                     return buf.ReadString(byteLen);
                 }
 
@@ -109,7 +109,7 @@ namespace Npgsql.TypeHandlers
                     pos += len;
                     if (pos < byteLen)
                     {
-                        await buf.ReadMore(async, cancellationToken: cancellationToken);
+                        await buf.ReadMore(async, cancellationToken);
                         continue;
                     }
                     break;
@@ -124,7 +124,7 @@ namespace Npgsql.TypeHandlers
             {
                 // The string's byte representation can fit in our read buffer, read it.
                 while (buf.ReadBytesLeft < byteLen)
-                    await buf.ReadMore(async, cancellationToken: cancellationToken);
+                    await buf.ReadMore(async, cancellationToken);
                 return buf.ReadChars(byteLen);
             }
 
@@ -138,7 +138,7 @@ namespace Npgsql.TypeHandlers
                 pos += len;
                 if (pos < byteLen)
                 {
-                    await buf.ReadMore(async, cancellationToken: cancellationToken);
+                    await buf.ReadMore(async, cancellationToken);
                     continue;
                 }
                 break;
@@ -151,7 +151,7 @@ namespace Npgsql.TypeHandlers
             // Make sure we have enough bytes in the buffer for a single character
             var maxBytes = Math.Min(buf.TextEncoding.GetMaxByteCount(1), len);
             while (buf.ReadBytesLeft < maxBytes)
-                await buf.ReadMore(async, cancellationToken: cancellationToken);
+                await buf.ReadMore(async, cancellationToken);
 
             var decoder = buf.TextEncoding.GetDecoder();
             decoder.Convert(buf.Buffer, buf.ReadPosition, maxBytes, _singleCharArray, 0, 1, true, out var bytesUsed, out var charsUsed, out _);
@@ -182,7 +182,7 @@ namespace Npgsql.TypeHandlers
                 {
                     // The bytes can fit in our read buffer, read it.
                     while (buf.ReadBytesLeft < byteLen)
-                        await buf.ReadMore(async, cancellationToken: cancellationToken);
+                        await buf.ReadMore(async, cancellationToken);
                     buf.ReadBytes(bytes, 0, byteLen);
                     return bytes;
                 }
@@ -200,7 +200,7 @@ namespace Npgsql.TypeHandlers
                     pos += len;
                     if (pos < byteLen)
                     {
-                        await buf.ReadMore(async, cancellationToken: cancellationToken);
+                        await buf.ReadMore(async, cancellationToken);
                         continue;
                     }
                     break;

--- a/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -23,7 +24,7 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null)
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             if (fieldDescription == null)
                 throw new Exception($"Received an unknown field but {nameof(fieldDescription)} is null (i.e. COPY mode)");
@@ -36,7 +37,7 @@ namespace Npgsql.TypeHandlers
                         : $"The field '{fieldDescription.Name}' has a type currently unknown to Npgsql (OID {fieldDescription.TypeOID}). You can retrieve it as a string by marking it as unknown, please see the FAQ."
                 );
 
-            return base.Read(buf, byteLen, async, fieldDescription);
+            return base.Read(buf, byteLen, async, cancellationToken, fieldDescription);
         }
 
         #endregion Read

--- a/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
@@ -24,7 +24,7 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             if (fieldDescription == null)
                 throw new Exception($"Received an unknown field but {nameof(fieldDescription)} is null (i.e. COPY mode)");
@@ -37,7 +37,7 @@ namespace Npgsql.TypeHandlers
                         : $"The field '{fieldDescription.Name}' has a type currently unknown to Npgsql (OID {fieldDescription.TypeOID}). You can retrieve it as a string by marking it as unknown, please see the FAQ."
                 );
 
-            return base.Read(buf, byteLen, async, cancellationToken, fieldDescription);
+            return base.Read(buf, byteLen, async, fieldDescription, cancellationToken: cancellationToken);
         }
 
         #endregion Read

--- a/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
@@ -37,7 +37,7 @@ namespace Npgsql.TypeHandlers
                         : $"The field '{fieldDescription.Name}' has a type currently unknown to Npgsql (OID {fieldDescription.TypeOID}). You can retrieve it as a string by marking it as unknown, please see the FAQ."
                 );
 
-            return base.Read(buf, byteLen, async, fieldDescription, cancellationToken: cancellationToken);
+            return base.Read(buf, byteLen, async, fieldDescription, cancellationToken);
         }
 
         #endregion Read

--- a/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -28,9 +29,9 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            var s = await base.Read(buf, len, async, fieldDescription);
+            var s = await base.Read(buf, len, async, cancellationToken, fieldDescription);
             if (typeof(TAny) == typeof(string))
                 return (TAny)(object)s;
 
@@ -44,8 +45,8 @@ namespace Npgsql.TypeHandlers
             return (TAny)(object)value;
         }
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => base.Read(buf, len, async, fieldDescription);
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => base.Read(buf, len, async, cancellationToken, fieldDescription);
 
         #endregion
 

--- a/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
@@ -31,7 +31,7 @@ namespace Npgsql.TypeHandlers
 
         protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            var s = await base.Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            var s = await base.Read(buf, len, async, fieldDescription, cancellationToken);
             if (typeof(TAny) == typeof(string))
                 return (TAny)(object)s;
 
@@ -46,7 +46,7 @@ namespace Npgsql.TypeHandlers
         }
 
         public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => base.Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => base.Read(buf, len, async, fieldDescription, cancellationToken);
 
         #endregion
 

--- a/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
@@ -29,9 +29,9 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            var s = await base.Read(buf, len, async, cancellationToken, fieldDescription);
+            var s = await base.Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
             if (typeof(TAny) == typeof(string))
                 return (TAny)(object)s;
 
@@ -45,8 +45,8 @@ namespace Npgsql.TypeHandlers
             return (TAny)(object)value;
         }
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => base.Read(buf, len, async, cancellationToken, fieldDescription);
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+            => base.Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         #endregion
 

--- a/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 
 namespace Npgsql.TypeHandling
@@ -16,9 +17,10 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
+        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Responsible for validating that a value represents a value of the correct and which can be

--- a/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
@@ -17,10 +17,10 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
+        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Responsible for validating that a value represents a value of the correct and which can be

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -68,10 +69,11 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => Read<TDefault>(buf, len, async, fieldDescription);
+        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => Read<TDefault>(buf, len, async, cancellationToken, fieldDescription);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,
@@ -80,11 +82,12 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(len, async);
+            await buf.Ensure(len, async, cancellationToken);
             return Read<TAny>(buf, len, fieldDescription);
         }
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -87,7 +87,7 @@ namespace Npgsql.TypeHandling
         /// <returns>The fully-read value.</returns>
         protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(len, async, cancellationToken: cancellationToken);
+            await buf.Ensure(len, async, cancellationToken);
             return Read<TAny>(buf, len, fieldDescription);
         }
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -69,11 +69,11 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => Read<TDefault>(buf, len, async, cancellationToken, fieldDescription);
+        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+            => Read<TDefault>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,
@@ -82,12 +82,12 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(len, async, cancellationToken);
+            await buf.Ensure(len, async, cancellationToken: cancellationToken);
             return Read<TAny>(buf, len, fieldDescription);
         }
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -73,7 +73,7 @@ namespace Npgsql.TypeHandling
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
         public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => Read<TDefault>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => Read<TDefault>(buf, len, async, fieldDescription, cancellationToken);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -61,8 +62,8 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's provider-specific type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => (await Read<TPsv>(buf, len, async, fieldDescription))!;
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => (await Read<TPsv>(buf, len, async, cancellationToken, fieldDescription))!;
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -62,7 +62,7 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's provider-specific type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => (await Read<TPsv>(buf, len, async, fieldDescription, cancellationToken: cancellationToken))!;
 
         #endregion Read

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -63,7 +63,7 @@ namespace Npgsql.TypeHandling
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
         internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => (await Read<TPsv>(buf, len, async, fieldDescription, cancellationToken: cancellationToken))!;
+            => (await Read<TPsv>(buf, len, async, fieldDescription, cancellationToken))!;
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -63,7 +63,7 @@ namespace Npgsql.TypeHandling
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
         internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => (await Read<TPsv>(buf, len, async, cancellationToken, fieldDescription))!;
+            => (await Read<TPsv>(buf, len, async, fieldDescription, cancellationToken: cancellationToken))!;
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -80,7 +80,7 @@ namespace Npgsql.TypeHandling
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
         internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => ReadAsObject(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            => ReadAsObject(buf, len, async, fieldDescription, cancellationToken);
 
         /// <summary>
         /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
@@ -93,8 +93,8 @@ namespace Npgsql.TypeHandling
             return len == -1
                ? default!
                : NullableHandler<TAny>.Exists
-                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, fieldDescription, cancellationToken: cancellationToken)
-                   : await Read<TAny>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, fieldDescription, cancellationToken)
+                   : await Read<TAny>(buf, len, async, fieldDescription, cancellationToken);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -93,7 +93,7 @@ namespace Npgsql.TypeHandling
             return len == -1
                ? default!
                : NullableHandler<TAny>.Exists
-                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, cancellationToken, fieldDescription)
+                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, fieldDescription, cancellationToken: cancellationToken)
                    : await Read<TAny>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
         }
 

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -88,7 +88,7 @@ namespace Npgsql.TypeHandling
         /// </summary>
         internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
-            await buf.Ensure(4, async, cancellationToken: cancellationToken);
+            await buf.Ensure(4, async, cancellationToken);
             var len = buf.ReadInt32();
             return len == -1
                ? default!

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -38,10 +38,10 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        protected internal abstract ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
+        protected internal abstract ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TAny"/> with the given length from the provided buffer,
@@ -65,7 +65,7 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's default read type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal abstract ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
+        internal abstract ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads a column as the type handler's provider-specific type, assuming that it is already entirely
@@ -80,7 +80,7 @@ namespace Npgsql.TypeHandling
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
         internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
-            => ReadAsObject(buf, len, async, cancellationToken, fieldDescription);
+            => ReadAsObject(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
@@ -88,13 +88,13 @@ namespace Npgsql.TypeHandling
         /// </summary>
         internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var len = buf.ReadInt32();
             return len == -1
                ? default!
                : NullableHandler<TAny>.Exists
                    ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, cancellationToken, fieldDescription)
-                   : await Read<TAny>(buf, len, async, cancellationToken, fieldDescription);
+                   : await Read<TAny>(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -79,14 +79,14 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's provider-specific type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
             => ReadAsObject(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
         /// If the length is -1 (null), this method will return the default value.
         /// </summary>
-        internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+        internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
         {
             await buf.Ensure(4, async, cancellationToken: cancellationToken);
             var len = buf.ReadInt32();

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.PostgresTypes;
@@ -58,22 +59,24 @@ namespace Npgsql.TypeHandling
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        public abstract ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
+        public abstract ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,
         /// using either sync or async I/O. Type handlers typically don't need to override this -
-        /// override <see cref="Read(NpgsqlReadBuffer, int, bool, FieldDescription)"/> - but may do
+        /// override <see cref="Read(NpgsqlReadBuffer, int, bool, CancellationToken, FieldDescription)"/> - but may do
         /// so in exceptional cases where reading of arbitrary types is required.
         /// </summary>
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
         /// <returns>The fully-read value.</returns>
-        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
         {
             var asTypedHandler = this as INpgsqlTypeHandler<TAny>;
             if (asTypedHandler == null)
@@ -82,7 +85,7 @@ namespace Npgsql.TypeHandling
                     : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TAny).Name}"
                 );
 
-            return asTypedHandler.Read(buf, len, async, fieldDescription);
+            return asTypedHandler.Read(buf, len, async, cancellationToken, fieldDescription);
         }
 
         /// <inheritdoc />
@@ -91,8 +94,8 @@ namespace Npgsql.TypeHandling
 
         // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
         // we must use the bang operator here to tell the compiler that a null value will never returned.
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => (await Read<TDefault>(buf, len, async, fieldDescription))!;
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null)
+            => (await Read<TDefault>(buf, len, async, cancellationToken, fieldDescription))!;
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => Read<TDefault>(buf, len, fieldDescription)!;

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -85,7 +85,7 @@ namespace Npgsql.TypeHandling
                     : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TAny).Name}"
                 );
 
-            return asTypedHandler.Read(buf, len, async, fieldDescription, cancellationToken: cancellationToken);
+            return asTypedHandler.Read(buf, len, async, fieldDescription, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -90,7 +90,7 @@ namespace Npgsql.TypeHandling
 
         /// <inheritdoc />
         public override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TAny>(buf, len, false, fieldDescription, cancellationToken: default).Result;
+            => Read<TAny>(buf, len, false, fieldDescription).Result;
 
         // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
         // we must use the bang operator here to tell the compiler that a null value will never returned.

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -90,7 +90,7 @@ namespace Npgsql.TypeHandling
 
         /// <inheritdoc />
         public override TAny Read<TAny>(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => Read<TAny>(buf, len, false, fieldDescription).Result;
+            => Read<TAny>(buf, len, false, default, fieldDescription).Result;
 
         // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
         // we must use the bang operator here to tell the compiler that a null value will never returned.

--- a/src/Npgsql/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/TypeHandling/NullableHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 
@@ -8,7 +9,7 @@ using Npgsql.BackendMessages;
 namespace Npgsql.TypeHandling
 {
     delegate T ReadDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
-    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
+    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
 
     delegate int ValidateAndGetLengthDelegate<T>(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
     delegate Task WriteAsyncDelegate<T>(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async);
@@ -48,9 +49,9 @@ namespace Npgsql.TypeHandling
             where T : struct
             => handler.Read<T>(buffer, columnLength, fieldDescription);
 
-        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription)
+        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             where T : struct
-            => await handler.Read<T>(buffer, columnLength, async, fieldDescription);
+            => await handler.Read<T>(buffer, columnLength, async, cancellationToken, fieldDescription);
 
         static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             where T : struct

--- a/src/Npgsql/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/TypeHandling/NullableHandler.cs
@@ -9,7 +9,7 @@ using Npgsql.BackendMessages;
 namespace Npgsql.TypeHandling
 {
     delegate T ReadDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
-    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription = null);
+    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
 
     delegate int ValidateAndGetLengthDelegate<T>(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
     delegate Task WriteAsyncDelegate<T>(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async);
@@ -49,7 +49,7 @@ namespace Npgsql.TypeHandling
             where T : struct
             => handler.Read<T>(buffer, columnLength, fieldDescription);
 
-        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
+        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             where T : struct
             => await handler.Read<T>(buffer, columnLength, async, fieldDescription, cancellationToken: cancellationToken);
 

--- a/src/Npgsql/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/TypeHandling/NullableHandler.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeHandling
 
         static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
             where T : struct
-            => await handler.Read<T>(buffer, columnLength, async, fieldDescription, cancellationToken: cancellationToken);
+            => await handler.Read<T>(buffer, columnLength, async, fieldDescription, cancellationToken);
 
         static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             where T : struct

--- a/src/Npgsql/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/TypeHandling/NullableHandler.cs
@@ -51,7 +51,7 @@ namespace Npgsql.TypeHandling
 
         static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, CancellationToken cancellationToken, FieldDescription? fieldDescription)
             where T : struct
-            => await handler.Read<T>(buffer, columnLength, async, cancellationToken, fieldDescription);
+            => await handler.Read<T>(buffer, columnLength, async, fieldDescription, cancellationToken: cancellationToken);
 
         static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             where T : struct

--- a/src/Npgsql/Util/StreamExtensions.cs
+++ b/src/Npgsql/Util/StreamExtensions.cs
@@ -30,7 +30,7 @@ namespace Npgsql.Util
             var sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {
-                var result = await stream.ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken: cancellationToken);
+                var result = await stream.ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken);
                 new Span<byte>(sharedBuffer, 0, result).CopyTo(buffer.Span);
                 return result;
             }
@@ -60,7 +60,7 @@ namespace Npgsql.Util
             buffer.Span.CopyTo(sharedBuffer);
             try
             {
-                await stream.WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken: cancellationToken);
+                await stream.WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken);
             }
             finally
             {

--- a/src/Npgsql/Util/StreamExtensions.cs
+++ b/src/Npgsql/Util/StreamExtensions.cs
@@ -30,7 +30,7 @@ namespace Npgsql.Util
             var sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {
-                var result = await stream.ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken);
+                var result = await stream.ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken: cancellationToken);
                 new Span<byte>(sharedBuffer, 0, result).CopyTo(buffer.Span);
                 return result;
             }
@@ -60,7 +60,7 @@ namespace Npgsql.Util
             buffer.Span.CopyTo(sharedBuffer);
             try
             {
-                await stream.WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken);
+                await stream.WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken: cancellationToken);
             }
             finally
             {

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -20,6 +20,7 @@ namespace Npgsql.Tests
                 // Make sure messages are in English
                 Options = "lc_messages=en_US.UTF-8"
             });
+
             conn.ExecuteNonQuery(@"
                      CREATE OR REPLACE FUNCTION pg_temp.emit_exception() RETURNS VOID AS
                         'BEGIN RAISE EXCEPTION ''testexception'' USING ERRCODE = ''12345'', DETAIL = ''testdetail''; END;'

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -20,7 +20,6 @@ namespace Npgsql.Tests
                 // Make sure messages are in English
                 Options = "lc_messages=en_US.UTF-8"
             });
-
             conn.ExecuteNonQuery(@"
                      CREATE OR REPLACE FUNCTION pg_temp.emit_exception() RETURNS VOID AS
                         'BEGIN RAISE EXCEPTION ''testexception'' USING ERRCODE = ''12345'', DETAIL = ''testdetail''; END;'

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -173,8 +173,7 @@ namespace Npgsql.Tests
             {
                 var cts = new CancellationTokenSource(1000).Token;
                 Assert.That(async () => await cmd.ExecuteNonQueryAsync(cts), Throws.Exception
-                    .TypeOf<PostgresException>()
-                    .With.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
+                    .TypeOf<OperationCanceledException>());
             }
         }
 

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -173,7 +173,8 @@ namespace Npgsql.Tests
             {
                 var cts = new CancellationTokenSource(1000).Token;
                 Assert.That(async () => await cmd.ExecuteNonQueryAsync(cts), Throws.Exception
-                    .TypeOf<OperationCanceledException>());
+                    .TypeOf<PostgresException>()
+                    .With.Property(nameof(PostgresException.SqlState)).EqualTo("57014"));
             }
         }
 


### PR DESCRIPTION
Related to #2437.

As this pr is already pretty big, I think it should be split in 3 parts:
- Reading cancellation part (this pr).
- Writing cancellation part.
- Wrap it all up, so it would work with the cancellation request from the user token.

Also, might be worth to add some `CancellationToken.ThrowIfCancellationRequested` calls for the sake of .net 4.6.1. (which doesn't support the cancellation on the socket layer).
