### PR TITLE
Fixed typo in NpgsqlSchema.GetIndexColumns.

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -361,7 +361,7 @@ WHERE
     a.attnum = ANY(ix.indkey) AND
     t.relkind = 'r'");
 
-            using var command = BuildCommand(conn, getIndexColumns, restrictions, false, "current_database()", "n.nspname", "t.relname", "i.relname", "a.attname");
+            using var command = BuildCommand(conn, getIndexColumns, restrictions, false, "current_database()", "n.nspname", "t.relname", "ix_cls.relname", "a.attname");
             using var adapter = new NpgsqlDataAdapter(command);
             await adapter.Fill(indexColumns, async, cancellationToken);
 

--- a/test/Npgsql.Tests/SchemaTests.cs
+++ b/test/Npgsql.Tests/SchemaTests.cs
@@ -435,7 +435,7 @@ CREATE UNIQUE INDEX idx_unique ON data (f1, f2);
                 Assert.That(index["index_name"], Is.EqualTo("idx_unique"));
                 Assert.That(index["type_desc"], Is.EqualTo(""));
 
-                string[] indexColumnRestrictions = { null!, null!, "data" };
+                string[] indexColumnRestrictions = { null!, null!, "data", "idx_unique" };
                 var dataTable2 = await GetSchema(conn, "INDEXCOLUMNS", indexColumnRestrictions);
                 var columns = dataTable2.Rows.Cast<DataRow>().ToList();
 


### PR DESCRIPTION
There was typo in GetIndexColumns uncovered by tests, as far as 4th member of restrictions parameter was never provided.

I have updated test to supply 4th parameter (which fails on master) and fixed typo in method.

Original exception:
>   Message: 
>     Npgsql.PostgresException : 42P01: missing FROM-clause entry for table "i"
>     Data:
>       Severity: ERROR
>       InvariantSeverity: ERROR
>       SqlState: 42P01
>       MessageText: missing FROM-clause entry for table "i"
>       Position: 783
>       File: d:\pginstaller_12.auto\postgres.windows-x64\src\backend\parser\parse_relation.c
>       Line: 3305
>       Routine: errorMissingRTE