### PR TITLE
Remove 2 memory allocations 

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -274,15 +274,15 @@ namespace Npgsql
 
         ValueTask<IBackendMessage> ReadMessage(bool async)
         {
-            return _isSequential ? ReadMessageSequential(async) : Connector.ReadMessage(async);
+            return _isSequential ? ReadMessageSequential(Connector, async) : Connector.ReadMessage(async);
 
-            async ValueTask<IBackendMessage> ReadMessageSequential(bool async2)
+            static async ValueTask<IBackendMessage> ReadMessageSequential(NpgsqlConnector connector, bool async2)
             {
-                var msg = await Connector.ReadMessage(async2, DataRowLoadingMode.Sequential);
+                var msg = await connector.ReadMessage(async2, DataRowLoadingMode.Sequential);
                 if (msg.Code == BackendMessageCode.DataRow)
                 {
                     // Make sure that the datarow's column count is already buffered
-                    await Connector.ReadBuffer.Ensure(2, async);
+                    await connector.ReadBuffer.Ensure(2, async2);
                     return msg;
                 }
                 return msg;

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -82,9 +82,9 @@ namespace Npgsql.TypeHandlers
         {
             return buf.ReadBytesLeft >= byteLen
                 ? new ValueTask<string>(buf.ReadString(byteLen))
-                : ReadLong();
+                : ReadLong(buf, byteLen, async);
 
-            async ValueTask<string> ReadLong()
+            static async ValueTask<string> ReadLong(NpgsqlReadBuffer buf, int byteLen, bool async)
             {
                 if (byteLen <= buf.Size)
                 {


### PR DESCRIPTION
Removed 2 closure allocations by making local functions static and passing all context via args. 

~300k / 1.75M allocation were removed.

![image](https://user-images.githubusercontent.com/1737207/99851939-0d666a00-2b91-11eb-978b-bc340af6c634.png)

