### PR TITLE
Intern strings read from the database

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Clean
+        run: dotnet clean -v m
+        
+      - name: Clear cache
+        run: dotnet nuget locals all --clear
+        
       - name: NuGet Cache
         uses: actions/cache@v2
         with:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.3" />
-    <PackageReference Update="System.Memory" Version="4.5.3" />
+    <PackageReference Update="System.Memory" Version="4.5.4" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="System.Text.Json" Version="4.6.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-    <PackageReference Include="Ben.StringIntern" Version="0.1.7" />
+    <PackageReference Include="Ben.StringIntern" Version="0.1.8" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -11,12 +11,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+    <PackageReference Include="Ben.StringIntern" Version="0.1.7" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -18,6 +18,7 @@ using NpgsqlTypes;
 using static Npgsql.Util.Statics;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using Ben.Collections;
 
 namespace Npgsql
 {
@@ -796,7 +797,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     statement.Reset();
                     _statements.Clear();
                 }
-                statement.SQL = sb.ToString();
+                statement.SQL = sb.Intern();
                 statement.InputParameters.AddRange(inputList);
                 _statements.Add(statement);
                 break;

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Ben.Collections;
+
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
 
@@ -143,7 +146,7 @@ namespace Npgsql
                     }
                 }
             }
-            command.CommandText = query.ToString();
+            command.CommandText = query.Intern();
             command.Connection = conn;
 
             return command;

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -4,6 +4,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 
+using Ben.Collections;
+
 // ReSharper disable once CheckNamespace
 namespace NpgsqlTypes
 {
@@ -349,7 +351,7 @@ namespace NpgsqlTypes
 
             sb.Append(UpperBoundIsInclusive ? UpperInclusiveBound : UpperExclusiveBound);
 
-            return sb.ToString();
+            return sb.Intern();
         }
 
         // TODO: rewrite this to use ReadOnlySpan<char> for the 4.1 release

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -10,8 +10,8 @@ namespace Npgsql
 {
     class SqlQueryParser
     {
-        readonly Dictionary<string, int> _paramIndexMap = new();
-        readonly StringBuilder _rewrittenSql = new();
+        [ThreadStatic]
+        static Cache? s_cache;
 
         /// <summary>
         /// Receives a raw SQL query as passed in by the user, and performs some processing necessary
@@ -36,14 +36,45 @@ namespace Npgsql
             List<NpgsqlStatement> statements,
             bool standardConformingStrings,
             bool deriveParameters = false)
-            => ParseRawQuery(sql.AsSpan(), parameters, statements, standardConformingStrings, deriveParameters);
+        {
+            var cache = (s_cache ??= new ());
 
-        void ParseRawQuery(
-            ReadOnlySpan<char> sql,
+            var sb = (cache.sb ??= new());
+            var dict = (cache.dict ??= new());
+
+            ParseRawQuery(parameters, statements, standardConformingStrings, deriveParameters, sb, dict, sql.AsSpan());
+
+            if (dict.Count <= 32)
+            {
+                // Not too big, clear and keep
+                dict.Clear();
+            }
+            else
+            {
+                // Too big drop it from the cache
+                cache.dict = null;
+            }
+
+            if (sb.Length <= 150)
+            {
+                // Not too big, clear and keep
+                sb.Clear();
+            }
+            else
+            {
+                // Too big drop it from the cache
+                cache.sb = null;
+            }
+        }
+
+        static void ParseRawQuery(
             NpgsqlParameterCollection parameters,
             List<NpgsqlStatement> statements,
             bool standardConformingStrings,
-            bool deriveParameters)
+            bool deriveParameters,
+            StringBuilder rewrittenSql,
+            Dictionary<string, int> paramIndexMap,
+            ReadOnlySpan<char> sql)
         {
             Debug.Assert(deriveParameters == false || parameters.Count == 0);
 
@@ -126,7 +157,7 @@ namespace Npgsql
                 if (IsParamNameChar(ch))
                 {
                     if (currCharOfs - 1 > currTokenBeg)
-                        _rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - 1 - currTokenBeg));
+                        rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - 1 - currTokenBeg));
                     currTokenBeg = currCharOfs++ - 1;
                     goto Param;
                 }
@@ -144,7 +175,7 @@ namespace Npgsql
                 {
                     var paramName = Intern(sql.Slice(currTokenBeg + 1, currCharOfs - (currTokenBeg + 1)));
 
-                    if (!_paramIndexMap.TryGetValue(paramName, out var index))
+                    if (!paramIndexMap.TryGetValue(paramName, out var index))
                     {
                         // Parameter hasn't been seen before in this query
                         if (!parameters.TryGetValue(paramName, out var parameter))
@@ -158,7 +189,7 @@ namespace Npgsql
                             {
                                 // Parameter placeholder does not match a parameter on this command.
                                 // Leave the text as it was in the SQL, it may not be a an actual placeholder
-                                _rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg));
+                                rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg));
                                 currTokenBeg = currCharOfs;
                                 if (currCharOfs >= end)
                                     goto Finish;
@@ -172,10 +203,10 @@ namespace Npgsql
                             throw new Exception($"Parameter '{paramName}' referenced in SQL but is an out-only parameter");
 
                         statement.InputParameters.Add(parameter);
-                        index = _paramIndexMap[paramName] = statement.InputParameters.Count;
+                        index = paramIndexMap[paramName] = statement.InputParameters.Count;
                     }
-                    _rewrittenSql.Append('$');
-                    _rewrittenSql.Append(index);
+                    rewrittenSql.Append('$');
+                    rewrittenSql.Append(index);
                     currTokenBeg = currCharOfs;
 
                     if (currCharOfs >= end)
@@ -420,8 +451,8 @@ namespace Npgsql
             goto Finish;
 
         SemiColon:
-            _rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg - 1));
-            statement.SQL = _rewrittenSql.Intern();
+            rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg - 1));
+            statement.SQL = rewrittenSql.Intern();
             while (currCharOfs < end)
             {
                 ch = sql[currCharOfs];
@@ -433,7 +464,7 @@ namespace Npgsql
                 // TODO: Handle end of line comment? Although psql doesn't seem to handle them...
 
                 currTokenBeg = currCharOfs;
-                if (_rewrittenSql.Length > 0)
+                if (rewrittenSql.Length > 0)
                     MoveToNextStatement();
                 goto None;
             }
@@ -442,8 +473,8 @@ namespace Npgsql
             return;
 
         Finish:
-            _rewrittenSql.Append(sql.Slice(currTokenBeg, end - currTokenBeg));
-            statement.SQL = _rewrittenSql.Intern();
+            rewrittenSql.Append(sql.Slice(currTokenBeg, end - currTokenBeg));
+            statement.SQL = rewrittenSql.Intern();
             if (statements.Count > statementIndex + 1)
                statements.RemoveRange(statementIndex + 1, statements.Count - (statementIndex + 1));
 
@@ -460,8 +491,8 @@ namespace Npgsql
                     statement = new NpgsqlStatement();
                     statements.Add(statement);
                 }
-                _paramIndexMap.Clear();
-                _rewrittenSql.Clear();
+                paramIndexMap.Clear();
+                rewrittenSql.Clear();
             }
         }
 
@@ -479,5 +510,11 @@ namespace Npgsql
 
         static bool IsParamNameChar(char ch)
             => char.IsLetterOrDigit(ch) || ch == '_' || ch == '.';  // why dot??
+
+        class Cache
+        {
+            public Dictionary<string, int>? dict;
+            public StringBuilder? sb;
+        }
     }
 }

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
+using Ben.Collections;
+using static Ben.Collections.Specialized.StringCache;
+
 namespace Npgsql
 {
     class SqlQueryParser
@@ -139,7 +142,7 @@ namespace Npgsql
                 lastChar = ch;
                 if (currCharOfs >= end || !IsParamNameChar(ch = sql[currCharOfs]))
                 {
-                    var paramName = sql.Slice(currTokenBeg + 1, currCharOfs - (currTokenBeg + 1)).ToString();
+                    var paramName = Intern(sql.Slice(currTokenBeg + 1, currCharOfs - (currTokenBeg + 1)));
 
                     if (!_paramIndexMap.TryGetValue(paramName, out var index))
                     {
@@ -418,7 +421,7 @@ namespace Npgsql
 
         SemiColon:
             _rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg - 1));
-            statement.SQL = _rewrittenSql.ToString();
+            statement.SQL = _rewrittenSql.Intern();
             while (currCharOfs < end)
             {
                 ch = sql[currCharOfs];
@@ -440,7 +443,7 @@ namespace Npgsql
 
         Finish:
             _rewrittenSql.Append(sql.Slice(currTokenBeg, end - currTokenBeg));
-            statement.SQL = _rewrittenSql.ToString();
+            statement.SQL = _rewrittenSql.Intern();
             if (statements.Count > statementIndex + 1)
                statements.RemoveRange(statementIndex + 1, statements.Count - (statementIndex + 1));
 

--- a/src/Npgsql/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/TypeHandlers/TextHandler.cs
@@ -9,6 +9,7 @@ using Npgsql.PostgresTypes;
 using Npgsql.TypeHandling;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+using static Ben.Collections.Specialized.StringCache;
 
 namespace Npgsql.TypeHandlers
 {
@@ -114,7 +115,7 @@ namespace Npgsql.TypeHandlers
                     }
                     break;
                 }
-                return buf.TextEncoding.GetString(tempBuf);
+                return Intern(tempBuf, buf.TextEncoding);
             }
         }
 


### PR DESCRIPTION
When joining (and also unnormalized) tables with string fields there will be many repeats of identical `string`s which will be created as a new string instance each time. This PR dedupes them with a GC aware LRU cache.

Reuse the `StringBuilder` and parameter `Dictionary<string, int>` for query parsing

Drops *all* the `string`, `char[]`, `StringBuilder` and `Dictionary<string, int>` allocations; or 181MB per 100k requests for Fortunes

Allocations which are dropped:

![image](https://user-images.githubusercontent.com/1142958/104858097-c4bef900-5914-11eb-9bb6-6bb779d6ba0c.png)