### PR TITLE
Transactions do not reuse the connector on dispose

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -579,7 +579,6 @@ namespace Npgsql
                 // However, we do this for consistency as if we did (for the checks and exceptions)
                 using (connector.StartUserAction())
                 {
-                    connector.Transaction = new NpgsqlTransaction(connector);
                     connector.Transaction.Init(level);
                     return connector.Transaction;
                 }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -569,8 +569,13 @@ namespace Npgsql
             if (Connector != null && Connector.InTransaction)
                 throw new InvalidOperationException("A transaction is already in progress; nested/concurrent transactions aren't supported.");
 
-            var connector = await StartBindingScope(ConnectorBindingScope.Transaction, NpgsqlTimeout.Infinite, async,
-                cancellationToken);
+            // There was a commited/rollbacked transaction, but it was not disposed
+            var connector = ConnectorBindingScope == ConnectorBindingScope.Transaction ?
+                    Connector
+                    : await StartBindingScope(ConnectorBindingScope.Transaction, NpgsqlTimeout.Infinite, async,
+                        cancellationToken);
+
+            Debug.Assert(connector != null);
 
             try
             {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -579,6 +579,7 @@ namespace Npgsql
                 // However, we do this for consistency as if we did (for the checks and exceptions)
                 using (connector.StartUserAction())
                 {
+                    connector.Transaction = new NpgsqlTransaction(connector);
                     connector.Transaction.Init(level);
                     return connector.Transaction;
                 }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -737,6 +737,7 @@ namespace Npgsql
                 }
                 else if (ConnectorBindingScope == ConnectorBindingScope.Transaction)
                 {
+                    Debug.Assert(Connector != null);
                     // There was an open transaction, but it was not disposed
                     if (async)
                         return Connector.Transaction.DisposeAsync().AsTask();

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -683,7 +683,7 @@ namespace Npgsql
         /// Releases the connection. If the connection is pooled, it will be returned to the pool and made available for re-use.
         /// If it is non-pooled, the physical connection will be closed.
         /// </summary>
-        public override void Close() => Close(async: false);
+        public override void Close() => Close(async: false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Releases the connection. If the connection is pooled, it will be returned to the pool and made available for re-use.
@@ -699,12 +699,12 @@ namespace Npgsql
                 return Close(async: true);
         }
 
-        internal Task Close(bool async, CancellationToken cancellationToken = default)
+        internal async Task Close(bool async, CancellationToken cancellationToken = default)
         {
             // Even though NpgsqlConnection isn't thread safe we'll make sure this part is.
             // Because we really don't want double returns to the pool.
             if (Interlocked.Exchange(ref _closing, 1) == 1)
-                return Task.CompletedTask;
+                return;
 
             switch (FullState)
             {
@@ -715,7 +715,7 @@ namespace Npgsql
                 break;
             case ConnectionState.Closed:
                 Volatile.Write(ref _closing, 0);
-                return Task.CompletedTask;
+                return;
             case ConnectionState.Connecting:
                 Volatile.Write(ref _closing, 0);
                 throw new InvalidOperationException("Can't close, connection is in state " + FullState);
@@ -727,6 +727,19 @@ namespace Npgsql
             
             if (Settings.Multiplexing)
             {
+                if (ConnectorBindingScope == ConnectorBindingScope.Transaction)
+                {
+                    Debug.Assert(Connector != null);
+                    // There was an open transaction, but it was not disposed
+                    // After it is disposed, the connector is returned to the pool
+                    // And the current scope should be None
+                    // So we fall through below and close the connection
+                    if (async)
+                        await Connector.Transaction.DisposeAsync();
+                    else
+                        Connector.Transaction.Dispose();
+                }
+
                 // TODO: The following shouldn't exist - we need to flow down the regular path to close any
                 // open reader / COPY. See test CloseDuringRead with multiplexing.
                 if (ConnectorBindingScope == ConnectorBindingScope.None)
@@ -738,22 +751,11 @@ namespace Npgsql
                     Log.Debug("Connection closed (multiplexing)");
                     OnStateChange(OpenToClosedEventArgs);
                     Volatile.Write(ref _closing, 0);
-                    return Task.CompletedTask;
-                }
-                else if (ConnectorBindingScope == ConnectorBindingScope.Transaction)
-                {
-                    Debug.Assert(Connector != null);
-                    // There was an open transaction, but it was not disposed
-                    if (async)
-                        return Connector.Transaction.DisposeAsync().AsTask();
-                    else
-                        Connector.Transaction.Dispose();
-
-                    return Task.CompletedTask;
+                    return;
                 }
             }
 
-            return CloseAsync(cancellationToken);
+            await CloseAsync(cancellationToken);
 
             async Task CloseAsync(CancellationToken cancellationToken)
             {

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -104,11 +104,10 @@ namespace Npgsql
         internal TransactionStatus TransactionStatus { get; set; }
 
         /// <summary>
-        /// A transaction object for this connector. Since only one transaction can be in progress at any given time,
-        /// this instance is recycled. To check whether a transaction is currently in progress on this connector,
-        /// see <see cref="TransactionStatus"/>.
+        /// A transaction object for this connector.
+        /// To check whether a transaction is currently in progress on this connector, see <see cref="TransactionStatus"/>.
         /// </summary>
-        internal NpgsqlTransaction Transaction { get; }
+        internal NpgsqlTransaction Transaction { get; set; }
 
         /// <summary>
         /// The NpgsqlConnection that (currently) owns this connector. Null if the connector isn't
@@ -1772,6 +1771,8 @@ namespace Npgsql
                 throw new InvalidOperationException($"Internal Npgsql bug: unexpected value {TransactionStatus} of enum {nameof(TransactionStatus)}. Please file a bug.");
             }
 
+            // TODO: if multiplexing is on and the TransactionStatus is Pending, InTransactionBlock or InFailedTransactionBlock
+            // the connector is already in the pool by this point
             if (_sendResetOnClose)
             {
                 if (PreparedStatementManager.NumPrepared > 0)

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1301,8 +1301,6 @@ namespace Npgsql
         internal async Task Rollback(bool async, CancellationToken cancellationToken = default)
         {
             Log.Debug("Rolling back transaction", Id);
-            // TODO: On successful rollback, the connector might be returned to the pool, if multiplexing is on.
-            // In this case, we might call EndUserAction on the connector, which might be in use.
             using (StartUserAction())
                 await ExecuteInternalCommand(PregeneratedMessages.RollbackTransaction, async, cancellationToken);
         }

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -104,10 +104,11 @@ namespace Npgsql
         internal TransactionStatus TransactionStatus { get; set; }
 
         /// <summary>
-        /// A transaction object for this connector.
-        /// To check whether a transaction is currently in progress on this connector, see <see cref="TransactionStatus"/>.
+        /// A transaction object for this connector. Since only one transaction can be in progress at any given time,
+        /// this instance is recycled. To check whether a transaction is currently in progress on this connector,
+        /// see <see cref="TransactionStatus"/>.
         /// </summary>
-        internal NpgsqlTransaction Transaction { get; set; }
+        internal NpgsqlTransaction Transaction { get; }
 
         /// <summary>
         /// The NpgsqlConnection that (currently) owns this connector. Null if the connector isn't
@@ -1771,8 +1772,6 @@ namespace Npgsql
                 throw new InvalidOperationException($"Internal Npgsql bug: unexpected value {TransactionStatus} of enum {nameof(TransactionStatus)}. Please file a bug.");
             }
 
-            // TODO: if multiplexing is on and the TransactionStatus is Pending, InTransactionBlock or InFailedTransactionBlock
-            // the connector is already in the pool by this point
             if (_sendResetOnClose)
             {
                 if (PreparedStatementManager.NumPrepared > 0)

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1753,6 +1753,8 @@ namespace Npgsql
             switch (TransactionStatus)
             {
             case TransactionStatus.Idle:
+                // There is an undisposed transaction on multiplexing connection
+                endBindingScope = Connection?.ConnectorBindingScope == ConnectorBindingScope.Transaction;
                 break;
             case TransactionStatus.Pending:
                 // BeginTransaction() was called, but was left in the write buffer and not yet sent to server.

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -41,13 +41,7 @@ namespace Npgsql
         /// <summary>
         /// If true, the transaction has been committed/rolled back, but not disposed.
         /// </summary>
-        internal bool IsCompleted => _isCompleted || _connector.TransactionStatus == TransactionStatus.Idle;
-
-        /// <summary>
-        /// Only useful for multiplexing, as on commit/rollback the connector will return to the pool.
-        /// And we shouldn't use it after that.
-        /// </summary>
-        bool _isCompleted;
+        internal bool IsCompleted => _connector.TransactionStatus == TransactionStatus.Idle;
 
         internal bool IsDisposed;
 
@@ -136,7 +130,6 @@ namespace Npgsql
             {
                 Log.Debug("Committing transaction", _connector.Id);
                 await _connector.ExecuteInternalCommand(PregeneratedMessages.CommitTransaction, async, cancellationToken);
-                _isCompleted = true;
             }
         }
 
@@ -165,15 +158,12 @@ namespace Npgsql
         /// </summary>
         public override void Rollback() => Rollback(false).GetAwaiter().GetResult();
 
-        async Task Rollback(bool async, CancellationToken cancellationToken = default)
+        Task Rollback(bool async, CancellationToken cancellationToken = default)
         {
             CheckReady();
-
-            if (!_connector.DatabaseInfo.SupportsTransactions)
-                return;
-
-            await _connector.Rollback(async, cancellationToken);
-            _isCompleted = true;
+            return _connector.DatabaseInfo.SupportsTransactions
+                ? _connector.Rollback(async, cancellationToken)
+                : Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -346,6 +346,8 @@ namespace Npgsql
                     Rollback();
                 }
 
+                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Transaction);
+
                 IsDisposed = true;
             }
         }
@@ -367,6 +369,8 @@ namespace Npgsql
                         return DisposeAsyncInternal();
                 }
 
+                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Transaction);
+
                 IsDisposed = true;
             }
             return default;
@@ -376,6 +380,7 @@ namespace Npgsql
                 // We're disposing, so no cancellation token
                 await _connector.CloseOngoingOperations(async: true);
                 await Rollback(async: true);
+                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Transaction);
                 IsDisposed = true;
             }
         }

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -346,7 +346,7 @@ namespace Npgsql
                     Rollback();
                 }
 
-                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Transaction);
+                _connector.Connection?.EndBindingScope(ConnectorBindingScope.Transaction);
 
                 IsDisposed = true;
             }
@@ -380,7 +380,7 @@ namespace Npgsql
                 // We're disposing, so no cancellation token
                 await _connector.CloseOngoingOperations(async: true);
                 await Rollback(async: true);
-                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Transaction);
+                _connector.Connection?.EndBindingScope(ConnectorBindingScope.Transaction);
                 IsDisposed = true;
             }
         }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -740,7 +740,7 @@ namespace Npgsql.Tests
                 {
                     connection.Open();
                     command.Connection = connection;
-                    var tx = connection.BeginTransaction();
+                    using var tx = connection.BeginTransaction();
                     await command.ExecuteScalarAsync();
                     await tx.CommitAsync();
                 }

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -740,7 +740,7 @@ namespace Npgsql.Tests
                 {
                     connection.Open();
                     command.Connection = connection;
-                    using var tx = connection.BeginTransaction();
+                    var tx = connection.BeginTransaction();
                     await command.ExecuteScalarAsync();
                     await tx.CommitAsync();
                 }

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -470,12 +470,12 @@ namespace Npgsql.Tests
         [Test]
         [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
         // More at #3254
-        public async Task Bug3248()
+        public async Task Bug3248DisposeTransactionRollback()
         {
             if (!IsMultiplexing)
                 return;
 
-            var conn = await OpenConnectionAsync();
+            using var conn = await OpenConnectionAsync();
             await using (var tx = conn.BeginTransaction())
             {
                 Assert.That(conn.Connector, Is.Not.Null);
@@ -484,10 +484,25 @@ namespace Npgsql.Tests
                 Assert.That(conn.Connector, Is.Not.Null);
             }
 
+            Assert.That(conn.Connector, Is.Null);
+        }
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
+        // More at #3254
+        public async Task Bug3248DisposeConnectionRollback()
+        {
+            if (!IsMultiplexing)
+                return;
+
+            var conn = await OpenConnectionAsync();
+            var tx = conn.BeginTransaction();
+            Assert.That(conn.Connector, Is.Not.Null);
+            Assert.That(async () => await conn.ExecuteScalarAsync("SELECT * FROM \"unknown_table\"", tx: tx),
+                Throws.Exception.TypeOf<PostgresException>());
             Assert.That(conn.Connector, Is.Not.Null);
 
             await conn.DisposeAsync();
-
             Assert.That(conn.Connector, Is.Null);
         }
 

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -467,6 +467,69 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
+        // More at #3254
+        public async Task Bug3248Commit()
+        {
+            if (!IsMultiplexing)
+                return;
+
+            var conn = await OpenConnectionAsync();
+
+            await using (var tx = conn.BeginTransaction())
+            {
+                Assert.That(conn.Connector, Is.Not.Null);
+                await conn.ExecuteScalarAsync("SELECT 1", tx: tx);
+                await tx.CommitAsync();
+                Assert.That(conn.Connector, Is.Not.Null);
+            }
+
+            Assert.That(conn.Connector, Is.Null);
+        }
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
+        // More at #3254
+        public async Task Bug3248Rollback()
+        {
+            if (!IsMultiplexing)
+                return;
+
+            var conn = await OpenConnectionAsync();
+
+            await using (var tx = conn.BeginTransaction())
+            {
+                Assert.That(conn.Connector, Is.Not.Null);
+                await conn.ExecuteScalarAsync("SELECT 1", tx: tx);
+                await tx.RollbackAsync();
+                Assert.That(conn.Connector, Is.Not.Null);
+            }
+
+            Assert.That(conn.Connector, Is.Null);
+        }
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
+        // More at #3254
+        public async Task Bug3248ErrorRollback()
+        {
+            if (!IsMultiplexing)
+                return;
+
+            var conn = await OpenConnectionAsync();
+
+            await using (var tx = conn.BeginTransaction())
+            {
+                Assert.That(conn.Connector, Is.Not.Null);
+                Assert.That(async () => await conn.ExecuteScalarAsync("SELECT * FROM \"unknown_table\"", tx: tx),
+                    Throws.Exception.TypeOf<PostgresException>());
+                Assert.That(conn.Connector, Is.Not.Null);
+            }
+
+            Assert.That(conn.Connector, Is.Null);
+        }
+
         class NoTransactionDatabaseInfoFactory : INpgsqlDatabaseInfoFactory
         {
             public async Task<NpgsqlDatabaseInfo?> Load(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async)

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -467,6 +467,38 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/3248")]
+        // More at #3254
+        public async Task Bug3248()
+        {
+            if (!IsMultiplexing)
+                return;
+
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                MaxPoolSize = 1,
+            };
+
+            var conn = await OpenConnectionAsync(csb.ToString());
+
+            var tx = conn.BeginTransaction();
+            var connector = conn.Connector!;
+            Assert.That(connector, Is.Not.Null);
+            await conn.ExecuteScalarAsync("SELECT 1", tx: tx);
+            await tx.CommitAsync();
+
+            conn = await OpenConnectionAsync(csb.ToString());
+            await using var _ = conn;
+            await using var otherTx = conn.BeginTransaction();
+
+            Assert.That(connector, Is.EqualTo(conn.Connector));
+            Assert.That(connector.TransactionStatus, Is.EqualTo(TransactionStatus.Pending));
+
+            await tx.DisposeAsync();
+            Assert.That(connector.TransactionStatus, Is.EqualTo(TransactionStatus.Pending));
+        }
+
         class NoTransactionDatabaseInfoFactory : INpgsqlDatabaseInfoFactory
         {
             public async Task<NpgsqlDatabaseInfo?> Load(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async)


### PR DESCRIPTION
I went with a simple way of creating a new transaction.