### PR TITLE
Further improvements for TimeoutCancellationTokenSourceWrapper

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -838,9 +838,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         void BeginSend(NpgsqlConnector connector)
         {
-            connector.WriteBuffer.Timeout = CommandTimeout > 0
-                ? TimeSpan.FromSeconds(CommandTimeout)
-                : Timeout.InfiniteTimeSpan;
+            connector.WriteBuffer.Timeout = TimeSpan.FromSeconds(CommandTimeout);
             connector.WriteBuffer.CurrentCommand = this;
             FlushOccurred = false;
         }
@@ -1164,11 +1162,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                         if (cancellationToken.CanBeCanceled)
                         {
-                            if (connector.CommandCts.IsCancellationRequested)
-                            {
-                                connector.CommandCts.Dispose();
-                                connector.CommandCts = new TimeoutCancellationTokenSourceWrapper(TimeSpan.FromSeconds(connector.Settings.CancellationTimeout));
-                            }
+                            connector.CommandCts.Reset(CancellationToken.None);
 
                             registration = cancellationToken.Register(o =>
                             {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -184,6 +184,7 @@ namespace Npgsql
         /// The timeout for reading messages that are part of the user's command
         /// (i.e. which aren't internal prepended commands).
         /// </summary>
+        /// <remarks>Precision is milliseconds</remarks>
         internal int UserTimeout { private get; set; }
 
         /// <summary>
@@ -240,6 +241,7 @@ namespace Npgsql
         /// <summary>
         /// The minimum timeout that can be set on internal commands such as COMMIT, ROLLBACK.
         /// </summary>
+        /// <remarks>Precision is seconds</remarks>
         internal const int MinimumInternalCommandTimeout = 3;
 
         #endregion
@@ -347,6 +349,10 @@ namespace Npgsql
         bool IntegratedSecurity => Settings.IntegratedSecurity;
         internal bool ConvertInfinityDateTime => Settings.ConvertInfinityDateTime;
 
+        /// <summary>
+        /// The actual command timeout value that gets set on internal commands.
+        /// </summary>
+        /// <remarks>Precision is milliseconds</remarks>
         int InternalCommandTimeout
         {
             get
@@ -355,6 +361,9 @@ namespace Npgsql
                 if (internalTimeout == -1)
                     return Math.Max(Settings.CommandTimeout, MinimumInternalCommandTimeout) * 1000;
 
+                // Todo: Decide what we really want here
+                // This assertion can easily fail if InternalCommandTimeout is set to 1 or 2 in the connection string
+                // We probably don't want to allow these values but in that case a Debug.Assert is the wrong way to enforce it.
                 Debug.Assert(internalTimeout == 0 || internalTimeout >= MinimumInternalCommandTimeout);
                 return internalTimeout * 1000;
             }

--- a/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
+++ b/src/Npgsql/Util/TimeoutCancellationTokenSourceWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
+using static System.Threading.Timeout;
 
 namespace Npgsql.Util
 {
@@ -15,8 +17,13 @@ namespace Npgsql.Util
     {
         public TimeSpan Timeout { get; set; }
         CancellationTokenSource _timeoutCts = new CancellationTokenSource();
+        CancellationToken _linkedToken;
 
-        public TimeoutCancellationTokenSourceWrapper() => Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+#if DEBUG
+        bool _isRunning;
+#endif
+
+        public TimeoutCancellationTokenSourceWrapper() => Timeout = InfiniteTimeSpan;
 
         public TimeoutCancellationTokenSourceWrapper(TimeSpan timeout) => Timeout = timeout;
 
@@ -24,28 +31,100 @@ namespace Npgsql.Util
         /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>
         /// and make sure that it hasn't been cancelled yet
         /// </summary>
-        public CancellationToken Start()
+        /// <param name="cancellationToken">An optional cancellation token that will be linked with the
+        /// contained <see cref="CancellationTokenSource"/></param>
+        /// <returns>The <see cref="CancellationToken"/> from the wrapped <see cref="CancellationTokenSource"/></returns>
+        public CancellationToken Start(CancellationToken cancellationToken = default)
         {
-            _timeoutCts.CancelAfter(Timeout);
-            if (_timeoutCts.IsCancellationRequested)
+#if DEBUG
+            Debug.Assert(!_isRunning);
+#endif
+
+            // If we already wrap a linked token source or we want to wrap a linked token source and the token to
+            // link isn't the same one that's already linked we always have to create a new CancellationTokenSource
+            if ((_linkedToken.CanBeCanceled || cancellationToken.CanBeCanceled) && _linkedToken != cancellationToken)
             {
                 _timeoutCts.Dispose();
-                _timeoutCts = new CancellationTokenSource(Timeout);
+                _timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _timeoutCts.CancelAfter(Timeout);
+            }
+            else
+            {
+                _timeoutCts.CancelAfter(Timeout);
+                if (_timeoutCts.IsCancellationRequested)
+                {
+                    _timeoutCts.Dispose();
+                    _timeoutCts = new CancellationTokenSource(Timeout);
+                }
             }
 
+            _linkedToken = cancellationToken;
+#if DEBUG
+            _isRunning = true;
+#endif
             return _timeoutCts.Token;
         }
 
         /// <summary>
-        /// Reset the timeout on the wrapped <see cref="CancellationTokenSource"/>
+        /// Restart the timeout on the wrapped <see cref="CancellationTokenSource"/> without reinitializing it,
+        /// even if <see cref="IsCancellationRequested"/> is already set to <see langword="true"/>
         /// </summary>
-        public void Restart() => _timeoutCts.CancelAfter(Timeout);
+        public void RestartTimeoutWithoutReset() => _timeoutCts.CancelAfter(Timeout);
+
+        /// <summary>
+        /// Reset the wrapper to contain a unstarted and uncancelled <see cref="CancellationTokenSource"/>
+        /// in order make sure the next call to <see cref="Start"/> will not invalidate
+        /// the cancellation token.
+        /// </summary>
+        /// <param name="cancellationToken">An optional cancellation token that will be linked with the
+        /// contained <see cref="CancellationTokenSource"/></param>
+        /// <returns>The <see cref="CancellationToken"/> from the wrapped <see cref="CancellationTokenSource"/></returns>
+        public CancellationToken Reset(CancellationToken cancellationToken = default)
+        {
+            if ((_linkedToken.CanBeCanceled || cancellationToken.CanBeCanceled) && _linkedToken != cancellationToken)
+            {
+                _timeoutCts.Dispose();
+                _timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            }
+            else
+            {
+                _timeoutCts.CancelAfter(InfiniteTimeSpan);
+                if (_timeoutCts.IsCancellationRequested)
+                {
+                    _timeoutCts.Dispose();
+                    _timeoutCts = new CancellationTokenSource();
+                }
+            }
+
+            _linkedToken = cancellationToken;
+#if DEBUG
+            _isRunning = false;
+#endif
+            return _timeoutCts.Token;
+        }
 
         /// <summary>
         /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>
         /// to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>
         /// </summary>
-        public void Stop() => _timeoutCts.CancelAfter(System.Threading.Timeout.InfiniteTimeSpan);
+        /// <remarks>
+        /// <see cref="IsCancellationRequested"/> can still arrive at a state
+        /// where it's value is <see langword="true"/> if the <see cref="CancellationToken"/>
+        /// passed to <see cref="Start"/> gets a cancellation request.
+        /// If this is the case it will be resolved upon the next call to <see cref="Start"/>
+        /// or <see cref="Reset"/>
+        /// </remarks>
+        public void Stop()
+        {
+#if DEBUG
+            Debug.Assert(_isRunning);
+#endif
+
+            _timeoutCts.CancelAfter(InfiniteTimeSpan);
+#if DEBUG
+            _isRunning = false;
+#endif
+        }
 
         /// <summary>
         /// Cancel the wrapped <see cref="CancellationTokenSource"/>


### PR DESCRIPTION
1. Add a Reset() method to reset the contained cancellation token source without starting the timeout
2. Add an optional cancellation token parameter to Start() and Reset() to support creating a linked cancellation token source inside the wrapper

Also add some documentation around the resolution of timeouts