### PR TITLE
Add DateTime support to nodatimes TimestampTzHandler. Follow-up fix for #2439

### DIFF
--- a/src/Npgsql.NodaTime/TimestampTzHandler.cs
+++ b/src/Npgsql.NodaTime/TimestampTzHandler.cs
@@ -24,7 +24,8 @@ namespace Npgsql.NodaTime
     }
 
     sealed class TimestampTzHandler : NpgsqlSimpleTypeHandler<Instant>, INpgsqlSimpleTypeHandler<ZonedDateTime>,
-                              INpgsqlSimpleTypeHandler<OffsetDateTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>
+                              INpgsqlSimpleTypeHandler<OffsetDateTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>, 
+                              INpgsqlSimpleTypeHandler<DateTime>
     {
         readonly IDateTimeZoneProvider _dateTimeZoneProvider;
         readonly BclTimestampTzHandler _bclHandler;
@@ -128,6 +129,15 @@ namespace Npgsql.NodaTime
             => _bclHandler.ValidateAndGetLength(value, parameter);
 
         void INpgsqlSimpleTypeHandler<DateTimeOffset>.Write(DateTimeOffset value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
+            => _bclHandler.Write(value, buf, parameter);
+
+        DateTime INpgsqlSimpleTypeHandler<DateTime>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription) 
+            => _bclHandler.Read<DateTime>(buf, len, fieldDescription);
+
+        int INpgsqlSimpleTypeHandler<DateTime>.ValidateAndGetLength(DateTime value, NpgsqlParameter? parameter) 
+            => _bclHandler.ValidateAndGetLength(value, parameter);
+
+        void INpgsqlSimpleTypeHandler<DateTime>.Write(DateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) 
             => _bclHandler.Write(value, buf, parameter);
     }
 }


### PR DESCRIPTION
Add DateTime support to nodatimes TimestampTzHandler.
When implementing #2439, i overlooked that the BCLs `TimestampTzHandler` supports `DateTime` through the inherited `TimestampHandler`.

This came to my attention today while running `BuiltInDataTypesNpgsqlTest` with the nodatime plugin enabled. (https://github.com/npgsql/efcore.pg/issues/1490)