### PR TITLE
Switch to UnixDomainSocketEndPoint where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,8 +143,14 @@ jobs:
 
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_scram SUPERUSER LOGIN PASSWORD 'npgsql_tests_scram'"
 
-          # Disable trust authentication, requiring MD5 passwords - some tests must fail if a password isn't provided.
-          echo "host all npgsql_tests_scram all scram-sha-256" > pgsql/PGDATA/pg_hba.conf
+          # Disable trust authentication except for unix domain sockets, requiring MD5
+          # passwords - some tests must fail if a password isn't provided.
+          if [ ${{ matrix.pg_major }} -ge 13 ]; then
+                echo "local all all trust" > pgsql/PGDATA/pg_hba.conf
+                echo "host all npgsql_tests_scram all scram-sha-256" >> pgsql/PGDATA/pg_hba.conf
+          else
+                echo "host all npgsql_tests_scram all scram-sha-256" > pgsql/PGDATA/pg_hba.conf
+          fi
           echo "host all all all md5" >> pgsql/PGDATA/pg_hba.conf
           echo "host replication all all md5" >> pgsql/PGDATA/pg_hba.conf
 

--- a/src/Npgsql/Netstandard20/UnixDomainSocketEndPoint.cs
+++ b/src/Npgsql/Netstandard20/UnixDomainSocketEndPoint.cs
@@ -1,15 +1,16 @@
-﻿using System.Net.Sockets;
+﻿#if NETSTANDARD2_0
+using System.Net.Sockets;
 using System.Text;
 
 // ReSharper disable once CheckNamespace
 namespace System.Net
 {
     // Copied and adapted from https://github.com/mono/mono/blob/master/mcs/class/Mono.Posix/Mono.Unix/UnixEndPoint.cs
-    class UnixEndPoint : EndPoint
+    class UnixDomainSocketEndPoint : EndPoint
     {
         string _filename;
 
-        public UnixEndPoint (string filename)
+        public UnixDomainSocketEndPoint (string filename)
         {
             if (filename == null)
                 throw new ArgumentNullException(nameof(filename));
@@ -40,7 +41,7 @@ namespace System.Net
             if (socketAddress.Size == 2) {
                 // Empty filename.
                 // Probably from RemoteEndPoint which on linux does not return the file name.
-                return new UnixEndPoint("a") { _filename = "" };
+                return new UnixDomainSocketEndPoint("a") { _filename = "" };
             }
             var size = socketAddress.Size - 2;
             var bytes = new byte[size];
@@ -54,7 +55,7 @@ namespace System.Net
             }
 
             var name = Encoding.UTF8.GetString(bytes, 0, size);
-            return new UnixEndPoint(name);
+            return new UnixDomainSocketEndPoint(name);
         }
 
         public override SocketAddress Serialize()
@@ -77,7 +78,7 @@ namespace System.Net
 
         public override bool Equals(object? o)
         {
-            var other = o as UnixEndPoint;
+            var other = o as UnixDomainSocketEndPoint;
             if (other == null)
                 return false;
 
@@ -85,3 +86,4 @@ namespace System.Net
         }
     }
 }
+#endif

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -723,7 +723,7 @@ namespace Npgsql
         {
             // Note that there aren't any timeout-able or cancellable DNS methods
             var endpoints = Path.IsPathRooted(Host)
-                ? new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) }
+                ? new EndPoint[] { new UnixDomainSocketEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) }
                 : Dns.GetHostAddresses(Host).Select(a => new IPEndPoint(a, Port)).ToArray();
             timeout.Check();
 
@@ -791,7 +791,7 @@ namespace Npgsql
         {
             // Note that there aren't any timeout-able or cancellable DNS methods
             var endpoints = Path.IsPathRooted(Host)
-                ? new EndPoint[] { new UnixEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) }
+                ? new EndPoint[] { new UnixDomainSocketEndPoint(Path.Combine(Host, $".s.PGSQL.{Port}")) }
                 : (await Dns.GetHostAddressesAsync(Host).WithCancellationAndTimeout(timeout, cancellationToken))
                 .Select(a => new IPEndPoint(a, Port)).ToArray();
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -497,8 +497,6 @@ namespace Npgsql.Tests
                 // right backend version
                 using var versionConnection = await OpenConnectionAsync();
                 MinimumPgVersion(versionConnection, "13.0", "Unix-domain sockets support on Windows was introduced in PostgreSQL 13");
-
-                Assert.Ignore("This test currently fails on Windows against PG13 (#2942)");
             }
 
             var port = new NpgsqlConnectionStringBuilder(ConnectionString).Port;


### PR DESCRIPTION
This means that everything but .NET Standard 2.0 will use the standard
UnixDomainSocketEndPoint from .NET Core

Closes #2942
(for everything but .NET Standard 2.0 which will not support Unix Domain Sockets on Windows)