### PR TITLE
Disable PG cancellation when doing replication on old backends

### DIFF
--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -52,7 +52,7 @@ namespace Npgsql
             _connector.Flush();
 
             CopyOutResponseMessage copyOutResponse;
-            var msg = _connector.ReadMessageWithoutCancellation();
+            var msg = _connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult();
             switch (msg.Code)
             {
             case BackendMessageCode.CopyOutResponse:
@@ -144,9 +144,9 @@ namespace Npgsql
             if (numColumns == -1)
             {
                 Debug.Assert(_leftToReadInDataMsg == 0);
-                Expect<CopyDoneMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
-                Expect<CommandCompleteMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
+                Expect<CopyDoneMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
+                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
                 _column = -1;
                 _isConsumed = true;
                 return -1;
@@ -384,8 +384,8 @@ namespace Npgsql
                 // Read to the end
                 _connector.SkipUntil(BackendMessageCode.CopyDone);
                 // We intentionally do not pass a CancellationToken since we don't want to cancel cleanup
-                Expect<CommandCompleteMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken: default), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken: default), _connector);
+                Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken: default), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken: default), _connector);
             }
 
             _connector.EndUserAction();

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -56,7 +56,7 @@ namespace Npgsql
             _connector.Flush();
 
             CopyInResponseMessage copyInResponse;
-            var msg = _connector.ReadMessageWithoutCancellation();
+            var msg = _connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult();
             switch (msg.Code)
             {
                 case BackendMessageCode.CopyInResponse:
@@ -408,8 +408,8 @@ namespace Npgsql
                 _buf.EndCopyMode();
                 await _connector.WriteCopyDone(async, cancellationToken);
                 await _connector.Flush(async, cancellationToken);
-                var cmdComplete = Expect<CommandCompleteMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
-                Expect<ReadyForQueryMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
+                var cmdComplete = Expect<CommandCompleteMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
+                Expect<ReadyForQueryMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
                 _state = ImporterState.Committed;
                 return cmdComplete.Rows;
             }
@@ -447,7 +447,7 @@ namespace Npgsql
             await _connector.Flush(async, cancellationToken);
             try
             {
-                var msg = await _connector.ReadMessageWithoutCancellation(async, cancellationToken);
+                var msg = await _connector.ReadMessage(async, pgCancellation: false, cancellationToken);
                 // The CopyFail should immediately trigger an exception from the read above.
                 throw _connector.Break(
                     new NpgsqlException("Expected ErrorResponse when cancelling COPY but got: " + msg.Code));

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -480,8 +480,10 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                 foreach (var statement in _statements)
                 {
-                    Expect<ParseCompleteMessage>(connector.ReadMessageWithoutCancellation(), connector);
-                    var paramTypeOIDs = Expect<ParameterDescriptionMessage>(connector.ReadMessageWithoutCancellation(), connector).TypeOIDs;
+                    Expect<ParseCompleteMessage>(
+                        connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult(), connector);
+                    var paramTypeOIDs = Expect<ParameterDescriptionMessage>(
+                        connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult(), connector).TypeOIDs;
 
                     if (statement.InputParameters.Count != paramTypeOIDs.Count)
                     {
@@ -515,7 +517,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                         }
                     }
 
-                    var msg = connector.ReadMessageWithoutCancellation();
+                    var msg = connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult();
                     switch (msg.Code)
                     {
                     case BackendMessageCode.RowDescription:
@@ -526,7 +528,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     }
                 }
 
-                Expect<ReadyForQueryMessage>(connector.ReadMessageWithoutCancellation(), connector);
+                Expect<ReadyForQueryMessage>(connector.ReadMessage(async: false, pgCancellation: false).GetAwaiter().GetResult(), connector);
                 sendTask.GetAwaiter().GetResult();
             }
         }

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -22,7 +22,7 @@ namespace Npgsql
             Log.Trace("Authenticating...", Id);
 
             timeout.CheckAndApply(this);
-            var msg = Expect<AuthenticationRequestMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
             switch (msg.AuthRequestType)
             {
             case AuthenticationRequestType.AuthenticationOk:
@@ -64,7 +64,7 @@ namespace Npgsql
 
             await WritePassword(encoded, async, cancellationToken);
             await Flush(async, cancellationToken);
-            Expect<AuthenticationRequestMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
         }
 
         async Task AuthenticateSASL(List<string> mechanisms, string username, bool async, CancellationToken cancellationToken = default)
@@ -164,7 +164,7 @@ namespace Npgsql
             await WriteSASLInitialResponse(mechanism, PGUtil.UTF8Encoding.GetBytes($"{cbindFlag},,n=*,r={clientNonce}"), async, cancellationToken);
             await Flush(async, cancellationToken);
 
-            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
             if (saslContinueMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLContinue)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
             var firstServerMsg = AuthenticationSCRAMServerFirstMessage.Load(saslContinueMsg.Payload);
@@ -197,7 +197,7 @@ namespace Npgsql
             await WriteSASLResponse(Encoding.UTF8.GetBytes(messageStr), async, cancellationToken);
             await Flush(async, cancellationToken);
 
-            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
             if (saslFinalServerMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLFinal)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
 
@@ -205,7 +205,7 @@ namespace Npgsql
             if (scramFinalServerMsg.ServerSignature != Convert.ToBase64String(serverSignature))
                 throw new NpgsqlException("[SCRAM] Unable to verify server signature");
 
-            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
             if (okMsg.AuthRequestType != AuthenticationRequestType.AuthenticationOk)
                 throw new NpgsqlException("[SASL] Expected AuthenticationOK message");
 
@@ -297,7 +297,7 @@ namespace Npgsql
 
             await WritePassword(result, async, cancellationToken);
             await Flush(async, cancellationToken);
-            Expect<AuthenticationRequestMessage>(await ReadMessageWithoutCancellation(async, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
         }
 
         async Task AuthenticateGSS(bool async)
@@ -393,7 +393,7 @@ namespace Npgsql
             {
                 if (_leftToRead == 0)
                 {
-                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessageWithoutCancellation(async, cancellationToken), _connector);
+                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
                     if (response.AuthRequestType == AuthenticationRequestType.AuthenticationOk)
                         throw new AuthenticationCompleteException();
                     var gssMsg = response as AuthenticationGSSContinueMessage;

--- a/src/Npgsql/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/NpgsqlReadBuffer.cs
@@ -128,16 +128,16 @@ namespace Npgsql
         }
 
         public Task Ensure(int count, bool async, CancellationToken cancellationToken = default)
-            => Ensure(count, async, readingNotifications: false, attemptPostgresCancellation: false, cancellationToken);
+            => Ensure(count, async, readingNotifications: false, pgCancellation: false, cancellationToken);
 
         public Task EnsureAsync(int count, CancellationToken cancellationToken = default)
-            => Ensure(count, async: true, readingNotifications: false, attemptPostgresCancellation: false, cancellationToken);
+            => Ensure(count, async: true, readingNotifications: false, pgCancellation: false, cancellationToken);
 
         /// <summary>
         /// Ensures that <paramref name="count"/> bytes are available in the buffer, and if
         /// not, reads from the socket until enough is available.
         /// </summary>
-        internal Task Ensure(int count, bool async, bool readingNotifications, bool attemptPostgresCancellation,
+        internal Task Ensure(int count, bool async, bool readingNotifications, bool pgCancellation,
             CancellationToken cancellationToken = default)
         {
             return count <= ReadBytesLeft ? Task.CompletedTask : EnsureLong();
@@ -221,7 +221,7 @@ namespace Npgsql
                             // Note that if PG cancellation fails, the exception for that is already logged internally by CancelRequest.
                             // We simply continue and throw the timeout one.
                             // TODO: As an optimization, we can still attempt to send a cancellation request, but after that immediately break the connection
-                            if (attemptPostgresCancellation && !wasCancellationRequested && Connector.CancelRequest(requestedByUser: false))
+                            if (pgCancellation && !wasCancellationRequested && Connector.CancelRequest(requestedByUser: false))
                             {
                                 // If the cancellation timeout is negative, we break the connection immediately
                                 var cancellationTimeout = Connector.Settings.CancellationTimeout;

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Tests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        public const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+        public const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;Port=5432";
 
         /// <summary>
         /// The connection string that will be used when opening the connection to the tests database.

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Tests
         /// Unless the NPGSQL_TEST_DB environment variable is defined, this is used as the connection string for the
         /// test database.
         /// </summary>
-        public const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;Port=5432";
+        public const string DefaultConnectionString = "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
 
         /// <summary>
         /// The connection string that will be used when opening the connection to the tests database.


### PR DESCRIPTION
When doing replication, don't do PG cancellation on old backends. Refactors API for reading messages without PG cancellation to accept a parameter.

I think this also shows some design limitations remaining in how we manage cancellation, I'll file a separate issue with some thoughts.

Fixes #3304

