### PR TITLE
Fixed running multiple type loading queries in parallel

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1787,7 +1787,8 @@ namespace Npgsql
             connector.LoadDatabaseInfo(
                     forceReload: true,
                     NpgsqlTimeout.Infinite,
-                    async: false).GetAwaiter().GetResult();
+                    async: false,
+                    CancellationToken.None).GetAwaiter().GetResult();
             // Increment the change counter on the global type mapper. This will make conn.Open() pick up the
             // new DatabaseInfo and set up a new connection type mapper
             TypeMapping.GlobalTypeMapper.Instance.RecordChange();

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -148,6 +148,11 @@ namespace Npgsql
         volatile Exception? _breakReason;
 
         /// <summary>
+        /// Semaphore, used to synchronize DatabaseInfo between multiple connections, so it wouldn't be loaded in parallel.
+        /// </summary>
+        static readonly SemaphoreSlim DatabaseInfoSemaphore = new SemaphoreSlim(1);
+
+        /// <summary>
         /// <para>
         /// Used by the pool to indicate that I/O is currently in progress on this connector, so that another write
         /// isn't started concurrently. Note that since we have only one write loop, this is only ever usedto
@@ -450,7 +455,7 @@ namespace Npgsql
 
                 State = ConnectorState.Ready;
 
-                await LoadDatabaseInfo(forceReload: false, timeout, async);
+                await LoadDatabaseInfo(forceReload: false, timeout, async, cancellationToken);
 
                 if (Settings.Pooling && !Settings.Multiplexing && !Settings.NoResetOnClose && DatabaseInfo.SupportsDiscard)
                 {
@@ -482,7 +487,8 @@ namespace Npgsql
             }
         }
 
-        internal async Task LoadDatabaseInfo(bool forceReload, NpgsqlTimeout timeout, bool async)
+        internal async Task LoadDatabaseInfo(bool forceReload, NpgsqlTimeout timeout, bool async,
+            CancellationToken cancellationToken = default)
         {
             // Super hacky stuff...
 
@@ -494,8 +500,36 @@ namespace Npgsql
             // being set up (even if its empty)
             TypeMapper = new ConnectorTypeMapper(this);
 
-            if (forceReload || !NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out var database))
-                NpgsqlDatabaseInfo.Cache[ConnectionString] = database = await NpgsqlDatabaseInfo.Load(Connection, timeout, async);
+            NpgsqlDatabaseInfo database = null!;
+
+            if (forceReload)
+            {
+                NpgsqlDatabaseInfo.Cache[ConnectionString] = database = await NpgsqlDatabaseInfo.Load(Connection,
+                    timeout, async);
+            }
+            else if (!NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out database))
+            {
+                var hasSemaphore = async
+                    ? await DatabaseInfoSemaphore.WaitAsync(timeout.TimeLeft, cancellationToken)
+                    : DatabaseInfoSemaphore.Wait(timeout.TimeLeft, cancellationToken);
+
+                // We've timed out - calling Check, to throw the correct exception
+                if (!hasSemaphore)
+                    timeout.Check();
+
+                try
+                {
+                    if (!NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out database))
+                    {
+                        NpgsqlDatabaseInfo.Cache[ConnectionString] = database = await NpgsqlDatabaseInfo.Load(Connection,
+                            timeout, async);
+                    }
+                }
+                finally
+                {
+                    DatabaseInfoSemaphore.Release();
+                }
+            }
 
             DatabaseInfo = database;
             TypeMapper.Bind(DatabaseInfo);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -500,14 +500,7 @@ namespace Npgsql
             // being set up (even if its empty)
             TypeMapper = new ConnectorTypeMapper(this);
 
-            NpgsqlDatabaseInfo? database;
-
-            if (forceReload)
-            {
-                NpgsqlDatabaseInfo.Cache[ConnectionString] = database = await NpgsqlDatabaseInfo.Load(Connection,
-                    timeout, async);
-            }
-            else if (!NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out database))
+            if (forceReload || !NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out var database))
             {
                 var hasSemaphore = async
                     ? await DatabaseInfoSemaphore.WaitAsync(timeout.TimeLeft, cancellationToken)
@@ -519,7 +512,7 @@ namespace Npgsql
 
                 try
                 {
-                    if (!NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out database))
+                    if (forceReload || !NpgsqlDatabaseInfo.Cache.TryGetValue(ConnectionString, out database))
                     {
                         NpgsqlDatabaseInfo.Cache[ConnectionString] = database = await NpgsqlDatabaseInfo.Load(Connection,
                             timeout, async);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -500,7 +500,7 @@ namespace Npgsql
             // being set up (even if its empty)
             TypeMapper = new ConnectorTypeMapper(this);
 
-            NpgsqlDatabaseInfo database = null!;
+            NpgsqlDatabaseInfo? database;
 
             if (forceReload)
             {
@@ -531,7 +531,7 @@ namespace Npgsql
                 }
             }
 
-            DatabaseInfo = database;
+            DatabaseInfo = database!;
             TypeMapper.Bind(DatabaseInfo);
         }
 


### PR DESCRIPTION
Fixes #3095

There is one corner case - that is, opening multiple connections at the same time on different connection strings. While this can be fixed, not sure if it really should be.

Also, `NpgsqlDatabaseInfo.Load` doesn't support `CancellationToken` - maybe something we should take a look at some point?