### PR TITLE
Passing the cancellation token from the command to the read and write buffers

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1170,22 +1170,19 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             {
                                 var cmd = (NpgsqlCommand)o!;
                                 var cn = cmd._boundConnector!;
-                                lock (cn)
-                                {
-                                    // No point in doing anything, if the connection is already broken
-                                    if (cn.IsBroken)
-                                        return;
+                                // No point in doing anything, if the connection is already broken
+                                if (cn.IsBroken)
+                                    return;
 
-                                    try
-                                    {
-                                        cmd.Cancel(true);
-                                        if (cn.Settings.CancellationTimeout > 0)
-                                            cn.CommandCts.CancelAfter(cn.Settings.CancellationTimeout * 1000);
-                                    }
-                                    catch
-                                    {
-                                        cn.CommandCts.Cancel();
-                                    }
+                                try
+                                {
+                                    cmd.Cancel(true);
+                                    if (cn.Settings.CancellationTimeout > 0)
+                                        cn.CommandCts.CancelAfter(cn.Settings.CancellationTimeout * 1000);
+                                }
+                                catch
+                                {
+                                    cn.CommandCts.Cancel();
                                 }
                             }, this);
                             finalCt = connector.CommandCts.Token;

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1164,16 +1164,16 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                             registration = cancellationToken.Register(o =>
                             {
-                                (var cmd, var cn) = (Tuple<NpgsqlCommand, NpgsqlConnector>)o;
+                                (var cmd, var cn) = (Tuple<NpgsqlCommand, NpgsqlConnector>)o!;
                                 try
                                 {
-                                    cmd!.Cancel(true);
-                                    if (cn!.Settings.CancellationTimeout > 0)
-                                        cn!.CommandCts.CancelAfter(cn!.Settings.CancellationTimeout * 1000);
+                                    cmd.Cancel(true);
+                                    if (cn.Settings.CancellationTimeout > 0)
+                                        cn.CommandCts.CancelAfter(cn.Settings.CancellationTimeout * 1000);
                                 }
                                 catch
                                 {
-                                    cn!.CommandCts.Cancel();
+                                    cn.CommandCts.Cancel();
                                 }
                             }, Tuple.Create(this, connector));
                             finalCt = connector.CommandCts.Token;

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1160,8 +1160,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             try
                             {
                                 ((NpgsqlCommand)cmd!).Cancel(true);
-                                // Setting the timeout for the case, when reading the response for the cancellation request took too long
-                                cts!.CancelAfter(connector.Settings.HardCommandTimeout);
                             }
                             catch
                             {

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -902,27 +902,27 @@ namespace Npgsql
         int _internalCommandTimeout;
 
         /// <summary>
-        /// The time to wait (in seconds) while trying to read a response for a cancellation request for a timed out query, before terminating the attempt and generating an error.
+        /// The time to wait (in seconds) while trying to read a response for a cancellation request for a timed out or cancelled query, before terminating the attempt and generating an error.
         /// Defaults to 2 seconds.
         /// </summary>
         [Category("Timeouts")]
-        [Description("After Command Timeout is reached and command cancellation is attempted, Npgsql waits for this additional timeout (in seconds) before breaking the connection. Defaults to 2, set to zero for infinity.")]
-        [DisplayName("Cancellation Read Timeout")]
+        [Description("After Command Timeout is reached (or user supplied cancellation token is cancelled) and command cancellation is attempted, Npgsql waits for this additional timeout (in seconds) before breaking the connection. Defaults to 2, set to zero for infinity.")]
+        [DisplayName("Cancellation Timeout")]
         [NpgsqlConnectionStringProperty]
         [DefaultValue(2)]
-        public int HardCommandTimeout
+        public int CancellationTimeout
         {
-            get => _hardCommandTimeout;
+            get => _cancellationTimeout;
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(HardCommandTimeout)} can't be negative");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(CancellationTimeout)} can't be negative");
 
-                _hardCommandTimeout = value;
-                SetValue(nameof(HardCommandTimeout), value);
+                _cancellationTimeout = value;
+                SetValue(nameof(CancellationTimeout), value);
             }
         }
-        int _hardCommandTimeout;
+        int _cancellationTimeout;
 
         #endregion
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1180,7 +1180,7 @@ namespace Npgsql
                             {
                                 CancelRequest(throwExceptions: true);
                                 _originalTimeoutException = e;
-                                ReadBuffer.Timeout = TimeSpan.FromSeconds(Settings.HardCommandTimeout);
+                                ReadBuffer.Timeout = TimeSpan.FromSeconds(Settings.CancellationTimeout);
                             }
                             catch (Exception)
                             {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -227,6 +227,8 @@ namespace Npgsql
 
         internal int ClearCounter { get; set; }
 
+        internal CancellationTokenSource CommandCts = new CancellationTokenSource();
+
         static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlConnector));
 
         #endregion

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -271,7 +271,7 @@ namespace Npgsql.Tests
                 Assert.Ignore("Async cancellation isn't supported with multiplexing yet.");
 
             using (var conn = await OpenConnectionAsync())
-            using (var cmd = CreateSleepCommand(conn, 5))
+            using (var cmd = CreateSleepCommand(conn))
             {
                 var cancellationSource = new CancellationTokenSource(300);
                 var t = cmd.ExecuteNonQueryAsync(cancellationSource.Token);

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -268,7 +268,7 @@ namespace Npgsql.Tests
         public async Task CancelAsync()
         {
             if (IsMultiplexing)
-                return;
+                Assert.Ignore("Async cancellation isn't supported with multiplexing yet.");
 
             using (var conn = await OpenConnectionAsync())
             using (var cmd = CreateSleepCommand(conn, 5))

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -267,8 +267,11 @@ namespace Npgsql.Tests
         [Test, Description("Cancels an async query with the cancellation token")]
         public async Task CancelAsync()
         {
+            if (IsMultiplexing)
+                return;
+
             using (var conn = await OpenConnectionAsync())
-            using (var cmd = CreateSleepCommand(conn))
+            using (var cmd = CreateSleepCommand(conn, 5))
             {
                 var cancellationSource = new CancellationTokenSource(300);
                 var t = cmd.ExecuteNonQueryAsync(cancellationSource.Token);


### PR DESCRIPTION
Closes #2437.

The final part for the cancellation story. The only thing missing here is the timeout, after which the token would be cancelled. It seems, I would have to add another parameter to the connection string (as `HardCommandTimeout` is only until the next read, not for the whole cancellation request). @roji objections?