### PR TITLE
Removed unrelated test requirement

### DIFF
--- a/test/Npgsql.Tests/Types/TsQueryTests.cs
+++ b/test/Npgsql.Tests/Types/TsQueryTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Threading.Tasks;
 using NpgsqlTypes;
 using NUnit.Framework;
 
@@ -80,12 +79,5 @@ namespace Npgsql.Tests.Types
                     new NpgsqlTsQueryLexeme("f"))
             }
         };
-
-        [OneTimeSetUp]
-        public async Task SetUp()
-        {
-            using var conn = await OpenConnectionAsync();
-            await TestUtil.EnsureExtensionAsync(conn, "ltree");
-        }
     }
 }


### PR DESCRIPTION
`tsquery` tests doesn't need `ltree`. The mistake was brought by copy-paste.