### PR TITLE
Use NET variable to conditional compile for .NET 5

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -786,8 +786,7 @@ namespace Npgsql
                     // cancellation and timeout. On older TFMs, we fake-cancel the operation, i.e. stop waiting
                     // and raise the exception, but the actual connection task is left running.
 
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
                     await socket.ConnectAsync(endpoint)
                         .WithCancellationAndTimeout(perIpTimeout, cancellationToken);
 #else

--- a/src/Npgsql/NpgsqlException.cs
+++ b/src/Npgsql/NpgsqlException.cs
@@ -42,8 +42,7 @@ namespace Npgsql
         /// Specifies whether the exception is considered transient, that is, whether retrying the operation could
         /// succeed (e.g. a network error or a timeout).
         /// </summary>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public virtual bool IsTransient
 #else
         public override bool IsTransient

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -207,8 +207,7 @@ namespace Npgsql
         /// Creates a transaction save point.
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public void Save(string name) => Save(name, false).GetAwaiter().GetResult();
 #else
         public override void Save(string name) => Save(name, false).GetAwaiter().GetResult();
@@ -219,8 +218,7 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public Task SaveAsync(string name, CancellationToken cancellationToken = default)
 #else
         public override Task SaveAsync(string name, CancellationToken cancellationToken = default)
@@ -255,8 +253,7 @@ namespace Npgsql
         /// Rolls back a transaction from a pending savepoint state.
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public void Rollback(string name)
 #else
         public override void Rollback(string name)
@@ -268,8 +265,7 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public Task RollbackAsync(string name, CancellationToken cancellationToken = default)
 #else
         public override Task RollbackAsync(string name, CancellationToken cancellationToken = default)
@@ -304,8 +300,7 @@ namespace Npgsql
         /// Releases a transaction from a pending savepoint state.
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public void Release(string name) => Release(name, false).GetAwaiter().GetResult();
 #else
         public override void Release(string name) => Release(name, false).GetAwaiter().GetResult();
@@ -316,8 +311,7 @@ namespace Npgsql
         /// </summary>
         /// <param name="name">The name of the savepoint.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public Task ReleaseAsync(string name, CancellationToken cancellationToken = default)
 #else
         public override Task ReleaseAsync(string name, CancellationToken cancellationToken = default)

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -253,8 +253,7 @@ namespace Npgsql
         /// See http://www.postgresql.org/docs/current/static/errcodes-appendix.html
         /// </remarks>
         [PublicAPI]
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         public string SqlState { get; }
 #else
         public override string SqlState { get; }

--- a/src/Npgsql/TaskExtensions.cs
+++ b/src/Npgsql/TaskExtensions.cs
@@ -64,8 +64,7 @@ namespace Npgsql
             return await task;
         }
 
-// TODO: NET5_0 is here because of https://github.com/dotnet/sdk/issues/13377, remove for 5.0.0-rc2
-#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
+#if !NET // i.e. >= NET5_0
         /// <summary>
         /// Allows you to cancel awaiting for a non-cancellable task.
         /// </summary>


### PR DESCRIPTION
Based on [recommendation](https://github.com/dotnet/sdk/issues/13377#issuecomment-692889030) from Microsoft
Replace occurrences of
```cs
#if (NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1) && !NET5_0
```
introduced in #3165
by
```cs
#if !NET // i.e. >= NET5_0
```