### PR TITLE
Add a wrapper for CancellationTokenSource with a resettable timeout

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1158,6 +1158,12 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                         if (cancellationToken.CanBeCanceled)
                         {
+                            if (connector.CommandCts.IsCancellationRequested)
+                            {
+                                connector.CommandCts.Dispose();
+                                connector.CommandCts = new TimeoutCancellationTokenSourceWrapper();
+                            }
+
                             registration = cancellationToken.Register(o =>
                             {
                                 var cmd = (NpgsqlCommand)o!;

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -298,9 +298,7 @@ namespace Npgsql
             ConnectionString = connectionString;
             PostgresParameters = new Dictionary<string, string>();
             Transaction = new NpgsqlTransaction(this);
-            CommandCts = new TimeoutCancellationTokenSourceWrapper(settings.CancellationTimeout > 0
-                ? TimeSpan.FromSeconds(settings.CancellationTimeout)
-                : Timeout.InfiniteTimeSpan);
+            CommandCts = new TimeoutCancellationTokenSourceWrapper();
 
             CancelLock = new object();
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1062,9 +1062,7 @@ namespace Npgsql
                     try
                     {
                         // TODO: There could be room for optimization here, rather than the async call(s)
-                        ReadBuffer.Timeout = InternalCommandTimeout > 0
-                            ? TimeSpan.FromMilliseconds(InternalCommandTimeout)
-                            : Timeout.InfiniteTimeSpan;
+                        ReadBuffer.Timeout = TimeSpan.FromMilliseconds(InternalCommandTimeout);
                         for (; _pendingPrependedResponses > 0; _pendingPrependedResponses--)
                             await ReadMessageLong(DataRowLoadingMode.Skip, false, true, cancellationToken2);
                     }
@@ -1078,9 +1076,7 @@ namespace Npgsql
 
                 try
                 {
-                    ReadBuffer.Timeout = UserTimeout > 0
-                        ? TimeSpan.FromMilliseconds(UserTimeout)
-                        : Timeout.InfiniteTimeSpan;
+                    ReadBuffer.Timeout = TimeSpan.FromMilliseconds(UserTimeout);
 
                     while (true)
                     {
@@ -1175,9 +1171,7 @@ namespace Npgsql
                             {
                                 CancelRequest(throwExceptions: true);
                                 _originalTimeoutException = e;
-                                ReadBuffer.Timeout = Settings.CancellationTimeout > 0
-                                    ? TimeSpan.FromSeconds(Settings.CancellationTimeout)
-                                    : Timeout.InfiniteTimeSpan;
+                                ReadBuffer.Timeout = TimeSpan.FromSeconds(Settings.CancellationTimeout);
                             }
                             catch (Exception)
                             {

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -45,10 +45,16 @@ namespace Npgsql
                 {
                     Debug.Assert(_underlyingSocket != null);
 
-                    _underlyingSocket.ReceiveTimeout = value == InfiniteTimeSpan
-                        ? 0
-                        : (int)value.TotalMilliseconds;
-                    _timeoutCts.Timeout = value;
+                    if (value > TimeSpan.Zero)
+                    {
+                        _underlyingSocket.ReceiveTimeout = (int)value.TotalMilliseconds;
+                        _timeoutCts.Timeout = value;
+                    }
+                    else
+                    {
+                        _underlyingSocket.ReceiveTimeout = -1;
+                        _timeoutCts.Timeout = InfiniteTimeSpan;
+                    }
                 }
             }
         }

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Util;
+using static System.Threading.Timeout;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -30,7 +31,7 @@ namespace Npgsql
 
         readonly Socket? _underlyingSocket;
 
-        TimeoutCancellationTokenSourceWrapper _timeoutCts;
+        readonly TimeoutCancellationTokenSourceWrapper _timeoutCts;
 
         /// <summary>
         /// Timeout for sync and async reads
@@ -44,7 +45,7 @@ namespace Npgsql
                 {
                     Debug.Assert(_underlyingSocket != null);
 
-                    _underlyingSocket.ReceiveTimeout = value == System.Threading.Timeout.InfiniteTimeSpan
+                    _underlyingSocket.ReceiveTimeout = value == InfiniteTimeSpan
                         ? 0
                         : (int)value.TotalMilliseconds;
                     _timeoutCts.Timeout = value;
@@ -102,7 +103,7 @@ namespace Npgsql
             Connector = connector;
             Underlying = stream;
             _underlyingSocket = socket;
-            _timeoutCts = new TimeoutCancellationTokenSourceWrapper(System.Threading.Timeout.InfiniteTimeSpan);
+            _timeoutCts = new TimeoutCancellationTokenSourceWrapper();
             Size = size;
             Buffer = ArrayPool<byte>.Shared.Rent(size);
             TextEncoding = textEncoding;
@@ -153,7 +154,7 @@ namespace Npgsql
                 try
                 {
                     var finalCt = cancellationToken;
-                    if (async && Timeout > System.Threading.Timeout.InfiniteTimeSpan)
+                    if (async && Timeout > TimeSpan.Zero)
                     {
                         _timeoutCts.Start();
                         finalCt = _timeoutCts.Token;

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -43,10 +43,16 @@ namespace Npgsql
                 {
                     Debug.Assert(_underlyingSocket != null);
 
-                    _underlyingSocket.SendTimeout = value == InfiniteTimeSpan
-                        ? 0
-                        : (int)value.TotalMilliseconds;
-                    _timeoutCts.Timeout = value;
+                    if (value > TimeSpan.Zero)
+                    {
+                        _underlyingSocket.SendTimeout = (int)value.TotalMilliseconds;
+                        _timeoutCts.Timeout = value;
+                    }
+                    else
+                    {
+                        _underlyingSocket.SendTimeout = -1;
+                        _timeoutCts.Timeout = InfiniteTimeSpan;
+                    }
                 }
             }
         }

--- a/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
+++ b/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+
+namespace Npgsql.Util
+{
+    /// <summary>
+    /// Internal struct wrapping a <see cref="CancellationTokenSource"/> for timeouts.
+    /// </summary>
+    /// <remarks>
+    /// Since there's no way to reset a <see cref="CancellationTokenSource"/> once it was cancelled,
+    /// we need to make sure that an existing cancellation token source hasn't been cancelled,
+    /// every time we start it (see https://github.com/dotnet/runtime/issues/4694).
+    /// </remarks>
+    class TimeoutCancellationTokenSourceWrapper : IDisposable
+    {
+        public TimeSpan Timeout { get; set; }
+        CancellationTokenSource _timeoutCts = new CancellationTokenSource();
+
+        public TimeoutCancellationTokenSourceWrapper(TimeSpan timeout) => Timeout = timeout;
+
+        /// <summary>
+        /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>
+        /// and make sure that it hasn't been cancelled yet
+        /// </summary>
+        public void Start()
+        {
+            _timeoutCts.CancelAfter(Timeout);
+            if (_timeoutCts.IsCancellationRequested)
+            {
+                _timeoutCts.Dispose();
+                _timeoutCts = new CancellationTokenSource(Timeout);
+            }
+        }
+
+        /// <summary>
+        /// Reset the timeout on the wrapped <see cref="CancellationTokenSource"/>
+        /// </summary>
+        public void Restart() => _timeoutCts.CancelAfter(Timeout);
+
+        /// <summary>
+        /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>
+        /// to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
+        /// </summary>
+        public void Stop() => _timeoutCts.CancelAfter(System.Threading.Timeout.InfiniteTimeSpan);
+
+        /// <summary>
+        /// Cancel the wrapped <see cref="CancellationTokenSource"/>
+        /// </summary>
+        public void Cancel() => _timeoutCts.Cancel();
+
+        /// <summary>
+        /// The <see cref="CancellationToken"/> from the wrapped
+        /// <see cref="CancellationTokenSource"/> .
+        /// </summary>
+        /// <remarks>
+        /// The token is only valid after calling <see cref="Start"/>
+        /// and before calling <see cref="Start"/> the next time.
+        /// Otherwise you may end up with a token that has already been
+        /// cancelled or belongs to a cancellation token source that has
+        /// been disposed.
+        /// </remarks>
+        public CancellationToken Token => _timeoutCts.Token;
+
+        public void Dispose() => _timeoutCts.Dispose();
+    }
+}

--- a/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
+++ b/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
@@ -16,13 +16,15 @@ namespace Npgsql.Util
         public TimeSpan Timeout { get; set; }
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
 
+        public TimeoutCancellationTokenSourceWrapper() => Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+
         public TimeoutCancellationTokenSourceWrapper(TimeSpan timeout) => Timeout = timeout;
 
         /// <summary>
         /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>
         /// and make sure that it hasn't been cancelled yet
         /// </summary>
-        public void Start()
+        public CancellationToken Start()
         {
             _timeoutCts.CancelAfter(Timeout);
             if (_timeoutCts.IsCancellationRequested)
@@ -30,6 +32,8 @@ namespace Npgsql.Util
                 _timeoutCts.Dispose();
                 _timeoutCts = new CancellationTokenSource(Timeout);
             }
+
+            return _timeoutCts.Token;
         }
 
         /// <summary>
@@ -60,6 +64,8 @@ namespace Npgsql.Util
         /// been disposed.
         /// </remarks>
         public CancellationToken Token => _timeoutCts.Token;
+
+        public bool IsCancellationRequested => _timeoutCts.IsCancellationRequested;
 
         public void Dispose() => _timeoutCts.Dispose();
     }


### PR DESCRIPTION
Since resetting a timeout on a CancellationTokenSource is a pretty
common thing to do and that'll probably never be supported out of the
box (https://github.com/dotnet/runtime/issues/4694), put the uglyness of
resetting the timeout in one place so that we don't have to repeat it
all the time.

PS: I take suggestions for the name of the wrapper. I personally don't really care.