### PR TITLE
Switch to sending Sync instead of query for keepalive

### DIFF
--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -2119,7 +2119,7 @@ namespace Npgsql
                     return;
 
                 Log.Trace("Performed keepalive", Id);
-                WritePregenerated(PregeneratedMessages.KeepAlive);
+                WriteSync(async: false);
                 Flush();
                 SkipUntil(BackendMessageCode.ReadyForQuery);
             }
@@ -2178,7 +2178,7 @@ namespace Npgsql
 
                 // Time for a keepalive
                 var keepaliveTime = Stopwatch.StartNew();
-                await WritePregenerated(PregeneratedMessages.KeepAlive, async, cancellationToken);
+                await WriteSync(async, cancellationToken);
                 await Flush(async, cancellationToken);
 
                 var receivedNotification = false;
@@ -2205,25 +2205,9 @@ namespace Npgsql
                         continue;
                     }
 
-                    if (msg.Code != expectedMessageCode)
+                    if (msg.Code != BackendMessageCode.ReadyForQuery)
                         throw new NpgsqlException($"Received unexpected message of type {msg.Code} while expecting {expectedMessageCode} as part of keepalive");
 
-                    switch (msg.Code)
-                    {
-                    case BackendMessageCode.RowDescription:
-                        expectedMessageCode = BackendMessageCode.DataRow;
-                        continue;
-                    case BackendMessageCode.DataRow:
-                        // DataRow is usually consumed by a reader, here we have to skip it manually.
-                        await ReadBuffer.Skip(((DataRowMessage)msg).Length, async);
-                        expectedMessageCode = BackendMessageCode.CommandComplete;
-                        continue;
-                    case BackendMessageCode.CommandComplete:
-                        expectedMessageCode = BackendMessageCode.ReadyForQuery;
-                        continue;
-                    case BackendMessageCode.ReadyForQuery:
-                        break;
-                    }
                     Log.Trace("Performed keepalive", Id);
 
                     if (receivedNotification)

--- a/src/Npgsql/PregeneratedMessages.cs
+++ b/src/Npgsql/PregeneratedMessages.cs
@@ -22,7 +22,6 @@ namespace Npgsql
             BeginTransReadUncommitted   = Generate(buf, "BEGIN TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
             CommitTransaction           = Generate(buf, "COMMIT");
             RollbackTransaction         = Generate(buf, "ROLLBACK");
-            KeepAlive                   = Generate(buf, "SELECT NULL");
             DiscardAll                  = Generate(buf, "DISCARD ALL");
         }
 
@@ -51,7 +50,6 @@ namespace Npgsql
         internal static readonly byte[] BeginTransReadUncommitted;
         internal static readonly byte[] CommitTransaction;
         internal static readonly byte[] RollbackTransaction;
-        internal static readonly byte[] KeepAlive;
 
         internal static readonly byte[] DiscardAll;
     }


### PR DESCRIPTION
Compatible with failed transaction state, seemer cleaner too.

Fixes #3511