### PR TITLE
Remove some allocations (continued)

### DIFF
--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -175,9 +175,9 @@ namespace Npgsql
                 throw new InvalidOperationException("Stream not open for writing");
             cancellationToken.ThrowIfCancellationRequested();
             using (NoSynchronizationContextScope.Enter())
-                return WriteAsyncInternal();
+                return WriteAsyncInternal(buffer, cancellationToken);
 
-            async ValueTask WriteAsyncInternal()
+            async ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
             {
                 if (buffer.Length == 0)
                     return;

--- a/src/Npgsql/Replication/PhysicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/PhysicalReplicationConnection.cs
@@ -51,9 +51,9 @@ namespace Npgsql.Replication
             string slotName, bool isTemporary = false, bool reserveWal = false, CancellationToken cancellationToken = default)
         {
             using var _ = NoSynchronizationContextScope.Enter();
-            return CreatePhysicalReplicationSlot();
+            return CreatePhysicalReplicationSlot(slotName, isTemporary, reserveWal, cancellationToken);
 
-            async Task<PhysicalReplicationSlot> CreatePhysicalReplicationSlot()
+            async Task<PhysicalReplicationSlot> CreatePhysicalReplicationSlot(string slotName, bool isTemporary, bool reserveWal, CancellationToken cancellationToken)
             {
                 var builder = new StringBuilder("CREATE_REPLICATION_SLOT ").Append(slotName);
                 if (isTemporary)


### PR DESCRIPTION
Stop referring to outer method parameters in async local functions

Part of #3554