### PR TITLE
Some more tweaks to multiple hosts

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -308,8 +308,7 @@ namespace Npgsql
                 {
                     // We've managed to increase the open counter, open a physical connections.
                     var connector = new NpgsqlConnector(conn, this) { ClearCounter = _clearCounter };
-                    var queryClusterState = _parentPool is not null && Settings.ReplicationMode == ReplicationMode.Off;
-                    await connector.Open(timeout, async, queryClusterState, cancellationToken);
+                    await connector.Open(timeout, async, cancellationToken);
 
                     var i = 0;
                     for (; i < _max; i++)

--- a/src/Npgsql/MultiHostConnectorPool.cs
+++ b/src/Npgsql/MultiHostConnectorPool.cs
@@ -352,19 +352,9 @@ namespace Npgsql
         }
 
         static TargetSessionAttributes GetTargetSessionAttributes(NpgsqlConnection connection)
-        {
-            var result = connection.Settings.TargetSessionAttributesParsed;
-            if (result is not null)
-                return result.Value;
-
-            if (PostgresEnvironment.TargetSessionAttributes is string s)
-            {
-                if (!Enum.TryParse<TargetSessionAttributes>(s, out var parsed))
-                    throw new ArgumentException($"The environment variable PGTARGETSESSIONATTRS contains an invalid value '{s}'");
-                return parsed;
-            }
-
-            return default;
-        }
+            => connection.Settings.TargetSessionAttributesParsed ??
+               (PostgresEnvironment.TargetSessionAttributes is string s
+                   ? NpgsqlConnectionStringBuilder.ParseTargetSessionAttributes(s)
+                   : default);
     }
 }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -182,8 +182,11 @@ namespace Npgsql
             var hostsSeparator = settings.Host?.IndexOf(',');
             if (hostsSeparator.HasValue && hostsSeparator == -1)
             {
-                if (settings.TargetSessionAttributesParsed != TargetSessionAttributes.Any)
-                    throw new NotSupportedException("TargetSessionAttributes other then Any is only supported with multiple hosts");
+                if (settings.TargetSessionAttributesParsed is not null &&
+                    settings.TargetSessionAttributesParsed != TargetSessionAttributes.Any)
+                {
+                    throw new NotSupportedException("Target Session Attributes other then Any is only supported with multiple hosts");
+                }
 
                 var portSeparator = settings.Host!.IndexOf(':');
                 if (!Path.IsPathRooted(settings.Host) && portSeparator != -1)

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -517,21 +517,42 @@ namespace Npgsql
         [NpgsqlConnectionStringProperty]
         public string? TargetSessionAttributes
         {
-            get => TargetSessionAttributesParsed?.ToString();
+            get => TargetSessionAttributesParsed switch
+            {
+                Npgsql.TargetSessionAttributes.Any           => "any",
+                Npgsql.TargetSessionAttributes.Primary       => "primary",
+                Npgsql.TargetSessionAttributes.Standby       => "standby",
+                Npgsql.TargetSessionAttributes.PreferPrimary => "prefer-primary",
+                Npgsql.TargetSessionAttributes.PreferStandby => "prefer-standby",
+                Npgsql.TargetSessionAttributes.ReadWrite     => "read-write",
+                Npgsql.TargetSessionAttributes.ReadOnly      => "read-only",
+                null => null,
+
+                _ => throw new ArgumentException($"Unhandled enum value '{TargetSessionAttributesParsed}'")
+            };
+
             set
             {
-                if (value is null)
-                    TargetSessionAttributesParsed = null;
-                else if (Enum.TryParse<TargetSessionAttributes>(value, out var parsed))
-                    TargetSessionAttributesParsed = parsed;
-                else
-                    throw new ArgumentException($"'Target Session Attributes' contains an invalid value '{value}'");
-
+                TargetSessionAttributesParsed = value is null ? null : ParseTargetSessionAttributes(value);
                 SetValue(nameof(TargetSessionAttributes), TargetSessionAttributesParsed);
             }
         }
 
         internal TargetSessionAttributes? TargetSessionAttributesParsed { get; private set; }
+
+        internal static TargetSessionAttributes ParseTargetSessionAttributes(string s)
+            => s switch
+            {
+                "any"            => Npgsql.TargetSessionAttributes.Any,
+                "primary"        => Npgsql.TargetSessionAttributes.Primary,
+                "standby"        => Npgsql.TargetSessionAttributes.Standby,
+                "prefer-primary" => Npgsql.TargetSessionAttributes.PreferPrimary,
+                "prefer-standby" => Npgsql.TargetSessionAttributes.PreferStandby,
+                "read-write"     => Npgsql.TargetSessionAttributes.ReadWrite,
+                "read-only"      => Npgsql.TargetSessionAttributes.ReadOnly,
+
+                _ => throw new ArgumentException($"TargetSessionAttributes contains an invalid value '{s}'")
+            };
 
         /// <summary>
         /// Controls for how long the host's cached state will be considered as valid.

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -508,74 +508,6 @@ namespace Npgsql
         }
         string? _timezone;
 
-        /// <summary>
-        /// Determines the preferred PostgreSQL target server type.
-        /// </summary>
-        [Category("Connection")]
-        [Description("Determines the preferred PostgreSQL target server type.")]
-        [DisplayName("Target Session Attributes")]
-        [NpgsqlConnectionStringProperty]
-        public string? TargetSessionAttributes
-        {
-            get => TargetSessionAttributesParsed switch
-            {
-                Npgsql.TargetSessionAttributes.Any           => "any",
-                Npgsql.TargetSessionAttributes.Primary       => "primary",
-                Npgsql.TargetSessionAttributes.Standby       => "standby",
-                Npgsql.TargetSessionAttributes.PreferPrimary => "prefer-primary",
-                Npgsql.TargetSessionAttributes.PreferStandby => "prefer-standby",
-                Npgsql.TargetSessionAttributes.ReadWrite     => "read-write",
-                Npgsql.TargetSessionAttributes.ReadOnly      => "read-only",
-                null => null,
-
-                _ => throw new ArgumentException($"Unhandled enum value '{TargetSessionAttributesParsed}'")
-            };
-
-            set
-            {
-                TargetSessionAttributesParsed = value is null ? null : ParseTargetSessionAttributes(value);
-                SetValue(nameof(TargetSessionAttributes), value);
-            }
-        }
-
-        internal TargetSessionAttributes? TargetSessionAttributesParsed { get; private set; }
-
-        internal static TargetSessionAttributes ParseTargetSessionAttributes(string s)
-            => s switch
-            {
-                "any"            => Npgsql.TargetSessionAttributes.Any,
-                "primary"        => Npgsql.TargetSessionAttributes.Primary,
-                "standby"        => Npgsql.TargetSessionAttributes.Standby,
-                "prefer-primary" => Npgsql.TargetSessionAttributes.PreferPrimary,
-                "prefer-standby" => Npgsql.TargetSessionAttributes.PreferStandby,
-                "read-write"     => Npgsql.TargetSessionAttributes.ReadWrite,
-                "read-only"      => Npgsql.TargetSessionAttributes.ReadOnly,
-
-                _ => throw new ArgumentException($"TargetSessionAttributes contains an invalid value '{s}'")
-            };
-
-        /// <summary>
-        /// Controls for how long the host's cached state will be considered as valid.
-        /// </summary>
-        [Category("Connection")]
-        [Description("Controls for how long the host's cached state will be considered as valid.")]
-        [DisplayName("Host Recheck Seconds")]
-        [DefaultValue(10)]
-        [NpgsqlConnectionStringProperty]
-        public int HostRecheckSeconds
-        {
-            get => _hostRecheckSeconds;
-            set
-            {
-                if (value < 0)
-                    throw new ArgumentException($"{HostRecheckSeconds} cannot be negative", nameof(HostRecheckSeconds));
-                _hostRecheckSeconds = value;
-                SetValue(nameof(HostRecheckSeconds), value);
-                _hostRecheckSecondsTranslated = null;
-            }
-        }
-        int _hostRecheckSeconds;
-
         #endregion
 
         #region Properties - Security
@@ -954,24 +886,6 @@ namespace Npgsql
         }
         int _connectionLifetime;
 
-        /// <summary>
-        /// Enables balancing between multiple hosts by round-robin.
-        /// </summary>
-        [Category("Pooling")]
-        [Description("Enables balancing between multiple hosts by round-robin.")]
-        [DisplayName("Load Balance Hosts")]
-        [NpgsqlConnectionStringProperty]
-        public bool LoadBalanceHosts
-        {
-            get => _loadBalanceHosts;
-            set
-            {
-                _loadBalanceHosts = value;
-                SetValue(nameof(LoadBalanceHosts), value);
-            }
-        }
-        bool _loadBalanceHosts;
-
         #endregion
 
         #region Properties - Timeouts
@@ -1071,6 +985,96 @@ namespace Npgsql
         int _cancellationTimeout;
 
         #endregion
+
+        #region Properties - Failover and load balancing
+
+        /// <summary>
+        /// Determines the preferred PostgreSQL target server type.
+        /// </summary>
+        [Category("Failover and load balancing")]
+        [Description("Determines the preferred PostgreSQL target server type.")]
+        [DisplayName("Target Session Attributes")]
+        [NpgsqlConnectionStringProperty]
+        public string? TargetSessionAttributes
+        {
+            get => TargetSessionAttributesParsed switch
+            {
+                Npgsql.TargetSessionAttributes.Any           => "any",
+                Npgsql.TargetSessionAttributes.Primary       => "primary",
+                Npgsql.TargetSessionAttributes.Standby       => "standby",
+                Npgsql.TargetSessionAttributes.PreferPrimary => "prefer-primary",
+                Npgsql.TargetSessionAttributes.PreferStandby => "prefer-standby",
+                Npgsql.TargetSessionAttributes.ReadWrite     => "read-write",
+                Npgsql.TargetSessionAttributes.ReadOnly      => "read-only",
+                null => null,
+
+                _ => throw new ArgumentException($"Unhandled enum value '{TargetSessionAttributesParsed}'")
+            };
+
+            set
+            {
+                TargetSessionAttributesParsed = value is null ? null : ParseTargetSessionAttributes(value);
+                SetValue(nameof(TargetSessionAttributes), value);
+            }
+        }
+
+        internal TargetSessionAttributes? TargetSessionAttributesParsed { get; private set; }
+
+        internal static TargetSessionAttributes ParseTargetSessionAttributes(string s)
+            => s switch
+            {
+                "any"            => Npgsql.TargetSessionAttributes.Any,
+                "primary"        => Npgsql.TargetSessionAttributes.Primary,
+                "standby"        => Npgsql.TargetSessionAttributes.Standby,
+                "prefer-primary" => Npgsql.TargetSessionAttributes.PreferPrimary,
+                "prefer-standby" => Npgsql.TargetSessionAttributes.PreferStandby,
+                "read-write"     => Npgsql.TargetSessionAttributes.ReadWrite,
+                "read-only"      => Npgsql.TargetSessionAttributes.ReadOnly,
+
+                _ => throw new ArgumentException($"TargetSessionAttributes contains an invalid value '{s}'")
+            };
+
+        /// <summary>
+        /// Enables balancing between multiple hosts by round-robin.
+        /// </summary>
+        [Category("Failover and load balancing")]
+        [Description("Enables balancing between multiple hosts by round-robin.")]
+        [DisplayName("Load Balance Hosts")]
+        [NpgsqlConnectionStringProperty]
+        public bool LoadBalanceHosts
+        {
+            get => _loadBalanceHosts;
+            set
+            {
+                _loadBalanceHosts = value;
+                SetValue(nameof(LoadBalanceHosts), value);
+            }
+        }
+        bool _loadBalanceHosts;
+
+        /// <summary>
+        /// Controls for how long the host's cached state will be considered as valid.
+        /// </summary>
+        [Category("Failover and load balancing")]
+        [Description("Controls for how long the host's cached state will be considered as valid.")]
+        [DisplayName("Host Recheck Seconds")]
+        [DefaultValue(10)]
+        [NpgsqlConnectionStringProperty]
+        public int HostRecheckSeconds
+        {
+            get => _hostRecheckSeconds;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentException($"{HostRecheckSeconds} cannot be negative", nameof(HostRecheckSeconds));
+                _hostRecheckSeconds = value;
+                SetValue(nameof(HostRecheckSeconds), value);
+                _hostRecheckSecondsTranslated = null;
+            }
+        }
+        int _hostRecheckSeconds;
+
+        #endregion Properties - Failover and load balancing
 
         #region Properties - Entity Framework
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -534,7 +534,7 @@ namespace Npgsql
             set
             {
                 TargetSessionAttributesParsed = value is null ? null : ParseTargetSessionAttributes(value);
-                SetValue(nameof(TargetSessionAttributes), TargetSessionAttributesParsed);
+                SetValue(nameof(TargetSessionAttributes), value);
             }
         }
 

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -438,7 +438,7 @@ namespace Npgsql
         /// </summary>
         /// <remarks>Usually called by the RequestConnector
         /// Method of the connection pool manager.</remarks>
-        internal async Task Open(NpgsqlTimeout timeout, bool async, bool queryClusterState, CancellationToken cancellationToken)
+        internal async Task Open(NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(Connection != null && Connection.Connector == this);
             Debug.Assert(State == ConnectorState.Closed);
@@ -479,8 +479,6 @@ namespace Npgsql
                 }
 
                 await LoadDatabaseInfo(forceReload: false, timeout, async, cancellationToken);
-                if (queryClusterState)
-                    await QueryClusterState(timeout, async, cancellationToken);
 
                 if (Settings.Pooling && !Settings.Multiplexing && !Settings.NoResetOnClose && DatabaseInfo.SupportsDiscard)
                 {

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -7,31 +7,31 @@ namespace Npgsql
 {
     static class PostgresEnvironment
     {
-        public static string? User => Environment.GetEnvironmentVariable("PGUSER");
+        internal static string? User => Environment.GetEnvironmentVariable("PGUSER");
 
-        public static string? Password => Environment.GetEnvironmentVariable("PGPASSWORD");
+        internal static string? Password => Environment.GetEnvironmentVariable("PGPASSWORD");
 
-        public static string? PassFile => Environment.GetEnvironmentVariable("PGPASSFILE");
+        internal static string? PassFile => Environment.GetEnvironmentVariable("PGPASSFILE");
 
-        public static string? PassFileDefault => GetDefaultFilePath(PGUtil.IsWindows ? "pgpass.conf" : ".pgpass");
+        internal static string? PassFileDefault => GetDefaultFilePath(PGUtil.IsWindows ? "pgpass.conf" : ".pgpass");
 
-        public static string? SslCert => Environment.GetEnvironmentVariable("PGSSLCERT");
+        internal static string? SslCert => Environment.GetEnvironmentVariable("PGSSLCERT");
 
-        public static string? SslCertDefault => GetDefaultFilePath("postgresql.crt");
+        internal static string? SslCertDefault => GetDefaultFilePath("postgresql.crt");
 
-        public static string? SslCertRoot => Environment.GetEnvironmentVariable("PGSSLROOTCERT");
+        internal static string? SslCertRoot => Environment.GetEnvironmentVariable("PGSSLROOTCERT");
 
-        public static string? SslCertRootDefault => GetDefaultFilePath("root.crt");
+        internal static string? SslCertRootDefault => GetDefaultFilePath("root.crt");
 
-        public static string? SslKey => Environment.GetEnvironmentVariable("PGSSLKEY");
+        internal static string? SslKey => Environment.GetEnvironmentVariable("PGSSLKEY");
 
-        public static string? ClientEncoding => Environment.GetEnvironmentVariable("PGCLIENTENCODING");
+        internal static string? ClientEncoding => Environment.GetEnvironmentVariable("PGCLIENTENCODING");
 
-        public static string? TimeZone => Environment.GetEnvironmentVariable("PGTZ");
+        internal static string? TimeZone => Environment.GetEnvironmentVariable("PGTZ");
 
-        public static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
+        internal static string? Options => Environment.GetEnvironmentVariable("PGOPTIONS");
 
-        public static string? TargetSessionAttributes => Environment.GetEnvironmentVariable("PGTARGETSESSIONATTRS");
+        internal static string? TargetSessionAttributes => Environment.GetEnvironmentVariable("PGTARGETSESSIONATTRS");
 
         static string? GetDefaultFilePath(string fileName) =>
             Environment.GetEnvironmentVariable(PGUtil.IsWindows ? "APPDATA" : "HOME") is string appData &&

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -16,7 +16,7 @@ Npgsql.NpgsqlConnectionStringBuilder.SslKey.get -> string?
 Npgsql.NpgsqlConnectionStringBuilder.SslKey.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.SslPassword.get -> string?
 Npgsql.NpgsqlConnectionStringBuilder.SslPassword.set -> void
-Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.get -> string!
+Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.get -> string?
 Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.set -> void
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool

--- a/src/Npgsql/UnpooledConnectorSource.cs
+++ b/src/Npgsql/UnpooledConnectorSource.cs
@@ -21,7 +21,7 @@ namespace Npgsql
             NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         {
             var connector = new NpgsqlConnector(conn, this);
-            await connector.Open(timeout, async, queryClusterState: false, cancellationToken);
+            await connector.Open(timeout, async, cancellationToken);
             Interlocked.Increment(ref _numConnectors);
             return connector;
         }

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -578,26 +578,15 @@ namespace Npgsql.Tests
         static string MultipleHosts(params PgPostmasterMock[] postmasters)
             => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
 
-        public enum TestTargetSessionAttributes : byte
-        {
-            Any = TargetSessionAttributes.Any,
-            ReadWrite = TargetSessionAttributes.ReadWrite,
-            ReadOnly = TargetSessionAttributes.ReadOnly,
-            Primary = TargetSessionAttributes.Primary,
-            Standby = TargetSessionAttributes.Standby,
-            PreferPrimary = TargetSessionAttributes.PreferPrimary,
-            PreferStandby = TargetSessionAttributes.PreferStandby,
-        }
-
         class DisposableWrapper : IAsyncDisposable
         {
-            private readonly IEnumerable<IAsyncDisposable> disposables;
+            readonly IEnumerable<IAsyncDisposable> _disposables;
 
-            public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => this.disposables = disposables;
+            public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => _disposables = disposables;
 
             public async ValueTask DisposeAsync()
             {
-                foreach (var disposable in disposables)
+                foreach (var disposable in _disposables)
                     await disposable.DisposeAsync();
             }
         }


### PR DESCRIPTION
* Introduce spaces in connection string parameters
* Move PGTARGETSESSIONATTRS handling out of NpgsqlConnectionStringBuilder, to make the latter only represent the connection string.
* Various other minor tweaks and simplifications