### PR TITLE
Optimized reading rows in a sequential mode, if they are already in the buffer

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -88,9 +88,16 @@ namespace Npgsql
 
         /// <summary>
         /// The position in the buffer at which the current data row message ends.
-        /// Used only in non-sequential mode.
+        /// Used only when the row is consumed non-sequentially. 
         /// </summary>
         int _dataMsgEnd;
+
+        /// <summary>
+        /// Determines, if we can consume the row non-sequentially.
+        /// Mostly useful for a sequential mode, when the row is already in the buffer.
+        /// Should always be true for the non-sequential mode.
+        /// </summary>
+        bool CanConsumeRowNonSequential => _dataMsgEnd - Buffer.ReadPosition <= Buffer.ReadBytesLeft;
 
         int _charPos;
 
@@ -197,8 +204,13 @@ namespace Npgsql
                 State = ReaderState.InResult;
                 return true;
             case ReaderState.InResult:
-                if (_isSequential)
+                if (!CanConsumeRowNonSequential)
+                {
+                    // We should get here only if we're in a sequential mode
+                    Debug.Assert(_isSequential);
                     return null;
+                }
+                // We get here, if we're in a non-sequential mode (or the row is already in the buffer)
                 ConsumeRowNonSequential();
                 break;
             case ReaderState.BetweenResults:
@@ -697,10 +709,10 @@ namespace Npgsql
             Debug.Assert(_numColumns == RowDescription!.NumFields,
                 $"Row's number of columns ({_numColumns}) differs from the row description's ({RowDescription.NumFields})");
 
+            _dataMsgEnd = Buffer.ReadPosition + msg.Length - 2;
+
             if (!_isSequential)
             {
-                _dataMsgEnd = Buffer.ReadPosition + msg.Length - 2;
-
                 // Initialize our columns array with the offset and length of the first column
                 _columns.Clear();
                 var len = Buffer.ReadInt32();
@@ -2028,8 +2040,14 @@ namespace Npgsql
         {
             Debug.Assert(State == ReaderState.InResult || State == ReaderState.BeforeResult);
 
-            if (_isSequential)
+            if (!CanConsumeRowNonSequential)
+            {
+                // We should get here only if we're in a sequential mode
+                Debug.Assert(_isSequential);
                 return ConsumeRowSequential(async);
+            }
+
+            // We get here, if we're in a non-sequential mode (or the row is already in the buffer)
             ConsumeRowNonSequential();
             return Task.CompletedTask;
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -102,11 +102,7 @@ namespace Npgsql
             get
             {
                 var result = _dataMsgEnd - Buffer.ReadPosition <= Buffer.ReadBytesLeft;
-                if (!result)
-                {
-                    // We should get here only if we're in a sequential mode
-                    Debug.Assert(_isSequential);
-                }
+                Debug.Assert(result || _isSequential);
                 return result;
             }
         }


### PR DESCRIPTION
Fixes #2053

For comparison:

Before

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1256 (1909/November2018Update/19H2)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT


```
| Method | NumRows | Sequential |     Mean |    Error |   StdDev |   Median |
|------- |-------- |----------- |---------:|---------:|---------:|---------:|
|   **Read** |       **1** |      **False** | **143.4 μs** |  **4.16 μs** | **12.27 μs** | **140.3 μs** |
|   **Read** |       **1** |       **True** | **143.3 μs** |  **4.59 μs** | **13.23 μs** | **138.7 μs** |
|   **Read** |      **10** |      **False** | **139.2 μs** |  **3.18 μs** |  **9.13 μs** | **138.4 μs** |
|   **Read** |      **10** |       **True** | **147.0 μs** |  **3.86 μs** | **11.26 μs** | **145.4 μs** |
|   **Read** |     **100** |      **False** | **175.3 μs** |  **4.68 μs** | **13.66 μs** | **172.0 μs** |
|   **Read** |     **100** |       **True** | **205.3 μs** |  **5.55 μs** | **16.19 μs** | **204.9 μs** |
|   **Read** |    **1000** |      **False** | **401.3 μs** |  **7.98 μs** | **11.94 μs** | **399.3 μs** |
|   **Read** |    **1000** |       **True** | **590.9 μs** | **11.76 μs** | **12.58 μs** | **591.5 μs** |

After

| Method | NumRows | Sequential |     Mean |   Error |   StdDev |   Median |
|------- |-------- |----------- |---------:|--------:|---------:|---------:|
|   **Read** |       **1** |      **False** | **128.3 μs** | **2.56 μs** |  **7.19 μs** | **128.0 μs** |
|   **Read** |       **1** |       **True** | **125.9 μs** | **2.50 μs** |  **4.31 μs** | **125.6 μs** |
|   **Read** |      **10** |      **False** | **127.8 μs** | **2.51 μs** |  **3.08 μs** | **127.1 μs** |
|   **Read** |      **10** |       **True** | **136.1 μs** | **3.33 μs** |  **9.71 μs** | **133.7 μs** |
|   **Read** |     **100** |      **False** | **160.7 μs** | **4.41 μs** | **13.02 μs** | **158.2 μs** |
|   **Read** |     **100** |       **True** | **164.5 μs** | **5.26 μs** | **15.17 μs** | **158.7 μs** |
|   **Read** |    **1000** |      **False** | **395.2 μs** | **7.50 μs** |  **7.71 μs** | **396.5 μs** |
|   **Read** |    **1000** |       **True** | **394.7 μs** | **6.72 μs** |  **7.74 μs** | **394.6 μs** |