### PR TITLE
Ability to set connection string parameters keepalive time and interval

### DIFF
--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1308,23 +1308,6 @@ CREATE TABLE record ()");
                 Thread.Sleep(Timeout.Infinite);
         }
 
-        [Test, Description("Asserting TCP keepalive time and interval setting does not throw exceptions")]
-        public async Task TcpKeepaliveSupport()
-        {
-            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                TcpKeepAliveTime = 2000,
-                TcpKeepAliveInterval = 3000,
-            };
-
-            using (var conn = OpenConnection(csb))
-            using (var cmd = new NpgsqlCommand("SELECT 1", conn))
-            using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                reader.Read();
-            }
-        }
-
         [Test]
         public async Task ChangeParameter()
         {

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1308,6 +1308,23 @@ CREATE TABLE record ()");
                 Thread.Sleep(Timeout.Infinite);
         }
 
+        [Test, Description("Asserting TCP keepalive time and interval setting does not throw exceptions")]
+        public async Task TcpKeepaliveSupport()
+        {
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                TcpKeepAliveTime = 2000,
+                TcpKeepAliveInterval = 3000,
+            };
+
+            using (var conn = OpenConnection(csb))
+            using (var cmd = new NpgsqlCommand("SELECT 1", conn))
+            using (var reader = await cmd.ExecuteReaderAsync())
+            {
+                reader.Read();
+            }
+        }
+
         [Test]
         public async Task ChangeParameter()
         {


### PR DESCRIPTION
Recently closed PR: https://github.com/npgsql/npgsql/pull/3278

SIO_KEEPALIVE_VALS handling is supported in mono since version 2.11.0: https://github.com/mono/mono/commit/891af303aa9a335d0c2e8439c363d0817bdce774, but it's doesn't apply in npgsql.
