### PR TITLE
Ability to set connection string parameters keepalive time and interval

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -923,7 +923,7 @@ namespace Npgsql
         /// <summary>
         /// The number of seconds of connection inactivity before a TCP keepalive query is sent.
         /// Use of this option is discouraged, use <see cref="KeepAlive"/> instead if possible.
-        /// Set to 0 (the default) to disable. Supported only on Windows.
+        /// Set to 0 (the default) to disable.
         /// </summary>
         [Category("Advanced")]
         [Description("The number of milliseconds of connection inactivity before a TCP keepalive query is sent.")]
@@ -946,7 +946,6 @@ namespace Npgsql
         /// <summary>
         /// The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.
         /// Defaults to the value of <see cref="TcpKeepAliveTime"/>. <see cref="TcpKeepAliveTime"/> must be non-zero as well.
-        /// Supported only on Windows.
         /// </summary>
         [Category("Advanced")]
         [Description("The interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received.")]

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1304,6 +1304,23 @@ namespace Npgsql.Tests
                 Thread.Sleep(Timeout.Infinite);
         }
 
+        [Test, Description("Asserting TCP keepalive time and interval setting does not throw exceptions")]
+        public void TcpKeepaliveSupport()
+        {
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                TcpKeepAliveTime = 2000,
+                TcpKeepAliveInterval = 3000,
+            };
+
+            using (var conn = OpenConnection(csb))
+            using (var cmd = new NpgsqlCommand("SELECT 1", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+            }
+        }
+
         [Test]
         public void ChangeParameter()
         {


### PR DESCRIPTION
Hello.
SIO_KEEPALIVE_VALS handling is supported in mono since version 2.11.0: https://github.com/mono/mono/commit/891af303aa9a335d0c2e8439c363d0817bdce774, but it's doesn't apply in npgsql.
It would be very nice if these changes made it into 4.1.x.
If you are not already accepting such pull requests in 4.1.x then sorry for wasting your time.

Changes for netcore3.1 and above backported from: https://github.com/npgsql/npgsql/pull/3037/files#diff-6544882ef81854ab9fa862f633446ae09e60a35a4442bba92bd03deade9ae600

Example (with console app net461):
OS:
```
Fedora release 32 (Thirty Two)
```

Mono version:
```
Mono JIT compiler version 6.12.0.90 (tarball Fri Sep  4 13:50:02 UTC 2020)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       altstack
        Notifications: epoll
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug 
        Interpreter:   yes
        LLVM:          yes(610)
        Suspend:       hybrid
        GC:            sgen (concurrent by default)
```

Code (net461):
```
using System.Threading;
using Npgsql;

namespace npsql_tcpkeepalive_test
{
    class Program
    {
        static void Main(string[] args)
        {
            var connectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
            var csb = new NpgsqlConnectionStringBuilder(connectionString)
            {
                TcpKeepAliveTime = 4000,
                TcpKeepAliveInterval = 7000,
            };
            using (var conn = new NpgsqlConnection(csb.ToString()))
            {
                conn.Open();
                using (var cmd = new NpgsqlCommand("SELECT 1", conn))
                using (var reader = cmd.ExecuteReader())
                {
                    reader.Read();
                    Thread.Sleep(60000);
                }
            }
        }
    }
}
```

Result:
![2020-10-27_14-13](https://user-images.githubusercontent.com/20280287/97299062-6af2e980-1865-11eb-83cc-7c170edeb926.png)
