### PR TITLE
Memory reuse for clear text and MD5 authentication

### DIFF
--- a/src/Npgsql/BackendMessages/AuthenticationMessages.cs
+++ b/src/Npgsql/BackendMessages/AuthenticationMessages.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Npgsql.Logging;
 using Npgsql.Util;
 
@@ -38,19 +39,13 @@ namespace Npgsql.BackendMessages
     {
         internal override AuthenticationRequestType AuthRequestType => AuthenticationRequestType.AuthenticationMD5Password;
 
-        internal byte[] Salt { get; private set; }
+        internal int Salt { get; }
 
-        internal static AuthenticationMD5PasswordMessage Load(NpgsqlReadBuffer buf)
-        {
-            var salt = new byte[4];
-            buf.ReadBytes(salt, 0, 4);
-            return new AuthenticationMD5PasswordMessage(salt);
-        }
+        internal static AuthenticationMD5PasswordMessage Load(NpgsqlReadBuffer buf) =>
+            new AuthenticationMD5PasswordMessage(buf.ReadInt32(BitConverter.IsLittleEndian));
 
-        AuthenticationMD5PasswordMessage(byte[] salt)
-        {
+        AuthenticationMD5PasswordMessage(int salt) =>
             Salt = salt;
-        }
     }
 
     class AuthenticationSCMCredentialMessage : AuthenticationRequestMessage


### PR DESCRIPTION
This change slightly decreases memory usage, but not completely eliminates them because of .NET Standard 2 support. SASL authentication is untouched due to it's complexity; otherwise, no one can understand the code.

In case of dropping .NET Standard 2, it's possible to use stack allocations mostly and provide own buffers for hash methods.