### PR TITLE
Fix ReplicationConnection.SendFeedback reset of _requestFeedbackTimer

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -595,7 +595,8 @@ namespace Npgsql.Replication
             finally
             {
                 _sendFeedbackTimer!.Change(WalReceiverStatusInterval, Timeout.InfiniteTimeSpan);
-                _requestFeedbackTimer!.Change(_requestFeedbackInterval, Timeout.InfiniteTimeSpan);
+                if (requestReply)
+                    _requestFeedbackTimer!.Change(_requestFeedbackInterval, Timeout.InfiniteTimeSpan);
                 _feedbackSemaphore.Release();
             }
         }

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -475,11 +475,8 @@ namespace Npgsql.Tests.Replication
 
                     Assert.That(replicationMessageTask.IsCompleted, Is.False);
                     Assert.That(successTimeoutTask.IsCompletedSuccessfully);
-                    Assert.That(async () =>
-                    {
-                        streamingCts.Cancel();
-                        await replicationMessageTask;
-                    }, Throws.Exception.AssignableTo<OperationCanceledException>());
+                    streamingCts.Cancel();
+                    Assert.That(async () => await replicationMessageTask, Throws.Exception.AssignableTo<OperationCanceledException>());
                 });
 
         #endregion

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -233,12 +233,8 @@ namespace Npgsql.Tests.Replication
                 {
                     await using var c = await OpenConnectionAsync();
                     TestUtil.MinimumPgVersion(c, "10.0", "The SHOW command, which is required to run this test was added to the Streaming Replication Protocol in PostgreSQL 10");
-                    var messages = new ConcurrentQueue<ReplicationMessage>();
                     await c.ExecuteNonQueryAsync($"CREATE TABLE {tableName} (id serial PRIMARY KEY, name TEXT NOT NULL);");
-                    await using var rc = await OpenReplicationConnectionAsync(new NpgsqlConnectionStringBuilder(ConnectionString)
-                    {
-                        ApplicationName = slotName
-                    });
+                    await using var rc = await OpenReplicationConnectionAsync(new NpgsqlConnectionStringBuilder(ConnectionString));
                     var walSenderTimeout = ParseTimespan(await rc.Show("wal_sender_timeout"));
                     var info = await rc.IdentifySystem();
                     if (walSenderTimeout > TimeSpan.FromSeconds(3) && !TestUtil.IsOnBuildServer)
@@ -252,12 +248,13 @@ namespace Npgsql.Tests.Replication
                     using var streamingCts = new CancellationTokenSource();
 
                     var replicationEnumerator = StartReplication(rc, slotName, info.XLogPos, streamingCts.Token).GetAsyncEnumerator(streamingCts.Token);
-
-                    var delay = TimeSpan.FromTicks((long)(walSenderTimeout.Ticks * 1.1));
-                    Console.WriteLine($"Going to sleep for {delay}");
-                    await Task.Delay(delay, CancellationToken.None);
-
                     Assert.That(await replicationEnumerator.MoveNextAsync(), Is.True);
+
+                    await Task.Delay(walSenderTimeout * 1.1, CancellationToken.None);
+
+                    await c.ExecuteNonQueryAsync($"INSERT INTO \"{tableName}\" (name) VALUES ('val2')");
+                    Assert.That(await replicationEnumerator.MoveNextAsync(), Is.True);
+
                     var message = replicationEnumerator.Current;
                     Assert.That(message.WalStart, Is.GreaterThanOrEqualTo(info.XLogPos));
                     Assert.That(message.WalEnd, Is.GreaterThanOrEqualTo(message.WalStart));
@@ -459,22 +456,32 @@ namespace Npgsql.Tests.Replication
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3534")]
         public Task Bug3534()
             => SafeReplicationTest(
-                async (slotName, tableName) =>
+                async (slotName, _) =>
                 {
                     await using var rc = await OpenReplicationConnectionAsync();
-                    await CreateReplicationSlot(slotName);
                     var info = await rc.IdentifySystem();
+                    await CreateReplicationSlot(slotName);
                     using var streamingCts = new CancellationTokenSource();
                     rc.WalReceiverStatusInterval = TimeSpan.FromSeconds(1D);
                     rc.WalReceiverTimeout = TimeSpan.FromSeconds(3D);
                     await using var replicationEnumerator = StartReplication(rc, slotName, info.XLogPos, streamingCts.Token).GetAsyncEnumerator(streamingCts.Token);
 
-                    var replicationMessageTask = replicationEnumerator.MoveNextAsync().AsTask();
+                    var replicationMessageTask = replicationEnumerator.MoveNextAsync();
                     streamingCts.CancelAfter(rc.WalReceiverTimeout * 2);
 
                     Assert.Multiple(() =>
                     {
-                        Assert.That(async () => await replicationMessageTask, Throws.Exception.AssignableTo<OperationCanceledException>());
+                        Assert.That(async () =>
+                        {
+                            // We only expect one transaction here but we need to keep polling
+                            // because in physical replication we can't prevent internal transactions
+                            // from being sent to the replication connection
+                            while (true)
+                            {
+                                await replicationMessageTask;
+                                replicationMessageTask = replicationEnumerator.MoveNextAsync();
+                            }
+                        }, Throws.Exception.AssignableTo<OperationCanceledException>());
                         Assert.That(streamingCts.IsCancellationRequested);
                     });
                 });


### PR DESCRIPTION
Unconditionally resetting _requestFeedbackTimer led to cancellation of
idle replication connections due to the expiring timeout because we
never actually requested a keepalive from the server.
We must only reset _requestFeedbackTimer if we actually requested
feedback.

Closes #3534

We may want to backport this to 5.x