### PR TITLE
Remove some allocations

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -176,12 +176,13 @@ namespace Npgsql
         {
             return TryGetIdleConnector(out var connector)
                 ? new ValueTask<NpgsqlConnector>(AssignConnection(conn, connector))
-                : RentAsync();
+                : RentAsync(conn, timeout, async, cancellationToken);
 
-            async ValueTask<NpgsqlConnector> RentAsync()
+            async ValueTask<NpgsqlConnector> RentAsync(
+                NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
             {
                 // First, try to open a new physical connector. This will fail if we're at max capacity.
-                connector = await OpenNewConnector(conn, timeout, async, cancellationToken);
+                var connector = await OpenNewConnector(conn, timeout, async, cancellationToken);
                 if (connector != null)
                     return AssignConnection(conn, connector);
 

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -849,10 +849,10 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         internal Task Write(NpgsqlConnector connector, bool async, CancellationToken cancellationToken = default)
         {
             return (_behavior & CommandBehavior.SchemaOnly) == 0
-                ? WriteExecute(connector, async)
-                : WriteExecuteSchemaOnly(connector, async);
+                ? WriteExecute(connector, async, cancellationToken)
+                : WriteExecuteSchemaOnly(connector, async, cancellationToken);
 
-            async Task WriteExecute(NpgsqlConnector connector, bool async)
+            async Task WriteExecute(NpgsqlConnector connector, bool async, CancellationToken cancellationToken)
             {
                 for (var i = 0; i < _statements.Count; i++)
                 {
@@ -898,7 +898,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 await connector.WriteSync(async, cancellationToken);
             }
 
-            async Task WriteExecuteSchemaOnly(NpgsqlConnector connector, bool async)
+            async Task WriteExecuteSchemaOnly(NpgsqlConnector connector, bool async, CancellationToken cancellationToken)
             {
                 var wroteSomething = false;
                 for (var i = 0; i < _statements.Count; i++)

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -225,15 +225,15 @@ namespace Npgsql
                 // If we've never connected with this connection string, open a physical connector in order to generate
                 // any exception (bad user/password, IP address...). This reproduces the standard error behavior.
                 if (!_pool.IsBootstrapped)
-                    return BootstrapMultiplexing(cancellationToken);
+                    return BootstrapMultiplexing(async, cancellationToken);
 
                 CompleteOpen();
                 return Task.CompletedTask;
             }
 
-            return OpenAsync(cancellationToken);
+            return OpenAsync(async, cancellationToken);
 
-            async Task OpenAsync(CancellationToken cancellationToken2)
+            async Task OpenAsync(bool async, CancellationToken cancellationToken)
             {
                 Debug.Assert(!Settings.Multiplexing);
 
@@ -253,7 +253,7 @@ namespace Npgsql
                             _userFacingConnectionString = Settings.ToStringWithoutPassword();
 
                         connector = new NpgsqlConnector(this);
-                        await connector.Open(timeout, async, cancellationToken2);
+                        await connector.Open(timeout, async, cancellationToken);
                     }
                     else
                     {
@@ -270,7 +270,7 @@ namespace Npgsql
                             enlistToTransaction = null;
                         }
                         else
-                            connector = await _pool.Rent(this, timeout, async, cancellationToken2);
+                            connector = await _pool.Rent(this, timeout, async, cancellationToken);
                     }
 
                     Debug.Assert(connector.Connection == this,
@@ -310,12 +310,12 @@ namespace Npgsql
                 }
             }
 
-            async Task BootstrapMultiplexing(CancellationToken cancellationToken2)
+            async Task BootstrapMultiplexing(bool async, CancellationToken cancellationToken)
             {
                 try
                 {
                     var timeout = new NpgsqlTimeout(TimeSpan.FromSeconds(ConnectionTimeout));
-                    await _pool!.BootstrapMultiplexing(this, timeout, async, cancellationToken2);
+                    await _pool!.BootstrapMultiplexing(this, timeout, async, cancellationToken);
                     CompleteOpen();
                 }
                 catch

--- a/src/Npgsql/NpgsqlConnector.FrontendMessages.cs
+++ b/src/Npgsql/NpgsqlConnector.FrontendMessages.cs
@@ -21,12 +21,12 @@ namespace Npgsql
                       (name.Length + 1);   // Statement/portal name
 
             if (WriteBuffer.WriteSpaceLeft < len)
-                return FlushAndWrite(len, statementOrPortal, name, async);
+                return FlushAndWrite(len, statementOrPortal, name, async, cancellationToken);
 
             Write(len, statementOrPortal, name);
             return Task.CompletedTask;
 
-            async Task FlushAndWrite(int len, StatementOrPortal statementOrPortal, string name, bool async)
+            async Task FlushAndWrite(int len, StatementOrPortal statementOrPortal, string name, bool async, CancellationToken cancellationToken)
             {
                 await Flush(async, cancellationToken);
                 Debug.Assert(len <= WriteBuffer.WriteSpaceLeft, $"Message of type {GetType().Name} has length {len} which is bigger than the buffer ({WriteBuffer.WriteSpaceLeft})");
@@ -48,12 +48,12 @@ namespace Npgsql
                             sizeof(int);    // Length
 
             if (WriteBuffer.WriteSpaceLeft < len)
-                return FlushAndWrite(async);
+                return FlushAndWrite(async, cancellationToken);
 
             Write();
             return Task.CompletedTask;
 
-            async Task FlushAndWrite(bool async)
+            async Task FlushAndWrite(bool async, CancellationToken cancellationToken)
             {
                 await Flush(async, cancellationToken);
                 Debug.Assert(len <= WriteBuffer.WriteSpaceLeft, $"Message of type {GetType().Name} has length {len} which is bigger than the buffer ({WriteBuffer.WriteSpaceLeft})");
@@ -77,12 +77,12 @@ namespace Npgsql
                             sizeof(int);         // Max number of rows
 
             if (WriteBuffer.WriteSpaceLeft < len)
-                return FlushAndWrite(maxRows, async);
+                return FlushAndWrite(maxRows, async, cancellationToken);
 
             Write(maxRows);
             return Task.CompletedTask;
 
-            async Task FlushAndWrite(int maxRows, bool async)
+            async Task FlushAndWrite(int maxRows, bool async, CancellationToken cancellationToken)
             {
                 await Flush(async, cancellationToken);
                 Debug.Assert(10 <= WriteBuffer.WriteSpaceLeft, $"Message of type {GetType().Name} has length 10 which is bigger than the buffer ({WriteBuffer.WriteSpaceLeft})");
@@ -250,12 +250,12 @@ namespace Npgsql
                       name.Length + sizeof(byte);  // Statement or portal name plus null terminator
 
             if (WriteBuffer.WriteSpaceLeft < 10)
-                return FlushAndWrite(len, type, name, async);
+                return FlushAndWrite(len, type, name, async, cancellationToken);
 
             Write(len, type, name);
             return Task.CompletedTask;
 
-            async Task FlushAndWrite(int len, StatementOrPortal type, string name, bool async)
+            async Task FlushAndWrite(int len, StatementOrPortal type, string name, bool async, CancellationToken cancellationToken)
             {
                 await Flush(async, cancellationToken);
                 Debug.Assert(len <= WriteBuffer.WriteSpaceLeft, $"Message of type {GetType().Name} has length {len} which is bigger than the buffer ({WriteBuffer.WriteSpaceLeft})");
@@ -448,12 +448,12 @@ namespace Npgsql
         internal Task WritePregenerated(byte[] data, bool async = false, CancellationToken cancellationToken = default)
         {
             if (WriteBuffer.WriteSpaceLeft < data.Length)
-                return FlushAndWrite(data, async);
+                return FlushAndWrite(data, async, cancellationToken);
 
             WriteBuffer.WriteBytes(data, 0, data.Length);
             return Task.CompletedTask;
 
-            async Task FlushAndWrite(byte[] data, bool async)
+            async Task FlushAndWrite(byte[] data, bool async, CancellationToken cancellationToken)
             {
                 await Flush(async, cancellationToken);
                 Debug.Assert(data.Length <= WriteBuffer.WriteSpaceLeft, $"Pregenerated message has length {data.Length} which is bigger than the buffer ({WriteBuffer.WriteSpaceLeft})");


### PR DESCRIPTION
Stop referring to outer method parameters in async local functions

Part of #3554