### PR TITLE
Some fixup to the cancellation flow

### DIFF
--- a/src/Npgsql/ConnectorPool.Multiplexing.cs
+++ b/src/Npgsql/ConnectorPool.Multiplexing.cs
@@ -68,7 +68,7 @@ namespace Npgsql
             Debug.Assert(_multiplexCommandReader != null);
 
             var timeout = _writeCoalescingDelayTicks / 2;
-            var timeoutTokenSource = new TimeoutCancellationTokenSourceWrapper(TimeSpan.FromTicks(timeout));
+            var timeoutTokenSource = new ResettableCancellationTokenSource(TimeSpan.FromTicks(timeout));
             var timeoutToken = timeout == 0 ? CancellationToken.None : timeoutTokenSource.Token;
 
             while (true)

--- a/src/Npgsql/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/NpgsqlWriteBuffer.cs
@@ -29,7 +29,7 @@ namespace Npgsql
 
         readonly Socket? _underlyingSocket;
 
-        readonly TimeoutCancellationTokenSourceWrapper _timeoutCts;
+        readonly ResettableCancellationTokenSource _timeoutCts;
 
         /// <summary>
         /// Timeout for sync and async writes
@@ -94,7 +94,7 @@ namespace Npgsql
             Connector = connector;
             Underlying = stream;
             _underlyingSocket = socket;
-            _timeoutCts = new TimeoutCancellationTokenSourceWrapper();
+            _timeoutCts = new ResettableCancellationTokenSource();
             Size = size;
             Buffer = ArrayPool<byte>.Shared.Rent(size);
             TextEncoding = textEncoding;

--- a/src/Npgsql/Util/ResettableCancellationTokenSource.cs
+++ b/src/Npgsql/Util/ResettableCancellationTokenSource.cs
@@ -6,14 +6,14 @@ using static System.Threading.Timeout;
 namespace Npgsql.Util
 {
     /// <summary>
-    /// Internal struct wrapping a <see cref="CancellationTokenSource"/> for timeouts.
+    /// A wrapper around <see cref="CancellationTokenSource"/> to simplify reset management.
     /// </summary>
     /// <remarks>
     /// Since there's no way to reset a <see cref="CancellationTokenSource"/> once it was cancelled,
     /// we need to make sure that an existing cancellation token source hasn't been cancelled,
     /// every time we start it (see https://github.com/dotnet/runtime/issues/4694).
     /// </remarks>
-    class TimeoutCancellationTokenSourceWrapper : IDisposable
+    class ResettableCancellationTokenSource : IDisposable
     {
         public TimeSpan Timeout { get; set; }
         CancellationTokenSource _cts = new CancellationTokenSource();
@@ -23,9 +23,9 @@ namespace Npgsql.Util
         bool _isRunning;
 #endif
 
-        public TimeoutCancellationTokenSourceWrapper() => Timeout = InfiniteTimeSpan;
+        public ResettableCancellationTokenSource() => Timeout = InfiniteTimeSpan;
 
-        public TimeoutCancellationTokenSourceWrapper(TimeSpan timeout) => Timeout = timeout;
+        public ResettableCancellationTokenSource(TimeSpan timeout) => Timeout = timeout;
 
         /// <summary>
         /// Set the timeout on the wrapped <see cref="CancellationTokenSource"/>


### PR DESCRIPTION
Mainly change NpgsqlConnector.CancelRequest to return whether request was delivered, rather than throwing exceptions (which we caught and swallowed). Some other tweaks as well.

/cc @Brar