### PR TITLE
Expose parsed connection strings on NpgsqlConnection

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -56,9 +56,9 @@ namespace Npgsql
         internal NpgsqlConnector? Connector { get; set; }
 
         /// <summary>
-        /// The parsed connection string set by the user
+        /// The parsed connection string. Set only after the connection is opened.
         /// </summary>
-        internal NpgsqlConnectionStringBuilder Settings { get; private set; } = DefaultSettings;
+        public NpgsqlConnectionStringBuilder Settings { get; private set; } = DefaultSettings;
 
         static readonly NpgsqlConnectionStringBuilder DefaultSettings = new();
 

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Npgsql.NpgsqlConnection.BeginBinaryImportAsync(string! copyFromCommand, System.T
 Npgsql.NpgsqlConnection.BeginRawBinaryCopyAsync(string! copyCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Npgsql.NpgsqlRawCopyStream!>!
 Npgsql.NpgsqlConnection.BeginTextExportAsync(string! copyToCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextReader!>!
 Npgsql.NpgsqlConnection.BeginTextImportAsync(string! copyFromCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextWriter!>!
+Npgsql.NpgsqlConnection.Settings.get -> Npgsql.NpgsqlConnectionStringBuilder!
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool
 override NpgsqlTypes.NpgsqlTsQuery.GetHashCode() -> int


### PR DESCRIPTION
Allows users to know how the connection was configured without (re)-parsing the connection string.

For example, the idea is for EF Core to use this in order to know whether Enlist was set to false, and to skip accessing Transaction.Current if so (see https://github.com/dotnet/efcore/pull/24209).