### PR TITLE
Fixed multiple reader closing with ExecuteNonQuery

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1041,6 +1041,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             using var reader = await ExecuteReader(CommandBehavior.Default, async, cancellationToken);
             while (async ? await reader.NextResultAsync(cancellationToken) : reader.NextResult()) ;
 
+            reader.Close();
+
             return reader.RecordsAffected;
         }
 

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1041,8 +1041,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             using var reader = await ExecuteReader(CommandBehavior.Default, async, cancellationToken);
             while (async ? await reader.NextResultAsync(cancellationToken) : reader.NextResult()) ;
 
-            reader.Close();
-
             return reader.RecordsAffected;
         }
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1208,7 +1208,7 @@ namespace Npgsql
                     if (CurrentReader != null)
                     {
                         // The reader cleanup will call EndUserAction
-                        await CurrentReader.Cleanup(async);
+                        await CurrentReader.Cleanup(async, canCloseConnection: true);
                     }
                     else
                     {
@@ -1574,7 +1574,7 @@ namespace Npgsql
             var copyOperation = CurrentCopyOperation;
 
             if (reader != null)
-                await reader.Close(connectionClosing: true, async, withCleanup: true);
+                await reader.Close(connectionClosing: true, async, canCloseConnection: true);
             else if (copyOperation != null)
             {
                 // TODO: There's probably a race condition as the COPY operation may finish on its own during the next few lines

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1574,7 +1574,7 @@ namespace Npgsql
             var copyOperation = CurrentCopyOperation;
 
             if (reader != null)
-                await reader.Close(connectionClosing: true, async);
+                await reader.Close(connectionClosing: true, async, withCleanup: true);
             else if (copyOperation != null)
             {
                 // TODO: There's probably a race condition as the COPY operation may finish on its own during the next few lines

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -833,7 +833,7 @@ namespace Npgsql
         /// <summary>
         /// Releases the resources used by the <see cref="NpgsqlDataReader">NpgsqlDataReader</see>.
         /// </summary>
-        protected override void Dispose(bool disposing) => Close();
+        protected override void Dispose(bool disposing) => Close(connectionClosing: false, async: false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Releases the resources used by the <see cref="NpgsqlDataReader">NpgsqlDataReader</see>.

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -851,7 +851,7 @@ namespace Npgsql
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.
         /// </summary>
-        public override void Close() => Close(connectionClosing: false, async: false).GetAwaiter().GetResult();
+        public override void Close() { } // NO-OP per #3289
 
         /// <summary>
         /// Closes the <see cref="NpgsqlDataReader"/> reader, allowing a new command to be executed.
@@ -861,7 +861,7 @@ namespace Npgsql
 #else
         public override Task CloseAsync()
 #endif
-            => Close(connectionClosing: false, async: true);
+            => Task.CompletedTask; // NO-OP per #3289
 
         internal async Task Close(bool connectionClosing, bool async)
         {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -861,7 +861,10 @@ namespace Npgsql
 #else
         public override Task CloseAsync()
 #endif
-            => Close(connectionClosing: false, async: true, canCloseConnection: false);
+        {
+            using (NoSynchronizationContextScope.Enter())
+                return Close(connectionClosing: false, async: true, canCloseConnection: false);
+        }
 
         internal async Task Close(bool connectionClosing, bool async, bool canCloseConnection)
         {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -132,7 +132,10 @@ namespace Npgsql.Tests
                 await using var _ = await CreateTempTable(conn, "int INT", out var table);
 
                 var sb = new StringBuilder();
-                for (var i = 0; i < 15; i++)
+                for (var i = 0; i < 10; i++)
+                    sb.Append($"INSERT INTO {table} (int) VALUES ({i});");
+                sb.Append("SELECT 1;");
+                for (var i = 10; i < 15; i++)
                     sb.Append($"INSERT INTO {table} (int) VALUES ({i});");
                 var cmd = new NpgsqlCommand(sb.ToString(), conn);
                 var reader = await cmd.ExecuteReaderAsync(Behavior);


### PR DESCRIPTION
Closes #3289