### PR TITLE
Make Replication work for PostgreSQL 9.4 and above.

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -821,8 +821,9 @@ namespace Npgsql.Replication
             var connector = Connector;
             connector.UserTimeout = readTimeout > TimeSpan.Zero ? (int)readTimeout.TotalMilliseconds : 0;
 
-            if (connector.WriteBuffer != null)
-                connector.WriteBuffer.Timeout = writeTimeout;
+            var writeBuffer = connector.WriteBuffer;
+            if (writeBuffer != null)
+                writeBuffer.Timeout = writeTimeout;
         }
 
         void CheckDisposed()

--- a/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
@@ -79,11 +79,10 @@ namespace Npgsql.Tests.Replication
                     {
                         await using var rc = await OpenReplicationConnectionAsync();
                         await rc.CreateLogicalReplicationSlot(slotName, OutputPlugin, slotSnapshotInitMode: mode);
-                    }, Throws.ArgumentException
-                        .With.Property("ParamName").EqualTo("slotSnapshotInitMode")
-                        .And.Message.StartsWith("The EXPORT_SNAPSHOT, USE_SNAPSHOT and NOEXPORT_SNAPSHOT syntax was introduced in PostgreSQL")
+                    }, Throws.InstanceOf<NotSupportedException>()
+                        .With.Message.StartsWith("The EXPORT_SNAPSHOT, USE_SNAPSHOT and NOEXPORT_SNAPSHOT syntax was introduced in PostgreSQL")
                         .And.InnerException.TypeOf<PostgresException>()
-                        .And.InnerException.Property("SqlState").EqualTo("42601"));
+                        .And.InnerException.Property("SqlState").EqualTo(PostgresErrorCodes.SyntaxError));
                 });
 
         [Test(Description = "We can use the exported snapshot to query the database in the very moment the replication slot was created.")]

--- a/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
@@ -69,13 +69,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(message.Data, Does.StartWith("COMMIT "));
 
                     streamingCts.Cancel();
-                    var exception = Assert.ThrowsAsync(Is.AssignableTo<OperationCanceledException>(), async () => await messages.MoveNextAsync());
-                    if (c.PostgreSqlVersion < Version.Parse("9.4"))
-                    {
-                        Assert.That(exception, Has.InnerException.InstanceOf<PostgresException>()
-                            .And.InnerException.Property(nameof(PostgresException.SqlState))
-                            .EqualTo(PostgresErrorCodes.QueryCanceled));
-                    }
+                    await AssertReplicationCancellation(messages);
                 });
 
         [Test(Description = "Tests whether UPDATE commands get replicated via test_decoding plugin for tables using the default replica identity")]
@@ -108,13 +102,7 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2')");
                     Assert.That(message.Data, Does.StartWith("COMMIT "));
 
                     streamingCts.Cancel();
-                    var exception = Assert.ThrowsAsync(Is.AssignableTo<OperationCanceledException>(), async () => await messages.MoveNextAsync());
-                    if (c.PostgreSqlVersion < Version.Parse("9.4"))
-                    {
-                        Assert.That(exception, Has.InnerException.InstanceOf<PostgresException>()
-                            .And.InnerException.Property(nameof(PostgresException.SqlState))
-                            .EqualTo(PostgresErrorCodes.QueryCanceled));
-                    }
+                    await AssertReplicationCancellation(messages);
                 });
 
         [Test(Description = "Tests whether UPDATE commands get replicated via test_decoding plugin for tables using an index as replica identity")]
@@ -153,7 +141,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         [Test(Description = "Tests whether UPDATE commands get replicated via test_decoding plugin for tables using full replica identity")]
@@ -190,7 +177,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         [Test(Description = "Tests whether DELETE commands get replicated via test_decoding plugin for tables using the default replica identity")]
@@ -226,7 +212,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         [Test(Description = "Tests whether DELETE commands get replicated via test_decoding plugin for tables using an index as replica identity")]
@@ -265,7 +250,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         [Test(Description = "Tests whether DELETE commands get replicated via test_decoding plugin for tables using full replica identity")]
@@ -302,7 +286,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         [Test(Description = "Tests whether TRUNCATE commands get replicated via test_decoding plugin")]
@@ -339,7 +322,6 @@ INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
-                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
                 });
 
         static async ValueTask<TestDecodingData> NextMessage(IAsyncEnumerator<TestDecodingData> enumerator)


### PR DESCRIPTION
Please note that, although our tests are green, this will not actually work yet for PostgreSQL versions 9.4 to 9.6 because it depends on a fix for https://github.com/npgsql/npgsql/issues/3304