### PR TITLE
Refactor cancellation and timeout one more time :)

### DIFF
--- a/src/Npgsql.GeoJSON/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/GeoJSONHandler.cs
@@ -125,48 +125,48 @@ namespace Npgsql.GeoJSON
 
         #region Read
 
-        public override ValueTask<GeoJSONObject> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => ReadGeometry(buf, async, cancellationToken);
+        public override ValueTask<GeoJSONObject> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => ReadGeometry(buf, async);
 
-        async ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (Point)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (Point)await ReadGeometry(buf, async);
 
-        async ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (LineString)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (LineString)await ReadGeometry(buf, async);
 
-        async ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (Polygon)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (Polygon)await ReadGeometry(buf, async);
 
-        async ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiPoint)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (MultiPoint)await ReadGeometry(buf, async);
 
-        async ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiLineString)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (MultiLineString)await ReadGeometry(buf, async);
 
-        async ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (MultiPolygon)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (MultiPolygon)await ReadGeometry(buf, async);
 
-        async ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (GeometryCollection)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (GeometryCollection)await ReadGeometry(buf, async);
 
-        async ValueTask<IGeoJSONObject> INpgsqlTypeHandler<IGeoJSONObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<IGeoJSONObject> INpgsqlTypeHandler<IGeoJSONObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => await ReadGeometry(buf, async);
 
-        async ValueTask<IGeometryObject> INpgsqlTypeHandler<IGeometryObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (IGeometryObject)await ReadGeometry(buf, async, cancellationToken);
+        async ValueTask<IGeometryObject> INpgsqlTypeHandler<IGeometryObject>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (IGeometryObject)await ReadGeometry(buf, async);
 
-        async ValueTask<GeoJSONObject> ReadGeometry(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken = default)
+        async ValueTask<GeoJSONObject> ReadGeometry(NpgsqlReadBuffer buf, bool async)
         {
             var boundingBox = BoundingBox ? new BoundingBoxBuilder() : null;
-            var geometry = await ReadGeometryCore(buf, async, boundingBox, cancellationToken);
+            var geometry = await ReadGeometryCore(buf, async, boundingBox);
 
             geometry.BoundingBoxes = boundingBox?.Build();
             return geometry;
         }
 
-        async ValueTask<GeoJSONObject> ReadGeometryCore(NpgsqlReadBuffer buf, bool async, BoundingBoxBuilder? boundingBox, CancellationToken cancellationToken = default)
+        async ValueTask<GeoJSONObject> ReadGeometryCore(NpgsqlReadBuffer buf, bool async, BoundingBoxBuilder? boundingBox)
         {
-            await buf.Ensure(SizeOfHeader, async, cancellationToken);
+            await buf.Ensure(SizeOfHeader, async);
             var littleEndian = buf.ReadByte() > 0;
             var type = (EwkbGeometryType)buf.ReadUInt32(littleEndian);
 
@@ -175,7 +175,7 @@ namespace Npgsql.GeoJSON
 
             if (HasSrid(type))
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async);
                 crs = GetCrs(buf.ReadInt32(littleEndian));
             }
 
@@ -183,7 +183,7 @@ namespace Npgsql.GeoJSON
             {
             case EwkbGeometryType.Point:
                 {
-                    await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                    await buf.Ensure(SizeOfPoint(type), async);
                     var position = ReadPosition(buf, type, littleEndian);
                     boundingBox?.Accumulate(position);
                     geometry = new Point(position);
@@ -192,11 +192,11 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.LineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var coordinates = new Position[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < coordinates.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                        await buf.Ensure(SizeOfPoint(type), async);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         coordinates[i] = position;
@@ -207,14 +207,14 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.Polygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -227,12 +227,12 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPoint:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var points = new Point[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < points.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeader + SizeOfPoint(type), async);
+                        await buf.Skip(SizeOfHeader, async);
                         var position = ReadPosition(buf, type, littleEndian);
                         boundingBox?.Accumulate(position);
                         points[i] = new Point(position);
@@ -243,16 +243,16 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiLineString:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var lines = new LineString[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < lines.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async);
+                        await buf.Skip(SizeOfHeader, async);
                         var coordinates = new Position[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < coordinates.Length; ++j)
                         {
-                            await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                            await buf.Ensure(SizeOfPoint(type), async);
                             var position = ReadPosition(buf, type, littleEndian);
                             boundingBox?.Accumulate(position);
                             coordinates[j] = position;
@@ -265,19 +265,19 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.MultiPolygon:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var polygons = new Polygon[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < polygons.Length; ++i)
                     {
-                        await buf.Ensure(SizeOfHeaderWithLength, async, cancellationToken);
-                        await buf.Skip(SizeOfHeader, async, cancellationToken);
+                        await buf.Ensure(SizeOfHeaderWithLength, async);
+                        await buf.Skip(SizeOfHeader, async);
                         var lines = new LineString[buf.ReadInt32(littleEndian)];
                         for (var j = 0; j < lines.Length; ++j)
                         {
                             var coordinates = new Position[buf.ReadInt32(littleEndian)];
                             for (var k = 0; k < coordinates.Length; ++k)
                             {
-                                await buf.Ensure(SizeOfPoint(type), async, cancellationToken);
+                                await buf.Ensure(SizeOfPoint(type), async);
                                 var position = ReadPosition(buf, type, littleEndian);
                                 boundingBox?.Accumulate(position);
                                 coordinates[k] = position;
@@ -292,10 +292,10 @@ namespace Npgsql.GeoJSON
 
             case EwkbGeometryType.GeometryCollection:
                 {
-                    await buf.Ensure(SizeOfLength, async, cancellationToken);
+                    await buf.Ensure(SizeOfLength, async);
                     var elements = new IGeometryObject[buf.ReadInt32(littleEndian)];
                     for (var i = 0; i < elements.Length; ++i)
-                        elements[i] = (IGeometryObject)await ReadGeometryCore(buf, async, boundingBox, cancellationToken);
+                        elements[i] = (IGeometryObject)await ReadGeometryCore(buf, async, boundingBox);
                     geometry = new GeometryCollection(elements);
                     break;
                 }

--- a/src/Npgsql.Json.NET/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/JsonHandler.cs
@@ -28,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             if (typeof(T) == typeof(string) ||
                 typeof(T) == typeof(char[]) ||
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char) ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken);
+                return await base.Read<T>(buf, len, async, fieldDescription);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.Json.NET/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/JsonbHandler.cs
@@ -28,7 +28,7 @@ namespace Npgsql.Json.NET
         public JsonbHandler(PostgresType postgresType, NpgsqlConnection connection, JsonSerializerSettings settings)
             : base(postgresType, connection, isJsonb: true) => _settings = settings;
 
-        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             if (typeof(T) == typeof(string)             ||
                 typeof(T) == typeof(char[])             ||
@@ -36,10 +36,10 @@ namespace Npgsql.Json.NET
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await base.Read<T>(buf, len, async, fieldDescription, cancellationToken);
+                return await base.Read<T>(buf, len, async, fieldDescription);
             }
 
-            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription, cancellationToken), _settings);
+            return JsonConvert.DeserializeObject<T>(await base.Read<string>(buf, len, async, fieldDescription), _settings);
         }
 
         protected override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/NetTopologySuiteHandler.cs
@@ -34,28 +34,28 @@ namespace Npgsql.NetTopologySuite
 
         #region Read
 
-        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override ValueTask<Geometry> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
             => ReadCore<Geometry>(buf, len);
 
-        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<Point> INpgsqlTypeHandler<Point>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<Point>(buf, len);
 
-        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<LineString> INpgsqlTypeHandler<LineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<LineString>(buf, len);
 
-        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<Polygon> INpgsqlTypeHandler<Polygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<Polygon>(buf, len);
 
-        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<MultiPoint> INpgsqlTypeHandler<MultiPoint>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<MultiPoint>(buf, len);
 
-        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<MultiLineString> INpgsqlTypeHandler<MultiLineString>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<MultiLineString>(buf, len);
 
-        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<MultiPolygon> INpgsqlTypeHandler<MultiPolygon>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<MultiPolygon>(buf, len);
 
-        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<GeometryCollection> INpgsqlTypeHandler<GeometryCollection>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => ReadCore<GeometryCollection>(buf, len);
 
         ValueTask<T> ReadCore<T>(NpgsqlReadBuffer buf, int len)

--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -17,12 +17,12 @@ namespace Npgsql
 {
     partial class NpgsqlConnector
     {
-        async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken = default)
+        async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         {
             Log.Trace("Authenticating...", Id);
 
             timeout.CheckAndApply(this);
-            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            var msg = Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
             switch (msg.AuthRequestType)
             {
             case AuthenticationRequestType.AuthenticationOk:
@@ -64,7 +64,7 @@ namespace Npgsql
 
             await WritePassword(encoded, async, cancellationToken);
             await Flush(async, cancellationToken);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
         }
 
         async Task AuthenticateSASL(List<string> mechanisms, string username, bool async, CancellationToken cancellationToken = default)
@@ -164,7 +164,7 @@ namespace Npgsql
             await WriteSASLInitialResponse(mechanism, PGUtil.UTF8Encoding.GetBytes($"{cbindFlag},,n=*,r={clientNonce}"), async, cancellationToken);
             await Flush(async, cancellationToken);
 
-            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            var saslContinueMsg = Expect<AuthenticationSASLContinueMessage>(await ReadMessage(async), this);
             if (saslContinueMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLContinue)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
             var firstServerMsg = AuthenticationSCRAMServerFirstMessage.Load(saslContinueMsg.Payload);
@@ -197,7 +197,7 @@ namespace Npgsql
             await WriteSASLResponse(Encoding.UTF8.GetBytes(messageStr), async, cancellationToken);
             await Flush(async, cancellationToken);
 
-            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            var saslFinalServerMsg = Expect<AuthenticationSASLFinalMessage>(await ReadMessage(async), this);
             if (saslFinalServerMsg.AuthRequestType != AuthenticationRequestType.AuthenticationSASLFinal)
                 throw new NpgsqlException("[SASL] AuthenticationSASLFinal message expected");
 
@@ -205,7 +205,7 @@ namespace Npgsql
             if (scramFinalServerMsg.ServerSignature != Convert.ToBase64String(serverSignature))
                 throw new NpgsqlException("[SCRAM] Unable to verify server signature");
 
-            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            var okMsg = Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
             if (okMsg.AuthRequestType != AuthenticationRequestType.AuthenticationOk)
                 throw new NpgsqlException("[SASL] Expected AuthenticationOK message");
 
@@ -297,7 +297,7 @@ namespace Npgsql
 
             await WritePassword(result, async, cancellationToken);
             await Flush(async, cancellationToken);
-            Expect<AuthenticationRequestMessage>(await ReadMessage(async, pgCancellation: false, cancellationToken), this);
+            Expect<AuthenticationRequestMessage>(await ReadMessage(async), this);
         }
 
         async Task AuthenticateGSS(bool async)
@@ -393,7 +393,7 @@ namespace Npgsql
             {
                 if (_leftToRead == 0)
                 {
-                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async, pgCancellation: false, cancellationToken), _connector);
+                    var response = Expect<AuthenticationRequestMessage>(await _connector.ReadMessage(async), _connector);
                     if (response.AuthRequestType == AuthenticationRequestType.AuthenticationOk)
                         throw new AuthenticationCompleteException();
                     var gssMsg = response as AuthenticationGSSContinueMessage;

--- a/src/Npgsql/NpgsqlLargeObjectManager.cs
+++ b/src/Npgsql/NpgsqlLargeObjectManager.cs
@@ -33,7 +33,7 @@ namespace Npgsql
         /// <summary>
         /// Execute a function
         /// </summary>
-        internal async Task<T> ExecuteFunction<T>(string function, bool async, params object[] arguments)
+        internal async Task<T> ExecuteFunction<T>(string function, bool async, CancellationToken cancellationToken, params object[] arguments)
         {
             using var command = new NpgsqlCommand(function, Connection)
             {
@@ -44,14 +44,15 @@ namespace Npgsql
             foreach (var argument in arguments)
                 command.Parameters.Add(new NpgsqlParameter { Value = argument });
 
-            return (T)(async ? await command.ExecuteScalarAsync() : command.ExecuteScalar())!;
+            return (T)(async ? await command.ExecuteScalarAsync(cancellationToken) : command.ExecuteScalar())!;
         }
 
         /// <summary>
         /// Execute a function that returns a byte array
         /// </summary>
         /// <returns></returns>
-        internal async Task<int> ExecuteFunctionGetBytes(string function, byte[] buffer, int offset, int len, bool async, params object[] arguments)
+        internal async Task<int> ExecuteFunctionGetBytes(
+            string function, byte[] buffer, int offset, int len, bool async, CancellationToken cancellationToken, params object[] arguments)
         {
             using var command = new NpgsqlCommand(function, Connection)
             {
@@ -62,11 +63,11 @@ namespace Npgsql
                 command.Parameters.Add(new NpgsqlParameter { Value = argument });
 
             using var reader = async
-                ? await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess)
+                ? await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken)
                 : command.ExecuteReader(CommandBehavior.SequentialAccess);
 
             if (async)
-                await reader.ReadAsync();
+                await reader.ReadAsync(cancellationToken);
             else
                 reader.Read();
 
@@ -90,12 +91,10 @@ namespace Npgsql
         /// <returns>The oid for the large object created</returns>
         /// <exception cref="PostgresException">If an oid is already in use</exception>
         public Task<uint> CreateAsync(uint preferredOid, CancellationToken cancellationToken = default)
-            => cancellationToken.IsCancellationRequested
-                ? Task.FromCanceled<uint>(cancellationToken)
-                : Create(preferredOid, true);
+            => Create(preferredOid, true, cancellationToken);
 
-        Task<uint> Create(uint preferredOid, bool async)
-            => ExecuteFunction<uint>("lo_create", async, (int)preferredOid);
+        Task<uint> Create(uint preferredOid, bool async, CancellationToken cancellationToken = default)
+            => ExecuteFunction<uint>("lo_create", async, cancellationToken, (int)preferredOid);
 
         /// <summary>
         /// Opens a large object on the backend, returning a stream controlling this remote object.
@@ -119,15 +118,13 @@ namespace Npgsql
         /// <returns>An NpgsqlLargeObjectStream</returns>
         public Task<NpgsqlLargeObjectStream> OpenReadAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<NpgsqlLargeObjectStream>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return OpenRead(oid, true);
+                return OpenRead(oid, true, cancellationToken);
         }
 
-        async Task<NpgsqlLargeObjectStream> OpenRead(uint oid, bool async)
+        async Task<NpgsqlLargeObjectStream> OpenRead(uint oid, bool async, CancellationToken cancellationToken = default)
         {
-            var fd = await ExecuteFunction<int>("lo_open", async, (int)oid, InvRead);
+            var fd = await ExecuteFunction<int>("lo_open", async, cancellationToken, (int)oid, InvRead);
             return new NpgsqlLargeObjectStream(this, fd, false);
         }
 
@@ -149,15 +146,13 @@ namespace Npgsql
         /// <returns>An NpgsqlLargeObjectStream</returns>
         public Task<NpgsqlLargeObjectStream> OpenReadWriteAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<NpgsqlLargeObjectStream>(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return OpenReadWrite(oid, true);
+                return OpenReadWrite(oid, true, cancellationToken);
         }
 
-        async Task<NpgsqlLargeObjectStream> OpenReadWrite(uint oid, bool async)
+        async Task<NpgsqlLargeObjectStream> OpenReadWrite(uint oid, bool async, CancellationToken cancellationToken = default)
         {
-            var fd = await ExecuteFunction<int>("lo_open", async, (int)oid, InvRead | InvWrite);
+            var fd = await ExecuteFunction<int>("lo_open", async, cancellationToken, (int)oid, InvRead | InvWrite);
             return new NpgsqlLargeObjectStream(this, fd, true);
         }
 
@@ -166,7 +161,7 @@ namespace Npgsql
         /// </summary>
         /// <param name="oid">Oid of the object to delete</param>
         public void Unlink(uint oid)
-            => ExecuteFunction<object>("lo_unlink", false, (int)oid).GetAwaiter().GetResult();
+            => ExecuteFunction<object>("lo_unlink", false, CancellationToken.None, (int)oid).GetAwaiter().GetResult();
 
         /// <summary>
         /// Deletes a large object on the backend.
@@ -175,10 +170,8 @@ namespace Npgsql
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task UnlinkAsync(uint oid, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return ExecuteFunction<object>("lo_unlink", true, (int)oid);
+                return ExecuteFunction<object>("lo_unlink", true, cancellationToken, (int)oid);
         }
 
         /// <summary>
@@ -187,7 +180,7 @@ namespace Npgsql
         /// <param name="oid">Oid of the object to export</param>
         /// <param name="path">Path to write the file on the backend</param>
         public void ExportRemote(uint oid, string path)
-            => ExecuteFunction<object>("lo_export", false, (int)oid, path).GetAwaiter().GetResult();
+            => ExecuteFunction<object>("lo_export", false, CancellationToken.None, (int)oid, path).GetAwaiter().GetResult();
 
         /// <summary>
         /// Exports a large object stored in the database to a file on the backend. This requires superuser permissions.
@@ -197,10 +190,8 @@ namespace Npgsql
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task ExportRemoteAsync(uint oid, string path, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return ExecuteFunction<object>("lo_export", true, (int)oid, path);
+                return ExecuteFunction<object>("lo_export", true, cancellationToken, (int)oid, path);
         }
 
         /// <summary>
@@ -209,7 +200,7 @@ namespace Npgsql
         /// <param name="path">Path to read the file on the backend</param>
         /// <param name="oid">A preferred oid, or specify 0 if one should be automatically assigned</param>
         public void ImportRemote(string path, uint oid = 0)
-            => ExecuteFunction<object>("lo_import", false, path, (int)oid).GetAwaiter().GetResult();
+            => ExecuteFunction<object>("lo_import", false, CancellationToken.None, path, (int)oid).GetAwaiter().GetResult();
 
         /// <summary>
         /// Imports a large object to be stored as a large object in the database from a file stored on the backend. This requires superuser permissions.
@@ -219,10 +210,8 @@ namespace Npgsql
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         public Task ImportRemoteAsync(string path, uint oid, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
-                return ExecuteFunction<object>("lo_import", true, path, (int)oid);
+                return ExecuteFunction<object>("lo_import", true, cancellationToken, path, (int)oid);
         }
 
         /// <summary>

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -125,7 +125,7 @@ namespace Npgsql
             if (!_connector.DatabaseInfo.SupportsTransactions)
                 return;
 
-            using (_connector.StartUserAction())
+            using (_connector.StartUserAction(cancellationToken))
             {
                 Log.Debug("Committing transaction", _connector.Id);
                 await _connector.ExecuteInternalCommand(PregeneratedMessages.CommitTransaction, async, cancellationToken);
@@ -142,8 +142,6 @@ namespace Npgsql
         public override Task CommitAsync(CancellationToken cancellationToken = default)
 #endif
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Commit(true, cancellationToken);
         }
@@ -175,8 +173,6 @@ namespace Npgsql
         public override Task RollbackAsync(CancellationToken cancellationToken = default)
 #endif
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Rollback(true, cancellationToken);
         }
@@ -248,8 +244,6 @@ namespace Npgsql
         public Task SaveAsync(string name, CancellationToken cancellationToken = default)
 #endif
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             Save(name);
             return Task.CompletedTask;
         }
@@ -264,7 +258,7 @@ namespace Npgsql
             CheckReady();
             if (!_connector.DatabaseInfo.SupportsTransactions)
                 return;
-            using (_connector.StartUserAction())
+            using (_connector.StartUserAction(cancellationToken))
             {
                 Log.Debug($"Rolling back savepoint {name}", _connector.Id);
 
@@ -297,8 +291,6 @@ namespace Npgsql
         public Task RollbackAsync(string name, CancellationToken cancellationToken = default)
 #endif
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Rollback(name, true, cancellationToken);
         }
@@ -313,7 +305,7 @@ namespace Npgsql
             CheckReady();
             if (!_connector.DatabaseInfo.SupportsTransactions)
                 return;
-            using (_connector.StartUserAction())
+            using (_connector.StartUserAction(cancellationToken))
             {
                 Log.Debug($"Releasing savepoint {name}", _connector.Id);
 
@@ -345,8 +337,6 @@ namespace Npgsql
         public Task ReleaseAsync(string name, CancellationToken cancellationToken = default)
 #endif
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
             using (NoSynchronizationContextScope.Enter())
                 return Release(name, true, cancellationToken);
         }
@@ -430,7 +420,7 @@ namespace Npgsql
         static bool RequiresQuoting(string identifier)
         {
             Debug.Assert(identifier.Length > 0);
-            
+
             var first = identifier[0];
             if (first != '_' && !char.IsLower(first))
                 return true;

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -45,7 +45,7 @@ $@"SELECT
        SELECT * FROM pg_index
        WHERE pg_index.indrelid = cls.oid AND
              pg_index.indisunique AND
-             pg_index.{(pgVersion >= new Version(11, 0) ? "indnkeyatts" : "indnatts")} = 1 AND 
+             pg_index.{(pgVersion >= new Version(11, 0) ? "indnkeyatts" : "indnatts")} = 1 AND
              attnum = pg_index.indkey[0]
      ) AS isunique
 FROM pg_attribute AS attr
@@ -93,7 +93,7 @@ ORDER BY attnum";
 
         #endregion Column queries
 
-        internal async Task<ReadOnlyCollection<NpgsqlDbColumn>> GetColumnSchemaAsync(bool async, CancellationToken cancellationToken = default)
+        internal async Task<ReadOnlyCollection<NpgsqlDbColumn>> GetColumnSchema(bool async, CancellationToken cancellationToken = default)
         {
             // This is mainly for Amazon Redshift
             var oldQueryMode = _connection.PostgreSqlVersion < new Version(8, 2);
@@ -125,7 +125,7 @@ ORDER BY attnum";
                 using var connection = (NpgsqlConnection)((ICloneable)_connection).Clone();
 
                 await connection.Open(async, cancellationToken);
-                
+
                 using var cmd = new NpgsqlCommand(query, connection);
                 using var reader = await cmd.ExecuteReader(CommandBehavior.Default, async, cancellationToken);
                 while (async ? await reader.ReadAsync(cancellationToken): reader.Read())

--- a/src/Npgsql/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/TypeHandlers/ArrayHandler.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
@@ -59,13 +58,13 @@ namespace Npgsql.TypeHandlers
             => Read<TRequestedArray>(buf, len, false, fieldDescription).GetAwaiter().GetResult();
 
         /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async, cancellationToken);
+                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async);
 
             if (ArrayTypeInfo<TRequestedArray>.IsList)
-                return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async, cancellationToken);
+                return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async);
 
             throw new InvalidCastException(fieldDescription == null
                 ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
@@ -76,9 +75,9 @@ namespace Npgsql.TypeHandlers
         /// <summary>
         /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
         /// </summary>
-        protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, CancellationToken cancellationToken = default)
+        protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0)
         {
-            await buf.Ensure(12, async, cancellationToken);
+            await buf.Ensure(12, async);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -94,20 +93,20 @@ namespace Npgsql.TypeHandlers
 
             if (dimensions == 1)
             {
-                await buf.Ensure(8, async, cancellationToken);
+                await buf.Ensure(8, async);
                 var arrayLength = buf.ReadInt32();
 
                 buf.ReadInt32(); // Lower bound
 
                 var oneDimensional = new TRequestedElement[arrayLength];
                 for (var i = 0; i < oneDimensional.Length; i++)
-                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken: cancellationToken);
+                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
 
                 return oneDimensional;
             }
 
             var dimLengths = new int[dimensions];
-            await buf.Ensure(dimensions * 8, async, cancellationToken);
+            await buf.Ensure(dimensions * 8, async);
 
             for (var i = 0; i < dimensions; i++)
             {
@@ -122,7 +121,7 @@ namespace Npgsql.TypeHandlers
             var indices = new int[dimensions];
             while (true)
             {
-                var element = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken: cancellationToken);
+                var element = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
                 result.SetValue(element, indices);
 
                 // TODO: Overly complicated/inefficient...
@@ -145,9 +144,9 @@ namespace Npgsql.TypeHandlers
         /// <summary>
         /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
         /// </summary>
-        protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken = default)
+        protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
         {
-            await buf.Ensure(12, async, cancellationToken);
+            await buf.Ensure(12, async);
             var dimensions = buf.ReadInt32();
             var containsNulls = buf.ReadInt32() == 1;
             buf.ReadUInt32(); // Element OID. Ignored.
@@ -159,13 +158,13 @@ namespace Npgsql.TypeHandlers
             if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
                 throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
 
-            await buf.Ensure(8, async, cancellationToken);
+            await buf.Ensure(8, async);
             var length = buf.ReadInt32();
             buf.ReadInt32(); // We don't care about the lower bounds
 
             var list = new List<TRequestedElement>(length);
             for (var i = 0; i < length; i++)
-                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async, cancellationToken: cancellationToken));
+                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
             return list;
         }
 
@@ -192,8 +191,8 @@ namespace Npgsql.TypeHandlers
             public static readonly bool IsList;
             public static readonly Type? ElementType;
 
-            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<Array>> ReadArrayFunc = default!;
-            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<TArrayOrList>> ReadListFunc = default!;
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>> ReadArrayFunc = default!;
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>> ReadListFunc = default!;
             // ReSharper restore StaticMemberInGenericType
 
             public static bool IsArrayOrList => IsArray || IsList;
@@ -217,29 +216,28 @@ namespace Npgsql.TypeHandlers
                 var arrayHandlerParam = Expression.Parameter(typeof(ArrayHandler), "arrayHandler");
                 var bufferParam = Expression.Parameter(typeof(NpgsqlReadBuffer), "buf");
                 var asyncParam = Expression.Parameter(typeof(bool), "async");
-                var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
 
                 if (IsArray)
                 {
                     ReadArrayFunc = Expression
-                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<Array>>>(
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>>>(
                             Expression.Call(
                                 arrayHandlerParam,
                                 ReadArrayMethod.MakeGenericMethod(ElementType),
-                                bufferParam, asyncParam, Expression.Constant(type.GetArrayRank()), cancellationTokenParam),
-                            arrayHandlerParam, bufferParam, asyncParam, cancellationTokenParam)
+                                bufferParam, asyncParam, Expression.Constant(type.GetArrayRank())),
+                            arrayHandlerParam, bufferParam, asyncParam)
                         .Compile();
                 }
 
                 if (IsList)
                 {
                     ReadListFunc = Expression
-                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, CancellationToken, ValueTask<TArrayOrList>>>(
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>>>(
                             Expression.Call(
                                 arrayHandlerParam,
                                 ReadListMethod.MakeGenericMethod(ElementType),
-                                bufferParam, asyncParam, cancellationTokenParam),
-                            arrayHandlerParam, bufferParam, asyncParam, cancellationTokenParam)
+                                bufferParam, asyncParam),
+                            arrayHandlerParam, bufferParam, asyncParam)
                         .Compile();
                 }
             }
@@ -266,8 +264,8 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            =>  await ReadArray<TElement>(buf, async, cancellationToken: cancellationToken);
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            =>  await ReadArray<TElement>(buf, async);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => ReadArray<TElement>(buf, false).GetAwaiter().GetResult();
@@ -489,23 +487,23 @@ namespace Npgsql.TypeHandlers
         public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler)
             : base(arrayPostgresType, elementHandler) { }
 
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank(), cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank());
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<TElementPsv>(buf, async);
             }
-            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription);
         }
 
         internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
 
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => await ReadArray<TElementPsv>(buf, async, cancellationToken: cancellationToken);
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => await ReadArray<TElementPsv>(buf, async);
     }
 }

--- a/src/Npgsql/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/TypeHandlers/BitStringHandler.cs
@@ -49,9 +49,9 @@ namespace Npgsql.TypeHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numBits = buf.ReadInt32();
             var result = new BitArray(numBits);
             var bytesLeft = len - 4;  // Remove leading number of bits
@@ -83,13 +83,13 @@ namespace Npgsql.TypeHandlers
                     break;
 
                 Debug.Assert(buf.ReadBytesLeft == 0);
-                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async, cancellationToken);
+                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
             }
 
             if (bitNo < result.Length)
             {
                 var remainder = result.Length - bitNo;
-                await buf.Ensure(1, async, cancellationToken);
+                await buf.Ensure(1, async);
                 var lastChunk = buf.ReadByte();
                 for (var i = 7; i >= 8 - remainder; i--)
                     result[bitNo++] = (lastChunk & (1 << i)) != 0;
@@ -98,12 +98,12 @@ namespace Npgsql.TypeHandlers
             return result;
         }
 
-        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
             if (len > 4 + 4)
                 throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
 
-            await buf.Ensure(4 + 4, async, cancellationToken);
+            await buf.Ensure(4 + 4, async);
 
             var numBits = buf.ReadInt32();
             return numBits == 0
@@ -111,9 +111,9 @@ namespace Npgsql.TypeHandlers
                 : new BitVector32(buf.ReadInt32());
         }
 
-        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
-            await buf.Ensure(5, async, cancellationToken);
+            await buf.Ensure(5, async);
             var bitLen = buf.ReadInt32();
             if (bitLen != 1)
                 throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
@@ -121,13 +121,13 @@ namespace Npgsql.TypeHandlers
             return (b & 128) != 0;
         }
 
-        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
-                ? (object)await Read<bool>(buf, len, async, fieldDescription, cancellationToken)
-                : await Read<BitArray>(buf, len, async, fieldDescription, cancellationToken);
+                ? (object)await Read<bool>(buf, len, async, fieldDescription)
+                : await Read<BitArray>(buf, len, async, fieldDescription);
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
@@ -278,35 +278,35 @@ namespace Npgsql.TypeHandlers
             : base(postgresType, elementHandler) {}
 
         /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override async ValueTask<TRequestedArray> Read<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<BitArray>(buf, async);
             }
 
             if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
             {
                 if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async, cancellationToken: cancellationToken);
+                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async);
 
                 if (ArrayTypeInfo<TRequestedArray>.IsList)
-                    return (TRequestedArray)(object)await ReadList<bool>(buf, async, cancellationToken);
+                    return (TRequestedArray)(object)await ReadList<bool>(buf, async);
             }
 
-            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription, cancellationToken);
+            return await base.Read<TRequestedArray>(buf, len, async, fieldDescription);
         }
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => ReadAsObject(buf, len, false, fieldDescription).Result;
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
-                ? await ReadArray<bool>(buf, async, cancellationToken: cancellationToken)
-                : await ReadArray<BitArray>(buf, async, cancellationToken: cancellationToken);
+                ? await ReadArray<bool>(buf, async)
+                : await ReadArray<BitArray>(buf, async);
     }
 }

--- a/src/Npgsql/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/TypeHandlers/ByteaHandler.cs
@@ -43,7 +43,7 @@ namespace Npgsql.TypeHandlers
         public ByteaHandler(PostgresType postgresType) : base(postgresType) {}
 
         /// <inheritdoc />
-        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<byte[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             var bytes = new byte[len];
             var pos = 0;
@@ -54,12 +54,12 @@ namespace Npgsql.TypeHandlers
                 pos += toRead;
                 if (pos == len)
                     break;
-                await buf.ReadMore(async, cancellationToken);
+                await buf.ReadMore(async);
             }
             return bytes;
         }
 
-        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<ArraySegment<byte>> INpgsqlTypeHandler<ArraySegment<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing ArraySegment<byte> to PostgreSQL bytea is supported, no reading.");
 
         int ValidateAndGetLength(int bufferLen, NpgsqlParameter? parameter)
@@ -129,10 +129,10 @@ namespace Npgsql.TypeHandlers
         public Task Write(Memory<byte> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => Write((ReadOnlyMemory<byte>)value, buf, lengthCache, parameter, async, cancellationToken);
 
-        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<ReadOnlyMemory<byte>> INpgsqlTypeHandler<ReadOnlyMemory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescriptioncancellationToken)
             => throw new NotSupportedException("Only writing ReadOnlyMemory<byte> to PostgreSQL bytea is supported, no reading.");
 
-        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing Memory<byte> to PostgreSQL bytea is supported, no reading.");
 #endif
     }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler.cs
@@ -19,9 +19,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             Handlers = handlers;
         }
 
-        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public virtual async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(int), async);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -29,7 +29,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
 
             var args = new object?[Handlers.Length];
             foreach (var handler in Handlers)
-                args[handler.ParameterPosition] = await handler.Read(buffer, async, cancellationToken);
+                args[handler.ParameterPosition] = await handler.Read(buffer, async);
 
             return (TComposite)ConstructorInfo.Invoke(args);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeConstructorHandler`.cs
@@ -27,9 +27,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 .Compile();
         }
 
-        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override async ValueTask<TComposite> Read(NpgsqlReadBuffer buffer, bool async)
         {
-            await buffer.Ensure(sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(int), async);
 
             var fieldCount = buffer.ReadInt32();
             if (fieldCount != Handlers.Length)
@@ -40,14 +40,14 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             foreach (var handler in Handlers)
                 switch (handler.ParameterPosition)
                 {
-                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async, cancellationToken); break;
-                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async, cancellationToken); break;
-                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async, cancellationToken); break;
-                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async, cancellationToken); break;
-                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async, cancellationToken); break;
-                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async, cancellationToken); break;
-                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async, cancellationToken); break;
-                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async, cancellationToken); break;
+                    case 0: args.Argument1 = await handler.Read<T1>(buffer, async); break;
+                    case 1: args.Argument2 = await handler.Read<T2>(buffer, async); break;
+                    case 2: args.Argument3 = await handler.Read<T3>(buffer, async); break;
+                    case 3: args.Argument4 = await handler.Read<T4>(buffer, async); break;
+                    case 4: args.Argument5 = await handler.Read<T5>(buffer, async); break;
+                    case 5: args.Argument6 = await handler.Read<T6>(buffer, async); break;
+                    case 6: args.Argument7 = await handler.Read<T7>(buffer, async); break;
+                    case 7: args.Argument8 = await handler.Read<T8>(buffer, async); break;
                 }
 
             return _constructor(args);

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -32,17 +32,17 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _nameTranslator = nameTranslator;
         }
 
-        public override ValueTask<T> Read(NpgsqlReadBuffer buffer, int length, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override ValueTask<T> Read(NpgsqlReadBuffer buffer, int length, bool async, FieldDescription? fieldDescription = null)
         {
             Initialize();
 
             return _constructorHandler is null
                 ? ReadUsingMemberHandlers()
-                : _constructorHandler.Read(buffer, async, cancellationToken);
+                : _constructorHandler.Read(buffer, async);
 
             async ValueTask<T> ReadUsingMemberHandlers()
             {
-                await buffer.Ensure(sizeof(int), async, cancellationToken);
+                await buffer.Ensure(sizeof(int), async);
 
                 var fieldCount = buffer.ReadInt32();
                 if (fieldCount != _memberHandlers.Length)
@@ -52,7 +52,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = new ByReference<T> { Value = _constructor() };
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken);
+                        await member.Read(composite, buffer, async);
 
                     return composite.Value;
                 }
@@ -60,7 +60,7 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 {
                     var composite = _constructor();
                     foreach (var member in _memberHandlers)
-                        await member.Read(composite, buffer, async, cancellationToken);
+                        await member.Read(composite, buffer, async);
 
                     return composite;
                 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandler.cs
@@ -16,9 +16,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             PostgresType = postgresType;
         }
 
-        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
+        public abstract ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async);
 
-        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
+        public abstract ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async);
 
         public abstract Task Write(TComposite composite, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default);
 

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfClass.cs
@@ -50,12 +50,12 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _handler = handler;
         }
 
-        public override async ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override async ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async)
         {
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);
@@ -65,13 +65,13 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return;
 
             var value = NullableHandler<TMember>.Exists
-                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken: cancellationToken)
-                : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
+                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async)
+                : await _handler.Read<TMember>(buffer, length, async);
 
             _set(composite, value);
         }
 
-        public override ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async)
             => throw new NotSupportedException();
 
         public override async Task Write(TComposite composite, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeMemberHandlerOfStruct.cs
@@ -51,15 +51,15 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             _handler = handler;
         }
 
-        public override ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override ValueTask Read(TComposite composite, NpgsqlReadBuffer buffer, bool async)
             => throw new NotSupportedException();
 
-        public override async ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override async ValueTask Read(ByReference<TComposite> composite, NpgsqlReadBuffer buffer, bool async)
         {
             if (_set == null)
                 ThrowHelper.ThrowInvalidOperationException_NoPropertySetter(typeof(TComposite), MemberInfo);
 
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async);
 
             var oid = buffer.ReadUInt32();
             Debug.Assert(oid == PostgresType.OID);
@@ -69,8 +69,8 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return;
 
             var value = NullableHandler<TMember>.Exists
-                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async, cancellationToken: cancellationToken)
-                : await _handler.Read<TMember>(buffer, length, async, cancellationToken: cancellationToken);
+                ? await NullableHandler<TMember>.ReadAsync(_handler, buffer, length, async)
+                : await _handler.Read<TMember>(buffer, length, async);
 
             Set(composite, value);
         }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler.cs
@@ -19,9 +19,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
             ParameterPosition = parameterInfo.Position;
         }
 
-        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public async ValueTask<T> Read<T>(NpgsqlReadBuffer buffer, bool async)
         {
-            await buffer.Ensure(sizeof(uint) + sizeof(int), async, cancellationToken);
+            await buffer.Ensure(sizeof(uint) + sizeof(int), async);
 
             var oid = buffer.ReadUInt32();
             var length = buffer.ReadInt32();
@@ -29,10 +29,10 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
                 return default!;
 
             return NullableHandler<T>.Exists
-                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async, cancellationToken: cancellationToken)
-                : await Handler.Read<T>(buffer, length, async, cancellationToken: cancellationToken);
+                ? await NullableHandler<T>.ReadAsync(Handler, buffer, length, async)
+                : await Handler.Read<T>(buffer, length, async);
         }
 
-        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default);
+        public abstract ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async);
     }
 }

--- a/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
+++ b/src/Npgsql/TypeHandlers/CompositeHandlers/CompositeParameterHandler`.cs
@@ -10,9 +10,9 @@ namespace Npgsql.TypeHandlers.CompositeHandlers
         public CompositeParameterHandler(NpgsqlTypeHandler handler, ParameterInfo parameterInfo)
             : base(handler, parameterInfo) { }
 
-        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async, CancellationToken cancellationToken = default)
+        public override ValueTask<object?> Read(NpgsqlReadBuffer buffer, bool async)
         {
-            var task = Read<T>(buffer, async, cancellationToken: cancellationToken);
+            var task = Read<T>(buffer, async);
             return task.IsCompleted
                 ? new ValueTask<object?>(task.Result)
                 : AwaitTask();

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -45,9 +45,9 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<NpgsqlTsQuery> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numTokens = buf.ReadInt32();
             if (numTokens == 0)
                 return new NpgsqlTsQueryEmpty();
@@ -58,7 +58,7 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
 
             for (var tokenPos = 0; tokenPos < numTokens; tokenPos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async, cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleTokenBytes), async);
                 var readPos = buf.ReadPosition;
 
                 var isOper = buf.ReadByte() == 2;
@@ -120,23 +120,23 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
             }
         }
 
-        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryEmpty> INpgsqlTypeHandler<NpgsqlTsQueryEmpty>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryEmpty)await Read(buf, len, async, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryLexeme> INpgsqlTypeHandler<NpgsqlTsQueryLexeme>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryLexeme)await Read(buf, len, async, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryNot> INpgsqlTypeHandler<NpgsqlTsQueryNot>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryNot)await Read(buf, len, async, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryAnd> INpgsqlTypeHandler<NpgsqlTsQueryAnd>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryAnd)await Read(buf, len, async, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryOr> INpgsqlTypeHandler<NpgsqlTsQueryOr>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryOr)await Read(buf, len, async, fieldDescription);
 
-        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription, cancellationToken);
+        async ValueTask<NpgsqlTsQueryFollowedBy> INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (NpgsqlTsQueryFollowedBy)await Read(buf, len, async, fieldDescription);
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -35,16 +35,16 @@ namespace Npgsql.TypeHandlers.FullTextSearchHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<NpgsqlTsVector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numLexemes = buf.ReadInt32();
             len -= 4;
 
             var lexemes = new List<NpgsqlTsVector.Lexeme>();
             for (var lexemePos = 0; lexemePos < numLexemes; lexemePos++)
             {
-                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async, cancellationToken);
+                await buf.Ensure(Math.Min(len, MaxSingleLexemeBytes), async);
                 var posBefore = buf.ReadPosition;
 
                 List<NpgsqlTsVector.Lexeme.WordEntryPos>? positions = null;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -28,9 +28,9 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<NpgsqlPath> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(5, async, cancellationToken);
+            await buf.Ensure(5, async);
             var open = buf.ReadByte() switch
             {
                 1 => false,
@@ -42,7 +42,7 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
             var result = new NpgsqlPath(numPoints, open);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken);
+                await buf.Ensure(16, async);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -27,14 +27,14 @@ namespace Npgsql.TypeHandlers.GeometricHandlers
         #region Read
 
         /// <inheritdoc />
-        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<NpgsqlPolygon> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numPoints = buf.ReadInt32();
             var result = new NpgsqlPolygon(numPoints);
             for (var i = 0; i < numPoints; i++)
             {
-                await buf.Ensure(16, async, cancellationToken);
+                await buf.Ensure(16, async);
                 result.Add(new NpgsqlPoint(buf.ReadDouble(), buf.ReadDouble()));
             }
             return result;

--- a/src/Npgsql/TypeHandlers/HstoreHandler.cs
+++ b/src/Npgsql/TypeHandlers/HstoreHandler.cs
@@ -124,38 +124,38 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        async ValueTask<T> ReadInto<T>(T dictionary, int numElements, NpgsqlReadBuffer buf, bool async, CancellationToken cancellationToken = default)
+        async ValueTask<T> ReadInto<T>(T dictionary, int numElements, NpgsqlReadBuffer buf, bool async)
             where T : IDictionary<string, string?>
         {
             for (var i = 0; i < numElements; i++)
             {
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async);
                 var keyLen = buf.ReadInt32();
                 Debug.Assert(keyLen != -1);
-                var key = await _textHandler.Read(buf, keyLen, async, cancellationToken: cancellationToken);
+                var key = await _textHandler.Read(buf, keyLen, async);
 
-                await buf.Ensure(4, async, cancellationToken);
+                await buf.Ensure(4, async);
                 var valueLen = buf.ReadInt32();
 
                 dictionary[key] = valueLen == -1
                     ? null
-                    : await _textHandler.Read(buf, valueLen, async, cancellationToken: cancellationToken);
+                    : await _textHandler.Read(buf, valueLen, async);
             }
             return dictionary;
         }
 
         /// <inheritdoc />
         public override async ValueTask<Dictionary<string, string?>> Read(NpgsqlReadBuffer buf, int len, bool async,
-            FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+            FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numElements = buf.ReadInt32();
-            return await ReadInto(new Dictionary<string, string?>(numElements), numElements, buf, async, cancellationToken);
+            return await ReadInto(new Dictionary<string, string?>(numElements), numElements, buf, async);
         }
 
         ValueTask<IDictionary<string, string?>> INpgsqlTypeHandler<IDictionary<string, string?>>.Read(
-            NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => new ValueTask<IDictionary<string, string?>>(Read(buf, len, async, fieldDescription, cancellationToken).Result);
+            NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => new ValueTask<IDictionary<string, string?>>(Read(buf, len, async, fieldDescription).Result);
 
         #endregion
 
@@ -173,11 +173,11 @@ namespace Npgsql.TypeHandlers
             => Write((IDictionary<string, string?>)value, buf, lengthCache, parameter, async, cancellationToken);
 
         async ValueTask<ImmutableDictionary<string, string?>> INpgsqlTypeHandler<ImmutableDictionary<string, string?>>.Read(
-            NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+            NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var numElements = buf.ReadInt32();
-            return (await ReadInto(ImmutableDictionary<string, string?>.Empty.ToBuilder(), numElements, buf, async, cancellationToken))
+            return (await ReadInto(ImmutableDictionary<string, string?>.Empty.ToBuilder(), numElements, buf, async))
                 .ToImmutable();
         }
 

--- a/src/Npgsql/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/TypeHandlers/JsonHandler.cs
@@ -224,11 +224,11 @@ namespace Npgsql.TypeHandlers
         }
 
         /// <inheritdoc />
-        protected internal override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override async ValueTask<T> Read<T>(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null)
         {
             if (_isJsonb)
             {
-                await buf.Ensure(1, async, cancellationToken);
+                await buf.Ensure(1, async);
                 var version = buf.ReadByte();
                 if (version != JsonbProtocolVersion)
                     throw new NotSupportedException($"Don't know how to decode JSONB with wire format {version}, your connection is now broken");
@@ -241,20 +241,20 @@ namespace Npgsql.TypeHandlers
                 typeof(T) == typeof(char)               ||
                 typeof(T) == typeof(byte[]))
             {
-                return await _textHandler.Read<T>(buf, byteLen, async, fieldDescription, cancellationToken);
+                return await _textHandler.Read<T>(buf, byteLen, async, fieldDescription);
             }
 
             // See #2818 for possibly returning a JsonDocument directly over our internal buffer, rather
             // than deserializing to string.
-            var s = await _textHandler.Read(buf, byteLen, async, fieldDescription, cancellationToken);
+            var s = await _textHandler.Read(buf, byteLen, async, fieldDescription);
             return typeof(T) == typeof(JsonDocument)
                 ? (T)(object)JsonDocument.Parse(s)
                 : JsonSerializer.Deserialize<T>(s, _serializerOptions)!;
         }
 
         /// <inheritdoc />
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => Read<string>(buf, len, async, fieldDescription, cancellationToken);
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => Read<string>(buf, len, async, fieldDescription);
 
         /// <inheritdoc />
         public TextReader GetTextReader(Stream stream)

--- a/src/Npgsql/TypeHandlers/JsonPathHandler.cs
+++ b/src/Npgsql/TypeHandlers/JsonPathHandler.cs
@@ -52,15 +52,15 @@ namespace Npgsql.TypeHandlers
             : base(postgresType) => _textHandler = new TextHandler(postgresType, connection);
 
         /// <inheritdoc />
-        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async);
 
             var version = buf.ReadByte();
             if (version != JsonPathVersion)
                 throw new NotSupportedException($"Don't know how to decode JSONPATH with wire format {version}, your connection is now broken");
 
-            return await _textHandler.Read(buf, len - 1, async, fieldDescription, cancellationToken);
+            return await _textHandler.Read(buf, len - 1, async, fieldDescription);
         }
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeHandlers/LQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/LQueryHandler.cs
@@ -78,15 +78,15 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async);
 
             var version = buf.ReadByte();
             if (version != LQueryProtocolVersion)
                 throw new NotSupportedException($"Don't know how to decode lquery with wire format {version}, your connection is now broken");
 
-            return await base.Read(buf, len - 1, async, fieldDescription, cancellationToken);
+            return await base.Read(buf, len - 1, async, fieldDescription);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandlers/LTreeHandler.cs
+++ b/src/Npgsql/TypeHandlers/LTreeHandler.cs
@@ -80,15 +80,15 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async);
 
             var version = buf.ReadByte();
             if (version != LtreeProtocolVersion)
                 throw new NotSupportedException($"Don't know how to decode ltree with wire format {version}, your connection is now broken");
 
-            return await base.Read(buf, len - 1, async, fieldDescription, cancellationToken);
+            return await base.Read(buf, len - 1, async, fieldDescription);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandlers/LTxtQueryHandler.cs
+++ b/src/Npgsql/TypeHandlers/LTxtQueryHandler.cs
@@ -79,15 +79,15 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async);
 
             var version = buf.ReadByte();
             if (version != LTxtQueryProtocolVersion)
                 throw new NotSupportedException($"Don't know how to decode ltxtquery with wire format {version}, your connection is now broken");
 
-            return await base.Read(buf, len - 1, async, fieldDescription, cancellationToken);
+            return await base.Read(buf, len - 1, async, fieldDescription);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandlers/RangeHandler.cs
+++ b/src/Npgsql/TypeHandlers/RangeHandler.cs
@@ -72,12 +72,12 @@ namespace Npgsql.TypeHandlers
             => Read<TAny>(buf, len, false, fieldDescription).Result;
 
         /// <inheritdoc />
-        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => DoRead<TElement>(buf, len, async, fieldDescription, cancellationToken);
+        public override ValueTask<NpgsqlRange<TElement>> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => DoRead<TElement>(buf, len, async, fieldDescription);
 
-        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        private protected async ValueTask<NpgsqlRange<TAny>> DoRead<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
-            await buf.Ensure(1, async, cancellationToken);
+            await buf.Ensure(1, async);
 
             var flags = (RangeFlags)buf.ReadByte();
             if ((flags & RangeFlags.Empty) != 0)
@@ -87,10 +87,10 @@ namespace Npgsql.TypeHandlers
             var upperBound = default(TAny);
 
             if ((flags & RangeFlags.LowerBoundInfinite) == 0)
-                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken: cancellationToken);
+                lowerBound = await _elementHandler.ReadWithLength<TAny>(buf, async);
 
             if ((flags & RangeFlags.UpperBoundInfinite) == 0)
-                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async, cancellationToken: cancellationToken);
+                upperBound = await _elementHandler.ReadWithLength<TAny>(buf, async);
 
             return new NpgsqlRange<TAny>(lowerBound, upperBound, flags);
         }
@@ -210,8 +210,8 @@ namespace Npgsql.TypeHandlers
         public RangeHandler(PostgresType rangePostgresType, NpgsqlTypeHandler elementHandler)
             : base(rangePostgresType, elementHandler, new[] { typeof(NpgsqlRange<TElement1>), typeof(NpgsqlRange<TElement2>) }) {}
 
-        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
-            => DoRead<TElement2>(buf, len, async, fieldDescription, cancellationToken);
+        ValueTask<NpgsqlRange<TElement2>> INpgsqlTypeHandler<NpgsqlRange<TElement2>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => DoRead<TElement2>(buf, len, async, fieldDescription);
 
         /// <inheritdoc />
         public int ValidateAndGetLength(NpgsqlRange<TElement2> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)

--- a/src/Npgsql/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/TypeHandlers/RecordHandler.cs
@@ -39,20 +39,20 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override async ValueTask<object[]> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var fieldCount = buf.ReadInt32();
             var result = new object[fieldCount];
 
             for (var i = 0; i < fieldCount; i++)
             {
-                await buf.Ensure(8, async, cancellationToken);
+                await buf.Ensure(8, async);
                 var typeOID = buf.ReadUInt32();
                 var fieldLen = buf.ReadInt32();
                 if (fieldLen == -1)  // Null field, simply skip it and leave at default
                     continue;
-                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async, cancellationToken: cancellationToken);
+                result[i] = await _typeMapper.GetByOID(typeOID).ReadAsObject(buf, fieldLen, async);
             }
 
             return result;

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -78,7 +78,7 @@ namespace Npgsql.TypeHandlers
         #region Read
 
         /// <inheritdoc />
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null)
         {
             return buf.ReadBytesLeft >= byteLen
                 ? new ValueTask<string>(buf.ReadString(byteLen))
@@ -90,7 +90,7 @@ namespace Npgsql.TypeHandlers
                 {
                     // The string's byte representation can fit in our read buffer, read it.
                     while (buf.ReadBytesLeft < byteLen)
-                        await buf.ReadMore(async, cancellationToken);
+                        await buf.ReadMore(async);
                     return buf.ReadString(byteLen);
                 }
 
@@ -109,7 +109,7 @@ namespace Npgsql.TypeHandlers
                     pos += len;
                     if (pos < byteLen)
                     {
-                        await buf.ReadMore(async, cancellationToken);
+                        await buf.ReadMore(async);
                         continue;
                     }
                     break;
@@ -118,13 +118,13 @@ namespace Npgsql.TypeHandlers
             }
         }
 
-        async ValueTask<char[]> INpgsqlTypeHandler<char[]>.Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        async ValueTask<char[]> INpgsqlTypeHandler<char[]>.Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription)
         {
             if (byteLen <= buf.Size)
             {
                 // The string's byte representation can fit in our read buffer, read it.
                 while (buf.ReadBytesLeft < byteLen)
-                    await buf.ReadMore(async, cancellationToken);
+                    await buf.ReadMore(async);
                 return buf.ReadChars(byteLen);
             }
 
@@ -138,7 +138,7 @@ namespace Npgsql.TypeHandlers
                 pos += len;
                 if (pos < byteLen)
                 {
-                    await buf.ReadMore(async, cancellationToken);
+                    await buf.ReadMore(async);
                     continue;
                 }
                 break;
@@ -146,12 +146,12 @@ namespace Npgsql.TypeHandlers
             return buf.TextEncoding.GetChars(tempBuf);
         }
 
-        async ValueTask<char> INpgsqlTypeHandler<char>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        async ValueTask<char> INpgsqlTypeHandler<char>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
             // Make sure we have enough bytes in the buffer for a single character
             var maxBytes = Math.Min(buf.TextEncoding.GetMaxByteCount(1), len);
             while (buf.ReadBytesLeft < maxBytes)
-                await buf.ReadMore(async, cancellationToken);
+                await buf.ReadMore(async);
 
             var decoder = buf.TextEncoding.GetDecoder();
             decoder.Convert(buf.Buffer, buf.ReadPosition, maxBytes, _singleCharArray, 0, 1, true, out var bytesUsed, out var charsUsed, out _);
@@ -163,10 +163,10 @@ namespace Npgsql.TypeHandlers
             return _singleCharArray[0];
         }
 
-        ValueTask<ArraySegment<char>> INpgsqlTypeHandler<ArraySegment<char>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<ArraySegment<char>> INpgsqlTypeHandler<ArraySegment<char>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
             => throw new NotSupportedException("Only writing ArraySegment<char> to PostgreSQL text is supported, no reading.");
 
-        ValueTask<byte[]> INpgsqlTypeHandler<byte[]>.Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken)
+        ValueTask<byte[]> INpgsqlTypeHandler<byte[]>.Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription)
         {
             var bytes = new byte[byteLen];
             if (buf.ReadBytesLeft >= byteLen)
@@ -182,7 +182,7 @@ namespace Npgsql.TypeHandlers
                 {
                     // The bytes can fit in our read buffer, read it.
                     while (buf.ReadBytesLeft < byteLen)
-                        await buf.ReadMore(async, cancellationToken);
+                        await buf.ReadMore(async);
                     buf.ReadBytes(bytes, 0, byteLen);
                     return bytes;
                 }
@@ -200,7 +200,7 @@ namespace Npgsql.TypeHandlers
                     pos += len;
                     if (pos < byteLen)
                     {
-                        await buf.ReadMore(async, cancellationToken);
+                        await buf.ReadMore(async);
                         continue;
                     }
                     break;

--- a/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnknownTypeHandler.cs
@@ -24,7 +24,7 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int byteLen, bool async, FieldDescription? fieldDescription = null)
         {
             if (fieldDescription == null)
                 throw new Exception($"Received an unknown field but {nameof(fieldDescription)} is null (i.e. COPY mode)");
@@ -37,7 +37,7 @@ namespace Npgsql.TypeHandlers
                         : $"The field '{fieldDescription.Name}' has a type currently unknown to Npgsql (OID {fieldDescription.TypeOID}). You can retrieve it as a string by marking it as unknown, please see the FAQ."
                 );
 
-            return base.Read(buf, byteLen, async, fieldDescription, cancellationToken);
+            return base.Read(buf, byteLen, async, fieldDescription);
         }
 
         #endregion Read

--- a/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/TypeHandlers/UnmappedEnumHandler.cs
@@ -29,9 +29,9 @@ namespace Npgsql.TypeHandlers
 
         #region Read
 
-        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            var s = await base.Read(buf, len, async, fieldDescription, cancellationToken);
+            var s = await base.Read(buf, len, async, fieldDescription);
             if (typeof(TAny) == typeof(string))
                 return (TAny)(object)s;
 
@@ -45,8 +45,8 @@ namespace Npgsql.TypeHandlers
             return (TAny)(object)value;
         }
 
-        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => base.Read(buf, len, async, fieldDescription, cancellationToken);
+        public override ValueTask<string> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => base.Read(buf, len, async, fieldDescription);
 
         #endregion
 

--- a/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/INpgsqlTypeHandler.cs
@@ -18,9 +18,8 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
+        ValueTask<T> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Responsible for validating that a value represents a value of the correct and which can be

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandler.cs
@@ -70,10 +70,9 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => Read<TDefault>(buf, len, async, fieldDescription, cancellationToken);
+        public sealed override ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => Read<TDefault>(buf, len, async, fieldDescription);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,
@@ -83,11 +82,10 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal sealed override async ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(len, async, cancellationToken);
+            await buf.Ensure(len, async);
             return Read<TAny>(buf, len, fieldDescription);
         }
 

--- a/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlSimpleTypeHandlerWithPsv.cs
@@ -62,8 +62,8 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's provider-specific type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => (await Read<TPsv>(buf, len, async, fieldDescription, cancellationToken))!;
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => (await Read<TPsv>(buf, len, async, fieldDescription))!;
 
         #endregion Read
 

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler.cs
@@ -39,9 +39,8 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        protected internal abstract ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
+        protected internal abstract ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TAny"/> with the given length from the provided buffer,
@@ -65,7 +64,7 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's default read type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal abstract ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
+        internal abstract ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Reads a column as the type handler's provider-specific type, assuming that it is already entirely
@@ -79,22 +78,22 @@ namespace Npgsql.TypeHandling
         /// Reads a column as the type handler's provider-specific type. If it is not already entirely in
         /// memory, sync or async I/O will be performed as specified by <paramref name="async"/>.
         /// </summary>
-        internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => ReadAsObject(buf, len, async, fieldDescription, cancellationToken);
+        internal virtual ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => ReadAsObject(buf, len, async, fieldDescription);
 
         /// <summary>
         /// Reads a value from the buffer, assuming our read position is at the value's preceding length.
         /// If the length is -1 (null), this method will return the default value.
         /// </summary>
-        internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        internal async ValueTask<TAny> ReadWithLength<TAny>(NpgsqlReadBuffer buf, bool async, FieldDescription? fieldDescription = null)
         {
-            await buf.Ensure(4, async, cancellationToken);
+            await buf.Ensure(4, async);
             var len = buf.ReadInt32();
             return len == -1
                ? default!
                : NullableHandler<TAny>.Exists
-                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, fieldDescription, cancellationToken)
-                   : await Read<TAny>(buf, len, async, fieldDescription, cancellationToken);
+                   ? await NullableHandler<TAny>.ReadAsync(this, buf, len, async, fieldDescription)
+                   : await Read<TAny>(buf, len, async, fieldDescription);
         }
 
         #endregion

--- a/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/TypeHandling/NpgsqlTypeHandler`.cs
@@ -60,23 +60,21 @@ namespace Npgsql.TypeHandling
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        public abstract ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
+        public abstract ValueTask<TDefault> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null);
 
         /// <summary>
         /// Reads a value of type <typeparamref name="TDefault"/> with the given length from the provided buffer,
         /// using either sync or async I/O. Type handlers typically don't need to override this -
-        /// override <see cref="Read(NpgsqlReadBuffer, int, bool, FieldDescription, CancellationToken)"/> - but may do
+        /// override <see cref="Read(NpgsqlReadBuffer, int, bool, FieldDescription)"/> - but may do
         /// so in exceptional cases where reading of arbitrary types is required.
         /// </summary>
         /// <param name="buf">The buffer from which to read.</param>
         /// <param name="len">The byte length of the value. The buffer might not contain the full length, requiring I/O to be performed.</param>
         /// <param name="async">If I/O is required to read the full length of the value, whether it should be performed synchronously or asynchronously.</param>
         /// <param name="fieldDescription">Additional PostgreSQL information about the type, such as the length in varchar(30).</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
         /// <returns>The fully-read value.</returns>
-        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
+        protected internal override ValueTask<TAny> Read<TAny>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
             var asTypedHandler = this as INpgsqlTypeHandler<TAny>;
             if (asTypedHandler == null)
@@ -85,7 +83,7 @@ namespace Npgsql.TypeHandling
                     : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TAny).Name}"
                 );
 
-            return asTypedHandler.Read(buf, len, async, fieldDescription, cancellationToken);
+            return asTypedHandler.Read(buf, len, async, fieldDescription);
         }
 
         /// <inheritdoc />
@@ -94,8 +92,8 @@ namespace Npgsql.TypeHandling
 
         // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
         // we must use the bang operator here to tell the compiler that a null value will never returned.
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default)
-            => (await Read<TDefault>(buf, len, async, fieldDescription, cancellationToken: cancellationToken))!;
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => (await Read<TDefault>(buf, len, async, fieldDescription))!;
 
         internal override object ReadAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
             => Read<TDefault>(buf, len, fieldDescription)!;

--- a/src/Npgsql/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/TypeHandling/NullableHandler.cs
@@ -9,7 +9,7 @@ using Npgsql.BackendMessages;
 namespace Npgsql.TypeHandling
 {
     delegate T ReadDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
-    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null, CancellationToken cancellationToken = default);
+    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
 
     delegate int ValidateAndGetLengthDelegate<T>(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
     delegate Task WriteAsyncDelegate<T>(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default);
@@ -49,9 +49,9 @@ namespace Npgsql.TypeHandling
             where T : struct
             => handler.Read<T>(buffer, columnLength, fieldDescription);
 
-        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription, CancellationToken cancellationToken = default)
+        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription)
             where T : struct
-            => await handler.Read<T>(buffer, columnLength, async, fieldDescription, cancellationToken);
+            => await handler.Read<T>(buffer, columnLength, async, fieldDescription);
 
         static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             where T : struct

--- a/src/Npgsql/VolatileResourceManager.cs
+++ b/src/Npgsql/VolatileResourceManager.cs
@@ -200,7 +200,7 @@ namespace Npgsql
                         throw new Exception($"Could not roll back after {MaximumRollbackAttempts} attempts, aborting. Transaction is in an unknown state.");
 
                     Log.Warn($"Connection in use while trying to rollback, will cancel and retry (localid={_txId}", _connector.Id);
-                    _connector.CancelRequest();
+                    _connector.PerformPostgresCancellation();
                     // Cancellations are asynchronous, give it some time
                     Thread.Sleep(500);
                 }

--- a/test/Npgsql.Tests/NotificationTests.cs
+++ b/test/Npgsql.Tests/NotificationTests.cs
@@ -169,7 +169,7 @@ namespace Npgsql.Tests
             using (var conn = OpenConnection())
             {
                 Assert.That(async () => await conn.WaitAsync(new CancellationToken(true)),
-                    Throws.Exception.TypeOf<TaskCanceledException>());
+                    Throws.Exception.TypeOf<OperationCanceledException>());
                 Assert.That(conn.ExecuteScalar("SELECT 1"), Is.EqualTo(1));
             }
 


### PR DESCRIPTION
OK, I think I finally have something nice working. In a nutshell:

* There's a single NpgsqlConnector.StartCancellableOperation. You call it, give it the user's token and tell it if you want PG cancellation or not. It returns a disposable which you dispose at the end of the operation. That's it.
* The token is registered to call PerformUserCancellation, which will either do PG cancellation or go directly to hard cancellation (his same method is called by the sync NpgsqlCommand.Cancel). This also takes care of non-PG cancellation, so no more need to flow the user's cancellation token down the stack. This makes PG and non-PG cancellations work very similarly, obviates having to pass the tokens around all the time, and will simplify ResettableCancellationTokenSource (since it will only ever have one token).
* It's tempting to think of merging the new cancellable operation mechanism and the existing user action mechanism. But an entire command is a user action, encompassing multiple cancellable operations (e.g. ExecuteReader, NextResult, Read...). Maybe something specific for simple operations can be done, where the user action has the same scope as the cancellable operation.

This a draft - @vonzshik I wanted some early feedback from you. If this is a good direction, here's the stuff still to be done by me:

* Dispose cancellation registrations asynchronously as appropriate
* Clean up ResettableCancellationTokenSource now that it doesn't have to deal with a second token
* Remove cancellation tokens from the type handler hierarchy etc.
* Finish up replication
* COPY is messy, but this isn't really related to this PR (to be cleaned up later)