### PR TITLE
Fixed event counters (busy/idle connections count)

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -187,7 +187,7 @@ namespace Npgsql
             // The canonical pool is the 'base' pool so we need to set that up first. If someone beats us to it use what they put.
             // The connection string pool can either be added here or above, if it's added above we should just use that.
             var newPool = new ConnectorPool(Settings, canonical);
-            _pool = PoolManager.GetOrAdd(canonical, newPool);
+            _pool = PoolManager.GetOrAdd(canonical, newPool, true);
 
             // If the pool we created was the one that ended up being stored we need to increment the appropriate counter.
             // Avoids a race condition where multiple threads will create a pool but only one will be stored.

--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -96,11 +96,10 @@ namespace Npgsql
             // Note: there's no attempt here to be coherent in terms of race conditions, especially not with regards
             // to different counters. So idle and busy and be unsynchronized, as they're not polled together.
             var sum = 0;
-            foreach (var kv in PoolManager.Pools)
+            foreach (var pool in PoolManager.Pools)
             {
-                var pool = kv.Pool;
                 if (pool == null)
-                    return sum;
+                    break;
                 sum += pool.Statistics.Idle;
             }
             return sum;
@@ -111,13 +110,11 @@ namespace Npgsql
             // Note: there's no attempt here to be coherent in terms of race conditions, especially not with regards
             // to different counters. So idle and busy and be unsynchronized, as they're not polled together.
             var sum = 0;
-            foreach (var kv in PoolManager.Pools)
+            foreach (var pool in PoolManager.Pools)
             {
-                var pool = kv.Pool;
                 if (pool == null)
-                    return sum;
-                var (_, _, busy) = pool.Statistics;
-                sum += busy;
+                    break;
+                sum += pool.Statistics.Busy;
             }
             return sum;
         }

--- a/src/Npgsql/PoolManager.cs
+++ b/src/Npgsql/PoolManager.cs
@@ -17,7 +17,7 @@ namespace Npgsql
         internal const int InitialPoolsSize = 10;
 
         static readonly object Lock = new();
-        static volatile (string Key, ConnectorPool Pool)[] _poolsAliases = new (string, ConnectorPool)[InitialPoolsSize];
+        static volatile (string Key, ConnectorPool Pool)[] _poolsByKey = new (string, ConnectorPool)[InitialPoolsSize];
         static volatile ConnectorPool?[] _pools = new ConnectorPool[InitialPoolsSize];
         static volatile int _nextSlot;
 

--- a/test/Npgsql.Tests/PoolManagerTests.cs
+++ b/test/Npgsql.Tests/PoolManagerTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
 
 namespace Npgsql.Tests
 {
@@ -17,6 +19,16 @@ namespace Npgsql.Tests
             }.ToString();
             using (var conn = new NpgsqlConnection(connString2))
                 conn.Open();
+        }
+
+        [Test]
+        public void WithNonCanonicalConnString()
+        {
+            var nonCanonicalConnString = ConnectionString + ";";
+            using (var conn = new NpgsqlConnection(nonCanonicalConnString))
+                conn.Open();
+            // Only one pool, but two alias in PoolManager (for canonical connection string and for noncanonical)
+            Assert.AreEqual(1, PoolManager.Pools.Count(p => p != null));
         }
 
 #if DEBUG


### PR DESCRIPTION
If a non-canonical connection string is used (e.g. trailing semicolon), EventCounters produces idle and busy connections count different from the actual ones.

The reason:
- PoolManager.Pools can contain duplicate pools under different keys (one corresponds to the original connection string, the other to the canonical one)
- NpgsqlEventSource sums the connections count from all values ​​in the PoolManager.Pools