### PR TITLE
Fixed socket connection using IPv6 for async method

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -838,7 +838,11 @@ namespace Npgsql
             {
                 var endpoint = endpoints[i];
                 Log.Trace($"Attempting to connect to {endpoint}");
-                var protocolType = endpoint.AddressFamily == AddressFamily.InterNetwork ? ProtocolType.Tcp : ProtocolType.IP;
+                var protocolType =
+                    endpoint.AddressFamily == AddressFamily.InterNetwork ||
+                    endpoint.AddressFamily == AddressFamily.InterNetworkV6
+                    ? ProtocolType.Tcp
+                    : ProtocolType.IP;
                 var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, protocolType);
                 CancellationTokenSource? combinedCts = null;
                 try


### PR DESCRIPTION
Original issue: https://github.com/npgsql/npgsql/issues/3363
Implementing following fix for async method: https://github.com/npgsql/npgsql/pull/3364