### PR TITLE
b/cleanupNullRef

### DIFF
--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -436,10 +436,13 @@ namespace Npgsql
 #pragma warning disable CS8625
         void Cleanup()
         {
-            Log.Debug("COPY operation ended", _connector.Id);
-            _connector.CurrentCopyOperation = null;
-            _connector.Connection!.EndBindingScope(ConnectorBindingScope.Copy);
-            _connector = null;
+            if (_connector != null)
+            {
+                Log.Debug("COPY operation ended", _connector.Id);
+                _connector.CurrentCopyOperation = null;
+                _connector.Connection!.EndBindingScope(ConnectorBindingScope.Copy);
+                _connector = null;  
+            }
             _readBuf = null;
             _writeBuf = null;
             _isDisposed = true;


### PR DESCRIPTION
Hi All,
I haven't been able to reproduce this but a few of our customers have reported this issue:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Npgsql.NpgsqlRawCopyStream.Cleanup()
   at Npgsql.NpgsqlRawCopyStream.DisposeAsync(Boolean disposing, Boolean async)
   at Npgsql.NpgsqlRawCopyStream.Dispose(Boolean disposing)
   at System.IO.Stream.Close()
```

