### PR TITLE
Implement PG mock for testing

### DIFF
--- a/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
+++ b/src/Npgsql/BackendMessages/CommandCompleteMessage.cs
@@ -103,6 +103,6 @@ namespace Npgsql.BackendMessages
             return result;
         }
 
-        public BackendMessageCode Code => BackendMessageCode.CompletedResponse;
+        public BackendMessageCode Code => BackendMessageCode.CommandComplete;
     }
 }

--- a/src/Npgsql/Common.cs
+++ b/src/Npgsql/Common.cs
@@ -14,7 +14,7 @@ namespace Npgsql
         BackendKeyData        = (byte)'K',
         BindComplete          = (byte)'2',
         CloseComplete         = (byte)'3',
-        CompletedResponse     = (byte)'C',
+        CommandComplete       = (byte)'C',
         CopyData              = (byte)'d',
         CopyDone              = (byte)'c',
         CopyBothResponse      = (byte)'W',

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -64,7 +64,7 @@ namespace Npgsql
                             nameof(copyToCommand)));
                 }
                 break;
-            case BackendMessageCode.CompletedResponse:
+            case BackendMessageCode.CommandComplete:
                 throw new InvalidOperationException(
                     "This API only supports import/export from the client, i.e. COPY commands containing TO/FROM STDIN. " +
                     "To import/export with files on your PostgreSQL machine, simply execute the command with ExecuteNonQuery. " +

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -68,7 +68,7 @@ namespace Npgsql
                                 nameof(copyFromCommand)));
                     }
                     break;
-                case BackendMessageCode.CompletedResponse:
+                case BackendMessageCode.CommandComplete:
                     throw new InvalidOperationException(
                         "This API only supports import/export from the client, i.e. COPY commands containing TO/FROM STDIN. " +
                         "To import/export with files on your PostgreSQL machine, simply execute the command with ExecuteNonQuery. " +

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1424,7 +1424,13 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         internal void FixupRowDescription(RowDescriptionMessage rowDescription, bool isFirst)
         {
             for (var i = 0; i < rowDescription.NumFields; i++)
-                rowDescription[i].FormatCode = (UnknownResultTypeList == null || !isFirst ? AllResultTypesAreUnknown : UnknownResultTypeList[i]) ? FormatCode.Text : FormatCode.Binary;
+            {
+                var field = rowDescription[i];
+                field.FormatCode = (UnknownResultTypeList == null || !isFirst ? AllResultTypesAreUnknown : UnknownResultTypeList[i])
+                    ? FormatCode.Text
+                    : FormatCode.Binary;
+                field.ResolveHandler();
+            }
         }
 
         void LogCommand()

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1222,7 +1222,7 @@ namespace Npgsql
                     return _rowDescriptionMessage.Load(buf, TypeMapper);
                 case BackendMessageCode.DataRow:
                     return _dataRowMessage.Load(len);
-                case BackendMessageCode.CompletedResponse:
+                case BackendMessageCode.CommandComplete:
                     return _commandCompleteMessage.Load(buf, len);
                 case BackendMessageCode.ReadyForQuery:
                     var rfq = _readyForQueryMessage.Load(buf);
@@ -2008,9 +2008,9 @@ namespace Npgsql
                     case BackendMessageCode.DataRow:
                         // DataRow is usually consumed by a reader, here we have to skip it manually.
                         await ReadBuffer.Skip(((DataRowMessage)msg).Length, async, cancellationToken);
-                        expectedMessageCode = BackendMessageCode.CompletedResponse;
+                        expectedMessageCode = BackendMessageCode.CommandComplete;
                         continue;
-                    case BackendMessageCode.CompletedResponse:
+                    case BackendMessageCode.CommandComplete:
                         expectedMessageCode = BackendMessageCode.ReadyForQuery;
                         continue;
                     case BackendMessageCode.ReadyForQuery:

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -349,7 +349,7 @@ namespace Npgsql
                         var completedMsg = await Connector.ReadMessage(async, DataRowLoadingMode.Skip, cancellationToken);
                         switch (completedMsg.Code)
                         {
-                        case BackendMessageCode.CompletedResponse:
+                        case BackendMessageCode.CommandComplete:
                         case BackendMessageCode.EmptyQueryResponse:
                             ProcessMessage(completedMsg);
                             break;
@@ -440,7 +440,7 @@ namespace Npgsql
                         msg = await ReadMessage(async, cancellationToken);
                         switch (msg.Code)
                         {
-                        case BackendMessageCode.CompletedResponse:
+                        case BackendMessageCode.CommandComplete:
                         case BackendMessageCode.EmptyQueryResponse:
                             break;
                         default:
@@ -470,7 +470,7 @@ namespace Npgsql
                     switch (msg.Code)
                     {
                     case BackendMessageCode.DataRow:
-                    case BackendMessageCode.CompletedResponse:
+                    case BackendMessageCode.CommandComplete:
                         break;
                     default:
                         throw Connector.UnexpectedMessageReceived(msg.Code);
@@ -651,7 +651,7 @@ namespace Npgsql
                 ProcessDataRowMessage((DataRowMessage)msg);
                 return;
 
-            case BackendMessageCode.CompletedResponse:
+            case BackendMessageCode.CommandComplete:
                 var completed = (CommandCompleteMessage)msg;
                 switch (completed.StatementType)
                 {
@@ -1793,7 +1793,7 @@ namespace Npgsql
         /// </summary>
         public override DataTable? GetSchemaTable()
             => GetSchemaTable(async: false).GetAwaiter().GetResult();
-        
+
         /// <summary>
         /// Asynchronously returns a System.Data.DataTable that describes the column metadata of the DataReader.
         /// </summary>

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -75,7 +75,7 @@ namespace Npgsql
                 IsBinary = copyOutResponse.IsBinary;
                 _canRead = true;
                 break;
-            case BackendMessageCode.CompletedResponse:
+            case BackendMessageCode.CommandComplete:
                 throw new InvalidOperationException(
                     "This API only supports import/export from the client, i.e. COPY commands containing TO/FROM STDIN. " +
                     "To import/export with files on your PostgreSQL machine, simply execute the command with ExecuteNonQuery. " +

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -124,7 +124,11 @@ namespace Npgsql
             Ensure(count, false).GetAwaiter().GetResult();
         }
 
-        public Task Ensure(int count, bool async, CancellationToken cancellationToken = default) => Ensure(count, async, false, cancellationToken);
+        public Task Ensure(int count, bool async, CancellationToken cancellationToken = default)
+            => Ensure(count, async, dontBreakOnCancellation: false, cancellationToken);
+
+        public Task EnsureAsync(int count, CancellationToken cancellationToken = default)
+            => Ensure(count, async: true, dontBreakOnCancellation: false, cancellationToken);
 
         /// <summary>
         /// Ensures that <paramref name="count"/> bytes are available in the buffer, and if

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -23,49 +23,49 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL 8-byte "bigint" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("int8", 20)]
+        [BuiltInPostgresType("int8", PostgresTypeOIDs.Int8)]
         Bigint = 1,
 
         /// <summary>
         /// Corresponds to the PostgreSQL 8-byte floating-point "double" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("float8", 701)]
+        [BuiltInPostgresType("float8", PostgresTypeOIDs.Float8)]
         Double = 8,
 
         /// <summary>
         /// Corresponds to the PostgreSQL 4-byte "integer" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("int4", 23)]
+        [BuiltInPostgresType("int4", PostgresTypeOIDs.Int4)]
         Integer = 9,
 
         /// <summary>
         /// Corresponds to the PostgreSQL arbitrary-precision "numeric" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("numeric", 1700)]
+        [BuiltInPostgresType("numeric", PostgresTypeOIDs.Numeric)]
         Numeric = 13,
 
         /// <summary>
         /// Corresponds to the PostgreSQL floating-point "real" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("float4", 700)]
+        [BuiltInPostgresType("float4", PostgresTypeOIDs.Float4)]
         Real = 17,
 
         /// <summary>
         /// Corresponds to the PostgreSQL 2-byte "smallint" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-        [BuiltInPostgresType("int2", 21)]
+        [BuiltInPostgresType("int2", PostgresTypeOIDs.Int2)]
         Smallint = 18,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "money" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-money.html</remarks>
-        [BuiltInPostgresType("money", 790)]
+        [BuiltInPostgresType("money", PostgresTypeOIDs.Money)]
         Money = 12,
 
         #endregion
@@ -76,7 +76,7 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "boolean" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-boolean.html</remarks>
-        [BuiltInPostgresType("bool", 16)]
+        [BuiltInPostgresType("bool", PostgresTypeOIDs.Bool)]
         Boolean = 2,
 
         #endregion
@@ -87,49 +87,49 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL geometric "box" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("box", 603)]
+        [BuiltInPostgresType("box", PostgresTypeOIDs.Box)]
         Box = 3,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "circle" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("circle", 718)]
+        [BuiltInPostgresType("circle", PostgresTypeOIDs.Circle)]
         Circle = 5,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "line" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("line", 628)]
+        [BuiltInPostgresType("line", PostgresTypeOIDs.Line)]
         Line = 10,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "lseg" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("lseg", 601)]
+        [BuiltInPostgresType("lseg", PostgresTypeOIDs.LSeg)]
         LSeg = 11,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "path" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("path", 602)]
+        [BuiltInPostgresType("path", PostgresTypeOIDs.Path)]
         Path = 14,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "point" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("point", 600)]
+        [BuiltInPostgresType("point", PostgresTypeOIDs.Point)]
         Point = 15,
 
         /// <summary>
         /// Corresponds to the PostgreSQL geometric "polygon" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-        [BuiltInPostgresType("polygon", 604)]
+        [BuiltInPostgresType("polygon", PostgresTypeOIDs.Polygon)]
         Polygon = 16,
 
         #endregion
@@ -140,28 +140,28 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "char(n)" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-        [BuiltInPostgresType("bpchar", 1042)]
+        [BuiltInPostgresType("bpchar", PostgresTypeOIDs.BPChar)]
         Char = 6,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "text" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-        [BuiltInPostgresType("text", 25)]
+        [BuiltInPostgresType("text", PostgresTypeOIDs.Text)]
         Text = 19,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "varchar" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-        [BuiltInPostgresType("varchar", 1043)]
+        [BuiltInPostgresType("varchar", PostgresTypeOIDs.Varchar)]
         Varchar = 22,
 
         /// <summary>
         /// Corresponds to the PostgreSQL internal "name" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-        [BuiltInPostgresType("name", 19)]
+        [BuiltInPostgresType("name", PostgresTypeOIDs.Name)]
         Name = 32,
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace NpgsqlTypes
         ///
         /// See https://www.postgresql.org/docs/current/static/datatype-text.html
         /// </remarks>
-        [BuiltInPostgresType("char", 18)]
+        [BuiltInPostgresType("char", PostgresTypeOIDs.Char)]
         InternalChar = 38,
 
         #endregion
@@ -189,7 +189,7 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "bytea" type, holding a raw byte string.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-binary.html</remarks>
-        [BuiltInPostgresType("bytea", 17)]
+        [BuiltInPostgresType("bytea", PostgresTypeOIDs.Bytea)]
         Bytea = 4,
 
         #endregion
@@ -200,21 +200,21 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "date" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("date", 1082)]
+        [BuiltInPostgresType("date", PostgresTypeOIDs.Date)]
         Date = 7,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "time" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("time", 1083)]
+        [BuiltInPostgresType("time", PostgresTypeOIDs.Time)]
         Time = 20,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "timestamp" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("timestamp", 1114)]
+        [BuiltInPostgresType("timestamp", PostgresTypeOIDs.Timestamp)]
         Timestamp = 21,
 
         /// <summary>
@@ -228,14 +228,14 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "timestamp with time zone" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("timestamptz", 1184)]
+        [BuiltInPostgresType("timestamptz", PostgresTypeOIDs.TimestampTz)]
         TimestampTz = 26,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "interval" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("interval", 1186)]
+        [BuiltInPostgresType("interval", PostgresTypeOIDs.Interval)]
         Interval = 30,
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "time with time zone" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-        [BuiltInPostgresType("timetz", 1266)]
+        [BuiltInPostgresType("timetz", PostgresTypeOIDs.TimeTz)]
         TimeTz = 31,
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace NpgsqlTypes
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
         [Obsolete("The PostgreSQL abstime time is obsolete.")]
-        [BuiltInPostgresType("abstime", 702)]
+        [BuiltInPostgresType("abstime", PostgresTypeOIDs.Abstime)]
         Abstime = 33,
 
         #endregion
@@ -268,28 +268,28 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "inet" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-        [BuiltInPostgresType("inet", 869)]
+        [BuiltInPostgresType("inet", PostgresTypeOIDs.Inet)]
         Inet = 24,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "cidr" type, a field storing an IPv4 or IPv6 network.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-        [BuiltInPostgresType("cidr", 650)]
+        [BuiltInPostgresType("cidr", PostgresTypeOIDs.Cidr)]
         Cidr = 44,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "macaddr" type, a field storing a 6-byte physical address.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-        [BuiltInPostgresType("macaddr", 829)]
+        [BuiltInPostgresType("macaddr", PostgresTypeOIDs.Macaddr)]
         MacAddr = 34,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "macaddr8" type, a field storing a 6-byte or 8-byte physical address.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-        [BuiltInPostgresType("macaddr8", 774)]
+        [BuiltInPostgresType("macaddr8", PostgresTypeOIDs.Macaddr8)]
         MacAddr8 = 54,
 
         #endregion
@@ -300,14 +300,14 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "bit" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-bit.html</remarks>
-        [BuiltInPostgresType("bit", 1560)]
+        [BuiltInPostgresType("bit", PostgresTypeOIDs.Bit)]
         Bit = 25,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "varbit" type, a field storing a variable-length string of bits.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-boolean.html</remarks>
-        [BuiltInPostgresType("varbit", 1562)]
+        [BuiltInPostgresType("varbit", PostgresTypeOIDs.Varbit)]
         Varbit = 39,
 
         #endregion
@@ -318,21 +318,21 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "tsvector" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-        [BuiltInPostgresType("tsvector", 3614)]
+        [BuiltInPostgresType("tsvector", PostgresTypeOIDs.TsVector)]
         TsVector = 45,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "tsquery" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-        [BuiltInPostgresType("tsquery", 3615)]
+        [BuiltInPostgresType("tsquery", PostgresTypeOIDs.TsQuery)]
         TsQuery = 46,
 
         /// <summary>
-        /// Corresponds to the PostgreSQL "tsquery" type.
+        /// Corresponds to the PostgreSQL "regconfig" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-        [BuiltInPostgresType("regconfig", 3734)]
+        [BuiltInPostgresType("regconfig", PostgresTypeOIDs.Regconfig)]
         Regconfig = 56,
 
         #endregion
@@ -343,7 +343,7 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "uuid" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-uuid.html</remarks>
-        [BuiltInPostgresType("uuid", 2950)]
+        [BuiltInPostgresType("uuid", PostgresTypeOIDs.Uuid)]
         Uuid = 27,
 
         #endregion
@@ -354,7 +354,7 @@ namespace NpgsqlTypes
         /// Corresponds to the PostgreSQL "xml" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-xml.html</remarks>
-        [BuiltInPostgresType("xml", 142)]
+        [BuiltInPostgresType("xml", PostgresTypeOIDs.Xml)]
         Xml = 28,
 
         #endregion
@@ -366,7 +366,7 @@ namespace NpgsqlTypes
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-json.html</remarks>
         /// <seealso cref="Jsonb"/>
-        [BuiltInPostgresType("json", 114)]
+        [BuiltInPostgresType("json", PostgresTypeOIDs.Json)]
         Json = 35,
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace NpgsqlTypes
         /// Supported since PostgreSQL 9.4.
         /// See https://www.postgresql.org/docs/current/static/datatype-json.html
         /// </remarks>
-        [BuiltInPostgresType("jsonb", 3802)]
+        [BuiltInPostgresType("jsonb", PostgresTypeOIDs.Jsonb)]
         Jsonb = 36,
 
         /// <summary>
@@ -388,7 +388,7 @@ namespace NpgsqlTypes
         /// Supported since PostgreSQL 12.
         /// See https://www.postgresql.org/docs/current/datatype-json.html#DATATYPE-JSONPATH
         /// </remarks>
-        [BuiltInPostgresType("jsonpath", 4072)]
+        [BuiltInPostgresType("jsonpath", PostgresTypeOIDs.JsonPath)]
         JsonPath = 57,
 
         #endregion
@@ -435,53 +435,53 @@ namespace NpgsqlTypes
         /// <summary>
         /// Corresponds to the PostgreSQL "refcursor" type.
         /// </summary>
-        [BuiltInPostgresType("refcursor", 1790)]
+        [BuiltInPostgresType("refcursor", PostgresTypeOIDs.Refcursor)]
         Refcursor = 23,
 
         /// <summary>
         /// Corresponds to the PostgreSQL internal "oidvector" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-        [BuiltInPostgresType("oidvector", 30)]
+        [BuiltInPostgresType("oidvector", PostgresTypeOIDs.Oidvector)]
         Oidvector = 29,
 
         /// <summary>
         /// Corresponds to the PostgreSQL internal "int2vector" type.
         /// </summary>
-        [BuiltInPostgresType("int2vector", 22)]
+        [BuiltInPostgresType("int2vector", PostgresTypeOIDs.Int2vector)]
         Int2Vector = 52,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "oid" type.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-        [BuiltInPostgresType("oid", 26)]
+        [BuiltInPostgresType("oid", PostgresTypeOIDs.Oid)]
         Oid = 41,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "xid" type, an internal transaction identifier.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-        [BuiltInPostgresType("xid", 28)]
+        [BuiltInPostgresType("xid", PostgresTypeOIDs.Xid)]
         Xid = 42,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "cid" type, an internal command identifier.
         /// </summary>
         /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-        [BuiltInPostgresType("cid", 29)]
+        [BuiltInPostgresType("cid", PostgresTypeOIDs.Cid)]
         Cid = 43,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "regtype" type, a numeric (OID) ID of a type in the pg_type table.
         /// </summary>
-        [BuiltInPostgresType("regtype", 2206)]
+        [BuiltInPostgresType("regtype", PostgresTypeOIDs.Regtype)]
         Regtype = 49,
 
         /// <summary>
         /// Corresponds to the PostgreSQL "tid" type, a tuple id identifying the physical location of a row within its table.
         /// </summary>
-        [BuiltInPostgresType("tid", 27)]
+        [BuiltInPostgresType("tid", PostgresTypeOIDs.Tid)]
         Tid = 53,
 
         #endregion
@@ -497,7 +497,7 @@ namespace NpgsqlTypes
         /// This value shouldn't ordinarily be used, and makes sense only when sending a data type
         /// unsupported by Npgsql.
         /// </remarks>
-        [BuiltInPostgresType("unknown", 705)]
+        [BuiltInPostgresType("unknown", PostgresTypeOIDs.Unknown)]
         Unknown = 40,
 
         #endregion

--- a/src/Npgsql/PostgresTypeOIDs.cs
+++ b/src/Npgsql/PostgresTypeOIDs.cs
@@ -1,0 +1,87 @@
+namespace Npgsql
+{
+    /// <summary>
+    /// Holds well-known, built-in PostgreSQL type OIDs.
+    /// </summary>
+    static class PostgresTypeOIDs
+    {
+        // Numeric
+        internal const uint Int8        = 20;
+        internal const uint Float8      = 701;
+        internal const uint Int4        = 23;
+        internal const uint Numeric     = 1700;
+        internal const uint Float4      = 700;
+        internal const uint Int2        = 21;
+        internal const uint Money       = 790;
+
+        // Boolean
+        internal const uint Bool        = 16;
+
+        // Geometric
+        internal const uint Box         = 603;
+        internal const uint Circle      = 718;
+        internal const uint Line        = 628;
+        internal const uint LSeg        = 601;
+        internal const uint Path        = 602;
+        internal const uint Point       = 600;
+        internal const uint Polygon     = 604;
+
+        // Character
+        internal const uint BPChar      = 1042;
+        internal const uint Text        = 25;
+        internal const uint Varchar     = 1043;
+        internal const uint Name        = 19;
+        internal const uint Char        = 18;
+
+        // Binary data
+        internal const uint Bytea       = 17;
+
+        // Date/Time
+        internal const uint Date        = 1082;
+        internal const uint Time        = 1083;
+        internal const uint Timestamp   = 1114;
+        internal const uint TimestampTz = 1184;
+        internal const uint Interval    = 1186;
+        internal const uint TimeTz      = 1266;
+        internal const uint Abstime     = 702;
+
+        // Network address
+        internal const uint Inet        = 869;
+        internal const uint Cidr        = 650;
+        internal const uint Macaddr     = 829;
+        internal const uint Macaddr8    = 774;
+
+        // Bit string
+        internal const uint Bit         = 1560;
+        internal const uint Varbit      = 1562;
+
+        // Text search
+        internal const uint TsVector    = 3614;
+        internal const uint TsQuery     = 3615;
+        internal const uint Regconfig   = 3734;
+
+        // UUID
+        internal const uint Uuid        = 2950;
+
+        // XML
+        internal const uint Xml         = 142;
+
+        // JSON
+        internal const uint Json        = 114;
+        internal const uint Jsonb       = 3802;
+        internal const uint JsonPath    = 4072;
+
+        // Internal
+        internal const uint Refcursor   = 1790;
+        internal const uint Oidvector   = 30;
+        internal const uint Int2vector  = 22;
+        internal const uint Oid         = 26;
+        internal const uint Xid         = 28;
+        internal const uint Cid         = 29;
+        internal const uint Regtype     = 2206;
+        internal const uint Tid         = 27;
+
+        // Special
+        internal const uint Unknown     = 705;
+    }
+}

--- a/src/Npgsql/Util/PGUtil.cs
+++ b/src/Npgsql/Util/PGUtil.cs
@@ -56,7 +56,7 @@ namespace Npgsql.Util
             case BackendMessageCode.BackendKeyData:
             case BackendMessageCode.BindComplete:
             case BackendMessageCode.CloseComplete:
-            case BackendMessageCode.CompletedResponse:
+            case BackendMessageCode.CommandComplete:
             case BackendMessageCode.CopyData:
             case BackendMessageCode.CopyDone:
             case BackendMessageCode.CopyBothResponse:

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -314,8 +314,7 @@ namespace Npgsql.Tests
             if (IsMultiplexing)
                 return; // Multiplexing, cancellation
 
-            var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 1 };
-            await using var postmasterMock = new PgPostmasterMock(builder.ConnectionString);
+            await using var postmasterMock = new PgPostmasterMock(ConnectionString);
             using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
             await using var conn = await OpenConnectionAsync(connectionString);
 

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -308,6 +308,7 @@ namespace Npgsql.Tests
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
         }
 
+#if !NET461 // .NET 4.6.1 doesn't support cancellation tokens on socket operations, so no hard cancellation
         [Test, Description("Cancels an async query with the cancellation token, with unsuccessful PG cancellation (socket break)")]
         public async Task CancelAsyncHard()
         {
@@ -332,6 +333,7 @@ namespace Npgsql.Tests
             Assert.That(postmasterMock.GetPendingCancellationRequest().ProcessId,
                 Is.EqualTo(processId));
         }
+#endif
 
         [Test, Description("Check that cancel only affects the command on which its was invoked")]
         [Explicit("Timing-sensitive")]

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql.Tests.Support;
 using NpgsqlTypes;
 using NUnit.Framework;
 using static Npgsql.Tests.TestUtil;
@@ -167,23 +168,47 @@ namespace Npgsql.Tests
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
         }
 
-// Timeout for async queries is not supported for .net 4.6.1
-#if !NET461
-        [Test, Description("Checks that CommandTimeout gets enforced for async queries")]
+#if !NET461 // .NET 4.6.1 doesn't support cancellation tokens on socket operations, so no async timeouts
+        [Test, Description("Times out an async operation, testing that cancellation occurs successfully")]
         [IssueLink("https://github.com/npgsql/npgsql/issues/607")]
         [Timeout(10000)]
-        public async Task TimeoutAsync()
+        public async Task TimeoutAsyncSoft()
         {
             if (IsMultiplexing)
                 return; // Multiplexing, Timeout
 
-            using var conn = await OpenConnectionAsync(ConnectionString + ";CommandTimeout=1");
+            using var conn = await OpenConnectionAsync(builder => builder.CommandTimeout = 1);
             using var cmd = CreateSleepCommand(conn, 10);
-            Assert.That(async () => await cmd.ExecuteNonQueryAsync(), Throws.Exception
-                .TypeOf<NpgsqlException>()
-                .With.InnerException.TypeOf<TimeoutException>()
-                );
+            Assert.That(async () => await cmd.ExecuteNonQueryAsync(),
+                Throws.Exception
+                    .TypeOf<NpgsqlException>()
+                    .With.InnerException.TypeOf<TimeoutException>());
             Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
+        }
+
+        [Test, Description("Times out an async operation, with unsuccessful cancellation (socket break)")]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/607")]
+        [Timeout(10000)]
+        public async Task TimeoutAsyncHard()
+        {
+            if (IsMultiplexing)
+                return; // Multiplexing, Timeout
+
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 1 };
+            await using var postmasterMock = new PgPostmasterMock(builder.ConnectionString);
+            using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
+            await using var conn = await OpenConnectionAsync(connectionString);
+
+            var processId = conn.ProcessID;
+
+            Assert.That(async () => await conn.ExecuteScalarAsync("SELECT 1"),
+                Throws.Exception
+                    .TypeOf<NpgsqlException>()
+                    .With.InnerException.TypeOf<TimeoutException>());
+
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
+            Assert.That(postmasterMock.GetPendingCancellationRequest().ProcessId,
+                Is.EqualTo(processId));
         }
 #endif
 
@@ -264,25 +289,49 @@ namespace Npgsql.Tests
             }
         }
 
-        [Test, Description("Cancels an async query with the cancellation token")]
-        public async Task CancelAsync()
+        [Test, Description("Cancels an async query with the cancellation token, with successful PG cancellation")]
+        public async Task CancelAsyncSoft()
         {
             if (IsMultiplexing)
-                Assert.Ignore("Async cancellation isn't supported with multiplexing yet.");
+                return; // Multiplexing, cancellation
 
-            using (var conn = await OpenConnectionAsync())
-            using (var cmd = CreateSleepCommand(conn))
-            {
-                var cancellationSource = new CancellationTokenSource(300);
-                var t = cmd.ExecuteNonQueryAsync(cancellationSource.Token);
-                Assert.That(async () => await t.ConfigureAwait(false), Throws.Exception.TypeOf<PostgresException>());
+            await using var conn = await OpenConnectionAsync();
+            using var cmd = CreateSleepCommand(conn);
+            var cancellationSource = new CancellationTokenSource();
+            var t = cmd.ExecuteNonQueryAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+            Assert.That(async () => await t, Throws.Exception.TypeOf<PostgresException>());
 
-                // Since cancellation triggers a PostgresException and not a TaskCanceledException, the task's state
-                // is Faulted and not Canceled. This isn't amazing, but we have to choose between this and the
-                // principle of always raising server/network errors as NpgsqlException for easy catching.
-                Assert.That(t.IsFaulted);
-                Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
-            }
+            // Since cancellation triggers a PostgresException and not a TaskCanceledException, the task's state
+            // is Faulted and not Canceled. This isn't amazing, but we have to choose between this and the
+            // principle of always raising server/network errors as NpgsqlException for easy catching.
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open));
+        }
+
+        [Test, Description("Cancels an async query with the cancellation token, with unsuccessful PG cancellation (socket break)")]
+        public async Task CancelAsyncHard()
+        {
+            if (IsMultiplexing)
+                return; // Multiplexing, cancellation
+
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 1 };
+            await using var postmasterMock = new PgPostmasterMock(builder.ConnectionString);
+            using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
+            await using var conn = await OpenConnectionAsync(connectionString);
+
+            var processId = conn.ProcessID;
+
+            var cancellationSource = new CancellationTokenSource();
+            using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            var t = cmd.ExecuteScalarAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+            Assert.That(async () => await t, Throws.Exception
+                .TypeOf<OperationCanceledException>()
+                .With.InnerException.Null);
+
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
+            Assert.That(postmasterMock.GetPendingCancellationRequest().ProcessId,
+                Is.EqualTo(processId));
         }
 
         [Test, Description("Check that cancel only affects the command on which its was invoked")]

--- a/test/Npgsql.Tests/Support/PgPostmasterMock.cs
+++ b/test/Npgsql.Tests/Support/PgPostmasterMock.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;

--- a/test/Npgsql.Tests/Support/PgPostmasterMock.cs
+++ b/test/Npgsql.Tests/Support/PgPostmasterMock.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Npgsql.Util;
+
+namespace Npgsql.Tests.Support
+{
+    class PgPostmasterMock : IAsyncDisposable
+    {
+        const int ReadBufferSize = 8192;
+        const int WriteBufferSize = 8192;
+        const int CancelRequestCode = 1234 << 16 | 5678;
+
+        static readonly Encoding Encoding = PGUtil.UTF8Encoding;
+        static readonly Encoding RelaxedEncoding = PGUtil.RelaxedUTF8Encoding;
+
+        readonly Socket _socket;
+        readonly Task _acceptTask;
+        readonly List<PgServerMock> _allServers = new List<PgServerMock>();
+        readonly Queue<PgServerMock> _pendingServers = new Queue<PgServerMock>();
+        readonly Queue<(int ProcessId, int Secret)> _pendingCancellationRequests
+            = new Queue<(int ProcessId, int Secret)>();
+        int _processIdCounter;
+
+        internal string ConnectionString { get; }
+
+        internal PgPostmasterMock(string? connectionString = null)
+        {
+            var connectionStringBuilder =
+                new NpgsqlConnectionStringBuilder(connectionString ?? TestUtil.ConnectionString);
+
+            _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+            _socket.Bind(endpoint);
+            var localEndPoint = (IPEndPoint)_socket.LocalEndPoint!;
+            connectionStringBuilder.Host = localEndPoint.Address.ToString();
+            connectionStringBuilder.Port = localEndPoint.Port;
+            connectionStringBuilder.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
+            ConnectionString = connectionStringBuilder.ConnectionString;
+
+            _socket.Listen(5);
+            _acceptTask = AcceptAndAuthenticate();
+        }
+
+        async Task AcceptAndAuthenticate()
+        {
+            while (true)
+            {
+                var clientSocket = await _socket.AcceptAsync();
+
+                var stream = new NetworkStream(clientSocket, true);
+                var readBuffer = new NpgsqlReadBuffer(null!, stream, clientSocket, ReadBufferSize, Encoding, RelaxedEncoding);
+                var writeBuffer = new NpgsqlWriteBuffer(null!, stream, clientSocket, WriteBufferSize, Encoding);
+
+                await readBuffer.EnsureAsync(4);
+                var len = readBuffer.ReadInt32();
+                await readBuffer.EnsureAsync(len - 4);
+
+                if (readBuffer.ReadInt32() == CancelRequestCode)
+                {
+                    _pendingCancellationRequests.Enqueue((readBuffer.ReadInt32(), readBuffer.ReadInt32()));
+                    readBuffer.Dispose();
+                    writeBuffer.Dispose();
+                    stream.Dispose();
+                    continue;
+                }
+
+                // This is not a cancellation, "spawn" a new server
+                readBuffer.ReadPosition -= 8;
+                var serverMock = new PgServerMock(stream, readBuffer, writeBuffer, ++_processIdCounter);
+                await serverMock.Startup();
+
+                _allServers.Add(serverMock);
+                _pendingServers.Enqueue(serverMock);
+            }
+
+            // ReSharper disable once FunctionNeverReturns
+        }
+
+        internal PgServerMock GetPendingServer()
+            => _pendingServers.TryDequeue(out var server)
+                ? server
+                : throw new InvalidOperationException("No pending server");
+
+        internal (int ProcessId, int Secret) GetPendingCancellationRequest()
+            => _pendingCancellationRequests.TryDequeue(out var cancellationRequest)
+                ? cancellationRequest
+                : throw new InvalidOperationException("No pending cancellation request");
+
+        public async ValueTask DisposeAsync()
+        {
+            // Stop accepting new connections
+            _socket.Dispose();
+            try
+            {
+                await _acceptTask;
+            }
+            catch
+            {
+                // Swallow all exceptions
+            }
+
+            // Destroy all servers created by this postmaster
+            foreach (var server in _allServers)
+                server.Dispose();
+        }
+    }
+}

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 
 namespace Npgsql.Tests.Support
 {
-    public class PgServerMock : IDisposable
+    class PgServerMock : IDisposable
     {
         static readonly Encoding Encoding = PGUtil.UTF8Encoding;
 

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -20,6 +20,7 @@ namespace Npgsql.Tests.Support
         readonly NpgsqlWriteBuffer _writeBuffer;
         bool _disposed;
 
+        const int BackendSecret = 12345;
         internal int ProcessId { get; }
 
         internal PgServerMock(
@@ -58,7 +59,7 @@ namespace Npgsql.Tests.Support
                 { "standard_conforming_strings", "on" }
 
             });
-            WriteBackendKeyData(12345, 67890);
+            WriteBackendKeyData(ProcessId, BackendSecret);
             WriteReadyForQuery();
 
             await FlushAsync();
@@ -200,8 +201,8 @@ namespace Npgsql.Tests.Support
             CheckDisposed();
             _writeBuffer.WriteByte((byte)BackendMessageCode.BackendKeyData);
             _writeBuffer.WriteInt32(4 + 4 + 4);
-            _writeBuffer.WriteInt32(ProcessId);
-            _writeBuffer.WriteInt32(12345);
+            _writeBuffer.WriteInt32(processId);
+            _writeBuffer.WriteInt32(secret);
             return this;
         }
 

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.Util;
+using NUnit.Framework;
+
+namespace Npgsql.Tests.Support
+{
+    public class PgServerMock : IDisposable
+    {
+        static readonly Encoding Encoding = PGUtil.UTF8Encoding;
+
+        readonly NetworkStream _stream;
+        readonly NpgsqlReadBuffer _readBuffer;
+        readonly NpgsqlWriteBuffer _writeBuffer;
+        bool _disposed;
+
+        internal int ProcessId { get; }
+
+        internal PgServerMock(
+            NetworkStream stream,
+            NpgsqlReadBuffer readBuffer,
+            NpgsqlWriteBuffer writeBuffer,
+            int processId)
+        {
+            ProcessId = processId;
+            _stream = stream;
+            _readBuffer = readBuffer;
+            _writeBuffer = writeBuffer;
+        }
+
+        internal async Task Startup()
+        {
+            // Read and skip the startup message
+            await _readBuffer.EnsureAsync(4);
+            var startupMessageLen = _readBuffer.ReadInt32();
+            await _readBuffer.EnsureAsync(startupMessageLen - 4);
+            _readBuffer.Skip(startupMessageLen - 4);
+
+            WriteAuthenticateOk();
+            WriteParameterStatuses(new Dictionary<string, string>
+            {
+                { "server_version", "13" },
+                { "server_encoding", "UTF8" },
+                { "client_encoding", "UTF8" },
+                { "application_name", "Mock" },
+                { "is_superuser", "on" },
+                { "session_authorization", "foo" },
+                { "DateStyle", "ISO, MDY" },
+                { "IntervalStyle", "postgres" },
+                { "TimeZone", "UTC" },
+                { "integer_datetimes", "on" },
+                { "standard_conforming_strings", "on" }
+
+            });
+            WriteBackendKeyData(12345, 67890);
+            WriteReadyForQuery();
+
+            await FlushAsync();
+        }
+
+        internal async Task ReadMessageType(byte expectedCode)
+        {
+            CheckDisposed();
+
+            await _readBuffer.EnsureAsync(5);
+            var actualCode = _readBuffer.ReadByte();
+            Assert.That(actualCode, Is.EqualTo(expectedCode),
+                $"Expected message of type '{(char)expectedCode}' but got '{(char)actualCode}'");
+            var len = _readBuffer.ReadInt32();
+            _readBuffer.Skip(len - 4);
+        }
+
+        internal Task FlushAsync()
+        {
+            CheckDisposed();
+            return _writeBuffer.Flush(async: true);
+        }
+
+        internal Task WriteScalarResponse(int value)
+            => WriteParseComplete()
+                .WriteBindComplete()
+                .WriteRowDescription(new FieldDescription(PostgresTypeOIDs.Int4))
+                .WriteDataRow(BitConverter.GetBytes(BinaryPrimitives.ReverseEndianness(value)))
+                .WriteCommandComplete()
+                .WriteReadyForQuery()
+                .FlushAsync();
+
+        #region Low-level message writing
+
+        internal PgServerMock WriteParseComplete()
+        {
+            CheckDisposed();
+            _writeBuffer.WriteByte((byte)BackendMessageCode.ParseComplete);
+            _writeBuffer.WriteInt32(4);
+            return this;
+        }
+
+        internal PgServerMock WriteBindComplete()
+        {
+            CheckDisposed();
+            _writeBuffer.WriteByte((byte)BackendMessageCode.BindComplete);
+            _writeBuffer.WriteInt32(4);
+            return this;
+        }
+
+        internal PgServerMock WriteRowDescription(params FieldDescription[] fields)
+        {
+            CheckDisposed();
+
+            _writeBuffer.WriteByte((byte)BackendMessageCode.RowDescription);
+            _writeBuffer.WriteInt32(4 + 2 + fields.Sum(f => Encoding.GetByteCount(f.Name) + 1 + 18));
+            _writeBuffer.WriteInt16(fields.Length);
+
+            foreach (var field in fields)
+            {
+                _writeBuffer.WriteNullTerminatedString(field.Name);
+                _writeBuffer.WriteUInt32(field.TableOID);
+                _writeBuffer.WriteInt16(field.ColumnAttributeNumber);
+                _writeBuffer.WriteUInt32(field.TypeOID);
+                _writeBuffer.WriteInt16(field.TypeSize);
+                _writeBuffer.WriteInt32(field.TypeModifier);
+                _writeBuffer.WriteInt16((short)field.FormatCode);
+            }
+
+            return this;
+        }
+
+        internal PgServerMock WriteDataRow(params byte[][] columnValues)
+        {
+            CheckDisposed();
+
+            _writeBuffer.WriteByte((byte)BackendMessageCode.DataRow);
+            _writeBuffer.WriteInt32(4 + 2 + columnValues.Sum(v => 4 + v.Length));
+            _writeBuffer.WriteInt16(columnValues.Length);
+
+            foreach (var field in columnValues)
+            {
+                _writeBuffer.WriteInt32(field.Length);
+                _writeBuffer.WriteBytes(field);
+            }
+
+            return this;
+        }
+
+        internal PgServerMock WriteCommandComplete(string tag = "")
+        {
+            CheckDisposed();
+
+            _writeBuffer.WriteByte((byte)BackendMessageCode.CommandComplete);
+            _writeBuffer.WriteInt32(4 + Encoding.GetByteCount(tag) + 1);
+            _writeBuffer.WriteNullTerminatedString(tag);
+            return this;
+        }
+
+        internal PgServerMock WriteReadyForQuery(TransactionStatus transactionStatus = TransactionStatus.Idle)
+        {
+            CheckDisposed();
+            _writeBuffer.WriteByte((byte)BackendMessageCode.ReadyForQuery);
+            _writeBuffer.WriteInt32(4 + 1);
+            _writeBuffer.WriteByte((byte)transactionStatus);
+            return this;
+        }
+
+        internal PgServerMock WriteAuthenticateOk()
+        {
+            CheckDisposed();
+            _writeBuffer.WriteByte((byte)BackendMessageCode.AuthenticationRequest);
+            _writeBuffer.WriteInt32(4 + 4);
+            _writeBuffer.WriteInt32(0);
+            return this;
+        }
+
+        internal PgServerMock WriteParameterStatuses(Dictionary<string, string> parameters)
+        {
+            foreach (var kv in parameters)
+                WriteParameterStatus(kv.Key, kv.Value);
+            return this;
+        }
+
+        internal PgServerMock WriteParameterStatus(string name, string value)
+        {
+            CheckDisposed();
+
+            _writeBuffer.WriteByte((byte)BackendMessageCode.ParameterStatus);
+            _writeBuffer.WriteInt32(4 + Encoding.GetByteCount(name) + 1 + Encoding.GetByteCount(value) + 1);
+            _writeBuffer.WriteNullTerminatedString(name);
+            _writeBuffer.WriteNullTerminatedString(value);
+
+            return this;
+        }
+
+        internal PgServerMock WriteBackendKeyData(int processId, int secret)
+        {
+            CheckDisposed();
+            _writeBuffer.WriteByte((byte)BackendMessageCode.BackendKeyData);
+            _writeBuffer.WriteInt32(4 + 4 + 4);
+            _writeBuffer.WriteInt32(ProcessId);
+            _writeBuffer.WriteInt32(12345);
+            return this;
+        }
+
+        #endregion Low-level message writing
+
+        void CheckDisposed()
+        {
+            if (_stream is null)
+                throw new ObjectDisposedException(nameof(PgServerMock));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _readBuffer.Dispose();
+            _writeBuffer.Dispose();
+            _stream.Dispose();
+
+            _disposed = true;
+        }
+    }
+}

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 
@@ -13,6 +13,19 @@ namespace Npgsql.Tests
 {
     public static class TestUtil
     {
+        /// <summary>
+        /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
+        /// test database.
+        /// </summary>
+        public const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+
+        /// <summary>
+        /// The connection string that will be used when opening the connection to the tests database.
+        /// May be overridden in fixtures, e.g. to set special connection parameters
+        /// </summary>
+        public static string ConnectionString { get; }
+            = Environment.GetEnvironmentVariable("NPGSQL_TEST_DB") ?? DefaultConnectionString;
+
         public static bool IsOnBuildServer =>
             Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null ||
             Environment.GetEnvironmentVariable("CI") != null;
@@ -451,4 +464,21 @@ namespace Npgsql.Tests
         Pooled,
         Unpooled
     }
+
+#if NET461 || NETSTANDARD2_0
+    static class QueueExtensions
+    {
+        public static bool TryDequeue<T>(this Queue<T> queue, out T result)
+        {
+            if (queue.Count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = queue.Dequeue();
+            return true;
+        }
+    }
+#endif
 }


### PR DESCRIPTION
This introduces a full mocking infrastructure for PostgreSQL (postmaster and server), to allow us to reliably test various timing related issues, or produce errors which we can't trigger with real PG. This is just a first batch of work, and the mock is currently pretty low-level. I suspect that as we start using this more, the infrastructure will involve.

This adds two tests using the new mocking infrastructure to exercise hard cancellation/timeout, /cc @vonzshik. Take a look at these tests to see how the mock is used.

Closes #3193

/cc @YohDeadfall @Brar