### PR TITLE
Fix PostgresException.Message being incorrectly serialized to JSON (#3204)

### DIFF
--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -40,6 +40,7 @@ namespace Npgsql
             string? internalQuery = null, string? where = null, string? schemaName = null, string? tableName = null,
             string? columnName = null, string? dataTypeName = null, string? constraintName = null, string? file = null,
             string? line = null, string? routine = null)
+            : base(sqlState + ": " + messageText)
         {
             MessageText = messageText;
             Severity = severity;
@@ -182,11 +183,6 @@ namespace Npgsql
                     builder.AppendLine().Append("    ").Append(propertyName).Append(": ").Append(propertyValue);
             }
         }
-
-        /// <summary>
-        /// Gets a the PostgreSQL error message and code.
-        /// </summary>
-        public override string Message => SqlState + ": " + MessageText;
 
         /// <summary>
         /// Specifies whether the exception is considered transient, that is, whether retrying the operation could

--- a/test/Npgsql.Tests/ExceptionTests.cs
+++ b/test/Npgsql.Tests/ExceptionTests.cs
@@ -42,6 +42,7 @@ namespace Npgsql.Tests
             Assert.That(ex.InvariantSeverity, Is.EqualTo("ERROR"));
             Assert.That(ex.SqlState, Is.EqualTo("12345"));
             Assert.That(ex.Position, Is.EqualTo(0));
+            Assert.That(ex.Message, Is.EqualTo("12345: testexception"));
 
             var data = ex.Data;
             Assert.That(data[nameof(PostgresException.Severity)], Is.EqualTo("ERROR"));
@@ -49,6 +50,7 @@ namespace Npgsql.Tests
             Assert.That(data.Contains(nameof(PostgresException.Position)), Is.False);
 
             var exString = ex.ToString();
+            Assert.That(exString, Does.StartWith("Npgsql.PostgresException (0x80004005): 12345: testexception"));
             Assert.That(exString, Contains.Substring(nameof(PostgresException.Severity) + ": ERROR"));
             Assert.That(exString, Contains.Substring(nameof(PostgresException.SqlState) + ": 12345"));
 
@@ -317,5 +319,21 @@ $$ LANGUAGE 'plpgsql';");
         }
 #pragma warning restore 618
 #pragma warning restore MSLIB0003
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3204")]
+        public void JsonNetExceptionMessage()
+        {
+            // The exception must be thrown and caught to reproduce the problem
+            try
+            {
+                throw new PostgresException("the message", "low", "low2", "XX123");
+            }
+            catch (Exception ex)
+            {
+                var json = Newtonsoft.Json.JsonConvert.SerializeObject(ex);
+                Assert.That(json, Contains.Substring(",\"Message\":\"XX123: the message\","));
+            }
+        }
     }
 }

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Set the base Exception.Message property instead of overriding it.