### PR TITLE
Fixed potential torn reads in EventCounters

### DIFF
--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -134,35 +134,35 @@ namespace Npgsql
                 // overhead by at all times even when counters aren't enabled.
                 // On disable, PollingCounters will stop polling for values so it should be fine to leave them around.
 
-                _bytesWrittenPerSecondCounter = new IncrementingPollingCounter("bytes-written-per-second", this, () => _bytesWritten)
+                _bytesWrittenPerSecondCounter = new IncrementingPollingCounter("bytes-written-per-second", this, () => Volatile.Read(ref _bytesWritten))
                 {
                     DisplayName = "Bytes Written",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _bytesReadPerSecondCounter = new IncrementingPollingCounter("bytes-read-per-second", this, () => _bytesRead)
+                _bytesReadPerSecondCounter = new IncrementingPollingCounter("bytes-read-per-second", this, () => Volatile.Read(ref _bytesRead))
                 {
                     DisplayName = "Bytes Read",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _commandsPerSecondCounter = new IncrementingPollingCounter("commands-per-second", this, () => _totalCommands)
+                _commandsPerSecondCounter = new IncrementingPollingCounter("commands-per-second", this, () => Volatile.Read(ref _totalCommands))
                 {
                     DisplayName = "Command Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _totalCommandsCounter = new PollingCounter("total-commands", this, () => _totalCommands)
+                _totalCommandsCounter = new PollingCounter("total-commands", this, () => Volatile.Read(ref _totalCommands))
                 {
                     DisplayName = "Total Commands",
                 };
 
-                _currentCommandsCounter = new PollingCounter("current-commands", this, () => _currentCommands)
+                _currentCommandsCounter = new PollingCounter("current-commands", this, () => Volatile.Read(ref _currentCommands))
                 {
                     DisplayName = "Current Commands"
                 };
 
-                _failedCommandsCounter = new PollingCounter("failed-commands", this, () => _failedCommands)
+                _failedCommandsCounter = new PollingCounter("failed-commands", this, () => Volatile.Read(ref _failedCommands))
                 {
                     DisplayName = "Failed Commands"
                 };
@@ -170,7 +170,7 @@ namespace Npgsql
                 _preparedCommandsRatioCounter = new PollingCounter(
                     "prepared-commands-ratio",
                     this,
-                    () => (double)_totalPreparedCommands / (double)_totalCommands)
+                    () => (double)Volatile.Read(ref _totalPreparedCommands) / Volatile.Read(ref _totalCommands))
                 {
                     DisplayName = "Prepared Commands Ratio",
                     DisplayUnits = "%"
@@ -191,17 +191,17 @@ namespace Npgsql
                     DisplayName = "Busy Connections"
                 };
 
-                _multiplexingAverageCommandsPerBatchCounter = new PollingCounter("multiplexing-average-commands-per-batch", this, () => (double)_multiplexingCommandsSent / _multiplexingBatchesSent)
+                _multiplexingAverageCommandsPerBatchCounter = new PollingCounter("multiplexing-average-commands-per-batch", this, () => (double)Volatile.Read(ref _multiplexingCommandsSent) / Volatile.Read(ref _multiplexingBatchesSent))
                 {
                     DisplayName = "Average commands per multiplexing batch"
                 };
 
-                _multiplexingAverageWaitsPerBatchCounter = new PollingCounter("multiplexing-average-waits-per-batch", this, () => (double)_multiplexingWaits / _multiplexingBatchesSent)
+                _multiplexingAverageWaitsPerBatchCounter = new PollingCounter("multiplexing-average-waits-per-batch", this, () => (double)Volatile.Read(ref _multiplexingWaits) / Volatile.Read(ref _multiplexingBatchesSent))
                 {
                     DisplayName = "Average waits per multiplexing batch"
                 };
 
-                _multiplexingAverageWriteTimePerBatchCounter = new PollingCounter("multiplexing-average-write-time-per-batch", this, () => (double)_multiplexingTicksWritten / _multiplexingBatchesSent / 1000)
+                _multiplexingAverageWriteTimePerBatchCounter = new PollingCounter("multiplexing-average-write-time-per-batch", this, () => (double)Volatile.Read(ref _multiplexingTicksWritten) / Volatile.Read(ref _multiplexingBatchesSent) / 1000)
                 {
                     DisplayName = "Average write time per multiplexing batch (us)",
                     DisplayUnits = "us"


### PR DESCRIPTION
The backing fields for the counters are `long`, so there was potential torn read on 32-bit platforms.
`Volatile.Read` ensures that the value is read in a atomic way, so no torn reads can occur.