### PR TITLE
DRAFT: Basic support for pg connection file

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -163,6 +163,7 @@ namespace Npgsql
 
             // Connection string hasn't been seen before. Parse it.
             var settings = new NpgsqlConnectionStringBuilder(_connectionString);
+            settings.InitServiceFile();
             settings.Validate();
             Settings = settings;
 

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -31,6 +31,12 @@ namespace Npgsql
 
         public static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
 
+        public static string? Service => Environment.GetEnvironmentVariable("PGSERVICE");
+
+        public static string? ServiceFile => Environment.GetEnvironmentVariable("PGSERVICEFILE");
+
+        public static string? ServiceFileDefault => GetDefaultFilePath(".pg_service.conf");
+
         static string? GetDefaultFilePath(string fileName) =>
             Environment.GetEnvironmentVariable(PGUtil.IsWindows ? "APPDATA" : "HOME") is string appData &&
             Path.Combine(appData, "postgresql", fileName) is string filePath &&

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -8,6 +8,8 @@ Npgsql.NpgsqlConnection.BeginBinaryImportAsync(string! copyFromCommand, System.T
 Npgsql.NpgsqlConnection.BeginRawBinaryCopyAsync(string! copyCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Npgsql.NpgsqlRawCopyStream!>!
 Npgsql.NpgsqlConnection.BeginTextExportAsync(string! copyToCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextReader!>!
 Npgsql.NpgsqlConnection.BeginTextImportAsync(string! copyFromCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextWriter!>!
+Npgsql.NpgsqlConnectionStringBuilder.Service.get -> string?
+Npgsql.NpgsqlConnectionStringBuilder.Service.set -> void
 Npgsql.TypeHandlers.ArrayHandler.ArrayHandler(Npgsql.PostgresTypes.PostgresType! arrayPostgresType, Npgsql.TypeHandling.NpgsqlTypeHandler! elementHandler, Npgsql.ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1) -> void
 *REMOVED*Npgsql.TypeHandlers.ArrayHandler.ReadArray<TRequestedElement>(Npgsql.NpgsqlReadBuffer! buf, bool async, int expectedDimensions = 0) -> System.Threading.Tasks.ValueTask<System.Array!>
 Npgsql.TypeHandlers.ArrayHandler.ReadArray<TRequestedElement>(Npgsql.NpgsqlReadBuffer! buf, bool async, int expectedDimensions = 0, bool readAsObject = false) -> System.Threading.Tasks.ValueTask<System.Array!>

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -570,6 +570,18 @@ namespace Npgsql.Tests
             }
         }
 
+        [Test]
+        public async Task ServiceFile()
+        {
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                Service = "TestService",
+            };
+
+            using var conn = await OpenConnectionAsync(csb);
+            Assert.That(await conn.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
+        }
+
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/903")]
         public void DataSource()
         {


### PR DESCRIPTION
Closes #3493

Missing:
1. Throwing errors on missing files/sections
2. Fix documentation for `Service` attribute
3. Parse every file, not the first one found
4. Move service file parsing to separate class
5. Possible cache service files?
6. Fix test