### PR TITLE
Fixed writing of NodaTime.Duration if there is too many seconds

### DIFF
--- a/src/Npgsql.NodaTime/IntervalHandler.cs
+++ b/src/Npgsql.NodaTime/IntervalHandler.cs
@@ -55,7 +55,7 @@ namespace Npgsql.NodaTime
 
         public override void Write(Period value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
         {
-            // be mindful, what the end result must be long
+            // Note that the end result must be long
             // see #3438
             var microsecondsInDay =
                 (((value.Hours * NodaConstants.MinutesPerHour + value.Minutes) * NodaConstants.SecondsPerMinute + value.Seconds) * NodaConstants.MillisecondsPerSecond + value.Milliseconds) * 1000 +
@@ -84,7 +84,7 @@ namespace Npgsql.NodaTime
         {
             const long microsecondsPerSecond = 1_000_000;
 
-            // be mindful, what the end result must be long
+            // Note that the end result must be long
             // see #3438
             var microsecondsInDay =
                 (((value.Hours * NodaConstants.MinutesPerHour + value.Minutes) * NodaConstants.SecondsPerMinute + value.Seconds) *

--- a/src/Npgsql.NodaTime/IntervalHandler.cs
+++ b/src/Npgsql.NodaTime/IntervalHandler.cs
@@ -55,6 +55,8 @@ namespace Npgsql.NodaTime
 
         public override void Write(Period value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
         {
+            // be mindful, what the end result must be long
+            // see #3438
             var microsecondsInDay =
                 (((value.Hours * NodaConstants.MinutesPerHour + value.Minutes) * NodaConstants.SecondsPerMinute + value.Seconds) * NodaConstants.MillisecondsPerSecond + value.Milliseconds) * 1000 +
                 value.Nanoseconds / 1000; // Take the microseconds, discard the nanosecond remainder
@@ -80,8 +82,10 @@ namespace Npgsql.NodaTime
 
         public void Write(Duration value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
         {
-            const int microsecondsPerSecond = 1_000_000;
+            const long microsecondsPerSecond = 1_000_000;
 
+            // be mindful, what the end result must be long
+            // see #3438
             var microsecondsInDay =
                 (((value.Hours * NodaConstants.MinutesPerHour + value.Minutes) * NodaConstants.SecondsPerMinute + value.Seconds) *
                     microsecondsPerSecond + value.SubsecondNanoseconds / 1000); // Take the microseconds, discard the nanosecond remainder

--- a/test/Npgsql.PluginTests/NodaTimeTests.cs
+++ b/test/Npgsql.PluginTests/NodaTimeTests.cs
@@ -424,6 +424,24 @@ namespace Npgsql.PluginTests
             }
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3438")]
+        public void Bug3438()
+        {
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
+
+            var expected = Duration.FromSeconds(2148);
+
+            cmd.Parameters.Add(new NpgsqlParameter("p1", NpgsqlDbType.Interval) { Value = expected });
+            cmd.Parameters.AddWithValue("p2", expected);
+            using var reader = cmd.ExecuteReader();
+            reader.Read();
+            for (var i = 0; i < 2; i++)
+            {
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Period)));
+            }
+        }
+
         [Test]
         public void IntervalAsTimeSpan()
         {


### PR DESCRIPTION
Fixes #3438