### PR TITLE
Use Interlocked.Read instead of Volatile.Read for PollingCounters

### DIFF
--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -134,35 +134,35 @@ namespace Npgsql
                 // overhead by at all times even when counters aren't enabled.
                 // On disable, PollingCounters will stop polling for values so it should be fine to leave them around.
 
-                _bytesWrittenPerSecondCounter = new IncrementingPollingCounter("bytes-written-per-second", this, () => Volatile.Read(ref _bytesWritten))
+                _bytesWrittenPerSecondCounter = new IncrementingPollingCounter("bytes-written-per-second", this, () => Interlocked.Read(ref _bytesWritten))
                 {
                     DisplayName = "Bytes Written",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _bytesReadPerSecondCounter = new IncrementingPollingCounter("bytes-read-per-second", this, () => Volatile.Read(ref _bytesRead))
+                _bytesReadPerSecondCounter = new IncrementingPollingCounter("bytes-read-per-second", this, () => Interlocked.Read(ref _bytesRead))
                 {
                     DisplayName = "Bytes Read",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _commandsPerSecondCounter = new IncrementingPollingCounter("commands-per-second", this, () => Volatile.Read(ref _totalCommands))
+                _commandsPerSecondCounter = new IncrementingPollingCounter("commands-per-second", this, () => Interlocked.Read(ref _totalCommands))
                 {
                     DisplayName = "Command Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _totalCommandsCounter = new PollingCounter("total-commands", this, () => Volatile.Read(ref _totalCommands))
+                _totalCommandsCounter = new PollingCounter("total-commands", this, () => Interlocked.Read(ref _totalCommands))
                 {
                     DisplayName = "Total Commands",
                 };
 
-                _currentCommandsCounter = new PollingCounter("current-commands", this, () => Volatile.Read(ref _currentCommands))
+                _currentCommandsCounter = new PollingCounter("current-commands", this, () => Interlocked.Read(ref _currentCommands))
                 {
                     DisplayName = "Current Commands"
                 };
 
-                _failedCommandsCounter = new PollingCounter("failed-commands", this, () => Volatile.Read(ref _failedCommands))
+                _failedCommandsCounter = new PollingCounter("failed-commands", this, () => Interlocked.Read(ref _failedCommands))
                 {
                     DisplayName = "Failed Commands"
                 };
@@ -170,7 +170,7 @@ namespace Npgsql
                 _preparedCommandsRatioCounter = new PollingCounter(
                     "prepared-commands-ratio",
                     this,
-                    () => (double)Volatile.Read(ref _totalPreparedCommands) / Volatile.Read(ref _totalCommands))
+                    () => (double)Interlocked.Read(ref _totalPreparedCommands) / Interlocked.Read(ref _totalCommands))
                 {
                     DisplayName = "Prepared Commands Ratio",
                     DisplayUnits = "%"
@@ -191,17 +191,17 @@ namespace Npgsql
                     DisplayName = "Busy Connections"
                 };
 
-                _multiplexingAverageCommandsPerBatchCounter = new PollingCounter("multiplexing-average-commands-per-batch", this, () => (double)Volatile.Read(ref _multiplexingCommandsSent) / Volatile.Read(ref _multiplexingBatchesSent))
+                _multiplexingAverageCommandsPerBatchCounter = new PollingCounter("multiplexing-average-commands-per-batch", this, () => (double)Interlocked.Read(ref _multiplexingCommandsSent) / Interlocked.Read(ref _multiplexingBatchesSent))
                 {
                     DisplayName = "Average commands per multiplexing batch"
                 };
 
-                _multiplexingAverageWaitsPerBatchCounter = new PollingCounter("multiplexing-average-waits-per-batch", this, () => (double)Volatile.Read(ref _multiplexingWaits) / Volatile.Read(ref _multiplexingBatchesSent))
+                _multiplexingAverageWaitsPerBatchCounter = new PollingCounter("multiplexing-average-waits-per-batch", this, () => (double)Interlocked.Read(ref _multiplexingWaits) / Interlocked.Read(ref _multiplexingBatchesSent))
                 {
                     DisplayName = "Average waits per multiplexing batch"
                 };
 
-                _multiplexingAverageWriteTimePerBatchCounter = new PollingCounter("multiplexing-average-write-time-per-batch", this, () => (double)Volatile.Read(ref _multiplexingTicksWritten) / Volatile.Read(ref _multiplexingBatchesSent) / 1000)
+                _multiplexingAverageWriteTimePerBatchCounter = new PollingCounter("multiplexing-average-write-time-per-batch", this, () => (double)Interlocked.Read(ref _multiplexingTicksWritten) / Interlocked.Read(ref _multiplexingBatchesSent) / 1000)
                 {
                     DisplayName = "Average write time per multiplexing batch (us)",
                     DisplayUnits = "us"


### PR DESCRIPTION
With https://github.com/npgsql/npgsql/pull/3223#issuecomment-705592536 started at discussion about `Interlocked.Read` and `Volatile.Read`. Consensus is to use `Interlocked.Read` for the polling event counters. This change updates this.

/cc: @roji @YohDeadfall