### PR TITLE
Fully honor timeouts during connection phase

### DIFF
--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -21,8 +21,8 @@ namespace Npgsql
         {
             Log.Trace("Authenticating...", Id);
 
+            timeout.CheckAndApply(this);
             var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, cancellationToken), this);
-            timeout.Check();
             switch (msg.AuthRequestType)
             {
             case AuthenticationRequestType.AuthenticationOk:

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -214,6 +214,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};" : "")}
                 AllResultTypesAreUnknown = true
             };
 
+            timeout.CheckAndApply(conn.Connector!);
             using var reader = async ? await command.ExecuteReaderAsync() : command.ExecuteReader();
             var byOID = new Dictionary<uint, PostgresType>();
 
@@ -234,8 +235,6 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};" : "")}
             // Then load the types
             while (async ? await reader.ReadAsync() : reader.Read())
             {
-                timeout.Check();
-
                 var ns = reader.GetString("nspname");
                 var internalName = reader.GetString("typname");
                 var oid = uint.Parse(reader.GetString("oid"), NumberFormatInfo.InvariantInfo);

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -195,7 +195,7 @@ namespace Npgsql.Tests
                 return; // Multiplexing, Timeout
 
             var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { CommandTimeout = 1 };
-            await using var postmasterMock = new PgPostmasterMock(builder.ConnectionString);
+            await using var postmasterMock = PgPostmasterMock.Start(builder.ConnectionString);
             using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
             await using var conn = await OpenConnectionAsync(connectionString);
 
@@ -315,7 +315,7 @@ namespace Npgsql.Tests
             if (IsMultiplexing)
                 return; // Multiplexing, cancellation
 
-            await using var postmasterMock = new PgPostmasterMock(ConnectionString);
+            await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
             using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
             await using var conn = await OpenConnectionAsync(connectionString);
 

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -40,10 +40,7 @@ namespace Npgsql.Tests.Support
         internal async Task Startup()
         {
             // Read and skip the startup message
-            await _readBuffer.EnsureAsync(4);
-            var startupMessageLen = _readBuffer.ReadInt32();
-            await _readBuffer.EnsureAsync(startupMessageLen - 4);
-            _readBuffer.Skip(startupMessageLen - 4);
+            await SkipMessage();
 
             WriteAuthenticateOk();
             WriteParameterStatuses(new Dictionary<string, string>
@@ -65,6 +62,14 @@ namespace Npgsql.Tests.Support
             WriteReadyForQuery();
 
             await FlushAsync();
+        }
+
+        internal async Task SkipMessage()
+        {
+            await _readBuffer.EnsureAsync(4);
+            var len = _readBuffer.ReadInt32();
+            await _readBuffer.EnsureAsync(len - 4);
+            _readBuffer.Skip(len - 4);
         }
 
         internal async Task ReadMessageType(byte expectedCode)


### PR DESCRIPTION
Improve PG mocking infrastructure to support connection-time scenarios.

@russellfoster while working on the PostgreSQL mocking infrastructure for testing the issue, I ended up doing the fix as well.

Fixes #3227
Replaces #3226

/cc @russellfoster @vonzshik 