### PR TITLE
A few fixes and additions for multiple hosts

### DIFF
--- a/src/Npgsql/MultiHostConnectorPool.cs
+++ b/src/Npgsql/MultiHostConnectorPool.cs
@@ -143,7 +143,7 @@ namespace Npgsql
                         if (clusterState == ClusterState.Unknown)
                         {
                             // Opening a new physical connection refreshed the cluster state, check again
-                            // Note that we purposefuly ignore the expiration, as in case of the HostRecheckSeconds = 0
+                            // Note that we purposefully ignore the expiration, as in case of the HostRecheckSeconds = 0
                             // it will always be expired
                             clusterState = GetClusterState(pool, ignoreExpiration: true);
                             Debug.Assert(clusterState != ClusterState.Unknown);

--- a/src/Npgsql/MultiHostConnectorPool.cs
+++ b/src/Npgsql/MultiHostConnectorPool.cs
@@ -61,8 +61,8 @@ namespace Npgsql
                 _ => false
             };
 
-        static ClusterState GetClusterState(ConnectorPool pool)
-            => GetClusterState(pool.Settings.Host!, pool.Settings.Port, ignoreExpiration: false);
+        static ClusterState GetClusterState(ConnectorPool pool, bool ignoreExpiration = false)
+            => GetClusterState(pool.Settings.Host!, pool.Settings.Port, ignoreExpiration);
 
         static ClusterState GetClusterState(string host, int port, bool ignoreExpiration)
             => ClusterStateCache.GetClusterState(host, port, ignoreExpiration);
@@ -143,7 +143,9 @@ namespace Npgsql
                         if (clusterState == ClusterState.Unknown)
                         {
                             // Opening a new physical connection refreshed the cluster state, check again
-                            clusterState = GetClusterState(pool);
+                            // Note that we purposefuly ignore the expiration, as in case of the HostRecheckSeconds = 0
+                            // it will always be expired
+                            clusterState = GetClusterState(pool, ignoreExpiration: true);
                             Debug.Assert(clusterState != ClusterState.Unknown);
                             if (!clusterValidator(clusterState, preferredType))
                             {
@@ -190,9 +192,9 @@ namespace Npgsql
                 try
                 {
                     connector = await pool.Get(conn, new NpgsqlTimeout(timeoutPerHost), async, cancellationToken);
-                    // Get may be have opened a new physical connection and refreshed the cluster state, check again
                     if (clusterState == ClusterState.Unknown)
                     {
+                        // Get might have opened a new physical connection and refreshed the cluster state, check again
                         clusterState = GetClusterState(pool);
                         if (clusterState == ClusterState.Unknown)
                             clusterState = await connector.QueryClusterState(new NpgsqlTimeout(timeoutPerHost), async, cancellationToken);

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -520,7 +520,7 @@ namespace Npgsql
             catch (Exception e)
             {
                 ClusterStateCache.UpdateClusterState(Settings.Host!, Settings.Port, ClusterState.Offline,
-                    DateTime.UtcNow, TimeSpan.FromSeconds(Settings.HostRecheckSeconds));
+                    DateTime.UtcNow, Settings.HostRecheckSecondsTranslated);
                 Break(e);
                 throw;
             }
@@ -595,7 +595,7 @@ namespace Npgsql
                     ? ClusterState.PrimaryReadOnly
                     : ClusterState.PrimaryReadWrite;
             return ClusterStateCache.UpdateClusterState(Settings.Host!, Settings.Port, state, timeStamp,
-                TimeSpan.FromSeconds(Settings.HostRecheckSeconds));
+                Settings.HostRecheckSecondsTranslated);
         }
 
         void WriteStartupMessage(string username)
@@ -1241,7 +1241,7 @@ namespace Npgsql
                             {
                                 // Consider the database offline
                                 ClusterStateCache.UpdateClusterState(connector.Host, connector.Port, ClusterState.Offline, DateTime.UtcNow,
-                                    TimeSpan.FromSeconds(connector.Settings.HostRecheckSeconds));
+                                    connector.Settings.HostRecheckSecondsTranslated);
                                 throw connector.Break(error);
                             }
 
@@ -1295,7 +1295,7 @@ namespace Npgsql
                 {
                     // We've timed out even though we've send the cancellation request
                     ClusterStateCache.UpdateClusterState(connector.Host, connector.Port, ClusterState.Offline, DateTime.UtcNow,
-                            TimeSpan.FromSeconds(connector.Settings.HostRecheckSeconds));
+                            connector.Settings.HostRecheckSecondsTranslated);
                     throw;
                 }
                 catch (NpgsqlException)
@@ -1790,7 +1790,7 @@ namespace Npgsql
                     if (reason is NpgsqlException && reason.InnerException is IOException)
                     {
                         ClusterStateCache.UpdateClusterState(Host, Port, ClusterState.Offline, DateTime.UtcNow,
-                            TimeSpan.FromSeconds(Settings.HostRecheckSeconds));
+                            Settings.HostRecheckSecondsTranslated);
                     }
 
                     Log.Error("Breaking connector", reason, Id);

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -31,6 +31,8 @@ namespace Npgsql
 
         public static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
 
+        public static string? TargetSessionAttributes => Environment.GetEnvironmentVariable("PGTARGETSESSIONATTRS");
+
         static string? GetDefaultFilePath(string fileName) =>
             Environment.GetEnvironmentVariable(PGUtil.IsWindows ? "APPDATA" : "HOME") is string appData &&
             Path.Combine(appData, "postgresql", fileName) is string filePath &&

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -419,7 +419,7 @@ namespace Npgsql.Tests
                 Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
                 MaxPoolSize = 1,
-                HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
+                HostRecheckSeconds = alwaysCheckHostState ? 0 : int.MaxValue,
                 TargetSessionAttributesParsed = TargetSessionAttributes.PreferPrimary,
                 NoResetOnClose = true,
             };

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -299,6 +299,33 @@ namespace Npgsql.Tests
                 });
 
         [Test]
+        public void HostRecheckSeconds_default_value()
+        {
+            var builder = new NpgsqlConnectionStringBuilder();
+            Assert.That(builder.HostRecheckSeconds, Is.EqualTo(10));
+            Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(10)));
+        }
+
+        [Test]
+        public void HostRecheckSeconds_zero_value()
+        {
+            var builder = new NpgsqlConnectionStringBuilder
+            {
+                HostRecheckSeconds = 0,
+            };
+            Assert.That(builder.HostRecheckSeconds, Is.EqualTo(0));
+            Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(-1)));
+        }
+
+        [Test]
+        public void HostRecheckSeconds_invalid_throws()
+            => Assert.Throws<ArgumentException>(() =>
+                new NpgsqlConnectionStringBuilder
+                {
+                    HostRecheckSeconds = -1
+                });
+
+        [Test]
         public async Task Connect_with_load_balancing()
         {
             await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
@@ -382,6 +409,61 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public async Task Connect_state_changing_hosts([Values] bool alwaysCheckHostState)
+        {
+            await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+            await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+
+            var defaultCsb = new NpgsqlConnectionStringBuilder
+            {
+                Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+                MaxPoolSize = 1,
+                HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
+                TargetSessionAttributesParsed = TargetSessionAttributes.PreferPrimary,
+                NoResetOnClose = true,
+            };
+
+            using var _ = CreateTempPool(defaultCsb.ConnectionString, out var defaultConnectionString);
+
+            NpgsqlConnector firstConnector;
+            NpgsqlConnector secondConnector;
+            var firstServerTask = Task.Run(async () =>
+            {
+                var server = await primaryPostmaster.WaitForServerConnection();
+                if (!alwaysCheckHostState)
+                    return;
+
+                // Update the state after a 'failover'
+                await server.SendMockState(Standby);
+            });
+            var secondServerTask = Task.Run(async () =>
+            {
+                var server = await standbyPostmaster.WaitForServerConnection();
+                if (!alwaysCheckHostState)
+                    return;
+
+                // As TargetSessionAttributes is 'prefer', it does another cycle for the 'unpreferred'
+                await server.SendMockState(Standby);
+                // Update the state after a 'failover'
+                await server.SendMockState(Primary);
+            });
+
+            await using (var firstConnection = await OpenConnectionAsync(defaultConnectionString))
+            await using (var secondConnection = await OpenConnectionAsync(defaultConnectionString))
+            {
+                firstConnector = firstConnection.Connector!;
+                secondConnector = secondConnection.Connector!;
+            }
+
+            await using var thirdConnection = await OpenConnectionAsync(defaultConnectionString);
+            Assert.AreSame(alwaysCheckHostState ? secondConnector : firstConnector, thirdConnection.Connector);
+
+            await firstServerTask;
+            await secondServerTask;
+        }
+
+        [Test]
         public void Cluster_state_cache_basic()
         {
             const string host = nameof(Cluster_state_cache_basic);
@@ -408,7 +490,7 @@ namespace Npgsql.Tests
 
         // This is the only test in this class which actually connects to PostgreSQL (the others use the PostgreSQL mock)
         [Test, Timeout(10000), NonParallelizable]
-        public void IntegrationTest([Values] bool withLoadBalancing)
+        public void IntegrationTest([Values] bool loadBalancing, [Values] bool alwaysCheckHostState)
         {
             PoolManager.Reset();
 
@@ -417,7 +499,8 @@ namespace Npgsql.Tests
                 Host = "localhost,127.0.0.1",
                 Pooling = true,
                 MaxPoolSize = 2,
-                LoadBalanceHosts = withLoadBalancing
+                LoadBalanceHosts = loadBalancing,
+                HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
             };
 
             var queriesDone = 0;
@@ -432,9 +515,9 @@ namespace Npgsql.Tests
             var onlyStandbyClient = Client(csb, TargetSessionAttributes.Standby);
             var readOnlyClient = Client(csb, TargetSessionAttributes.ReadOnly);
 
-            Assert.DoesNotThrowAsync(async () => await clientsTask);
-            Assert.ThrowsAsync<NpgsqlException>(async () => await onlyStandbyClient);
-            Assert.ThrowsAsync<NpgsqlException>(async () => await readOnlyClient);
+            Assert.DoesNotThrowAsync(() => clientsTask);
+            Assert.ThrowsAsync<NpgsqlException>(() => onlyStandbyClient);
+            Assert.ThrowsAsync<NpgsqlException>(() => readOnlyClient);
             Assert.AreEqual(125, queriesDone);
 
             Assert.AreEqual(8, PoolManager.Pools.Where(x => x.Key is not null).Count());

--- a/test/Npgsql.Tests/Support/PgPostmasterMock.cs
+++ b/test/Npgsql.Tests/Support/PgPostmasterMock.cs
@@ -64,6 +64,17 @@ namespace Npgsql.Tests.Support
             var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
             _socket.Bind(endpoint);
 
+            // In some cases we can attempt to connect to a port, which was already in use (doesn't have to be a mock).
+            // Clearing the cached state, so the previous state is not leaking.
+            if (state != MockState.MultipleHostsDisabled)
+            {
+                var afterBindEndport = _socket.LocalEndPoint as IPEndPoint;
+                Debug.Assert(afterBindEndport is not null);
+                var host = afterBindEndport.Address.ToString();
+                var port = afterBindEndport.Port;
+                ClusterStateCache.RemoveClusterState(host, port);
+            }
+
             var localEndPoint = (IPEndPoint)_socket.LocalEndPoint!;
             Host = localEndPoint.Address.ToString();
             Port = localEndPoint.Port;


### PR DESCRIPTION
Fixed cluster state cache for tests.
Added environment variable for `TargetSessionAttributes`.
`HostRecheckSeconds` now treats 0 as no-state-caching (@mintsoft you might be interested in this).