### PR TITLE
Redesigned range type

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -25,5 +25,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
+	<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -1,530 +1,62 @@
-﻿using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text;
-
-// ReSharper disable once CheckNamespace
-namespace NpgsqlTypes
+﻿namespace NpgsqlTypes
 {
     /// <summary>
-    /// Represents a PostgreSQL range type.
+    /// Creates instances of the <see cref="NpgsqlRange{T}"/> struct.
     /// </summary>
-    /// <typeparam name="T">The element type of the values in the range.</typeparam>
-    /// <remarks>
-    /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
-    /// </remarks>
-    public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
+    public static class NpgsqlRange
     {
-        // -----------------------------------------------------------------------------------------------
-        // Regarding bitwise flag checks via @roji:
-        //
-        // > Note that Flags.HasFlag() used to be very inefficient compared to simply doing the
-        // > bit operation - this is why I've always avoided it. .NET Core 2.1 adds JIT intrinstics
-        // > for this, making Enum.HasFlag() fast, but I honestly don't see the value over just doing
-        // > a bitwise and operation, which would also be fast under .NET Core 2.0 and .NET Framework.
-        //
-        // See:
-        //   - https://github.com/npgsql/npgsql/pull/1939#pullrequestreview-121308396
-        //   - https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1
-        // -----------------------------------------------------------------------------------------------
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an empty range.
-        /// </summary>
-        const string EmptyLiteral = "empty";
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an infinite lower bound.
-        /// Some element types may have specific handling for this value distinct from a missing or null value.
-        /// </summary>
-        const string LowerInfinityLiteral = "-infinity";
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an infinite upper bound.
-        /// Some element types may have specific handling for this value distinct from a missing or null value.
-        /// </summary>
-        const string UpperInfinityLiteral = "infinity";
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an null bound.
-        /// Some element types may have specific handling for this value distinct from an infinite or missing value.
-        /// </summary>
-        const string NullLiteral = "null";
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent a lower inclusive bound.
-        /// </summary>
-        const char LowerInclusiveBound = '[';
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent a lower exclusive bound.
-        /// </summary>
-        const char LowerExclusiveBound = '(';
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an upper inclusive bound.
-        /// </summary>
-        const char UpperInclusiveBound = ']';
-
-        /// <summary>
-        /// Defined by PostgreSQL to represent an upper exclusive bound.
-        /// </summary>
-        const char UpperExclusiveBound = ')';
-
-        /// <summary>
-        /// Defined by PostgreSQL to separate the values for the upper and lower bounds.
-        /// </summary>
-        const char BoundSeparator = ',';
-
-        /// <summary>
-        /// The <see cref="TypeConverter"/> used by <see cref="Parse"/> to convert <see cref="string"/> bounds into <typeparamref name="T"/>.
-        /// </summary>
-        static readonly TypeConverter BoundConverter = TypeDescriptor.GetConverter(typeof(T));
-
-        /// <summary>
-        /// True if <typeparamref name="T"/> implements <see cref="IEquatable{T}"/>; otherwise, false.
-        /// </summary>
-        static readonly bool HasEquatableBounds = typeof(IEquatable<T>).IsAssignableFrom(typeof(T));
-
-        /// <summary>
-        /// Represents the empty range. This field is read-only.
-        /// </summary>
-        public static readonly NpgsqlRange<T> Empty = new NpgsqlRange<T>(default, default, RangeFlags.Empty);
-
-        /// <summary>
-        /// The lower bound of the range. Only valid when <see cref="LowerBoundInfinite"/> is false.
-        /// </summary>
-        [MaybeNull, AllowNull]
-        public T LowerBound { get; }
-
-        /// <summary>
-        /// The upper bound of the range. Only valid when <see cref="UpperBoundInfinite"/> is false.
-        /// </summary>
-        [MaybeNull, AllowNull]
-        public T UpperBound { get; }
-
-        /// <summary>
-        /// The characteristics of the boundaries.
-        /// </summary>
-        internal readonly RangeFlags Flags;
-
-        /// <summary>
-        /// True if the lower bound is part of the range (i.e. inclusive); otherwise, false.
-        /// </summary>
-        public bool LowerBoundIsInclusive => (Flags & RangeFlags.LowerBoundInclusive) != 0;
-
-        /// <summary>
-        /// True if the upper bound is part of the range (i.e. inclusive); otherwise, false.
-        /// </summary>
-        public bool UpperBoundIsInclusive => (Flags & RangeFlags.UpperBoundInclusive) != 0;
-
-        /// <summary>
-        /// True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.
-        /// </summary>
-        public bool LowerBoundInfinite => (Flags & RangeFlags.LowerBoundInfinite) != 0;
-
-        /// <summary>
-        /// True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.
-        /// </summary>
-        public bool UpperBoundInfinite => (Flags & RangeFlags.UpperBoundInfinite) != 0;
-
-        /// <summary>
-        /// True if the range is empty; otherwise, false.
-        /// </summary>
-        public bool IsEmpty => (Flags & RangeFlags.Empty) != 0;
-
-        /// <summary>
-        /// Constructs an <see cref="NpgsqlRange{T}"/> with inclusive and definite bounds.
-        /// </summary>
-        /// <param name="lowerBound">The lower bound of the range.</param>
-        /// <param name="upperBound">The upper bound of the range.</param>
-        public NpgsqlRange([AllowNull] T lowerBound, [AllowNull] T upperBound)
-            : this(lowerBound, true, false, upperBound, true, false) { }
-
-        /// <summary>
-        /// Constructs an <see cref="NpgsqlRange{T}"/> with definite bounds.
-        /// </summary>
-        /// <param name="lowerBound">The lower bound of the range.</param>
-        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
-        /// <param name="upperBound">The upper bound of the range.</param>
-        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
-        public NpgsqlRange(
-            [AllowNull] T lowerBound, bool lowerBoundIsInclusive,
-            [AllowNull] T upperBound, bool upperBoundIsInclusive)
-            : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) { }
-
-        /// <summary>
-        /// Constructs an <see cref="NpgsqlRange{T}"/>.
-        /// </summary>
-        /// <param name="lowerBound">The lower bound of the range.</param>
-        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
-        /// <param name="lowerBoundInfinite">True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-        /// <param name="upperBound">The upper bound of the range.</param>
-        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
-        /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-        public NpgsqlRange(
-            [AllowNull] T lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite,
-            [AllowNull] T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
-            : this(
-                lowerBound,
-                upperBound,
-                EvaluateBoundaryFlags(
-                    lowerBoundIsInclusive,
-                    upperBoundIsInclusive,
-                    lowerBoundInfinite,
-                    upperBoundInfinite)) { }
-
-        /// <summary>
-        /// Constructs an <see cref="NpgsqlRange{T}"/>.
-        /// </summary>
-        /// <param name="lowerBound">The lower bound of the range.</param>
-        /// <param name="upperBound">The upper bound of the range.</param>
-        /// <param name="flags">The characteristics of the range boundaries.</param>
-        internal NpgsqlRange([AllowNull] T lowerBound, [AllowNull] T upperBound, RangeFlags flags) : this()
-        {
-            // TODO: We need to check if the bounds are implicitly empty. E.g. '(1,1)' or '(0,0]'.
-            // See: https://github.com/npgsql/npgsql/issues/1943.
-
-            LowerBound = (flags & RangeFlags.LowerBoundInfinite) != 0 ? default : lowerBound;
-            UpperBound = (flags & RangeFlags.UpperBoundInfinite) != 0 ? default : upperBound;
-            Flags = flags;
-
-            if (IsEmptyRange(LowerBound, UpperBound, Flags))
-            {
-                LowerBound = default!;
-                UpperBound = default!;
-                Flags = RangeFlags.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Attempts to determine if the range is malformed or implicitly empty.
-        /// </summary>
-        /// <param name="lowerBound">The lower bound of the range.</param>
-        /// <param name="upperBound">The upper bound of the range.</param>
-        /// <param name="flags">The characteristics of the range boundaries.</param>
-        /// <returns>
-        /// True if the range is implicitly empty; otherwise, false.
-        /// </returns>
-        static bool IsEmptyRange([AllowNull] T lowerBound, [AllowNull] T upperBound, RangeFlags flags)
-        {
-            // ---------------------------------------------------------------------------------
-            // We only want to check for those conditions that are unambiguously erroneous:
-            //   1. The bounds must not be default values (including null).
-            //   2. The bounds must be definite (non-infinite).
-            //   3. The bounds must be inclusive.
-            //   4. The bounds must be considered equal.
-            //
-            // See:
-            //  - https://github.com/npgsql/npgsql/pull/1939
-            //  - https://github.com/npgsql/npgsql/issues/1943
-            // ---------------------------------------------------------------------------------
-
-            if ((flags & RangeFlags.Empty) == RangeFlags.Empty)
-                return true;
-
-            if ((flags & RangeFlags.Infinite) == RangeFlags.Infinite)
-                return false;
-
-            if ((flags & RangeFlags.Inclusive) == RangeFlags.Inclusive)
-                return false;
-
-            if (lowerBound is null || upperBound is null)
-                return false;
-
-            if (!HasEquatableBounds)
-                return lowerBound?.Equals(upperBound) ?? false;
-
-            var lower = (IEquatable<T>)lowerBound;
-            var upper = (IEquatable<T>)upperBound;
-
-            return !lower.Equals(default!) && !upper.Equals(default!) && lower.Equals(upperBound);
-        }
-
-        /// <summary>
-        /// Evaluates the boundary flags.
-        /// </summary>
-        /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
-        /// <param name="lowerBoundInfinite">True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-        /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
-        /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-        /// <returns>
-        /// The boundary characteristics.
-        /// </returns>
-        static RangeFlags EvaluateBoundaryFlags(bool lowerBoundIsInclusive, bool upperBoundIsInclusive, bool lowerBoundInfinite, bool upperBoundInfinite)
-        {
-            var result = RangeFlags.None;
-
-            // This is the only place flags are calculated.
-            if (lowerBoundIsInclusive)
-                result |= RangeFlags.LowerBoundInclusive;
-            if (upperBoundIsInclusive)
-                result |= RangeFlags.UpperBoundInclusive;
-            if (lowerBoundInfinite)
-                result |= RangeFlags.LowerBoundInfinite;
-            if (upperBoundInfinite)
-                result |= RangeFlags.UpperBoundInfinite;
-
-            // PostgreSQL automatically converts inclusive-infinities.
-            // See: https://www.postgresql.org/docs/current/static/rangetypes.html#RANGETYPES-INFINITE
-            if ((result & RangeFlags.LowerInclusiveInfinite) == RangeFlags.LowerInclusiveInfinite)
-                result &= ~RangeFlags.LowerBoundInclusive;
-
-            if ((result & RangeFlags.UpperInclusiveInfinite) == RangeFlags.UpperInclusiveInfinite)
-                result &= ~RangeFlags.UpperBoundInclusive;
-
-            return result;
-        }
-
-        /// <summary>
-        /// Indicates whether the <see cref="NpgsqlRange{T}"/> on the left is equal to the <see cref="NpgsqlRange{T}"/> on the right.
-        /// </summary>
-        /// <param name="x">The <see cref="NpgsqlRange{T}"/> on the left.</param>
-        /// <param name="y">The <see cref="NpgsqlRange{T}"/> on the right.</param>
-        /// <returns>
-        /// True if the <see cref="NpgsqlRange{T}"/> on the left is equal to the <see cref="NpgsqlRange{T}"/> on the right; otherwise, false.
-        /// </returns>
-        public static bool operator ==(NpgsqlRange<T> x, NpgsqlRange<T> y) => x.Equals(y);
-
-        /// <summary>
-        /// Indicates whether the <see cref="NpgsqlRange{T}"/> on the left is not equal to the <see cref="NpgsqlRange{T}"/> on the right.
-        /// </summary>
-        /// <param name="x">The <see cref="NpgsqlRange{T}"/> on the left.</param>
-        /// <param name="y">The <see cref="NpgsqlRange{T}"/> on the right.</param>
-        /// <returns>
-        /// True if the <see cref="NpgsqlRange{T}"/> on the left is not equal to the <see cref="NpgsqlRange{T}"/> on the right; otherwise, false.
-        /// </returns>
-        public static bool operator !=(NpgsqlRange<T> x, NpgsqlRange<T> y) => !x.Equals(y);
-
-        /// <inheritdoc />
-        public override bool Equals(object? o) => o is NpgsqlRange<T> range && Equals(range);
-
-        /// <inheritdoc />
-        public bool Equals(NpgsqlRange<T> other)
-        {
-            if (Flags != other.Flags)
-                return false;
-
-            if (HasEquatableBounds)
-            {
-                var lowerEqual = LowerBound is null
-                    ? other.LowerBound is null
-                    : !(other.LowerBound is null) && ((IEquatable<T>)LowerBound).Equals(other.LowerBound);
-
-                if (!lowerEqual)
-                    return false;
-
-                return UpperBound is null
-                    ? other.UpperBound is null
-                    : !(other.UpperBound is null) && ((IEquatable<T>)UpperBound).Equals(other.UpperBound);
-            }
-
-            return
-                (LowerBound?.Equals(other.LowerBound) ?? other.LowerBound is null) &&
-                (UpperBound?.Equals(other.UpperBound) ?? other.UpperBound is null);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-            => unchecked((397 * (int)Flags) ^ (397 * (LowerBound?.GetHashCode() ?? 0)) ^ (397 * (UpperBound?.GetHashCode() ?? 0)));
-
-        /// <inheritdoc />
-        public override string ToString()
-        {
-            if (IsEmpty)
-                return EmptyLiteral;
-
-            var sb = new StringBuilder();
-
-            sb.Append(LowerBoundIsInclusive ? LowerInclusiveBound : LowerExclusiveBound);
-
-            if (!LowerBoundInfinite)
-                sb.Append(LowerBound);
-
-            sb.Append(BoundSeparator);
-
-            if (!UpperBoundInfinite)
-                sb.Append(UpperBound);
-
-            sb.Append(UpperBoundIsInclusive ? UpperInclusiveBound : UpperExclusiveBound);
-
-            return sb.ToString();
-        }
-
-        // TODO: rewrite this to use ReadOnlySpan<char> for the 4.1 release
-        /// <summary>
-        /// Parses the well-known text representation of a PostgreSQL range type into a <see cref="NpgsqlRange{T}"/>.
-        /// </summary>
-        /// <param name="value">A PosgreSQL range type in a well-known text format.</param>
-        /// <returns>
-        /// The <see cref="NpgsqlRange{T}"/> represented by the <paramref name="value"/>.
-        /// </returns>
-        /// <exception cref="FormatException">
-        /// Malformed range literal.
-        /// </exception>
-        /// <exception cref="FormatException">
-        /// Malformed range literal. Missing left parenthesis or bracket.
-        /// </exception>
-        /// <exception cref="FormatException">
-        /// Malformed range literal. Missing right parenthesis or bracket.
-        /// </exception>
-        /// <exception cref="FormatException">
-        /// Malformed range literal. Missing comma after lower bound.
-        /// </exception>
-        /// <remarks>
-        /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
-        /// </remarks>
-        public static NpgsqlRange<T> Parse(string value)
-        {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
-
-            value = value.Trim();
-
-            if (value.Length < 3)
-                throw new FormatException("Malformed range literal.");
-
-            if (string.Equals(value, EmptyLiteral, StringComparison.OrdinalIgnoreCase))
-                return Empty;
-
-            var lowerInclusive = value[0] == LowerInclusiveBound;
-            var lowerExclusive = value[0] == LowerExclusiveBound;
-
-            if (!lowerInclusive && !lowerExclusive)
-                throw new FormatException("Malformed range literal. Missing left parenthesis or bracket.");
-
-            var upperInclusive = value[value.Length - 1] == UpperInclusiveBound;
-            var upperExclusive = value[value.Length - 1] == UpperExclusiveBound;
-
-            if (!upperInclusive && !upperExclusive)
-                throw new FormatException("Malformed range literal. Missing right parenthesis or bracket.");
-
-            var separator = value.IndexOf(BoundSeparator);
-
-            if (separator == -1)
-                throw new FormatException("Malformed range literal. Missing comma after lower bound.");
-
-            if (separator != value.LastIndexOf(BoundSeparator))
-                // TODO: this should be replaced to handle quoted commas.
-                throw new NotSupportedException("Ranges with embedded commas are not currently supported.");
-
-            // Skip the opening bracket and stop short of the separator.
-            var lowerSegment = value.Substring(1, separator - 1).Trim();
-
-            // Skip past the separator and stop short of the closing bracket.
-            var upperSegment = value.Substring(separator + 1, value.Length - separator - 2).Trim();
-
-            // TODO: infinity literals have special meaning to some types (e.g. daterange), we should consider a flag to track them.
-
-            var lowerInfinite =
-                lowerSegment.Length == 0 ||
-                string.Equals(lowerSegment, string.Empty, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(lowerSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(lowerSegment, LowerInfinityLiteral, StringComparison.OrdinalIgnoreCase);
-
-            var upperInfinite =
-                upperSegment.Length == 0 ||
-                string.Equals(upperSegment, string.Empty, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(upperSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(upperSegment, UpperInfinityLiteral, StringComparison.OrdinalIgnoreCase);
-
-            T lower = lowerInfinite ? default : (T)BoundConverter.ConvertFromString(lowerSegment);
-            T upper = upperInfinite ? default : (T)BoundConverter.ConvertFromString(upperSegment);
-
-            return new NpgsqlRange<T>(lower, lowerInclusive, lowerInfinite, upper, upperInclusive, upperInfinite);
-        }
-
-#nullable disable
-        /// <summary>
-        /// Represents a type converter for <see cref="NpgsqlRange{T}" />.
-        /// </summary>
-        public class RangeTypeConverter : TypeConverter
-        {
-            /// <summary>
-            /// Adds a <see cref="TypeConverterAttribute"/> to the closed form <see cref="NpgsqlRange{T}"/>.
-            /// </summary>
-            public static void Register() =>
-                TypeDescriptor.AddAttributes(
-                    typeof(NpgsqlRange<T>),
-                    new TypeConverterAttribute(typeof(RangeTypeConverter)));
-
-            /// <inheritdoc />
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-                => sourceType == typeof(string);
-
-            /// <inheritdoc />
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-                => destinationType == typeof(string);
-
-            /// <inheritdoc />
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-                => value is string s ? Parse(s) : base.ConvertFrom(context, culture, value);
-
-            /// <inheritdoc />
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-                => value.ToString();
-        }
-    }
-#nullable restore
-
-    /// <summary>
-    /// Represents characteristics of range type boundaries.
-    /// </summary>
-    /// <remarks>
-    /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
-    /// </remarks>
-    [Flags]
-    enum RangeFlags : byte
-    {
-        /// <summary>
-        /// The default flag. The range is not empty and has boundaries that are definite and exclusive.
-        /// </summary>
-        None = 0,
-
-        /// <summary>
-        /// The range is empty. E.g. '(0,0)', 'empty'.
-        /// </summary>
-        Empty = 1,
-
-        /// <summary>
-        /// The lower bound is inclusive. E.g. '[0,5]', '[0,5)', '[0,)'.
-        /// </summary>
-        LowerBoundInclusive = 2,
-
-        /// <summary>
-        /// The upper bound is inclusive. E.g. '[0,5]', '(0,5]', '(,5]'.
-        /// </summary>
-        UpperBoundInclusive = 4,
-
-        /// <summary>
-        /// The lower bound is infinite or indefinite. E.g. '(null,5]', '(-infinity,5]', '(,5]'.
-        /// </summary>
-        LowerBoundInfinite = 8,
-
-        /// <summary>
-        /// The upper bound is infinite or indefinite. E.g. '[0,null)', '[0,infinity)', '[0,)'.
-        /// </summary>
-        UpperBoundInfinite = 16,
-
-        /// <summary>
-        /// Both the lower and upper bounds are inclusive.
-        /// </summary>
-        Inclusive = LowerBoundInclusive | UpperBoundInclusive,
-
-        /// <summary>
-        /// Both the lower and upper bounds are indefinite.
-        /// </summary>
-        Infinite = LowerBoundInfinite | UpperBoundInfinite,
-
-        /// <summary>
-        /// The lower bound is both inclusive and indefinite. This represents an error condition.
-        /// </summary>
-        LowerInclusiveInfinite = LowerBoundInclusive | LowerBoundInfinite,
-
-        /// <summary>
-        /// The upper bound is both inclusive and indefinite. This represents an error condition.
-        /// </summary>
-        UpperInclusiveInfinite = UpperBoundInclusive | UpperBoundInfinite
+        /// <summary>Creates an empty range.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <returns>An empty range.</returns>
+        public static NpgsqlRange<T> Empty<T>() =>
+            default;
+
+        /// <summary>Creates a new range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An range having the provided bounds.</returns>
+        public static NpgsqlRange<T> Create<T>(T lowerBound, T upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound);
+
+        /// <summary>Creates a new range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An range having the provided bounds.</returns>
+        public static NpgsqlRange<T> Create<T>(T lowerBound, NpgsqlRangeBound<T> upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound);
+
+        /// <summary>Creates a new range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An range having the provided bounds.</returns>
+        public static NpgsqlRange<T> Create<T>(NpgsqlRangeBound<T> lowerBound, T upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound);
+
+        /// <summary>Creates a new range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An range having the provided bounds.</returns>
+        public static NpgsqlRange<T> Create<T>(NpgsqlRangeBound<T> lowerBound, NpgsqlRangeBound<T> upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound);
+
+        /// <summary>Creates a new exclusive range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An exclusive range having the provided bounds.</returns>
+        public static NpgsqlRange<T> CreateExclusive<T>(T lowerBound, T upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound, NpgsqlRangeFlags.None);
+
+        /// <summary>Creates a inclusive new range using provided bounds.</summary>
+        /// <typeparam name="T">The element type of the values in the range.</typeparam>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <returns>An inclusive range having the provided bounds.</returns>
+        public static NpgsqlRange<T> CreateInclusive<T>(T lowerBound, T upperBound) =>
+            new NpgsqlRange<T>(lowerBound, upperBound, NpgsqlRangeFlags.LowerBoundInclusive | NpgsqlRangeFlags.UpperBoundInclusive);
     }
 }

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeBound.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeBound.cs
@@ -27,13 +27,5 @@ namespace NpgsqlTypes
         /// <returns>An infinite bound.</returns>
         public static NpgsqlRangeBound<T> Infinite<T>() =>
             new NpgsqlRangeBound<T>(default, NpgsqlRangeBoundFlags.Infinity);
-
-        internal static bool Equals<T>([AllowNull] T left, [AllowNull] T right) =>
-            left is null ? right is null : right is { } &&
-            EqualityComparer<T>.Default.Equals(left, right);
-
-        internal static int Compare<T>([AllowNull] T left, [AllowNull] T right) =>
-            left is null ? right is null ? 0 : -1 :
-            right is null ? 1 : Comparer<T>.Default.Compare(left, right);
     }
 }

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeBound.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeBound.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NpgsqlTypes
+{
+    /// <summary>
+    /// Creates instances of the <see cref="NpgsqlRangeBound{T}"/> struct.
+    /// </summary>
+    public static class NpgsqlRangeBound
+    {
+        /// <summary>Creates a new exclusive range bound instance using the provided value.</summary>
+        /// <typeparam name="T">The element type of the range bound.</typeparam>
+        /// <param name="value">The vallue of the new <see cref="NpgsqlRangeBound{T}"/> to be created.</param>
+        /// <returns>An exclusive bound containing the provided value.</returns>
+        public static NpgsqlRangeBound<T> Exclusive<T>(T value) =>
+            new NpgsqlRangeBound<T>(value, false);
+
+        /// <summary>Creates a new inclusive range bound instance using the provided value.</summary>
+        /// <typeparam name="T">The element type of the range bound.</typeparam>
+        /// <param name="value">The vallue of the new <see cref="NpgsqlRangeBound{T}"/> to be created.</param>
+        /// <returns>An inclusive bound containing the provided value.</returns>
+        public static NpgsqlRangeBound<T> Inclusive<T>(T value) =>
+            new NpgsqlRangeBound<T>(value, true);
+
+        /// <summary>Creates a new infinite range bound instance.</summary>
+        /// <typeparam name="T">The element type of the range bound.</typeparam>
+        /// <returns>An infinite bound.</returns>
+        public static NpgsqlRangeBound<T> Infinite<T>() =>
+            new NpgsqlRangeBound<T>(default, NpgsqlRangeBoundFlags.Infinity);
+
+        internal static bool Equals<T>([AllowNull] T left, [AllowNull] T right) =>
+            left is null ? right is null : right is { } &&
+            EqualityComparer<T>.Default.Equals(left, right);
+
+        internal static int Compare<T>([AllowNull] T left, [AllowNull] T right) =>
+            left is null ? right is null ? 0 : -1 :
+            right is null ? 1 : Comparer<T>.Default.Compare(left, right);
+    }
+}

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundFlags.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundFlags.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NpgsqlTypes
+{
+    [Flags]
+    enum NpgsqlRangeBoundFlags : byte
+    {
+        Inclusive = NpgsqlRangeFlags.LowerBoundInclusive,
+        Infinity = NpgsqlRangeFlags.LowerBoundInfinite
+    }
+}

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundOfT.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundOfT.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace NpgsqlTypes
@@ -39,7 +40,9 @@ namespace NpgsqlTypes
         /// <summary>Determines whether this instance and another specified <see cref="NpgsqlRange{T}"/> have the same value.</summary>
         /// <param name="other">The range to compare to this instance.</param>
         /// <returns><see langword="true"/> if <paramref name="other"/> has the same value as this instance; otherwise, <see langword="false"/>.</returns>
-        public bool Equals(NpgsqlRangeBound<T> other) => Flags == other.Flags && NpgsqlRangeBound.Equals(ValueInternal, other.ValueInternal);
+        public bool Equals(NpgsqlRangeBound<T> other) =>
+            Flags == other.Flags &&
+            EqualityComparer<T>.Default.Equals(ValueInternal!, other.ValueInternal!);
 
         /// <inheritdoc/>
         public override bool Equals(object? other) => other is NpgsqlRangeBound<T> bound && Equals(bound);

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundOfT.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeBoundOfT.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NpgsqlTypes
+{
+    /// <summary>Represents a bound of an <see cref="NpgsqlRange{T}"/>.</summary>
+    /// <typeparam name="T">The element type of the range bound.</typeparam>
+    public readonly struct NpgsqlRangeBound<T> : IEquatable<NpgsqlRangeBound<T>>
+    {
+        [MaybeNull]
+        internal T ValueInternal { get; }
+        internal NpgsqlRangeBoundFlags Flags { get; }
+
+        /// <summary>Gets a value indicating whether the current <see cref="NpgsqlRangeBound{T}"/> object is inclusive.</summary>
+        /// <value><see langword="true"/> if the current <see cref="NpgsqlRangeBound{T}"/> object is inclusive; otherwise, <see langword="false"/>.</value>
+        public bool IsInclusive => Flags.HasFlag(NpgsqlRangeBoundFlags.Inclusive);
+
+        /// <summary>Gets a value indicating whether the current <see cref="NpgsqlRangeBound{T}"/> object is infinite.</summary>
+        /// <value><see langword="true"/> if the current <see cref="NpgsqlRangeBound{T}"/> object is infinite; otherwise, <see langword="false"/>.</value>
+        public bool IsInfinite => Flags.HasFlag(NpgsqlRangeBoundFlags.Infinity);
+
+        /// <summary>Gets the value of the current <see cref="NpgsqlRangeBound{T}"/> object if it is finity.</summary>
+        /// <value>The value of the current <see cref="NpgsqlRangeBound{T}"/> object if the <see cref="IsInfinite"/> property is <see langword="false"/>. An exception is thrown if the HasValue property is <see langword="true"/>.</value>
+        /// <exception cref="InvalidOperationException">The <see cref="IsInfinite"/> property is <see langword="true"/>.</exception>
+        [MaybeNull]
+        public T Value => IsInfinite
+            ? throw new InvalidOperationException()
+            : ValueInternal;
+
+        /// <summary>Constructs a <see cref="NpgsqlRangeBound{T}"/> from the given value and the bound type.</summary>
+        /// <param name="value">The value of the bound.</param>
+        /// <param name="isInclusive">Indicates whether bound is inclusive or not. If <see langword="true"/>, the bound is incluse; otherwise, exclusive.</param>
+        public NpgsqlRangeBound(T value, bool isInclusive = false) =>
+            (ValueInternal, Flags) = (value, isInclusive ? NpgsqlRangeBoundFlags.Inclusive : default);
+
+        internal NpgsqlRangeBound([AllowNull] T value, NpgsqlRangeBoundFlags flags) =>
+            (ValueInternal, Flags) = (value, flags);
+
+        /// <summary>Determines whether this instance and another specified <see cref="NpgsqlRange{T}"/> have the same value.</summary>
+        /// <param name="other">The range to compare to this instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="other"/> has the same value as this instance; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(NpgsqlRangeBound<T> other) => Flags == other.Flags && NpgsqlRangeBound.Equals(ValueInternal, other.ValueInternal);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? other) => other is NpgsqlRangeBound<T> bound && Equals(bound);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(ValueInternal!, Flags);
+
+        /// <summary>Determines whether two specified range bounds have the same value.</summary>
+        /// <param name="left">The <see cref="NpgsqlRangeBound{T}"/> to compare on the left.</param>
+        /// <param name="right">The <see cref="NpgsqlRangeBound{T}"/> to compare on the right.</param>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+        public static bool operator ==(NpgsqlRangeBound<T> left, NpgsqlRangeBound<T> right) => left.Equals(right);
+
+        /// <summary>Determines whether two specified range bounds have different values.</summary>
+        /// <param name="left">The <see cref="NpgsqlRangeBound{T}"/> to compare on the left.</param>
+        /// <param name="right">The <see cref="NpgsqlRangeBound{T}"/> to compare on the right.</param>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+        public static bool operator !=(NpgsqlRangeBound<T> left, NpgsqlRangeBound<T> right) => !left.Equals(right);
+
+        /// <summary>Creates a new <see cref="NpgsqlRangeBound{T}"/> object initialized to a specified value.</summary>
+        /// <param name="value">A value to implicitly convert.</param>
+        /// <returns>A <see cref="NpgsqlRangeBound{T}"/> object whose <see cref="Value"/> property is initialized with the value parameter.</returns>
+        public static implicit operator NpgsqlRangeBound<T>(T value) => new NpgsqlRangeBound<T>(value);
+    }
+}

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeFlags.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeFlags.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace NpgsqlTypes
+{
+    [Flags]
+    enum NpgsqlRangeFlags : byte
+    {
+        None = 0,
+        Empty = 1,
+        LowerBoundInclusive = 2,
+        UpperBoundInclusive = 4,
+        LowerBoundInfinite = 8,
+        UpperBoundInfinite = 16,
+    }
+}

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeOfT.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeOfT.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace NpgsqlTypes
@@ -50,7 +51,7 @@ namespace NpgsqlTypes
             if (lowerBound.IsInfinite || upperBound.IsInfinite)
                 return;
 
-            var difference = NpgsqlRangeBound.Compare(LowerBoundInternal, UpperBoundInternal);
+            var difference = Comparer<T>.Default.Compare(LowerBoundInternal!, UpperBoundInternal!);
             if (difference > 0)
                 throw new ArgumentException("The upper bound cannot be less that the lower bound.", nameof(upperBound));
         }
@@ -75,8 +76,8 @@ namespace NpgsqlTypes
         /// <returns><see langword="true"/> if <paramref name="other"/> has the same value as this instance; otherwise, <see langword="false"/>.</returns>
         public bool Equals(NpgsqlRange<T> other) =>
             Flags == other.Flags &&
-            NpgsqlRangeBound.Equals(LowerBoundInternal, other.LowerBoundInternal) &&
-            NpgsqlRangeBound.Equals(UpperBoundInternal, other.UpperBoundInternal);
+            EqualityComparer<T>.Default.Equals(LowerBoundInternal!, other.LowerBoundInternal!) &&
+            EqualityComparer<T>.Default.Equals(UpperBoundInternal!, other.UpperBoundInternal!);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is NpgsqlRange<T> other && Equals(other);

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRangeOfT.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRangeOfT.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NpgsqlTypes
+{
+    /// <summary>Represents a PostgreSQL range type.</summary>
+    /// <typeparam name="T">The element type of the values in the range.</typeparam>
+    /// <remarks>See: https://www.postgresql.org/docs/current/static/rangetypes.html</remarks>
+    public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
+    {
+        [MaybeNull, AllowNull]
+        internal T LowerBoundInternal { get; }
+        [MaybeNull, AllowNull]
+        internal T UpperBoundInternal { get; }
+        internal NpgsqlRangeFlags Flags { get; }
+
+        /// <summary>Constructs a <see cref="NpgsqlRange{T}"/> from the given bounds.</summary>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <exception cref="T:ArgumentException"><paramref name="upperBound"/> is less than <paramref name="lowerBound"/>.</exception>
+        public NpgsqlRange(T lowerBound, T upperBound)
+            : this(lowerBound, upperBound, NpgsqlRangeFlags.LowerBoundInclusive) { }
+
+        /// <summary>Constructs a <see cref="NpgsqlRange{T}"/> from the given bounds.</summary>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <exception cref="T:ArgumentException"><paramref name="upperBound"/> is less than <paramref name="lowerBound"/>.</exception>
+        public NpgsqlRange(T lowerBound, NpgsqlRangeBound<T> upperBound)
+            : this(NpgsqlRangeBound.Inclusive(lowerBound), upperBound) { }
+
+        /// <summary>Constructs a <see cref="NpgsqlRange{T}"/> from the given bounds.</summary>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <exception cref="T:ArgumentException"><paramref name="upperBound"/> is less than <paramref name="lowerBound"/>.</exception>
+        public NpgsqlRange(NpgsqlRangeBound<T> lowerBound, T upperBound)
+            : this(lowerBound, NpgsqlRangeBound.Exclusive(upperBound)) { }
+
+        /// <summary>Constructs a <see cref="NpgsqlRange{T}"/> from the given bounds.</summary>
+        /// <param name="lowerBound">The lower bound.</param>
+        /// <param name="upperBound">The upper bound.</param>
+        /// <exception cref="T:ArgumentException"><paramref name="upperBound"/> is less than <paramref name="lowerBound"/>.</exception>
+        public NpgsqlRange(NpgsqlRangeBound<T> lowerBound, NpgsqlRangeBound<T> upperBound)
+        {
+            LowerBoundInternal = lowerBound.ValueInternal;
+            UpperBoundInternal = upperBound.ValueInternal;
+            Flags =
+                (NpgsqlRangeFlags)((int)lowerBound.Flags << 0) |
+                (NpgsqlRangeFlags)((int)upperBound.Flags << 1);
+
+            if (lowerBound.IsInfinite || upperBound.IsInfinite)
+                return;
+
+            var difference = NpgsqlRangeBound.Compare(LowerBoundInternal, UpperBoundInternal);
+            if (difference > 0)
+                throw new ArgumentException("The upper bound cannot be less that the lower bound.", nameof(upperBound));
+        }
+
+        internal NpgsqlRange([AllowNull] T lowerBound, [AllowNull] T upperBound, NpgsqlRangeFlags flags) =>
+            (LowerBoundInternal, UpperBoundInternal, Flags) = (lowerBound, upperBound, flags);
+
+        /// <summary>Gets the lower bound of the current <see cref="NpgsqlRange{T}"/> object.</summary>
+        /// <value>The lower bound of the current <see cref="NpgsqlRange{T}"/> object.</value>
+        public NpgsqlRangeBound<T> LowerBound => new NpgsqlRangeBound<T>(LowerBoundInternal, (NpgsqlRangeBoundFlags)((int)Flags >> 0));
+
+        /// <summary>Gets the upper bound of the current <see cref="NpgsqlRange{T}"/> object.</summary>
+        /// <value>The upper bound of the current <see cref="NpgsqlRange{T}"/> object.</value>
+        public NpgsqlRangeBound<T> UpperBound => new NpgsqlRangeBound<T>(LowerBoundInternal, (NpgsqlRangeBoundFlags)((int)Flags >> 2));
+
+        /// <summary>Gets a value indicating whether the current <see cref="NpgsqlRange{T}"/> object is empty.</summary>
+        /// <value><see langword="true"/> if the current <see cref="NpgsqlRange{T}"/> object is empty; otherwise, <see langword="false"/>.</value>
+        public bool IsEmpty => Flags == NpgsqlRangeFlags.Empty;
+
+        /// <summary>Determines whether this instance and another specified <see cref="NpgsqlRange{T}"/> have the same value.</summary>
+        /// <param name="other">The range to compare to this instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="other"/> has the same value as this instance; otherwise, <see langword="false"/>.</returns>
+        public bool Equals(NpgsqlRange<T> other) =>
+            Flags == other.Flags &&
+            NpgsqlRangeBound.Equals(LowerBoundInternal, other.LowerBoundInternal) &&
+            NpgsqlRangeBound.Equals(UpperBoundInternal, other.UpperBoundInternal);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is NpgsqlRange<T> other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(Flags, LowerBoundInternal!, UpperBoundInternal!);
+
+        /// <summary>Determines whether two specified ranges have the same value.</summary>
+        /// <param name="left">The <see cref="NpgsqlRange{T}"/> to compare on the left.</param>
+        /// <param name="right">The <see cref="NpgsqlRange{T}"/> to compare on the right.</param>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+        public static bool operator ==(NpgsqlRange<T> left, NpgsqlRange<T> right) => left.Equals(right);
+
+        /// <summary>Determines whether two specified ranges have different values.</summary>
+        /// <param name="left">The <see cref="NpgsqlRange{T}"/> to compare on the left.</param>
+        /// <param name="right">The <see cref="NpgsqlRange{T}"/> to compare on the right.</param>
+        /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+        public static bool operator !=(NpgsqlRange<T> left, NpgsqlRange<T> right) => !left.Equals(right);
+    }
+}

--- a/test/Npgsql.Tests/TypeMapperTests.cs
+++ b/test/Npgsql.Tests/TypeMapperTests.cs
@@ -24,7 +24,7 @@ namespace Npgsql.Tests
             using (var conn = OpenConnection(connectionString))
             using (var cmd = new NpgsqlCommand("SELECT @p", conn))
             {
-                var range = new NpgsqlRange<int>(8, true, false, 0, false, true);
+                var range = new NpgsqlRange<int>(8, NpgsqlRangeBound.Infinite<int>());
                 var parameters = new[]
                 {
                     // Base

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Data;
-using System.Globalization;
 using System.Threading.Tasks;
 using NpgsqlTypes;
 using NUnit.Framework;
@@ -64,28 +62,26 @@ namespace Npgsql.Tests.Types
         [Test]
         public async Task Range()
         {
-            using (var conn = await OpenConnectionAsync())
-            using (var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn))
-            {
-                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Range | NpgsqlDbType.Integer) { Value = NpgsqlRange<int>.Empty };
-                var p2 = new NpgsqlParameter { ParameterName = "p2", Value = new NpgsqlRange<int>(1, 10) };
-                var p3 = new NpgsqlParameter { ParameterName = "p3", Value = new NpgsqlRange<int>(1, false, 10, false) };
-                var p4 = new NpgsqlParameter { ParameterName = "p4", Value = new NpgsqlRange<int>(0, false, true, 10, false, false) };
-                Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Range | NpgsqlDbType.Integer));
-                cmd.Parameters.Add(p1);
-                cmd.Parameters.Add(p2);
-                cmd.Parameters.Add(p3);
-                cmd.Parameters.Add(p4);
-                using (var reader = await cmd.ExecuteReaderAsync())
-                {
-                    reader.Read();
+            using var conn = await OpenConnectionAsync();
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn);
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Range | NpgsqlDbType.Integer) { Value = NpgsqlRange.Empty<int>() };
+            var p2 = new NpgsqlParameter { ParameterName = "p2", Value = NpgsqlRange.CreateInclusive(1, 10) };
+            var p3 = new NpgsqlParameter { ParameterName = "p3", Value = NpgsqlRange.CreateExclusive(1, 10) };
+            var p4 = new NpgsqlParameter { ParameterName = "p4", Value = NpgsqlRange.Create(NpgsqlRangeBound.Infinite<int>(), 10) };
 
-                    Assert.That(reader[0].ToString(), Is.EqualTo("empty"));
-                    Assert.That(reader[1].ToString(), Is.EqualTo("[1,11)"));
-                    Assert.That(reader[2].ToString(), Is.EqualTo("[2,10)"));
-                    Assert.That(reader[3].ToString(), Is.EqualTo("(,10)"));
-                }
-            }
+            Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Range | NpgsqlDbType.Integer));
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            cmd.Parameters.Add(p3);
+            cmd.Parameters.Add(p4);
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+
+            Assert.That(reader[0], Is.EqualTo(NpgsqlRange.Empty<int>()));
+            Assert.That(reader[1], Is.EqualTo(NpgsqlRange.Create(1, 11)));
+            Assert.That(reader[2], Is.EqualTo(NpgsqlRange.Create(2, 10)));
+            Assert.That(reader[3], Is.EqualTo(NpgsqlRange.Create(NpgsqlRangeBound.Infinite<int>(), 10)));
         }
 
         [Test]
@@ -94,48 +90,49 @@ namespace Npgsql.Tests.Types
             if (IsMultiplexing)
                 Assert.Ignore("Multiplexing, ReloadTypes");
 
-            using (var conn = await OpenConnectionAsync())
-            {
-                await conn.ExecuteNonQueryAsync("CREATE TYPE pg_temp.textrange AS RANGE(subtype=text)");
-                conn.ReloadTypes();
-                Assert.That(await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
+            using var conn = await OpenConnectionAsync();
+            await conn.ExecuteNonQueryAsync("CREATE TYPE pg_temp.textrange AS RANGE(subtype=text)");
+            conn.ReloadTypes();
+            Assert.That(await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
 
-                var value = new NpgsqlRange<string>(
-                    new string('a', conn.Settings.WriteBufferSize + 10),
-                    new string('z', conn.Settings.WriteBufferSize + 10)
-                );
+            var value = new NpgsqlRange<string>(
+                new string('a', conn.Settings.WriteBufferSize + 10),
+                new string('z', conn.Settings.WriteBufferSize + 10)
+            );
 
-                //var value = new NpgsqlRange<string>("bar", "foo");
-                using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-                {
-                    cmd.Parameters.Add(new NpgsqlParameter("p", NpgsqlDbType.Range | NpgsqlDbType.Text) { Value = value });
-                    using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
-                    {
-                        reader.Read();
-                        Assert.That(reader[0], Is.EqualTo(value));
-                    }
-                }
-            }
+            using var cmd = new NpgsqlCommand("SELECT @p", conn) { Parameters = { new NpgsqlParameter("p", NpgsqlDbType.Range | NpgsqlDbType.Text) { Value = value } } };
+            using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
+            reader.Read();
+            Assert.That(reader[0], Is.EqualTo(value));
         }
 
         [Test]
         public void RangeEquality_FiniteRange()
         {
-            var r1 = new NpgsqlRange<int>(0, true, false, 1, false, false);
+            var r1 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Inclusive(0),
+                NpgsqlRangeBound.Exclusive(1));
 
             //different bounds
-            var r2 = new NpgsqlRange<int>(1, true, false, 2, false, false);
+            var r2 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Inclusive(1),
+                NpgsqlRangeBound.Exclusive(2));
             Assert.IsFalse(r1 == r2);
 
             //lower bound is not inclusive
-            var r3 = new NpgsqlRange<int>(0, false, false, 1, false, false);
-            Assert.IsFalse(r1 == r3);
+            var r3 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Exclusive(0),
+                NpgsqlRangeBound.Exclusive(1));
 
             //upper bound is inclusive
-            var r4 = new NpgsqlRange<int>(0, true, false, 1, true, false);
+            var r4 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Inclusive(0),
+                NpgsqlRangeBound.Inclusive(1));
             Assert.IsFalse(r1 == r4);
 
-            var r5 = new NpgsqlRange<int>(0, true, false, 1, false, false);
+            var r5 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Inclusive(0),
+                NpgsqlRangeBound.Exclusive(1));
             Assert.IsTrue(r1 == r5);
 
             //check some other combinations while we are here
@@ -147,54 +144,44 @@ namespace Npgsql.Tests.Types
         [Test]
         public void RangeEquality_InfiniteRange()
         {
-            var r1 = new NpgsqlRange<int>(0, false, true, 1, false, false);
-
-            //different upper bound (lower bound shoulnd't matter since it is infinite)
-            var r2 = new NpgsqlRange<int>(1, false, true, 2, false, false);
-            Assert.IsFalse(r1 == r2);
+            var r1 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Infinite<int>(),
+                NpgsqlRangeBound.Exclusive(1));
 
             //upper bound is inclusive
-            var r3 = new NpgsqlRange<int>(0, false, true, 1, true, false);
-            Assert.IsFalse(r1 == r3);
+            var r2 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Infinite<int>(),
+                NpgsqlRangeBound.Inclusive(1));
+            Assert.IsFalse(r1 == r2);
 
             //value of lower bound shoulnd't matter since it is infinite
-            var r4 = new NpgsqlRange<int>(10, false, true, 1, false, false);
-            Assert.IsTrue(r1 == r4);
+            var r3 = new NpgsqlRange<int>(
+                NpgsqlRangeBound.Infinite<int>(),
+                NpgsqlRangeBound.Exclusive(1));
+            Assert.IsTrue(r1 == r3);
 
             //check some other combinations while we are here
             Assert.IsFalse(r2 == r3);
-            Assert.IsFalse(r2 == r4);
-            Assert.IsFalse(r3 == r4);
         }
 
         [Test]
         public void RangeHashCode_ValueTypes()
         {
             NpgsqlRange<int> a = default;
-            NpgsqlRange<int> b = NpgsqlRange<int>.Empty;
-            NpgsqlRange<int> c = NpgsqlRange<int>.Parse("(,)");
+            var b = NpgsqlRange.Empty<int>();
 
-            Assert.IsFalse(a.Equals(b));
-            Assert.IsFalse(a.Equals(c));
-            Assert.IsFalse(b.Equals(c));
-            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
-            Assert.AreNotEqual(a.GetHashCode(), c.GetHashCode());
-            Assert.AreNotEqual(b.GetHashCode(), c.GetHashCode());
+            Assert.IsTrue(a.Equals(b));
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
         }
 
         [Test]
         public void RangeHashCode_ReferenceTypes()
         {
-            NpgsqlRange<string> a= default;
-            NpgsqlRange<string> b = NpgsqlRange<string>.Empty;
-            NpgsqlRange<string> c = NpgsqlRange<string>.Parse("(,)");
+            NpgsqlRange<string> a = default;
+            var b = NpgsqlRange.Empty<string>();
 
-            Assert.IsFalse(a.Equals(b));
-            Assert.IsFalse(a.Equals(c));
-            Assert.IsFalse(b.Equals(c));
-            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
-            Assert.AreNotEqual(a.GetHashCode(), c.GetHashCode());
-            Assert.AreNotEqual(b.GetHashCode(), c.GetHashCode());
+            Assert.IsTrue(a.Equals(b));
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
         }
 
         [Test]
@@ -222,215 +209,6 @@ namespace Npgsql.Tests.Types
             using (var conn = await OpenConnectionAsync())
                 TestUtil.MinimumPgVersion(conn, "9.2.0");
         }
-
-        #region ParseTests
-
-        [Theory]
-        [TestCaseSource(nameof(DateTimeRangeTheoryData))]
-        public void GivenDateRangeLiteral_WhenConverted_ThenReturnsDateRange(NpgsqlRange<DateTime> input)
-        {
-            // Arrange
-            var wellKnownText = input.ToString();
-
-            // Act
-            var result = NpgsqlRange<DateTime>.Parse(wellKnownText);
-
-            // Assert
-            Assert.AreEqual(input, result);
-        }
-
-        [Theory]
-        [TestCase("empty")]
-        [TestCase("EMPTY")]
-        [TestCase("  EmPtY  ")]
-        public void GivenEmptyIntRangeLiteral_WhenParsed_ThenReturnsEmptyIntRange(string value)
-        {
-            // Act
-            var result = NpgsqlRange<int>.Parse(value);
-
-            // Assert
-            Assert.AreEqual(NpgsqlRange<int>.Empty, result);
-        }
-
-        [Theory]
-        [TestCase("(0,1)")]
-        [TestCase("(0,1]")]
-        [TestCase("[0,1)")]
-        [TestCase("[0,1]")]
-        [TestCase(" [ 0 , 1 ] ")]
-        public void GivenIntRangeLiteral_WhenParsed_ThenReturnsIntRange(string input)
-        {
-            // Act
-            var result = NpgsqlRange<int>.Parse(input);
-
-            // Assert
-            Assert.AreEqual(input.Replace(" ", null), result.ToString());
-        }
-
-        [Theory]
-        [TestCase("(1,1)", "empty")]
-        [TestCase("[1,1)", "empty")]
-        [TestCase("[,1]", "(,1]")]
-        [TestCase("[1,]", "[1,)")]
-        [TestCase("[,]", "(,)")]
-        [TestCase("[-infinity,infinity]", "(,)")]
-        [TestCase("[ -infinity , infinity ]", "(,)")]
-        [TestCase("[-infinity,infinity)", "(,)")]
-        [TestCase("(-infinity,infinity]", "(,)")]
-        [TestCase("(-infinity,infinity)", "(,)")]
-        [TestCase("[null,null]", "(,)")]
-        [TestCase("[null,infinity]", "(,)")]
-        [TestCase("[-infinity,null]", "(,)")]
-        public void GivenPoorlyFormedIntRangeLiteral_WhenParsed_ThenReturnsIntRange(string input, string normalized)
-        {
-            // Act
-            var result = NpgsqlRange<int>.Parse(input);
-
-            // Assert
-            Assert.AreEqual(normalized, result.ToString());
-        }
-
-        [Theory]
-        [TestCase("(1,1)", "empty")]
-        [TestCase("[1,1)", "empty")]
-        [TestCase("[,1]", "(,1]")]
-        [TestCase("[1,]", "[1,)")]
-        [TestCase("[,]", "(,)")]
-        [TestCase("[-infinity,infinity]", "(,)")]
-        [TestCase("[ -infinity , infinity ]", "(,)")]
-        [TestCase("[-infinity,infinity)", "(,)")]
-        [TestCase("(-infinity,infinity]", "(,)")]
-        [TestCase("(-infinity,infinity)", "(,)")]
-        [TestCase("[null,null]", "(,)")]
-        [TestCase("[null,infinity]", "(,)")]
-        [TestCase("[-infinity,null]", "(,)")]
-        public void GivenPoorlyFormedNullableIntRangeLiteral_WhenParsed_ThenReturnsNullableIntRange(string input, string normalized)
-        {
-            // Act
-            var result = NpgsqlRange<int?>.Parse(input);
-
-            // Assert
-            Assert.AreEqual(normalized, result.ToString());
-        }
-
-        [Theory]
-        [TestCase("(a,a)", "empty")]
-        [TestCase("[a,a)", "empty")]
-        [TestCase("[a,a]", "[a,a]")]
-        [TestCase("(a,b)", "(a,b)")]
-        public void GivenStringRangeLiteral_WhenParsed_ThenReturnsStringRange(string input, string normalized)
-        {
-            // Act
-            var result = NpgsqlRange<string>.Parse(input);
-
-            // Assert
-            Assert.AreEqual(normalized, result.ToString());
-        }
-
-        [Theory]
-        [TestCase("(one,two)")]
-        public void GivenSimpleTypeRangeLiteral_WhenParsed_ThenReturnsSimpleTypeRange(string input)
-        {
-            // Act
-            var result = NpgsqlRange<SimpleType>.Parse(input);
-
-            // Assert
-            Assert.AreEqual(input, result.ToString());
-        }
-
-        [Theory]
-        [TestCase("0, 1)")]
-        [TestCase("(0 1)")]
-        [TestCase("(0, 1")]
-        [TestCase(" 0, 1 ")]
-        public void GivenMalformedRangeLiteral_WhenParsed_ThenThrowsFormatException(string input)
-        {
-            Assert.Throws<FormatException>(() => NpgsqlRange<int>.Parse(input));
-        }
-
-        [Test, Ignore("Fails only on build server, can't reproduce locally.")]
-        public void CanGetTypeConverter()
-        {
-            // Arrange
-            NpgsqlRange<int>.RangeTypeConverter.Register();
-            var converter = TypeDescriptor.GetConverter(typeof(NpgsqlRange<int>));
-
-            // Act
-            Assert.IsInstanceOf<NpgsqlRange<int>.RangeTypeConverter>(converter);
-            Assert.IsTrue(converter.CanConvertFrom(typeof(string)));
-            var result = converter.ConvertFromString("empty");
-
-            // Assert
-            Assert.AreEqual(NpgsqlRange<int>.Empty, result);
-        }
-
-        #endregion
-
-        #region TheoryData
-
-        [TypeConverter(typeof(SimpleTypeConverter))]
-        class SimpleType
-        {
-            string? Value { get; }
-
-            SimpleType(string? value)
-            {
-                Value = value;
-            }
-
-            public override string? ToString()
-            {
-                return Value;
-            }
-
-            class SimpleTypeConverter : TypeConverter
-            {
-                public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-                    => typeof(string) == sourceType;
-
-                public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-                    => new SimpleType(value.ToString());
-            }
-        }
-
-        // ReSharper disable once InconsistentNaming
-        static readonly DateTime May_17_2018 = DateTime.Parse("2018-05-17");
-
-        // ReSharper disable once InconsistentNaming
-        static readonly DateTime May_18_2018 = DateTime.Parse("2018-05-18");
-
-        /// <summary>
-        /// Provides theory data for <see cref="NpgsqlRange{T}"/> of <see cref="DateTime"/>.
-        /// </summary>
-        static object[][] DateTimeRangeTheoryData =>
-            new object[][]
-            {
-                // (2018-05-17, 2018-05-18)
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, false) },
-
-                // [2018-05-17, 2018-05-18]
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, true, false) },
-
-                // [2018-05-17, 2018-05-18)
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, true, false, May_18_2018, false, false) },
-
-                // (2018-05-17, 2018-05-18]
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, true, false) },
-
-                // (,)
-                new object[] { new NpgsqlRange<DateTime>(default, false, true, default, false, true) },
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, true) },
-
-                // (2018-05-17,)
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, default, false, true) },
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, false, May_18_2018, false, true) },
-
-                // (,2018-05-18)
-                new object[] { new NpgsqlRange<DateTime>(default, false, true, May_18_2018, false, false) },
-                new object[] { new NpgsqlRange<DateTime>(May_17_2018, false, true, May_18_2018, false, false) }
-            };
-
-        #endregion
 
         public RangeTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) {}
     }


### PR DESCRIPTION
This change was split from a large improvement of type handlers am working on to simplify review process. The idea of the new design to minimize API surface and make it more fluent and modern. The bound type represents a discrimination union which could have only three possible values: infinite, inclusive and exclusive. While it exists it isn't used inside the range to store values, but the range can return bounds as separate parts.

Fixes #2314