### PR TITLE
Fixed parameter order in assertion

### DIFF
--- a/test/Npgsql.Tests/Types/TypeHandlerTestBase.cs
+++ b/test/Npgsql.Tests/Types/TypeHandlerTestBase.cs
@@ -30,7 +30,7 @@ namespace Npgsql.Tests.Types
             using var conn = await OpenConnectionAsync();
             using var cmd = new NpgsqlCommand($"SELECT {query}", conn);
 
-            Assert.AreEqual(expected, actual: await cmd.ExecuteScalarAsync());
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(expected));
         }
 
         [Test]

--- a/test/Npgsql.Tests/Types/TypeHandlerTestBase.cs
+++ b/test/Npgsql.Tests/Types/TypeHandlerTestBase.cs
@@ -30,7 +30,7 @@ namespace Npgsql.Tests.Types
             using var conn = await OpenConnectionAsync();
             using var cmd = new NpgsqlCommand($"SELECT {query}", conn);
 
-            Assert.AreEqual(await cmd.ExecuteScalarAsync(), expected);
+            Assert.AreEqual(expected, actual: await cmd.ExecuteScalarAsync());
         }
 
         [Test]


### PR DESCRIPTION
Previously, there was an incorrect order which led to a misleading message by the test framework.