### PR TITLE
Trigger PG cancellation even for cancelled tokens for nested operations

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -1563,8 +1563,6 @@ namespace Npgsql
             CancellationToken cancellationToken = default,
             bool attemptPgCancellation = true)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             UserCancellationToken = cancellationToken;
             AttemptPostgresCancellation = attemptPgCancellation;
 

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -256,6 +256,9 @@ namespace Npgsql.Tests.Support
             return this;
         }
 
+        internal PgServerMock WriteCancellationResponse()
+            => WriteErrorResponse(PostgresErrorCodes.QueryCanceled, "Cancellation", "Query cancelled");
+
         internal PgServerMock WriteErrorResponse(string code)
             => WriteErrorResponse(code, "ERROR", "MOCK ERROR MESSAGE");
 


### PR DESCRIPTION
Thanks @vonzshik for flagging this

Co-authored-by: Nikita Kazmin <vonzshik@gmail.com>