### PR TITLE
Remove Task<int> allocation when reading from NetworkStream

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -175,7 +175,7 @@ namespace Npgsql.Internal
                     {
                         var toRead = buffer.Size - buffer.FilledBytes;
                         var read = async
-                            ? await buffer.Underlying.ReadAsync(buffer.Buffer, buffer.FilledBytes, toRead, finalCt)
+                            ? await buffer.Underlying.ReadAsync(buffer.Buffer.AsMemory(buffer.FilledBytes, toRead), finalCt)
                             : buffer.Underlying.Read(buffer.Buffer, buffer.FilledBytes, toRead);
 
                         if (read == 0)


### PR DESCRIPTION
The overload of Stream.ReadAsync which accepts a byte[] returns a Task<int>, which allocates on the heap. The overload that accepts Memory<byte> returns a ValueTask backed by an efficient IValueTaskSource implementation.