### PR TITLE
Fix race condition between opening and closing

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1253,6 +1253,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             await reader.NextResultAsync(CancellationToken.None);
                         else
                             reader.NextResult();
+
                         return reader;
                     }
                     catch

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1337,8 +1337,11 @@ namespace Npgsql
                 // In multiplexing mode, we can't support transaction in SQL: the connector must be removed from the
                 // writable connectors list, otherwise other commands may get written to it. So the user must tell us
                 // about the transaction via BeginTransaction.
-                if (Connection == null)
+                if (Connection is null)
+                {
+                    Debug.Assert(Settings.Multiplexing);
                     throw new NotSupportedException("In multiplexing mode, transactions must be started with BeginTransaction");
+                }
                 break;
             case TransactionStatus.Pending:
                 throw new Exception($"Internal Npgsql bug: invalid TransactionStatus {nameof(TransactionStatus.Pending)} received, should be frontend-only");


### PR DESCRIPTION
The Close code was setting the connector's Connection to null *after* returning to the pool, so it was in a race condition with opening code taking the same connector out of the pool.

Fixes #3241

For reference, here's test which reproduced this to me. Not committing it since it's highly timing-sensitive etc:

```c#
[Test]
public Task RaceCondition()
    => Task.WhenAll(Enumerable.Range(0, 100000).Select(async i =>
    {
        using var conn = await OpenConnectionAsync();
        using var tx = conn.BeginTransaction();
        using var cmd = new NpgsqlCommand("SELECT 1", conn, tx);

        using (var reader = await cmd.ExecuteReaderAsync())
        {
            reader.Read();
            _ = reader.GetInt32(0);
        }

        tx.Commit();
    }));
```