### PR TITLE
Real cancellation and timeout for ConnectAsync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,9 +48,6 @@ csharp_indent_switch_labels = false
 
 # Code analysis rules
 
-# Code files
-[*.{cs,vb}]
-
 # Reliability Rules
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one

--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,13 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = false
+
+# Code analysis rules
+
+# Code files
+[*.{cs,vb}]
+
+# Reliability Rules
+
+# CA2016: Forward the 'CancellationToken' parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = error

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -2062,7 +2062,8 @@ namespace Npgsql
                     while (true)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        var msg = await ReadMessageWithNotifications(true, cancellationToken);
+                        // TODO: Fully implement cancellation
+                        var msg = await ReadMessageWithNotifications(true, CancellationToken.None);
                         if (!keepaliveSent)
                         {
                             if (msg != null)
@@ -2086,7 +2087,7 @@ namespace Npgsql
                                 while (msg == null)
                                 {
                                     receivedNotification = true;
-                                    // Intentional, as this method would be rewritten
+                                    // TODO: Fully implement cancellation
                                     msg = await ReadMessage(true, CancellationToken.None);
                                 }
 
@@ -2100,9 +2101,9 @@ namespace Npgsql
                                     expectedMessageCode = BackendMessageCode.DataRow;
                                     break;
                                 case BackendMessageCode.DataRow:
-                                    // Intentional, as this method would be rewritten
+                                    // TODO: Fully implement cancellation
                                     // DataRow is usually consumed by a reader, here we have to skip it manually.
-                                    await ReadBuffer.Skip(((DataRowMessage)msg).Length, true, cancellationToken);
+                                    await ReadBuffer.Skip(((DataRowMessage)msg).Length, true, CancellationToken.None);
                                     expectedMessageCode = BackendMessageCode.CompletedResponse;
                                     break;
                                 case BackendMessageCode.CompletedResponse:

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -456,7 +456,7 @@ namespace Npgsql
                     // It is intentionally not awaited and will run as long as the connector is alive.
                     // The CommandsInFlightWriter channel is completed in Cleanup, which should cause this task
                     // to complete.
-                    _ = Task.Run(MultiplexingReadLoop)
+                    _ = Task.Run(MultiplexingReadLoop, CancellationToken.None)
                         .ContinueWith(t =>
                         {
                             // Note that we *must* observe the exception if the task is faulted.
@@ -755,7 +755,7 @@ namespace Npgsql
             }
             else
             {
-                // Note that there aren't any timeoutable or cancellable DNS methods
+                // Note that there aren't any timeout-able or cancellable DNS methods
                 endpoints = (await Dns.GetHostAddressesAsync(Host).WithCancellation(cancellationToken))
                     .Select(a => new IPEndPoint(a, Port)).ToArray();
             }
@@ -778,10 +778,36 @@ namespace Npgsql
                 Log.Trace($"Attempting to connect to {endpoint}");
                 var protocolType = endpoint.AddressFamily == AddressFamily.InterNetwork ? ProtocolType.Tcp : ProtocolType.IP;
                 var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, protocolType);
+                CancellationTokenSource? combinedCts = null;
+                CancellationTokenSource? timeoutCts = null;
                 try
                 {
+                    // .NET 5.0 added cancellation support to ConnectAsync, which allows us to implement real
+                    // cancellation and timeout. On older TFMs, we fake-cancel the operation, i.e. stop waiting
+                    // and raise the exception, but the actual connection task is left running.
+
+// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
+#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
                     await socket.ConnectAsync(endpoint)
                         .WithCancellationAndTimeout(perIpTimeout, cancellationToken);
+#else
+                    var finalCt = cancellationToken;
+
+                    if (perIpTimeout.IsSet)
+                    {
+                        timeoutCts = new CancellationTokenSource(perIpTimeout.TimeLeft.Milliseconds);
+                        finalCt = timeoutCts.Token;
+
+                        if (cancellationToken.CanBeCanceled)
+                        {
+                            combinedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                                cancellationToken, timeoutCts.Token);
+                            finalCt = combinedCts.Token;
+                        }
+                    }
+
+                    await socket.ConnectAsync(endpoint, finalCt);
+#endif
 
                     SetSocketOptions(socket);
                     _socket = socket;
@@ -789,7 +815,10 @@ namespace Npgsql
                 }
                 catch (Exception e)
                 {
-                    try { socket.Dispose(); }
+                    try
+                    {
+                        socket.Dispose();
+                    }
                     catch
                     {
                         // ignored
@@ -806,6 +835,11 @@ namespace Npgsql
                     {
                         throw new NpgsqlException("Exception while connecting", e);
                     }
+                }
+                finally
+                {
+                    timeoutCts?.Dispose();
+                    combinedCts?.Dispose();
                 }
             }
         }
@@ -2028,8 +2062,7 @@ namespace Npgsql
                     while (true)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        // Intentional, as this method would be rewritten
-                        var msg = await ReadMessageWithNotifications(true);
+                        var msg = await ReadMessageWithNotifications(true, cancellationToken);
                         if (!keepaliveSent)
                         {
                             if (msg != null)
@@ -2042,7 +2075,7 @@ namespace Npgsql
 
                         // A keepalive was sent. Consume the response (RowDescription, CommandComplete,
                         // ReadyForQuery) while also keeping track if an async message was received in between.
-                        keepaliveLock.Wait();
+                        await keepaliveLock.WaitAsync(CancellationToken.None);
                         try
                         {
                             var receivedNotification = false;
@@ -2069,7 +2102,7 @@ namespace Npgsql
                                 case BackendMessageCode.DataRow:
                                     // Intentional, as this method would be rewritten
                                     // DataRow is usually consumed by a reader, here we have to skip it manually.
-                                    await ReadBuffer.Skip(((DataRowMessage)msg).Length, true);
+                                    await ReadBuffer.Skip(((DataRowMessage)msg).Length, true, cancellationToken);
                                     expectedMessageCode = BackendMessageCode.CompletedResponse;
                                     break;
                                 case BackendMessageCode.CompletedResponse:

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -795,15 +795,9 @@ namespace Npgsql
 
                     if (perIpTimeout.IsSet)
                     {
-                        timeoutCts = new CancellationTokenSource(perIpTimeout.TimeLeft.Milliseconds);
+                        timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                        timeoutCts.CancelAfter(perIpTimeout.TimeLeft.Milliseconds);
                         finalCt = timeoutCts.Token;
-
-                        if (cancellationToken.CanBeCanceled)
-                        {
-                            combinedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                                cancellationToken, timeoutCts.Token);
-                            finalCt = combinedCts.Token;
-                        }
                     }
 
                     await socket.ConnectAsync(endpoint, finalCt);

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1352,7 +1352,7 @@ namespace Npgsql
             if (field.Handler is ITextReaderHandler handler)
                 return handler.GetTextReader(async
                     ? await GetStreamInternal(field, ordinal, true, cancellationToken)
-                    : GetStreamInternal(field, ordinal, false).Result);
+                    : GetStreamInternal(field, ordinal, false, CancellationToken.None).Result);
 
             throw new InvalidCastException($"The GetTextReader method is not supported for type {field.Handler.PgDisplayName}");
         }

--- a/src/Npgsql/TaskExtensions.cs
+++ b/src/Npgsql/TaskExtensions.cs
@@ -64,6 +64,8 @@ namespace Npgsql
             return await task;
         }
 
+// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
+#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
         /// <summary>
         /// Allows you to cancel awaiting for a non-cancellable task.
         /// </summary>
@@ -93,5 +95,6 @@ namespace Npgsql
                 .WithCancellation(cancellationToken)
                 .WithTimeout(timeout);
         }
+#endif
     }
 }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -373,7 +373,9 @@ namespace Npgsql.Tests
             }.ToString();
             using (var conn = new NpgsqlConnection(connString))
             {
-                Assert.That(async () => await conn.OpenAsync(), Throws.Exception.TypeOf<TimeoutException>());
+                Assert.That(async () => await conn.OpenAsync(), Throws.Exception
+                    .TypeOf<NpgsqlException>()
+                    .With.InnerException.TypeOf<TimeoutException>());
                 Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
             }
         }


### PR DESCRIPTION
Also enables the code analysis rule for flowing cancellation tokens
(part of #3162).

Fixes #2860
