### PR TITLE
Remove all occurrences of [PublicAPI]

### DIFF
--- a/src/Npgsql.LegacyPostgis/CodeAnnotations.cs
+++ b/src/Npgsql.LegacyPostgis/CodeAnnotations.cs
@@ -156,24 +156,6 @@ namespace JetBrains.Annotations
     }
 
     /// <summary>
-    /// This attribute is intended to mark publicly available API
-    /// which should not be removed and so is treated as used.
-    /// </summary>
-    [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
-#pragma warning disable CA1018
-    sealed class PublicAPIAttribute : Attribute
-#pragma warning restore CA1018
-    {
-        public PublicAPIAttribute() : this("") { }
-        public PublicAPIAttribute([NotNull] string comment)
-        {
-            Comment = comment;
-        }
-
-        public string Comment { get; private set; }
-    }
-
-    /// <summary>
     /// Describes dependency between method input and output.
     /// </summary>
     /// <syntax>

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -462,7 +462,6 @@ namespace Npgsql
         /// <summary>
         /// Completes the import process and signals to the database to write everything.
         /// </summary>
-        [PublicAPI]
         public void Close() => CloseAsync(false).GetAwaiter().GetResult();
 
         /// <summary>
@@ -470,7 +469,6 @@ namespace Npgsql
         /// </summary>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        [PublicAPI]
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -384,14 +384,12 @@ namespace Npgsql
         /// Backend server host name.
         /// </summary>
         [Browsable(true)]
-        [PublicAPI]
         public string? Host => Settings.Host;
 
         /// <summary>
         /// Backend server port.
         /// </summary>
         [Browsable(true)]
-        [PublicAPI]
         public int Port => Settings.Port;
 
         /// <summary>
@@ -427,13 +425,11 @@ namespace Npgsql
         /// <summary>
         /// Whether to use Windows integrated security to log in.
         /// </summary>
-        [PublicAPI]
         public bool IntegratedSecurity => Settings.IntegratedSecurity;
 
         /// <summary>
         /// User name.
         /// </summary>
-        [PublicAPI]
         public string? UserName => Settings.Username;
 
         internal string? Password => Settings.Password;
@@ -967,14 +963,12 @@ namespace Npgsql
         /// Meant for use by type plugins (e.g. NodaTime)
         /// </summary>
         [Browsable(false)]
-        [PublicAPI]
         public bool HasIntegerDateTimes => CheckOpenAndRunInTemporaryScope(c => c.DatabaseInfo.HasIntegerDateTimes);
 
         /// <summary>
         /// The connection's timezone as reported by PostgreSQL, in the IANA/Olson database format.
         /// </summary>
         [Browsable(false)]
-        [PublicAPI]
         public string Timezone => CheckOpenAndRunInTemporaryScope(c => c.Timezone);
 
         /// <summary>
@@ -982,7 +976,6 @@ namespace Npgsql
         /// (e.g. as a result of a SET command).
         /// </summary>
         [Browsable(false)]
-        [PublicAPI]
         public IReadOnlyDictionary<string, string> PostgresParameters
             => CheckOpenAndRunInTemporaryScope(c => c.PostgresParameters);
 
@@ -1203,7 +1196,6 @@ namespace Npgsql
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.TypeMapper.MapEnum() instead")]
         public void MapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             where TEnum : struct, Enum
@@ -1231,7 +1223,6 @@ namespace Npgsql
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.MapEnum() instead")]
         public static void MapEnumGlobally<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             where TEnum : struct, Enum
@@ -1248,7 +1239,6 @@ namespace Npgsql
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.UnmapEnum() instead")]
         public static void UnmapEnumGlobally<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             where TEnum : struct, Enum
@@ -1282,7 +1272,6 @@ namespace Npgsql
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="T">The .NET type to be mapped</typeparam>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.TypeMapper.MapComposite() instead")]
         public void MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => TypeMapper.MapComposite<T>(pgName, nameTranslator);
@@ -1309,7 +1298,6 @@ namespace Npgsql
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="T">The .NET type to be mapped</typeparam>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.MapComposite() instead")]
         public static void MapCompositeGlobally<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => GlobalTypeMapper.MapComposite<T>(pgName, nameTranslator);
@@ -1325,7 +1313,6 @@ namespace Npgsql
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
-        [PublicAPI]
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.UnmapComposite() instead")]
         public static void UnmapCompositeGlobally<T>(string pgName, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => GlobalTypeMapper.UnmapComposite<T>(pgName, nameTranslator);
@@ -1367,7 +1354,6 @@ namespace Npgsql
         /// The time-out value is passed to <see cref="Socket.ReceiveTimeout"/>.
         /// </param>
         /// <returns>true if an asynchronous message was received, false if timed out.</returns>
-        [PublicAPI]
         public bool Wait(TimeSpan timeout) => Wait((int)timeout.TotalMilliseconds);
 
         /// <summary>
@@ -1375,7 +1361,6 @@ namespace Npgsql
         /// exits immediately. The asynchronous message is delivered via the normal events
         /// (<see cref="Notification"/>, <see cref="Notice"/>).
         /// </summary>
-        [PublicAPI]
         public void Wait() => Wait(0);
 
         /// <summary>
@@ -1390,7 +1375,6 @@ namespace Npgsql
         /// </param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>true if an asynchronous message was received, false if timed out.</returns>
-        [PublicAPI]
         public Task<bool> WaitAsync(int timeout, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -1415,7 +1399,6 @@ namespace Npgsql
         /// </param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>true if an asynchronous message was received, false if timed out.</returns>
-        [PublicAPI]
         public Task<bool> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken = default) => WaitAsync((int)timeout.TotalMilliseconds, cancellationToken);
 
         /// <summary>
@@ -1424,7 +1407,6 @@ namespace Npgsql
         /// (<see cref="Notification"/>, <see cref="Notice"/>).
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
-        [PublicAPI]
         public Task WaitAsync(CancellationToken cancellationToken = default) => WaitAsync(0, cancellationToken);
 
         #endregion
@@ -1703,7 +1685,6 @@ namespace Npgsql
         /// (password, SSL callbacks) while changing other connection parameters (e.g.
         /// database or pooling)
         /// </summary>
-        [PublicAPI]
         public NpgsqlConnection CloneWith(string connectionString)
         {
             CheckDisposed();
@@ -1764,7 +1745,6 @@ namespace Npgsql
         /// <summary>
         /// Unprepares all prepared statements on this connection.
         /// </summary>
-        [PublicAPI]
         public void UnprepareAll()
         {
             if (Settings.Multiplexing)

--- a/src/Npgsql/NpgsqlDataAdapter.cs
+++ b/src/Npgsql/NpgsqlDataAdapter.cs
@@ -30,7 +30,6 @@ namespace Npgsql
         /// <summary>
         /// Row updated event.
         /// </summary>
-        [PublicAPI]
         public event NpgsqlRowUpdatedEventHandler? RowUpdated;
 
         /// <summary>
@@ -143,7 +142,7 @@ namespace Npgsql
 
         // Temporary implementation, waiting for official support in System.Data via https://github.com/dotnet/runtime/issues/22109
         internal async Task<int> Fill(DataTable dataTable, bool async, CancellationToken cancellationToken = default)
-        { 
+        {
             var command = SelectCommand;
             var activeConnection = command?.Connection ?? throw new InvalidOperationException("Connection required");
             var originalState = ConnectionState.Closed;

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -792,7 +792,6 @@ namespace Npgsql
         /// return true even if attempting to read a column will fail, e.g. before <see cref="Read()"/>
         /// has been called
         /// </summary>
-        [PublicAPI]
         public bool IsOnRow => State == ReaderState.InResult;
 
         /// <summary>
@@ -1708,7 +1707,6 @@ namespace Npgsql
         /// The returned representation can be used to access various information about the field.
         /// </summary>
         /// <param name="ordinal">The zero-based column index.</param>
-        [PublicAPI]
         public PostgresType GetPostgresType(int ordinal) => CheckRowDescriptionAndGetField(ordinal).PostgresType;
 
         /// <summary>

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -360,7 +360,6 @@ namespace Npgsql
         /// <summary>
         /// Used to specify which PostgreSQL type will be sent to the database for this parameter.
         /// </summary>
-        [PublicAPI]
         public string? DataTypeName
         {
             get

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -44,7 +44,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="parameterName">The name of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to retrieve.</param>
         /// <value>The <see cref="NpgsqlParameter">NpgsqlParameter</see> with the specified name, or a null reference if the parameter is not found.</value>
-        [PublicAPI]
         public new NpgsqlParameter this[string parameterName]
         {
             get
@@ -83,7 +82,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="index">The zero-based index of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to retrieve.</param>
         /// <value>The <see cref="NpgsqlParameter">NpgsqlParameter</see> at the specified index.</value>
-        [PublicAPI]
         public new NpgsqlParameter this[int index]
         {
             get => _internalList[index];
@@ -136,7 +134,6 @@ namespace Npgsql
         /// <param name="parameterName">The name of the <see cref="NpgsqlParameter">NpgsqlParameter</see>.</param>
         /// <param name="value">The Value of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to add to the collection.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(string parameterName, object value)
             => Add(new NpgsqlParameter(parameterName, value));
 
@@ -147,7 +144,6 @@ namespace Npgsql
         /// <param name="parameterType">One of the NpgsqlDbType values.</param>
         /// <param name="value">The Value of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to add to the collection.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(string parameterName, NpgsqlDbType parameterType, object value)
             => Add(new NpgsqlParameter(parameterName, parameterType) { Value = value });
 
@@ -159,7 +155,6 @@ namespace Npgsql
         /// <param name="parameterType">One of the NpgsqlDbType values.</param>
         /// <param name="size">The length of the column.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(string parameterName, NpgsqlDbType parameterType, int size, object value)
             => Add(new NpgsqlParameter(parameterName, parameterType, size) { Value = value });
 
@@ -172,7 +167,6 @@ namespace Npgsql
         /// <param name="size">The length of the column.</param>
         /// <param name="sourceColumn">The name of the source column.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(string parameterName, NpgsqlDbType parameterType, int size, string? sourceColumn, object value)
             => Add(new NpgsqlParameter(parameterName, parameterType, size, sourceColumn) { Value = value });
 
@@ -181,7 +175,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="value">The Value of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to add to the collection.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(object value)
             => Add(new NpgsqlParameter { Value = value });
 
@@ -191,7 +184,6 @@ namespace Npgsql
         /// <param name="parameterType">One of the NpgsqlDbType values.</param>
         /// <param name="value">The Value of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to add to the collection.</param>
         /// <returns>The parameter that was added.</returns>
-        [PublicAPI]
         public NpgsqlParameter AddWithValue(NpgsqlDbType parameterType, object value)
             => Add(new NpgsqlParameter { NpgsqlDbType = parameterType, Value = value });
 
@@ -201,7 +193,6 @@ namespace Npgsql
         /// <param name="parameterName">The name of the parameter.</param>
         /// <param name="parameterType">One of the DbType values.</param>
         /// <returns>The index of the new <see cref="NpgsqlParameter">NpgsqlParameter</see> object.</returns>
-        [PublicAPI]
         public NpgsqlParameter Add(string parameterName, NpgsqlDbType parameterType)
             => Add(new NpgsqlParameter(parameterName, parameterType));
 
@@ -212,7 +203,6 @@ namespace Npgsql
         /// <param name="parameterType">One of the DbType values.</param>
         /// <param name="size">The length of the column.</param>
         /// <returns>The index of the new <see cref="NpgsqlParameter">NpgsqlParameter</see> object.</returns>
-        [PublicAPI]
         public NpgsqlParameter Add(string parameterName, NpgsqlDbType parameterType, int size)
             => Add(new NpgsqlParameter(parameterName, parameterType, size));
 
@@ -224,7 +214,6 @@ namespace Npgsql
         /// <param name="size">The length of the column.</param>
         /// <param name="sourceColumn">The name of the source column.</param>
         /// <returns>The index of the new <see cref="NpgsqlParameter">NpgsqlParameter</see> object.</returns>
-        [PublicAPI]
         public NpgsqlParameter Add(string parameterName, NpgsqlDbType parameterType, int size, string sourceColumn)
             => Add(new NpgsqlParameter(parameterName, parameterType, size, sourceColumn));
 
@@ -233,7 +222,6 @@ namespace Npgsql
         #region IDataParameterCollection Member
 
         /// <inheritdoc />
-        [PublicAPI]
         // ReSharper disable once ImplicitNotNullOverridesUnknownExternalMember
         public override void RemoveAt(string parameterName)
             => RemoveAt(IndexOf(parameterName ?? throw new ArgumentNullException(nameof(parameterName))));
@@ -332,7 +320,6 @@ namespace Npgsql
         /// Removes the specified <see cref="NpgsqlParameter">NpgsqlParameter</see> from the collection.
         /// </summary>
         /// <param name="parameterName">The name of the <see cref="NpgsqlParameter">NpgsqlParameter</see> to remove from the collection.</param>
-        [PublicAPI]
         public void Remove(string parameterName)
         {
             if (parameterName is null)
@@ -472,7 +459,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="item">Parameter to find.</param>
         /// <returns>Index of the parameter, or -1 if the parameter is not present.</returns>
-        [PublicAPI]
         public int IndexOf(NpgsqlParameter item)
             => _internalList.IndexOf(item);
 
@@ -481,7 +467,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="index">Index of the existing parameter before which to insert the new one.</param>
         /// <param name="item">Parameter to insert.</param>
-        [PublicAPI]
         public void Insert(int index, NpgsqlParameter item)
         {
             if (item is null)
@@ -499,7 +484,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="item">Parameter to find.</param>
         /// <returns>True if the parameter was found, otherwise false.</returns>
-        [PublicAPI]
         public bool Contains(NpgsqlParameter item) => _internalList.Contains(item);
 
         /// <summary>
@@ -507,7 +491,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="item">Parameter to remove.</param>
         /// <returns>True if the parameter was found and removed, otherwise false.</returns>
-        [PublicAPI]
         public bool Remove(NpgsqlParameter item)
         {
             if (item == null)
@@ -530,7 +513,6 @@ namespace Npgsql
         /// </summary>
         /// <param name="array">Destination array.</param>
         /// <param name="arrayIndex">Starting index in destination array.</param>
-        [PublicAPI]
         public void CopyTo(NpgsqlParameter[] array, int arrayIndex)
             => _internalList.CopyTo(array, arrayIndex);
 
@@ -538,7 +520,6 @@ namespace Npgsql
         /// Convert collection to a System.Array.
         /// </summary>
         /// <returns>NpgsqlParameter[]</returns>
-        [PublicAPI]
         public NpgsqlParameter[] ToArray() => _internalList.ToArray();
 
         internal void CloneTo(NpgsqlParameterCollection other)

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDate.cs
@@ -34,13 +34,9 @@ namespace NpgsqlTypes
         /// </summary>
         public static readonly NpgsqlDate Era = new NpgsqlDate(0);
 
-        [PublicAPI]
         public const int MaxYear = 5874897;
-        [PublicAPI]
         public const int MinYear = -4714;
-        [PublicAPI]
         public static readonly NpgsqlDate MaxCalculableValue = new NpgsqlDate(MaxYear, 12, 31);
-        [PublicAPI]
         public static readonly NpgsqlDate MinCalculableValue = new NpgsqlDate(MinYear, 11, 24);
 
         public static readonly NpgsqlDate Infinity = new NpgsqlDate(InternalType.Infinity);
@@ -140,7 +136,6 @@ namespace NpgsqlTypes
             }
         }
 
-        [PublicAPI]
         public static bool TryParse(string str, out NpgsqlDate date)
         {
             try {
@@ -156,14 +151,14 @@ namespace NpgsqlTypes
 
         #region Public Properties
 
-        [PublicAPI] public static NpgsqlDate Now => new NpgsqlDate(DateTime.Now);
-        [PublicAPI] public static NpgsqlDate Today => Now;
-        [PublicAPI] public static NpgsqlDate Yesterday => Now.AddDays(-1);
-        [PublicAPI] public static NpgsqlDate Tomorrow => Now.AddDays(1);
+        public static NpgsqlDate Now => new NpgsqlDate(DateTime.Now);
+        public static NpgsqlDate Today => Now;
+        public static NpgsqlDate Yesterday => Now.AddDays(-1);
+        public static NpgsqlDate Tomorrow => Now.AddDays(1);
 
-        [PublicAPI] public int DayOfYear => _daysSinceEra - DaysForYears(Year) + 1;
+        public int DayOfYear => _daysSinceEra - DaysForYears(Year) + 1;
 
-        [PublicAPI] public int Year
+        public int Year
         {
             get
             {
@@ -174,7 +169,7 @@ namespace NpgsqlTypes
             }
         }
 
-        [PublicAPI] public int Month
+        public int Month
         {
             get
             {
@@ -189,18 +184,18 @@ namespace NpgsqlTypes
             }
         }
 
-        [PublicAPI] public int Day => DayOfYear - (IsLeapYear ? LeapYearDays : CommonYearDays)[Month - 1];
+        public int Day => DayOfYear - (IsLeapYear ? LeapYearDays : CommonYearDays)[Month - 1];
 
-        [PublicAPI] public DayOfWeek DayOfWeek => (DayOfWeek) ((_daysSinceEra + 1)%7);
+        public DayOfWeek DayOfWeek => (DayOfWeek) ((_daysSinceEra + 1)%7);
 
         internal int DaysSinceEra => _daysSinceEra;
 
-        [PublicAPI] public bool IsLeapYear => IsLeap(Year);
+        public bool IsLeapYear => IsLeap(Year);
 
-        [PublicAPI] public bool IsInfinity => _type == InternalType.Infinity;
-        [PublicAPI] public bool IsNegativeInfinity => _type == InternalType.NegativeInfinity;
+        public bool IsInfinity => _type == InternalType.Infinity;
+        public bool IsNegativeInfinity => _type == InternalType.NegativeInfinity;
 
-        [PublicAPI] public bool IsFinite
+        public bool IsFinite
             => _type switch {
                 InternalType.Finite           => true,
                 InternalType.Infinity         => false,
@@ -240,7 +235,6 @@ namespace NpgsqlTypes
 
         #region Arithmetic
 
-        [PublicAPI]
         public NpgsqlDate AddDays(int days)
             => _type switch
         {
@@ -250,7 +244,6 @@ namespace NpgsqlTypes
             _ => throw new InvalidOperationException($"Internal Npgsql bug: unexpected value {_type} of enum {nameof(NpgsqlDate)}.{nameof(InternalType)}. Please file a bug.")
         };
 
-        [PublicAPI]
         public NpgsqlDate AddYears(int years)
         {
             switch (_type) {
@@ -276,7 +269,6 @@ namespace NpgsqlTypes
             return new NpgsqlDate(newYear, Month, Day);
         }
 
-        [PublicAPI]
         public NpgsqlDate AddMonths(int months)
         {
             switch (_type) {
@@ -309,7 +301,6 @@ namespace NpgsqlTypes
 
         }
 
-        [PublicAPI]
         public NpgsqlDate Add(in NpgsqlTimeSpan interval)
         {
             switch (_type) {
@@ -326,7 +317,6 @@ namespace NpgsqlTypes
             return AddMonths(interval.Months).AddDays(interval.Days);
         }
 
-        [PublicAPI]
         internal NpgsqlDate Add(in NpgsqlTimeSpan interval, int carriedOverflow)
         {
             switch (_type) {

--- a/src/Npgsql/PostgresException.cs
+++ b/src/Npgsql/PostgresException.cs
@@ -230,14 +230,12 @@ namespace Npgsql
         /// Severity of the error or notice.
         /// Always present.
         /// </summary>
-        [PublicAPI]
         public string Severity { get; }
 
         /// <summary>
         /// Severity of the error or notice, not localized.
         /// Always present since PostgreSQL 9.6.
         /// </summary>
-        [PublicAPI]
         public string InvariantSeverity { get; }
 
         /// <summary>
@@ -248,7 +246,6 @@ namespace Npgsql
         /// Constants are defined in <seealso cref="PostgresErrorCodes"/>.
         /// See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         /// </remarks>
-        [PublicAPI]
 #if NET
         public override string SqlState { get; }
 #else
@@ -263,7 +260,7 @@ namespace Npgsql
         /// Constants are defined in <seealso cref="PostgresErrorCodes"/>.
         /// See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         /// </remarks>
-        [PublicAPI, Obsolete("Use SqlState instead")]
+        [Obsolete("Use SqlState instead")]
         public string Code => SqlState;
 
         /// <summary>
@@ -272,14 +269,12 @@ namespace Npgsql
         /// <remarks>
         /// Always present.
         /// </remarks>
-        [PublicAPI]
         public string MessageText { get; }
 
         /// <summary>
         /// An optional secondary error message carrying more detail about the problem.
         /// May run to multiple lines.
         /// </summary>
-        [PublicAPI]
         public string? Detail { get; }
 
         /// <summary>
@@ -287,7 +282,6 @@ namespace Npgsql
         /// This is intended to differ from Detail in that it offers advice (potentially inappropriate) rather than hard facts.
         /// May run to multiple lines.
         /// </summary>
-        [PublicAPI]
         public string? Hint { get; }
 
         /// <summary>
@@ -295,7 +289,6 @@ namespace Npgsql
         /// The first character has index 1, and positions are measured in characters not bytes.
         /// 0 means not provided.
         /// </summary>
-        [PublicAPI]
         public int Position { get; }
 
         /// <summary>
@@ -303,14 +296,12 @@ namespace Npgsql
         /// The <see cref="InternalQuery" /> field will always appear when this field appears.
         /// 0 means not provided.
         /// </summary>
-        [PublicAPI]
         public int InternalPosition { get; }
 
         /// <summary>
         /// The text of a failed internally-generated command.
         /// This could be, for example, a SQL query issued by a PL/pgSQL function.
         /// </summary>
-        [PublicAPI]
         public string? InternalQuery { get; }
 
         /// <summary>
@@ -318,14 +309,12 @@ namespace Npgsql
         /// Presently this includes a call stack traceback of active PL functions.
         /// The trace is one entry per line, most recent first.
         /// </summary>
-        [PublicAPI]
         public string? Where { get; }
 
         /// <summary>
         /// If the error was associated with a specific database object, the name of the schema containing that object, if any.
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? SchemaName { get; }
 
         /// <summary>
@@ -333,7 +322,6 @@ namespace Npgsql
         /// (Refer to the schema name field for the name of the table's schema.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? TableName { get; }
 
         /// <summary>
@@ -341,7 +329,6 @@ namespace Npgsql
         /// (Refer to the schema and table name fields to identify the table.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? ColumnName { get; }
 
         /// <summary>
@@ -349,7 +336,6 @@ namespace Npgsql
         /// (Refer to the schema name field for the name of the data type's schema.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? DataTypeName { get; }
 
         /// <summary>
@@ -358,26 +344,22 @@ namespace Npgsql
         /// (For this purpose, indexes are treated as constraints, even if they weren't created with constraint syntax.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? ConstraintName { get; }
 
         /// <summary>
         /// The file name of the source-code location where the error was reported.
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? File { get; }
 
         /// <summary>
         /// The line number of the source-code location where the error was reported.
         /// </summary>
-        [PublicAPI]
         public string? Line { get; }
 
         /// <summary>
         /// The name of the source-code routine reporting the error.
         /// </summary>
-        [PublicAPI]
         public string? Routine { get; }
 
         #endregion

--- a/src/Npgsql/PostgresNotice.cs
+++ b/src/Npgsql/PostgresNotice.cs
@@ -20,14 +20,12 @@ namespace Npgsql
         /// Severity of the error or notice.
         /// Always present.
         /// </summary>
-        [PublicAPI]
         public string Severity { get; set; }
 
         /// <summary>
         /// Severity of the error or notice, not localized.
         /// Always present since PostgreSQL 9.6.
         /// </summary>
-        [PublicAPI]
         public string InvariantSeverity { get; }
 
         /// <summary>
@@ -37,7 +35,6 @@ namespace Npgsql
         /// Always present.
         /// See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         /// </remarks>
-        [PublicAPI]
         public string SqlState { get; set; }
 
         /// <summary>
@@ -47,7 +44,7 @@ namespace Npgsql
         /// Always present.
         /// See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
         /// </remarks>
-        [PublicAPI, Obsolete("Use SqlState instead")]
+        [Obsolete("Use SqlState instead")]
         public string Code => SqlState;
 
         /// <summary>
@@ -56,14 +53,12 @@ namespace Npgsql
         /// <remarks>
         /// Always present.
         /// </remarks>
-        [PublicAPI]
         public string MessageText { get; set; }
 
         /// <summary>
         /// An optional secondary error message carrying more detail about the problem.
         /// May run to multiple lines.
         /// </summary>
-        [PublicAPI]
         public string? Detail { get; set; }
 
         /// <summary>
@@ -71,7 +66,6 @@ namespace Npgsql
         /// This is intended to differ from Detail in that it offers advice (potentially inappropriate) rather than hard facts.
         /// May run to multiple lines.
         /// </summary>
-        [PublicAPI]
         public string? Hint { get; set; }
 
         /// <summary>
@@ -79,7 +73,6 @@ namespace Npgsql
         /// The first character has index 1, and positions are measured in characters not bytes.
         /// 0 means not provided.
         /// </summary>
-        [PublicAPI]
         public int Position { get; set; }
 
         /// <summary>
@@ -87,14 +80,12 @@ namespace Npgsql
         /// The <see cref="InternalQuery" /> field will always appear when this field appears.
         /// 0 means not provided.
         /// </summary>
-        [PublicAPI]
         public int InternalPosition { get; set; }
 
         /// <summary>
         /// The text of a failed internally-generated command.
         /// This could be, for example, a SQL query issued by a PL/pgSQL function.
         /// </summary>
-        [PublicAPI]
         public string? InternalQuery { get; set; }
 
         /// <summary>
@@ -102,14 +93,12 @@ namespace Npgsql
         /// Presently this includes a call stack traceback of active PL functions.
         /// The trace is one entry per line, most recent first.
         /// </summary>
-        [PublicAPI]
         public string? Where { get; set; }
 
         /// <summary>
         /// If the error was associated with a specific database object, the name of the schema containing that object, if any.
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? SchemaName { get; set; }
 
         /// <summary>
@@ -117,7 +106,6 @@ namespace Npgsql
         /// (Refer to the schema name field for the name of the table's schema.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? TableName { get; set; }
 
         /// <summary>
@@ -125,7 +113,6 @@ namespace Npgsql
         /// (Refer to the schema and table name fields to identify the table.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? ColumnName { get; set; }
 
         /// <summary>
@@ -133,7 +120,6 @@ namespace Npgsql
         /// (Refer to the schema name field for the name of the data type's schema.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? DataTypeName { get; set; }
 
         /// <summary>
@@ -142,26 +128,22 @@ namespace Npgsql
         /// (For this purpose, indexes are treated as constraints, even if they weren't created with constraint syntax.)
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? ConstraintName { get; set; }
 
         /// <summary>
         /// The file name of the source-code location where the error was reported.
         /// </summary>
         /// <remarks>PostgreSQL 9.3 and up.</remarks>
-        [PublicAPI]
         public string? File { get; set; }
 
         /// <summary>
         /// The line number of the source-code location where the error was reported.
         /// </summary>
-        [PublicAPI]
         public string? Line { get; set; }
 
         /// <summary>
         /// The name of the source-code routine reporting the error.
         /// </summary>
-        [PublicAPI]
         public string? Routine { get; set; }
 
         #endregion

--- a/src/Npgsql/PostgresTypes/PostgresArrayType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresArrayType.cs
@@ -14,7 +14,6 @@ namespace Npgsql.PostgresTypes
         /// <summary>
         /// The PostgreSQL data type of the element contained within this array.
         /// </summary>
-        [PublicAPI]
         public PostgresType Element { get; }
 
         /// <summary>

--- a/src/Npgsql/PostgresTypes/PostgresDomainType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresDomainType.cs
@@ -18,13 +18,11 @@ namespace Npgsql.PostgresTypes
         /// <summary>
         /// The PostgreSQL data type of the base type, i.e. the type this domain is based on.
         /// </summary>
-        [PublicAPI]
         public PostgresType BaseType { get; }
 
         /// <summary>
         /// <b>True</b> if the domain has a NOT NULL constraint, otherwise <b>false</b>.
         /// </summary>
-        [PublicAPI]
         public bool NotNull { get; }
 
         /// <summary>

--- a/src/Npgsql/PostgresTypes/PostgresRangeType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresRangeType.cs
@@ -13,7 +13,6 @@ namespace Npgsql.PostgresTypes
         /// <summary>
         /// The PostgreSQL data type of the subtype of this range.
         /// </summary>
-        [PublicAPI]
         public PostgresType Subtype { get; }
 
         /// <summary>

--- a/src/Npgsql/PostgresTypes/PostgresType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresType.cs
@@ -47,13 +47,11 @@ namespace Npgsql.PostgresTypes
         /// <summary>
         /// The data type's OID - a unique id identifying the data type in a given database (in pg_type).
         /// </summary>
-        [PublicAPI]
         public uint OID { get; }
 
         /// <summary>
         /// The data type's namespace (or schema).
         /// </summary>
-        [PublicAPI]
         public string Namespace { get; }
 
         /// <summary>
@@ -63,41 +61,35 @@ namespace Npgsql.PostgresTypes
         /// Note that this is the standard, user-displayable type name (e.g. integer[]) rather than the internal
         /// PostgreSQL name as it is in pg_type (_int4). See <see cref="InternalName"/> for the latter.
         /// </remarks>
-        [PublicAPI]
         public string Name { get; }
 
         /// <summary>
         /// The full name of the backend type, including its namespace.
         /// </summary>
-        [PublicAPI]
         public string FullName { get; }
 
         /// <summary>
         /// A display name for this backend type, including the namespace unless it is pg_catalog (the namespace
         /// for all built-in types).
         /// </summary>
-        [PublicAPI]
         public string DisplayName => Namespace == "pg_catalog" ? Name : FullName;
 
         /// <summary>
         /// The data type's internal PostgreSQL name (e.g. integer[] not _int4).
         /// See <see cref="Name"/> for a more user-friendly name.
         /// </summary>
-        [PublicAPI]
         public string InternalName { get; }
 
         /// <summary>
         /// If a PostgreSQL array type exists for this type, it will be referenced here.
         /// Otherwise null.
         /// </summary>
-        [PublicAPI]
         public PostgresArrayType? Array { get; internal set; }
 
         /// <summary>
         /// If a PostgreSQL range type exists for this type, it will be referenced here.
         /// Otherwise null.
         /// </summary>
-        [PublicAPI]
         public PostgresRangeType? Range { get; internal set; }
 
         #endregion

--- a/src/Npgsql/Schema/NpgsqlDbColumn.cs
+++ b/src/Npgsql/Schema/NpgsqlDbColumn.cs
@@ -184,38 +184,32 @@ namespace Npgsql.Schema
         /// <summary>
         /// The <see cref="PostgresType" /> describing the type of this column.
         /// </summary>
-        [PublicAPI]
         public PostgresType PostgresType { get; internal set; }
 
         /// <summary>
         /// The OID of the type of this column in the PostgreSQL pg_type catalog table.
         /// </summary>
-        [PublicAPI]
         public uint TypeOID { get; internal set; }
 
         /// <summary>
         /// The OID of the PostgreSQL table of this column.
         /// </summary>
-        [PublicAPI]
         public uint TableOID { get; internal set; }
 
         /// <summary>
         /// The column's position within its table. Note that this is different from <see cref="ColumnOrdinal" />,
         /// which is the column's position within the resultset.
         /// </summary>
-        [PublicAPI]
         public short? ColumnAttributeNumber { get; internal set; }
 
         /// <summary>
         /// The default SQL expression for this column.
         /// </summary>
-        [PublicAPI]
         public string? DefaultValue { get; internal set; }
 
         /// <summary>
         /// The <see cref="NpgsqlDbType" /> value for this column's type.
         /// </summary>
-        [PublicAPI]
         public NpgsqlDbType? NpgsqlDbType { get; internal set; }
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -14,7 +14,6 @@ namespace Npgsql.TypeMapping
     /// </summary>
     /// <remarks>
     /// </remarks>
-    [PublicAPI]
     public interface INpgsqlTypeMapper
     {
         /// <summary>

--- a/src/Npgsql/Util/CodeAnnotations.cs
+++ b/src/Npgsql/Util/CodeAnnotations.cs
@@ -156,24 +156,6 @@ namespace JetBrains.Annotations
     }
 
     /// <summary>
-    /// This attribute is intended to mark publicly available API
-    /// which should not be removed and so is treated as used.
-    /// </summary>
-    [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
-#pragma warning disable CA1018
-    sealed class PublicAPIAttribute : Attribute
-#pragma warning restore CA1018
-    {
-        public PublicAPIAttribute() : this("") { }
-        public PublicAPIAttribute([NotNull] string comment)
-        {
-            Comment = comment;
-        }
-
-        public string Comment { get; private set; }
-    }
-
-    /// <summary>
     /// Describes dependency between method input and output.
     /// </summary>
     /// <syntax>


### PR DESCRIPTION
We don't use them consistently, and in any case all public methods in
Npgsql are part of the public API.
