### PR TITLE
Generate non-generic write logic with source generators

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Update="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Update="System.Memory" Version="4.5.3" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.SourceGenerators", "src\Npgsql.SourceGenerators\Npgsql.SourceGenerators.csproj", "{63026A19-60B8-4906-81CB-216F30E8094B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,14 @@ Global
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|x86.ActiveCfg = Release|Any CPU
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60}.Release|x86.Build.0 = Release|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Debug|x86.Build.0 = Debug|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|x86.ActiveCfg = Release|Any CPU
+		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,6 +148,7 @@ Global
 		{6CB12050-DC9B-4155-BADD-BFDD54CDD70F} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{F7C53EBD-0075-474F-A083-419257D04080} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
+		{63026A19-60B8-4906-81CB-216F30E8094B} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
@@ -46,7 +46,7 @@ namespace Npgsql.GeoJSON.Internal
         }
     }
 
-    sealed class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
+    sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
         INpgsqlTypeHandler<Point>, INpgsqlTypeHandler<MultiPoint>,
         INpgsqlTypeHandler<Polygon>, INpgsqlTypeHandler<MultiPolygon>,
         INpgsqlTypeHandler<LineString>, INpgsqlTypeHandler<MultiLineString>,
@@ -664,44 +664,6 @@ namespace Npgsql.GeoJSON.Internal
             if (altitude.HasValue)
                 buf.WriteDouble(altitude.Value);
         }
-
-        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value switch
-            {
-                Point converted => ((INpgsqlTypeHandler<Point>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiPoint converted => ((INpgsqlTypeHandler<MultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                Polygon converted => ((INpgsqlTypeHandler<Polygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiPolygon converted => ((INpgsqlTypeHandler<MultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                LineString converted => ((INpgsqlTypeHandler<LineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiLineString converted => ((INpgsqlTypeHandler<MultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                GeometryCollection converted => ((INpgsqlTypeHandler<GeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                GeoJSONObject converted => ((INpgsqlTypeHandler<GeoJSONObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                IGeoJSONObject converted => ((INpgsqlTypeHandler<IGeoJSONObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                IGeometryObject converted => ((INpgsqlTypeHandler<IGeometryObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type GeoJsonHandler")
-            };
-
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {
-                Point converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                Polygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                LineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                GeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                GeoJSONObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                IGeoJSONObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                IGeometryObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type GeoJsonHandler")
-            };
 
         #endregion
 

--- a/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
@@ -665,6 +665,44 @@ namespace Npgsql.GeoJSON.Internal
                 buf.WriteDouble(altitude.Value);
         }
 
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value switch
+            {
+                Point converted => ((INpgsqlTypeHandler<Point>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiPoint converted => ((INpgsqlTypeHandler<MultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                Polygon converted => ((INpgsqlTypeHandler<Polygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiPolygon converted => ((INpgsqlTypeHandler<MultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                LineString converted => ((INpgsqlTypeHandler<LineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiLineString converted => ((INpgsqlTypeHandler<MultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                GeometryCollection converted => ((INpgsqlTypeHandler<GeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                GeoJSONObject converted => ((INpgsqlTypeHandler<GeoJSONObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                IGeoJSONObject converted => ((INpgsqlTypeHandler<IGeoJSONObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                IGeometryObject converted => ((INpgsqlTypeHandler<IGeometryObject>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type GeoJsonHandler")
+            };
+
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {
+                Point converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                Polygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                LineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                GeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                GeoJSONObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                IGeoJSONObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                IGeometryObject converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type GeoJsonHandler")
+            };
+
         #endregion
 
         #region Crs

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -13,5 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Npgsql/Npgsql.csproj" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql.Json.NET/Internal/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonHandler.cs
@@ -76,7 +76,7 @@ namespace Npgsql.Json.NET.Internal
             return base.WriteWithLength(serialized, buf, lengthCache, parameter, async, cancellationToken);
         }
 
-        protected override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
             if (value is DBNull ||
                 value is string ||
@@ -91,7 +91,7 @@ namespace Npgsql.Json.NET.Internal
             return ValidateAndGetLength(value, ref lengthCache, parameter);
         }
 
-        protected override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (value is DBNull ||
                 value is string ||

--- a/src/Npgsql.Json.NET/Internal/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonbHandler.cs
@@ -76,7 +76,7 @@ namespace Npgsql.Json.NET.Internal
             return base.WriteWithLength(serialized, buf, lengthCache, parameter, async, cancellationToken);
         }
 
-        protected override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
             if (value is DBNull ||
                 value is string ||
@@ -91,7 +91,7 @@ namespace Npgsql.Json.NET.Internal
             return ValidateAndGetLength(value, ref lengthCache, parameter);
         }
 
-        protected override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (value is DBNull ||
                 value is string ||

--- a/src/Npgsql.LegacyPostgis/Internal/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/Internal/LegacyPostgisHandler.cs
@@ -14,7 +14,7 @@ namespace Npgsql.LegacyPostgis.Internal
             => new LegacyPostgisHandler(postgresType);
     }
 
-    class LegacyPostgisHandler : NpgsqlTypeHandler<PostgisGeometry>,
+    partial class LegacyPostgisHandler : NpgsqlTypeHandler<PostgisGeometry>,
         INpgsqlTypeHandler<PostgisPoint>, INpgsqlTypeHandler<PostgisMultiPoint>,
         INpgsqlTypeHandler<PostgisLineString>, INpgsqlTypeHandler<PostgisMultiLineString>,
         INpgsqlTypeHandler<PostgisPolygon>, INpgsqlTypeHandler<PostgisMultiPolygon>,
@@ -371,40 +371,6 @@ namespace Npgsql.LegacyPostgis.Internal
 
         public Task Write(PostgisGeometryCollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => Write((PostgisGeometry)value, buf, lengthCache, parameter, async, cancellationToken);
-
-        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value switch
-            {
-                PostgisPoint converted => ((INpgsqlTypeHandler<PostgisPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisMultiPoint converted => ((INpgsqlTypeHandler<PostgisMultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisLineString converted => ((INpgsqlTypeHandler<PostgisLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisMultiLineString converted => ((INpgsqlTypeHandler<PostgisMultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisPolygon converted => ((INpgsqlTypeHandler<PostgisPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisMultiPolygon converted => ((INpgsqlTypeHandler<PostgisMultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisGeometryCollection converted => ((INpgsqlTypeHandler<PostgisGeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                PostgisGeometry converted => ((INpgsqlTypeHandler<PostgisGeometry>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type LegacyPostgisHandler")
-            };
-
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {
-                PostgisPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisMultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisMultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisMultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisGeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                PostgisGeometry converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type LegacyPostgisHandler")
-            };
 
         #endregion Write
     }

--- a/src/Npgsql.LegacyPostgis/Internal/LegacyPostgisHandler.cs
+++ b/src/Npgsql.LegacyPostgis/Internal/LegacyPostgisHandler.cs
@@ -372,6 +372,40 @@ namespace Npgsql.LegacyPostgis.Internal
         public Task Write(PostgisGeometryCollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => Write((PostgisGeometry)value, buf, lengthCache, parameter, async, cancellationToken);
 
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value switch
+            {
+                PostgisPoint converted => ((INpgsqlTypeHandler<PostgisPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisMultiPoint converted => ((INpgsqlTypeHandler<PostgisMultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisLineString converted => ((INpgsqlTypeHandler<PostgisLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisMultiLineString converted => ((INpgsqlTypeHandler<PostgisMultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisPolygon converted => ((INpgsqlTypeHandler<PostgisPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisMultiPolygon converted => ((INpgsqlTypeHandler<PostgisMultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisGeometryCollection converted => ((INpgsqlTypeHandler<PostgisGeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                PostgisGeometry converted => ((INpgsqlTypeHandler<PostgisGeometry>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type LegacyPostgisHandler")
+            };
+
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {
+                PostgisPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisMultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisMultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisMultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisGeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                PostgisGeometry converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type LegacyPostgisHandler")
+            };
+
         #endregion Write
     }
 }

--- a/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
+++ b/src/Npgsql.LegacyPostgis/Npgsql.LegacyPostgis.csproj
@@ -11,6 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteHandler.cs
@@ -11,7 +11,7 @@ using Npgsql.PostgresTypes;
 
 namespace Npgsql.NetTopologySuite.Internal
 {
-    class NetTopologySuiteHandler : NpgsqlTypeHandler<Geometry>,
+    partial class NetTopologySuiteHandler : NpgsqlTypeHandler<Geometry>,
         INpgsqlTypeHandler<Point>,
         INpgsqlTypeHandler<LineString>,
         INpgsqlTypeHandler<Polygon>,
@@ -96,23 +96,6 @@ namespace Npgsql.NetTopologySuite.Internal
             return (int)_lengthStream.Length;
         }
 
-                public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value switch
-            {
-                Point converted => ((INpgsqlTypeHandler<Point>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                LineString converted => ((INpgsqlTypeHandler<LineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                Polygon converted => ((INpgsqlTypeHandler<Polygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiPoint converted => ((INpgsqlTypeHandler<MultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiLineString converted => ((INpgsqlTypeHandler<MultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                MultiPolygon converted => ((INpgsqlTypeHandler<MultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                GeometryCollection converted => ((INpgsqlTypeHandler<GeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                Geometry converted => ((INpgsqlTypeHandler<Geometry>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type NetTopologySuiteHandler")
-            };
-
         sealed class LengthStream : Stream
         {
             long _length;
@@ -180,23 +163,6 @@ namespace Npgsql.NetTopologySuite.Internal
             _writer.Write(value, buf.GetStream());
             return Task.CompletedTask;
         }
-
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {
-                Point converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                LineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                Polygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                MultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                GeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                Geometry converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type NetTopologySuiteHandler")
-            };
 
         #endregion
     }

--- a/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteHandler.cs
+++ b/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteHandler.cs
@@ -96,6 +96,23 @@ namespace Npgsql.NetTopologySuite.Internal
             return (int)_lengthStream.Length;
         }
 
+                public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value switch
+            {
+                Point converted => ((INpgsqlTypeHandler<Point>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                LineString converted => ((INpgsqlTypeHandler<LineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                Polygon converted => ((INpgsqlTypeHandler<Polygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiPoint converted => ((INpgsqlTypeHandler<MultiPoint>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiLineString converted => ((INpgsqlTypeHandler<MultiLineString>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                MultiPolygon converted => ((INpgsqlTypeHandler<MultiPolygon>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                GeometryCollection converted => ((INpgsqlTypeHandler<GeometryCollection>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                Geometry converted => ((INpgsqlTypeHandler<Geometry>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type NetTopologySuiteHandler")
+            };
+
         sealed class LengthStream : Stream
         {
             long _length;
@@ -163,6 +180,23 @@ namespace Npgsql.NetTopologySuite.Internal
             _writer.Write(value, buf.GetStream());
             return Task.CompletedTask;
         }
+
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {
+                Point converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                LineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                Polygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiPoint converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiLineString converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                MultiPolygon converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                GeometryCollection converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                Geometry converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type NetTopologySuiteHandler")
+            };
 
         #endregion
     }

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -13,5 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Npgsql/Npgsql.csproj" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql.NodaTime/Internal/DateHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/DateHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.NodaTime.Internal
         }
     }
 
-    sealed class DateHandler : NpgsqlSimpleTypeHandler<LocalDate>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<NpgsqlDate>
+    sealed partial class DateHandler : NpgsqlSimpleTypeHandler<LocalDate>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<NpgsqlDate>
     {
         /// <summary>
         /// Whether to convert positive and negative infinity values to Instant.{Max,Min}Value when

--- a/src/Npgsql.NodaTime/Internal/IntervalHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/IntervalHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.NodaTime.Internal
                 : throw new NotSupportedException($"The deprecated floating-point date/time format is not supported by {nameof(Npgsql)}.");
     }
 
-    sealed class IntervalHandler :
+    sealed partial class IntervalHandler :
         NpgsqlSimpleTypeHandler<Period>,
         INpgsqlSimpleTypeHandler<Duration>,
         INpgsqlSimpleTypeHandler<NpgsqlTimeSpan>,

--- a/src/Npgsql.NodaTime/Internal/TimeHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimeHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using NodaTime;
 using Npgsql.BackendMessages;
 using Npgsql.Internal;
@@ -17,7 +19,7 @@ namespace Npgsql.NodaTime.Internal
                 : throw new NotSupportedException($"The deprecated floating-point date/time format is not supported by {nameof(Npgsql)}.");
     }
 
-    sealed class TimeHandler : NpgsqlSimpleTypeHandler<LocalTime>, INpgsqlSimpleTypeHandler<TimeSpan>
+    sealed partial class TimeHandler : NpgsqlSimpleTypeHandler<LocalTime>, INpgsqlSimpleTypeHandler<TimeSpan>
     {
         readonly BclTimeHandler _bclHandler;
 

--- a/src/Npgsql.NodaTime/Internal/TimeTzHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimeTzHandler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.NodaTime.Internal
                 : throw new NotSupportedException($"The deprecated floating-point date/time format is not supported by {nameof(Npgsql)}.");
     }
 
-    sealed class TimeTzHandler : NpgsqlSimpleTypeHandler<OffsetTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>,
+    sealed partial class TimeTzHandler : NpgsqlSimpleTypeHandler<OffsetTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>,
                                   INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<TimeSpan>
     {
         readonly BclTimeTzHandler _bclHandler;

--- a/src/Npgsql.NodaTime/Internal/TimestampHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampHandler.cs
@@ -21,7 +21,7 @@ namespace Npgsql.NodaTime.Internal
         }
     }
 
-    sealed class TimestampHandler : NpgsqlSimpleTypeHandler<Instant>, INpgsqlSimpleTypeHandler<LocalDateTime>, INpgsqlSimpleTypeHandler<DateTime>
+    sealed partial class TimestampHandler : NpgsqlSimpleTypeHandler<Instant>, INpgsqlSimpleTypeHandler<LocalDateTime>, INpgsqlSimpleTypeHandler<DateTime>
     {
         static readonly Instant Instant0 = Instant.FromUtc(1, 1, 1, 0, 0, 0);
         static readonly Instant Instant2000 = Instant.FromUtc(2000, 1, 1, 0, 0, 0);

--- a/src/Npgsql.NodaTime/Internal/TimestampTzHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampTzHandler.cs
@@ -22,7 +22,7 @@ namespace Npgsql.NodaTime.Internal
         }
     }
 
-    sealed class TimestampTzHandler : NpgsqlSimpleTypeHandler<Instant>, INpgsqlSimpleTypeHandler<ZonedDateTime>,
+    sealed partial class TimestampTzHandler : NpgsqlSimpleTypeHandler<Instant>, INpgsqlSimpleTypeHandler<ZonedDateTime>,
                               INpgsqlSimpleTypeHandler<OffsetDateTime>, INpgsqlSimpleTypeHandler<DateTimeOffset>, 
                               INpgsqlSimpleTypeHandler<DateTime>
     {

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -12,5 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Npgsql\Npgsql.csproj" />
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql.SourceGenerators/EmbeddedResource.cs
+++ b/src/Npgsql.SourceGenerators/EmbeddedResource.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Npgsql.SourceGenerators
+{
+    static class EmbeddedResource
+    {
+        public static string GetContent(string relativePath)
+        {
+            var baseName = Assembly.GetExecutingAssembly().GetName().Name;
+            var resourceName = relativePath
+                .TrimStart('.')
+                .Replace(Path.DirectorySeparatorChar, '.')
+                .Replace(Path.AltDirectorySeparatorChar, '.');
+
+            using var stream = Assembly.GetExecutingAssembly()
+                .GetManifestResourceStream(baseName + "." + resourceName);
+
+            if (stream == null)
+                throw new NotSupportedException();
+
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
+++ b/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+    </ItemGroup>
+</Project>

--- a/src/Npgsql.SourceGenerators/TypeHandlerSourceGenerator.cs
+++ b/src/Npgsql.SourceGenerators/TypeHandlerSourceGenerator.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Npgsql.SourceGenerators
+{
+    [Generator]
+    class TypeHandlerSourceGenerator : ISourceGenerator
+    {
+        public void Initialize(GeneratorInitializationContext context)
+            => context.RegisterForSyntaxNotifications(() => new MySyntaxReceiver());
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            var compilation = context.Compilation;
+
+            var (simpleTypeHandlerInterfaceSymbol, typeHandlerInterfaceSymbol) = (
+                compilation.GetTypeByMetadataName("Npgsql.Internal.TypeHandling.INpgsqlSimpleTypeHandler`1"),
+                compilation.GetTypeByMetadataName("Npgsql.Internal.TypeHandling.INpgsqlTypeHandler`1"));
+
+            if (simpleTypeHandlerInterfaceSymbol is null || typeHandlerInterfaceSymbol is null)
+                throw new Exception("Could not find INpgsqlSimpleTypeHandler or INpgsqlTypeHandler");
+
+            foreach (var cds in ((MySyntaxReceiver)context.SyntaxReceiver!).TypeHandlerCandidates)
+            {
+                var semanticModel = compilation.GetSemanticModel(cds.SyntaxTree);
+                if (semanticModel.GetDeclaredSymbol(cds) is not INamedTypeSymbol typeSymbol)
+                    continue;
+
+                if (typeSymbol.AllInterfaces.Any(i =>
+                    i.OriginalDefinition.Equals(simpleTypeHandlerInterfaceSymbol, SymbolEqualityComparer.Default)))
+                {
+                    AugmentTypeHandler(typeSymbol, cds, isSimple: true);
+                    continue;
+                }
+
+                if (typeSymbol.AllInterfaces.Any(i =>
+                    i.OriginalDefinition.Equals(typeHandlerInterfaceSymbol, SymbolEqualityComparer.Default)))
+                {
+                    AugmentTypeHandler(typeSymbol, cds, isSimple: false);
+                }
+            }
+
+            void AugmentTypeHandler(INamedTypeSymbol typeSymbol, ClassDeclarationSyntax classDeclarationSyntax, bool isSimple)
+            {
+                var typeName = FormatTypeName(typeSymbol);
+
+                var usings = new HashSet<string>(
+                    new[]
+                    {
+                        "System",
+                        "System.Threading",
+                        "System.Threading.Tasks",
+                        "Npgsql.Internal"
+                    }.Concat(classDeclarationSyntax.SyntaxTree.GetCompilationUnitRoot().Usings
+                        .Where(u => u.Alias is null)
+                        .Select(u => u.Name.ToString())));
+
+                var ns = typeSymbol.ContainingNamespace.ToDisplayString();
+
+                var validateAccess = isSimple ? "protected" : "public";
+                var validationDispatchLines = typeSymbol.AllInterfaces
+                    .Where(i => i.OriginalDefinition.Equals(isSimple ? simpleTypeHandlerInterfaceSymbol : typeHandlerInterfaceSymbol, SymbolEqualityComparer.Default))
+                    .Select(i => $"{FormatTypeName(i.TypeArguments[0])} converted => (({FormatTypeName(i)})this).ValidateAndGetLength(converted, {(isSimple ? "" : "ref lengthCache, ")}parameter),");
+
+                var writeDispatchLines = typeSymbol.AllInterfaces
+                    .Where(i => i.OriginalDefinition.Equals(isSimple ? simpleTypeHandlerInterfaceSymbol : typeHandlerInterfaceSymbol, SymbolEqualityComparer.Default))
+                    .Select(i => $"{FormatTypeName(i.TypeArguments[0])} converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),");
+
+                var sourceBuilder = new StringBuilder();
+
+                foreach (var usingNamespace in usings.OrderBy(n => n))
+                    sourceBuilder.Append("using ").Append(usingNamespace).AppendLine(";");
+
+                // var sourceBuilder = new StringBuilder($@"
+                sourceBuilder.Append($@"
+
+#nullable enable
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable 618 // Member is obsolete
+
+namespace {ns}
+{{
+    partial class {typeName}
+    {{
+        {validateAccess} override int ValidateObjectAndGetLength(object value, {(isSimple ? "" : "ref NpgsqlLengthCache? lengthCache, ")}NpgsqlParameter? parameter)
+            => value switch
+            {{");
+                foreach (var line in validationDispatchLines)
+                    sourceBuilder.Append(@$"
+                {line}");
+
+                sourceBuilder.Append($@"
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($""Can't write CLR type {{value.GetType()}} with handler type {typeName}"")
+            }};
+
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {{");
+                foreach (var line in writeDispatchLines)
+                    sourceBuilder.Append(@$"
+                {line}");
+
+                sourceBuilder.Append($@"
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($""Can't write CLR type {{value.GetType()}} with handler type {typeName}"")
+            }};
+    }}
+}}");
+
+                context.AddSource(typeSymbol.Name + ".Generated.cs", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
+            }
+
+            static string FormatTypeName(ITypeSymbol typeSymbol)
+            {
+                if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+                {
+                    return namedTypeSymbol.IsGenericType
+                        ? new StringBuilder(namedTypeSymbol.Name)
+                            .Append('<')
+                            .Append(string.Join(",", namedTypeSymbol.TypeArguments.Select(FormatTypeName)))
+                            .Append('>')
+                            .ToString()
+                        : namedTypeSymbol.Name;
+                }
+
+                return typeSymbol.ToString();
+            }
+        }
+
+        class MySyntaxReceiver : ISyntaxReceiver
+        {
+            public List<ClassDeclarationSyntax> TypeHandlerCandidates { get; } = new();
+
+            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+            {
+                if (syntaxNode is ClassDeclarationSyntax cds &&
+                    cds.BaseList is not null &&
+                    cds.Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    TypeHandlerCandidates.Add(cds);
+                }
+            }
+        }
+    }
+}

--- a/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
@@ -317,7 +317,7 @@ namespace Npgsql.Internal.TypeHandlers
             => ValidateAndGetLength(value!, ref lengthCache);
 
         /// <inheritdoc />
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => ValidateAndGetLength(value!, ref lengthCache);
 
         int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache)
@@ -400,7 +400,7 @@ namespace Npgsql.Internal.TypeHandlers
             return len;
         }
 
-        internal override Task WriteWithLengthInternal<TAny>([AllowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteWithLengthInternal<TAny>([AllowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (buf.WriteSpaceLeft < 4)
                 return WriteWithLengthLong();
@@ -436,7 +436,7 @@ namespace Npgsql.Internal.TypeHandlers
         // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
         // us (need to handle many types of T, e.g. int[], int[,]...)
         /// <inheritdoc />
-        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => value is DBNull
                 ? WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
                 : WriteWithLengthInternal(value, buf, lengthCache, parameter, async, cancellationToken);

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -26,7 +26,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class BitStringHandler : NpgsqlTypeHandler<BitArray>,
+    public partial class BitStringHandler : NpgsqlTypeHandler<BitArray>,
         INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
     {
         /// <inheritdoc />

--- a/src/Npgsql/Internal/TypeHandlers/BoolHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BoolHandler.cs
@@ -1,9 +1,6 @@
-﻿using System.Data;
-using Npgsql.BackendMessages;
+﻿using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
-using Npgsql.TypeMapping;
-using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers
 {
@@ -17,7 +14,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class BoolHandler : NpgsqlSimpleTypeHandler<bool>
+    public partial class BoolHandler : NpgsqlSimpleTypeHandler<bool>
     {
         /// <inheritdoc />
         public BoolHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ByteaHandler.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
-using Npgsql.TypeMapping;
-using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers
 {
@@ -20,7 +17,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>
+    public partial class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>
 #if !NETSTANDARD2_0
         , INpgsqlTypeHandler<ReadOnlyMemory<byte>>, INpgsqlTypeHandler<Memory<byte>>
 #endif

--- a/src/Npgsql/Internal/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -14,7 +14,7 @@ using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers.CompositeHandlers
 {
-    class CompositeHandler<T> : NpgsqlTypeHandler<T>, ICompositeHandler
+    partial class CompositeHandler<T> : NpgsqlTypeHandler<T>, ICompositeHandler
     {
         readonly ConnectorTypeMapper _typeMapper;
         readonly INpgsqlNameTranslator _nameTranslator;

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/DateHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/DateHandler.cs
@@ -35,7 +35,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class DateHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDate>
+    public partial class DateHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDate>
     {
         /// <summary>
         /// Whether to convert positive and negative infinity values to DateTime.{Max,Min}Value when

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/IntervalHandler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class IntervalHandler : NpgsqlSimpleTypeHandlerWithPsv<TimeSpan, NpgsqlTimeSpan>
+    public partial class IntervalHandler : NpgsqlSimpleTypeHandlerWithPsv<TimeSpan, NpgsqlTimeSpan>
     {
         /// <summary>
         /// Constructs an <see cref="IntervalHandler"/>

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimeHandler.cs
@@ -37,7 +37,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TimeHandler : NpgsqlSimpleTypeHandler<TimeSpan>
+    public partial class TimeHandler : NpgsqlSimpleTypeHandler<TimeSpan>
     {
         /// <summary>
         /// Constructs a <see cref="TimeHandler"/>.

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimeTzHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimeTzHandler.cs
@@ -36,7 +36,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TimeTzHandler : NpgsqlSimpleTypeHandler<DateTimeOffset>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<TimeSpan>
+    public partial class TimeTzHandler : NpgsqlSimpleTypeHandler<DateTimeOffset>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<TimeSpan>
     {
         // Binary Format: int64 expressing microseconds, int32 expressing timezone in seconds, negative
 

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
@@ -38,7 +38,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TimestampHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>
+    public partial class TimestampHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>
     {
         /// <summary>
         /// Whether to convert positive and negative infinity values to DateTime.{Max,Min}Value when

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -37,7 +37,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TimestampTzHandler : TimestampHandler, INpgsqlSimpleTypeHandler<DateTimeOffset>
+    public partial class TimestampTzHandler : TimestampHandler, INpgsqlSimpleTypeHandler<DateTimeOffset>
     {
         /// <summary>
         /// Constructs an <see cref="TimestampTzHandler"/>.

--- a/src/Npgsql/Internal/TypeHandlers/EnumHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/EnumHandler.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Internal.TypeHandlers
         Type EnumType { get; }
     }
 
-    class EnumHandler<TEnum> : NpgsqlSimpleTypeHandler<TEnum>, IEnumHandler where TEnum : struct, Enum
+    partial class EnumHandler<TEnum> : NpgsqlSimpleTypeHandler<TEnum>, IEnumHandler where TEnum : struct, Enum
     {
         readonly Dictionary<TEnum, string> _enumToLabel;
         readonly Dictionary<string, TEnum> _labelToEnum;
@@ -72,7 +72,6 @@ namespace Npgsql.Internal.TypeHandlers
 
         #endregion
     }
-
 
     /// <summary>
     /// Interface implemented by all enum handler factories.

--- a/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -169,6 +169,40 @@ namespace Npgsql.Internal.TypeHandlers.FullTextSearchHandlers
             }
         }
 
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value switch
+            {
+                NpgsqlTsQueryEmpty converted => ((INpgsqlTypeHandler<NpgsqlTsQueryEmpty>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQueryLexeme converted => ((INpgsqlTypeHandler<NpgsqlTsQueryLexeme>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQueryNot converted => ((INpgsqlTypeHandler<NpgsqlTsQueryNot>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQueryAnd converted => ((INpgsqlTypeHandler<NpgsqlTsQueryAnd>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQueryOr converted => ((INpgsqlTypeHandler<NpgsqlTsQueryOr>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQueryFollowedBy converted => ((INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+                NpgsqlTsQuery converted => ((INpgsqlTypeHandler<NpgsqlTsQuery>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type TsQueryHandler")
+            };
+
+        /// <inheritdoc />
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {
+                NpgsqlTsQueryEmpty converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQueryLexeme converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQueryNot converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQueryAnd converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQueryOr converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQueryFollowedBy converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                NpgsqlTsQuery converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type BoolHandler")
+            };
+
         /// <inheritdoc />
         public override async Task Write(NpgsqlTsQuery query, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {

--- a/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsQueryHandler.cs
@@ -25,7 +25,7 @@ namespace Npgsql.Internal.TypeHandlers.FullTextSearchHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TsQueryHandler : NpgsqlTypeHandler<NpgsqlTsQuery>,
+    public partial class TsQueryHandler : NpgsqlTypeHandler<NpgsqlTsQuery>,
         INpgsqlTypeHandler<NpgsqlTsQueryEmpty>, INpgsqlTypeHandler<NpgsqlTsQueryLexeme>,
         INpgsqlTypeHandler<NpgsqlTsQueryNot>, INpgsqlTypeHandler<NpgsqlTsQueryAnd>,
         INpgsqlTypeHandler<NpgsqlTsQueryOr>, INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>
@@ -168,40 +168,6 @@ namespace Npgsql.Internal.TypeHandlers.FullTextSearchHandlers
                 throw new InvalidOperationException("Illegal node kind: " + node.Kind);
             }
         }
-
-        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value switch
-            {
-                NpgsqlTsQueryEmpty converted => ((INpgsqlTypeHandler<NpgsqlTsQueryEmpty>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQueryLexeme converted => ((INpgsqlTypeHandler<NpgsqlTsQueryLexeme>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQueryNot converted => ((INpgsqlTypeHandler<NpgsqlTsQueryNot>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQueryAnd converted => ((INpgsqlTypeHandler<NpgsqlTsQueryAnd>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQueryOr converted => ((INpgsqlTypeHandler<NpgsqlTsQueryOr>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQueryFollowedBy converted => ((INpgsqlTypeHandler<NpgsqlTsQueryFollowedBy>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-                NpgsqlTsQuery converted => ((INpgsqlTypeHandler<NpgsqlTsQuery>)this).ValidateAndGetLength(converted, ref lengthCache, parameter),
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type TsQueryHandler")
-            };
-
-        /// <inheritdoc />
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
-            NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {
-                NpgsqlTsQueryEmpty converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQueryLexeme converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQueryNot converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQueryAnd converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQueryOr converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQueryFollowedBy converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlTsQuery converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type BoolHandler")
-            };
 
         /// <inheritdoc />
         public override async Task Write(NpgsqlTsQuery query, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)

--- a/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/FullTextSearchHandlers/TsVectorHandler.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Internal.TypeHandlers.FullTextSearchHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TsVectorHandler : NpgsqlTypeHandler<NpgsqlTsVector>
+    public partial class TsVectorHandler : NpgsqlTypeHandler<NpgsqlTsVector>
     {
         // 2561 = 2046 (max length lexeme string) + (1) null terminator +
         // 2 (num_pos) + sizeof(int16) * 256 (max_num_pos (positions/wegihts))

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/BoxHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/BoxHandler.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class BoxHandler : NpgsqlSimpleTypeHandler<NpgsqlBox>
+    public partial class BoxHandler : NpgsqlSimpleTypeHandler<NpgsqlBox>
     {
         /// <inheritdoc />
         public BoxHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/CircleHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/CircleHandler.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class CircleHandler : NpgsqlSimpleTypeHandler<NpgsqlCircle>
+    public partial class CircleHandler : NpgsqlSimpleTypeHandler<NpgsqlCircle>
     {
         /// <inheritdoc />
         public CircleHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/LineHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/LineHandler.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class LineHandler : NpgsqlSimpleTypeHandler<NpgsqlLine>
+    public partial class LineHandler : NpgsqlSimpleTypeHandler<NpgsqlLine>
     {
         /// <inheritdoc />
         public LineHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/LineSegmentHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/LineSegmentHandler.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class LineSegmentHandler : NpgsqlSimpleTypeHandler<NpgsqlLSeg>
+    public partial class LineSegmentHandler : NpgsqlSimpleTypeHandler<NpgsqlLSeg>
     {
         /// <inheritdoc />
         public LineSegmentHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PathHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PathHandler.cs
@@ -19,7 +19,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class PathHandler : NpgsqlTypeHandler<NpgsqlPath>
+    public partial class PathHandler : NpgsqlTypeHandler<NpgsqlPath>
     {
         /// <inheritdoc />
         public PathHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PointHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PointHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
-using Npgsql.TypeMapping;
 using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
@@ -16,7 +15,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class PointHandler : NpgsqlSimpleTypeHandler<NpgsqlPoint>
+    public partial class PointHandler : NpgsqlSimpleTypeHandler<NpgsqlPoint>
     {
         /// <inheritdoc />
         public PointHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PolygonHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/GeometricHandlers/PolygonHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Internal.TypeHandlers.GeometricHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class PolygonHandler : NpgsqlTypeHandler<NpgsqlPolygon>
+    public partial class PolygonHandler : NpgsqlTypeHandler<NpgsqlPolygon>
     {
         /// <inheritdoc />
         public PolygonHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/InternalCharHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/InternalCharHandler.cs
@@ -14,7 +14,7 @@ namespace Npgsql.Internal.TypeHandlers.InternalTypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class InternalCharHandler : NpgsqlSimpleTypeHandler<char>,
+    public partial class InternalCharHandler : NpgsqlSimpleTypeHandler<char>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>
     {
         /// <inheritdoc />

--- a/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/PgLsnHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/PgLsnHandler.cs
@@ -6,7 +6,7 @@ using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers.InternalTypeHandlers
 {
-    class PgLsnHandler : NpgsqlSimpleTypeHandler<NpgsqlLogSequenceNumber>
+    partial class PgLsnHandler : NpgsqlSimpleTypeHandler<NpgsqlLogSequenceNumber>
     {
         public PgLsnHandler(PostgresType postgresType) : base(postgresType) {}
 

--- a/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/TidHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/InternalTypeHandlers/TidHandler.cs
@@ -7,7 +7,7 @@ using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers.InternalTypeHandlers
 {
-    class TidHandler : NpgsqlSimpleTypeHandler<NpgsqlTid>
+    partial class TidHandler : NpgsqlSimpleTypeHandler<NpgsqlTid>
     {
         public TidHandler(PostgresType postgresType) : base(postgresType) {}
 

--- a/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
@@ -189,10 +189,11 @@ namespace Npgsql.Internal.TypeHandlers
         }
 
         /// <inheritdoc />
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => value switch
             {
-                DBNull _                  => base.ValidateObjectAndGetLength(value, ref lengthCache, parameter),
+                DBNull                    => -1,
+                null                      => -1,
                 string s                  => ValidateAndGetLength(s, ref lengthCache, parameter),
                 char[] s                  => ValidateAndGetLength(s, ref lengthCache, parameter),
                 ArraySegment<char> s      => ValidateAndGetLength(s, ref lengthCache, parameter),
@@ -203,7 +204,7 @@ namespace Npgsql.Internal.TypeHandlers
             };
 
         /// <inheritdoc />
-        protected internal override async Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override async Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             // We call into WriteWithLength<T> below, which assumes it as at least enough write space for the length
             if (buf.WriteSpaceLeft < 4)
@@ -211,7 +212,7 @@ namespace Npgsql.Internal.TypeHandlers
 
             await (value switch
             {
-                DBNull _                  => base.WriteObjectWithLength(value, buf, lengthCache, parameter, async, cancellationToken),
+                DBNull                    => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
                 string s                  => WriteWithLength(s, buf, lengthCache, parameter, async, cancellationToken),
                 char[] s                  => WriteWithLength(s, buf, lengthCache, parameter, async, cancellationToken),
                 ArraySegment<char> s      => WriteWithLength(s, buf, lengthCache, parameter, async, cancellationToken),

--- a/src/Npgsql/Internal/TypeHandlers/JsonPathHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/JsonPathHandler.cs
@@ -37,7 +37,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class JsonPathHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
+    public partial class JsonPathHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
     {
         readonly TextHandler _textHandler;
 

--- a/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/CidrHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/CidrHandler.cs
@@ -22,7 +22,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class CidrHandler : NpgsqlSimpleTypeHandler<(IPAddress Address, int Subnet)>, INpgsqlSimpleTypeHandler<NpgsqlInet>
+    public partial class CidrHandler : NpgsqlSimpleTypeHandler<(IPAddress Address, int Subnet)>, INpgsqlSimpleTypeHandler<NpgsqlInet>
     {
         /// <inheritdoc />
         public CidrHandler(PostgresType postgresType) : base(postgresType) {}
@@ -52,27 +52,5 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
         /// <inheritdoc />
         public void Write(NpgsqlInet value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
             => InetHandler.DoWrite(value.Address, value.Netmask, buf, true);
-
-        protected override int ValidateObjectAndGetLength(object value, NpgsqlParameter? parameter)
-            => value switch
-            {
-                ValueTuple<IPAddress, int> converted => ((INpgsqlSimpleTypeHandler<(IPAddress, int)>)this).ValidateAndGetLength(converted, parameter),
-                NpgsqlInet converted => ((INpgsqlSimpleTypeHandler<NpgsqlInet>)this).ValidateAndGetLength(converted, parameter),
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type CidrHandler")
-            };
-
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {
-                ValueTuple<IPAddress, int> converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlInet converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type CidrHandler")
-            };
     }
 }

--- a/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -76,7 +76,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
         #region Write
 
         /// <inheritdoc />
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => value switch {
                 null => -1,
                 DBNull _ => -1,
@@ -87,7 +87,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
             };
 
         /// <inheritdoc />
-        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => value switch {
                 DBNull _ => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
                 IPAddress ip => WriteWithLengthInternal(ip, buf, lengthCache, parameter, async, cancellationToken),
@@ -153,5 +153,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
             };
 
         #endregion Write
+
+        protected override int ValidateObjectAndGetLength(object value, NpgsqlParameter? parameter) => throw new NotImplementedException();
     }
 }

--- a/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -24,7 +24,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class InetHandler : NpgsqlSimpleTypeHandlerWithPsv<IPAddress, (IPAddress Address, int Subnet)>,
+    public partial class InetHandler : NpgsqlSimpleTypeHandlerWithPsv<IPAddress, (IPAddress Address, int Subnet)>,
         INpgsqlSimpleTypeHandler<NpgsqlInet>
     {
         // ReSharper disable InconsistentNaming
@@ -74,27 +74,6 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
         #endregion Read
 
         #region Write
-
-        /// <inheritdoc />
-        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value switch {
-                null => -1,
-                DBNull _ => -1,
-                IPAddress ip => ValidateAndGetLength(ip, parameter),
-                ValueTuple<IPAddress, int> tup => ValidateAndGetLength(tup, parameter),
-                NpgsqlInet inet => ValidateAndGetLength(inet, parameter),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}")
-            };
-
-        /// <inheritdoc />
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch {
-                DBNull _ => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                IPAddress ip => WriteWithLengthInternal(ip, buf, lengthCache, parameter, async, cancellationToken),
-                ValueTuple<IPAddress, int> tup => WriteWithLengthInternal(tup, buf, lengthCache, parameter, async, cancellationToken),
-                NpgsqlInet inet => WriteWithLengthInternal(inet, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType().Name} to database type {PgDisplayName}")
-            };
 
         /// <inheritdoc />
         public override int ValidateAndGetLength(IPAddress value, NpgsqlParameter? parameter)
@@ -153,7 +132,5 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
             };
 
         #endregion Write
-
-        protected override int ValidateObjectAndGetLength(object value, NpgsqlParameter? parameter) => throw new NotImplementedException();
     }
 }

--- a/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/MacaddrHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/MacaddrHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Internal.TypeHandlers.NetworkHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class MacaddrHandler : NpgsqlSimpleTypeHandler<PhysicalAddress>
+    public partial class MacaddrHandler : NpgsqlSimpleTypeHandler<PhysicalAddress>
     {
         /// <inheritdoc />
         public MacaddrHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/DoubleHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/DoubleHandler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class DoubleHandler : NpgsqlSimpleTypeHandler<double>
+    public partial class DoubleHandler : NpgsqlSimpleTypeHandler<double>
     {
         /// <inheritdoc />
         public DoubleHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int16Handler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int16Handler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class Int16Handler : NpgsqlSimpleTypeHandler<short>,
+    public partial class Int16Handler : NpgsqlSimpleTypeHandler<short>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<sbyte>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>,
         INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int32Handler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int32Handler.cs
@@ -1,9 +1,7 @@
-﻿using System.Data;
+﻿using System;
 using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
-using Npgsql.TypeMapping;
-using NpgsqlTypes;
 
 namespace Npgsql.Internal.TypeHandlers.NumericHandlers
 {
@@ -17,7 +15,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class Int32Handler : NpgsqlSimpleTypeHandler<int>,
+    public partial class Int32Handler : NpgsqlSimpleTypeHandler<int>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<long>,
         INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int64Handler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/Int64Handler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class Int64Handler : NpgsqlSimpleTypeHandler<long>,
+    public partial class Int64Handler : NpgsqlSimpleTypeHandler<long>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>,
         INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>, INpgsqlSimpleTypeHandler<decimal>
     {

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/MoneyHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/MoneyHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class MoneyHandler : NpgsqlSimpleTypeHandler<decimal>
+    public partial class MoneyHandler : NpgsqlSimpleTypeHandler<decimal>
     {
         const int MoneyScale = 2;
 

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -18,7 +18,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class NumericHandler : NpgsqlSimpleTypeHandler<decimal>,
+    public partial class NumericHandler : NpgsqlSimpleTypeHandler<decimal>,
         INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>,
         INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>
     {

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/SingleHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/SingleHandler.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class SingleHandler : NpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>
+    public partial class SingleHandler : NpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>
     {
         /// <inheritdoc />
         public SingleHandler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/UInt32Handler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/UInt32Handler.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class UInt32Handler : NpgsqlSimpleTypeHandler<uint>
+    public partial class UInt32Handler : NpgsqlSimpleTypeHandler<uint>
     {
         /// <inheritdoc />
         public UInt32Handler(PostgresType postgresType) : base(postgresType) {}

--- a/src/Npgsql/Internal/TypeHandlers/RecordHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/RecordHandler.cs
@@ -26,7 +26,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// * The length of the column(32-bit integer), or -1 if null
     /// * The column data encoded as binary
     /// </remarks>
-    class RecordHandler : NpgsqlTypeHandler<object[]>
+    partial class RecordHandler : NpgsqlTypeHandler<object[]>
     {
         readonly ConnectorTypeMapper _typeMapper;
 

--- a/src/Npgsql/Internal/TypeHandlers/TextHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/TextHandler.cs
@@ -40,7 +40,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class TextHandler : NpgsqlTypeHandler<string>, INpgsqlTypeHandler<char[]>, INpgsqlTypeHandler<ArraySegment<char>>,
+    public partial class TextHandler : NpgsqlTypeHandler<string>, INpgsqlTypeHandler<char[]>, INpgsqlTypeHandler<ArraySegment<char>>,
         INpgsqlTypeHandler<char>, INpgsqlTypeHandler<byte[]>, ITextReaderHandler
     {
         // Text types are handled a bit more efficiently when sent as text than as binary

--- a/src/Npgsql/Internal/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/UnknownTypeHandler.cs
@@ -48,7 +48,7 @@ namespace Npgsql.Internal.TypeHandlers
         protected internal override int ValidateAndGetLength<T2>(T2 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => ValidateObjectAndGetLength(value!, ref lengthCache, parameter);
 
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
             if (value is string asString)
                 return base.ValidateAndGetLength(asString, ref lengthCache, parameter);
@@ -62,7 +62,7 @@ namespace Npgsql.Internal.TypeHandlers
             return base.ValidateAndGetLength(converted, ref lengthCache, parameter);
         }
 
-        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (value is DBNull)
                 return base.WriteObjectWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken);

--- a/src/Npgsql/Internal/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/UnmappedEnumHandler.cs
@@ -52,7 +52,7 @@ namespace Npgsql.Internal.TypeHandlers
 
         #region Write
 
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => value == null || value is DBNull
                 ? -1
                 : ValidateAndGetLength(value, ref lengthCache, parameter);
@@ -78,7 +78,7 @@ namespace Npgsql.Internal.TypeHandlers
         protected override Task WriteWithLength<TAny>(TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
             => WriteObjectWithLength(value!, buf, lengthCache, parameter, async, cancellationToken);
 
-        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (value is DBNull)
                 return WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken);

--- a/src/Npgsql/Internal/TypeHandlers/UuidHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/UuidHandler.cs
@@ -19,7 +19,7 @@ namespace Npgsql.Internal.TypeHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public class UuidHandler : NpgsqlSimpleTypeHandler<Guid>
+    public partial class UuidHandler : NpgsqlSimpleTypeHandler<Guid>
     {
         // The following table shows .NET GUID vs Postgres UUID (RFC 4122) layouts.
         //

--- a/src/Npgsql/Internal/TypeHandling/INpgsqlSimpleTypeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandling/INpgsqlSimpleTypeHandler.cs
@@ -21,7 +21,7 @@ namespace Npgsql.Internal.TypeHandling
 
         /// <summary>
         /// Responsible for validating that a value represents a value of the correct and which can be
-        /// written for PostgreSQL - if the value cannot be written for any reason, an exception shold be thrown.
+        /// written for PostgreSQL - if the value cannot be written for any reason, an exception should be thrown.
         /// Also returns the byte length needed to write the value.
         /// </summary>
         /// <param name="value">The value to be written to PostgreSQL</param>

--- a/src/Npgsql/Internal/TypeHandling/NpgsqlTypeHandler`.cs
+++ b/src/Npgsql/Internal/TypeHandling/NpgsqlTypeHandler`.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandlers;
 using Npgsql.PostgresTypes;
-using Npgsql.Util;
 
 namespace Npgsql.Internal.TypeHandling
 {
@@ -27,28 +22,10 @@ namespace Npgsql.Internal.TypeHandling
     /// </typeparam>
     public abstract class NpgsqlTypeHandler<TDefault> : NpgsqlTypeHandler, INpgsqlTypeHandler<TDefault>
     {
-        delegate int NonGenericValidateAndGetLength(NpgsqlTypeHandler handler, object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
-
-        readonly NonGenericValidateAndGetLength _nonGenericValidateAndGetLength;
-        readonly NonGenericWriteWithLength _nonGenericWriteWithLength;
-
-#pragma warning disable CA1823
-        static readonly ConcurrentDictionary<Type, (NonGenericValidateAndGetLength, NonGenericWriteWithLength)>
-            NonGenericDelegateCache = new();
-#pragma warning restore CA1823
-
         /// <summary>
         /// Constructs an <see cref="NpgsqlTypeHandler{TDefault}"/>.
         /// </summary>
-        protected NpgsqlTypeHandler(PostgresType postgresType)
-            : base(postgresType)
-            // Get code-generated delegates for non-generic ValidateAndGetLength/WriteWithLengthInternal
-            =>
-            (_nonGenericValidateAndGetLength, _nonGenericWriteWithLength) =
-                NonGenericDelegateCache.GetOrAdd(GetType(), t => (
-                    GenerateNonGenericValidationMethod(GetType()),
-                    GenerateNonGenericWriteMethod(GetType(), typeof(INpgsqlTypeHandler<>)))
-                );
+        protected NpgsqlTypeHandler(PostgresType postgresType) : base(postgresType) {}
 
         #region Read
 
@@ -128,7 +105,7 @@ namespace Npgsql.Internal.TypeHandling
         /// <summary>
         /// In the vast majority of cases writing a parameter to the buffer won't need to perform I/O.
         /// </summary>
-        internal override Task WriteWithLengthInternal<TAny>([AllowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        public override Task WriteWithLengthInternal<TAny>([AllowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             if (buf.WriteSpaceLeft < 4)
                 return WriteWithLengthLong();
@@ -171,109 +148,7 @@ namespace Npgsql.Internal.TypeHandling
             return typedHandler.Write(value, buf, lengthCache, parameter, async, cancellationToken);
         }
 
-        // Object overloads for non-generic NpgsqlParameter
-
-        /// <summary>
-        /// Called to validate and get the length of a value of a non-generic <see cref="NpgsqlParameter"/>.
-        /// Type handlers generally don't need to override this.
-        /// </summary>
-        protected internal override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value == null || value is DBNull
-                ? -1
-                : _nonGenericValidateAndGetLength(this, value, ref lengthCache, parameter);
-
-        /// <summary>
-        /// Called to write the value of a non-generic <see cref="NpgsqlParameter"/>.
-        /// Type handlers generally don't need to override this.
-        /// </summary>
-        protected internal override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value is DBNull
-                ? WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
-                : _nonGenericWriteWithLength(this, value, buf, lengthCache, parameter, async, cancellationToken);
-
         #endregion Write
-
-        #region Code generation for non-generic writing
-
-        // We need to support writing via non-generic NpgsqlParameter, which means we get requests
-        // to write some object with no generic typing information.
-        // We need to find out which INpgsqlTypeHandler interfaces our handler implements, and call
-        // the ValidateAndGetLength/WriteWithLengthInternal methods on the interface which corresponds to the
-        // value type.
-        // Since doing this with reflection every time is slow, we generate delegates to do this for us
-        // for each type handler.
-
-        static NonGenericValidateAndGetLength GenerateNonGenericValidationMethod(Type handlerType)
-        {
-            var interfaces = handlerType.GetInterfaces().Where(i =>
-                IntrospectionExtensions.GetTypeInfo(i).IsGenericType &&
-                i.GetGenericTypeDefinition() == typeof(INpgsqlTypeHandler<>)
-            ).Reverse().ToList();
-
-            Expression? ifElseExpression = null;
-
-            var handlerParam = Expression.Parameter(typeof(NpgsqlTypeHandler), "handler");
-            var valueParam = Expression.Parameter(typeof(object), "value");
-            var lengthCacheParam = Expression.Parameter(typeof(NpgsqlLengthCache).MakeByRefType(), "lengthCache");
-            var parameterParam = Expression.Parameter(typeof(NpgsqlParameter), "parameter");
-
-            var resultVariable = Expression.Variable(typeof(int), "result");
-
-            foreach (var i in interfaces)
-            {
-                var handledType = i.GenericTypeArguments[0];
-
-                ifElseExpression = Expression.IfThenElse(
-                    // Test whether the type of the value given to the delegate corresponds
-                    // to our current interface's handled type (i.e. the T in INpgsqlTypeHandler<T>)
-                    Expression.TypeEqual(valueParam, handledType),
-                    // If it corresponds, cast the handler type (this) to INpgsqlTypeHandler<T>
-                    // and call its ValidateAndGetLength method
-                    Expression.Assign(
-                        resultVariable,
-                        Expression.Call(
-                            Expression.Convert(handlerParam, i),
-                            i.GetMethod(nameof(INpgsqlTypeHandler<TDefault>.ValidateAndGetLength))!,
-                            // Cast the value from object down to the interface's T
-                            Expression.Convert(valueParam, handledType),
-                            lengthCacheParam,
-                            parameterParam
-                        )
-                    ),
-                    // If this is the first interface we're looking at, the else clause throws.
-                    // Otherwise we stick the previous interface's IfThenElse in our else clause
-                    ifElseExpression ?? Expression.Throw(
-                        Expression.New(
-                            MethodInfos.InvalidCastExceptionCtor,
-                            Expression.Call(  // Call string.Format to generate a nice informative exception message
-                                MethodInfos.StringFormat,
-                                new Expression[]
-                                {
-                                    Expression.Constant($"Can't write CLR type {{0}} with handler type {handlerType.Name}"),
-                                    Expression.Call(  // GetType() on the value
-                                        valueParam,
-                                        MethodInfos.ObjectGetType
-                                    )
-                                }
-                            )
-                        )
-                    )
-                );
-            }
-
-            if (ifElseExpression is null)
-                throw new Exception($"Type handler {handlerType.GetType().Name} does not implement the proper interface");
-
-            return Expression.Lambda<NonGenericValidateAndGetLength>(
-                Expression.Block(
-                    new[] { resultVariable },
-                    ifElseExpression, resultVariable
-                ),
-                handlerParam, valueParam, lengthCacheParam, parameterParam
-            ).Compile();
-        }
-
-        #endregion Code generation for non-generic writing
 
         #region Misc
 

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -12,6 +12,11 @@
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2039,7 +2039,17 @@ LANGUAGE plpgsql VOLATILE";
         }
 
         public override int ValidateAndGetLength(int value, NpgsqlParameter? parameter) => throw new NotSupportedException();
+        protected override int ValidateObjectAndGetLength(object value, NpgsqlParameter? parameter) => throw new NotSupportedException();
         public override void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => throw new NotSupportedException();
+
+        public override Task WriteObjectWithLength(
+            object value,
+            NpgsqlWriteBuffer buf,
+            NpgsqlLengthCache? lengthCache,
+            NpgsqlParameter? parameter,
+            bool async,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 
     #endregion


### PR DESCRIPTION
Removes a lot of ugly runtime code generation with expression trees.

I'm not completely sure if the complexity really is worth it - maybe just doing this manually everywhere makes more sense and is more maintainable (e.g. as in https://github.com/npgsql/npgsql/pull/3507#pullrequestreview-585031273). But this is just an opt-in mechanism which can be used where it makes sense, or the relevant code can be written manually.

Note that this doesn't cover all cases - some type handlers would have required more work to get their logic source-generated, and it didn't seem worth the effort.

Part of #2940
Part of #3300

/cc @Brar