### PR TITLE
Don't allocate Action in CloseAsync

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -736,17 +736,16 @@ namespace Npgsql
                 return Task.CompletedTask;
             }
 
-            return CloseAsync(cancellationToken);
+            return CloseAsync(async, cancellationToken);            
+        }
 
-            async Task CloseAsync(CancellationToken cancellationToken)
+        private async Task CloseAsync(bool async, CancellationToken cancellationToken)
+        {
+            Debug.Assert(Connector != null);
+            try
             {
-                Debug.Assert(Connector != null);
                 var connector = Connector;
                 Log.Trace("Closing connection...", connector.Id);
-
-#pragma warning disable CS0197
-                using var _ = Defer(static (c) => Volatile.Write(ref c._closing, 0), this);
-#pragma warning restore CS0197
 
                 if (connector.CurrentReader != null || connector.CurrentCopyOperation != null)
                 {
@@ -815,6 +814,10 @@ namespace Npgsql
                 ConnectorBindingScope = ConnectorBindingScope.None;
                 FullState = ConnectionState.Closed;
                 Log.Debug("Connection closed", connector.Id);
+            }
+            finally
+            {
+                Volatile.Write(ref _closing, 0);
             }
         }
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -739,7 +739,7 @@ namespace Npgsql
             return CloseAsync(async, cancellationToken);            
         }
 
-        private async Task CloseAsync(bool async, CancellationToken cancellationToken)
+        async Task CloseAsync(bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(Connector != null);
             try

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -744,7 +744,9 @@ namespace Npgsql
                 var connector = Connector;
                 Log.Trace("Closing connection...", connector.Id);
 
-                using var _ = Defer(() => Volatile.Write(ref _closing, 0));
+#pragma warning disable CS0197
+                using var _ = Defer(static (c) => Volatile.Write(ref c._closing, 0), this);
+#pragma warning restore CS0197
 
                 if (connector.CurrentReader != null || connector.CurrentCopyOperation != null)
                 {


### PR DESCRIPTION
Spotted this one while profiling

![image](https://user-images.githubusercontent.com/1142958/104827362-c5905600-5854-11eb-98b7-c9f6e50bb1f9.png)

The pragma is to suppress this warning
```
// Using a field of a marshal-by-reference class as a ref or out value
// or taking its address may cause a runtime exception
```
