### PR TITLE
Add BigInteger type support for PG numeric type

### DIFF
--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -404,6 +404,11 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
 
         public int ValidateAndGetLength(BigInteger value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get();
+
             var result = (ushort[]?)parameter?.ConvertedValue;
             if (result == null)
             {
@@ -411,7 +416,8 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
                 if (parameter != null)
                     parameter.ConvertedValue = result;
             }
-            return (4 + result[0]) * sizeof(ushort);
+
+            return lengthCache.Set((4 + result[0]) * sizeof(ushort));
         }
 
         public async Task Write(BigInteger value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async,

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -1,5 +1,9 @@
 ﻿using System;
 using System.Data;
+using System.Globalization;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
@@ -18,18 +22,21 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
     /// should be considered somewhat unstable, and  may change in breaking ways, including in non-major releases.
     /// Use it at your own risk.
     /// </remarks>
-    public partial class NumericHandler : NpgsqlSimpleTypeHandler<decimal>,
-        INpgsqlSimpleTypeHandler<byte>, INpgsqlSimpleTypeHandler<short>, INpgsqlSimpleTypeHandler<int>, INpgsqlSimpleTypeHandler<long>,
-        INpgsqlSimpleTypeHandler<float>, INpgsqlSimpleTypeHandler<double>
+    public partial class NumericHandler : NpgsqlTypeHandler<decimal>,
+        INpgsqlTypeHandler<byte>, INpgsqlTypeHandler<short>, INpgsqlTypeHandler<int>, INpgsqlTypeHandler<long>,
+        INpgsqlTypeHandler<float>, INpgsqlTypeHandler<double>, INpgsqlTypeHandler<BigInteger>
     {
         /// <inheritdoc />
-        public NumericHandler(PostgresType postgresType) : base(postgresType) {}
+        public NumericHandler(PostgresType postgresType) : base(postgresType) { }
 
         const int MaxDecimalScale = 28;
 
         const int SignPositive = 0x0000;
         const int SignNegative = 0x4000;
         const int SignNan = 0xC000;
+        const int SignPinf = 0xD000;
+        const int SignNinf = 0xF000;
+        const int SignSpecialMask = 0xC000;
 
         const int MaxGroupCount = 8;
         const int MaxGroupScale = 4;
@@ -39,15 +46,24 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
         #region Read
 
         /// <inheritdoc />
-        public override decimal Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
+        public override async ValueTask<decimal> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         {
+            await buf.Ensure(4 * sizeof(short), async);
             var result = new DecimalRaw();
             var groups = buf.ReadInt16();
             var weight = buf.ReadInt16() - groups + 1;
             var sign = buf.ReadUInt16();
 
-            if (sign == SignNan)
-                throw new InvalidCastException("Numeric NaN not supported by System.Decimal");
+            if ((sign & SignSpecialMask) == SignSpecialMask)
+            {
+                if (sign == SignNan)
+                    throw new InvalidCastException("Numeric NaN not supported by System.Decimal");
+                if (sign == SignPinf)
+                    throw new InvalidCastException("Numeric Infinity not supported by System.Decimal");
+                if (sign == SignNinf)
+                    throw new InvalidCastException("Numeric -Infinity not supported by System.Decimal");
+                throw new InvalidCastException("Numeric special value not supported by System.Decimal");
+            }
 
             if (sign == SignNegative)
                 DecimalRaw.Negate(ref result);
@@ -64,6 +80,11 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
             var scaleDifference = exponential
                 ? weight * MaxGroupScale
                 : weight * MaxGroupScale + scale;
+
+            if (groups > MaxGroupCount)
+                throw new OverflowException("Numeric value does not fit in a System.Decimal");
+
+            await buf.Ensure(groups * sizeof(ushort), async);
 
             if (groups == MaxGroupCount)
             {
@@ -103,30 +124,116 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
             return result.Value;
         }
 
-        byte INpgsqlSimpleTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (byte)Read(buf, len, fieldDescription);
+        async ValueTask<byte> INpgsqlTypeHandler<byte>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (byte)await Read(buf, len, async, fieldDescription);
 
-        short INpgsqlSimpleTypeHandler<short>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (short)Read(buf, len, fieldDescription);
+        async ValueTask<short> INpgsqlTypeHandler<short>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (short)await Read(buf, len, async, fieldDescription);
 
-        int INpgsqlSimpleTypeHandler<int>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (int)Read(buf, len, fieldDescription);
+        async ValueTask<int> INpgsqlTypeHandler<int>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (int)await Read(buf, len, async, fieldDescription);
 
-        long INpgsqlSimpleTypeHandler<long>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (long)Read(buf, len, fieldDescription);
+        async ValueTask<long> INpgsqlTypeHandler<long>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (long)await Read(buf, len, async, fieldDescription);
 
-        float INpgsqlSimpleTypeHandler<float>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (float)Read(buf, len, fieldDescription);
+        async ValueTask<float> INpgsqlTypeHandler<float>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (float)await Read(buf, len, async, fieldDescription);
 
-        double INpgsqlSimpleTypeHandler<double>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
-            => (double)Read(buf, len, fieldDescription);
+        async ValueTask<double> INpgsqlTypeHandler<double>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => (double)await Read(buf, len, async, fieldDescription);
+
+        async ValueTask<BigInteger> INpgsqlTypeHandler<BigInteger>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        {
+            await buf.Ensure(4 * sizeof(short), async);
+
+            var groups = (int)buf.ReadUInt16();
+            var weightLeft = (int)buf.ReadInt16();
+            var weightRight = weightLeft - groups + 1;
+            var sign = buf.ReadUInt16();
+            buf.ReadInt16(); // dscale
+
+            if (groups == 0)
+                return sign switch
+                {
+                    SignPositive or SignNegative => BigInteger.Zero,
+                    SignNan => throw new InvalidCastException("Numeric NaN not supported by BigInteger"),
+                    SignPinf => throw new InvalidCastException("Numeric Infinity not supported by BigInteger"),
+                    SignNinf => throw new InvalidCastException("Numeric -Infinity not supported by BigInteger"),
+                    _ => throw new InvalidCastException("Numeric special value not supported"),
+                };
+
+            if (weightRight < 0)
+            {
+                await buf.Skip(groups * sizeof(ushort), async);
+                throw new InvalidCastException("Numeric value with non-zero fractional digits not supported by BigInteger");
+            }
+
+            var digits = new ushort[groups];
+
+            for (var i = 0; i < groups; i++)
+            {
+                await buf.Ensure(sizeof(ushort), async);
+                digits[i] = buf.ReadUInt16();
+            }
+
+            // Calculate powers 10^8, 10^16, 10^32, ...
+            // We should have the last calculated power to be less than the input
+            var lenPow = 2; // 2 ushorts fit in one uint, represents 10^8
+            var numPowers = 0;
+            while (lenPow < weightLeft + 1)
+            {
+                lenPow <<= 1;
+                ++numPowers;
+            }
+            var factors = numPowers > 0 ? new BigInteger[numPowers] : null;
+            if (numPowers > 0)
+            {
+                factors![0] = new BigInteger(100000000U);
+                for (var i = 1; i < numPowers; i++)
+                    factors[i] = factors[i - 1] * factors[i - 1];
+            }
+
+            var result = ToBigIntegerInner(0, weightLeft + 1, digits, factors);
+            return sign == SignPositive ? result : -result;
+
+            static BigInteger ToBigIntegerInner(int offset, int length, ushort[] digits, BigInteger[]? factors)
+            {
+                if (length <= 2)
+                {
+                    var r = 0U;
+                    for (var i = offset; i < offset + length; i++)
+                    {
+                        r *= 10000U;
+                        r += i < digits.Length ? digits[i] : 0U;
+                    }
+                    return r;
+                }
+                else
+                {
+                    // Split the input into two halves, the lower one should be a power of two in digit length,
+                    // then multiply the higher part with a precomputed power of 10^8 and add the results.
+                    var lenFirstHalf = 2 << 1; // 2 ushorts fit in one uint, skip 1 since we've already covered the base case.
+                    var pos = 0;
+                    while (lenFirstHalf < length)
+                    {
+                        lenFirstHalf <<= 1;
+                        ++pos;
+                    }
+                    var factor = factors![pos];
+                    lenFirstHalf >>= 1;
+                    var lo = ToBigIntegerInner(offset + length - lenFirstHalf, lenFirstHalf, digits, factors);
+                    var hi = ToBigIntegerInner(offset, length - lenFirstHalf, digits, factors);
+                    return hi * factor + lo; // .NET uses Karatsuba multiplication, so this will be fast.
+                }
+            }
+        }
 
         #endregion
 
         #region Write
 
         /// <inheritdoc />
-        public override int ValidateAndGetLength(decimal value, NpgsqlParameter? parameter)
+        public override int ValidateAndGetLength(decimal value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
             var groupCount = 0;
             var raw = new DecimalRaw(value);
@@ -157,77 +264,172 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
         }
 
         /// <inheritdoc />
-        public int ValidateAndGetLength(short value, NpgsqlParameter? parameter)  => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(short value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
         /// <inheritdoc />
-        public int ValidateAndGetLength(int value, NpgsqlParameter? parameter)    => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(int value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
         /// <inheritdoc />
-        public int ValidateAndGetLength(long value, NpgsqlParameter? parameter)   => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(long value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
         /// <inheritdoc />
-        public int ValidateAndGetLength(float value, NpgsqlParameter? parameter)  => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(float value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
         /// <inheritdoc />
-        public int ValidateAndGetLength(double value, NpgsqlParameter? parameter) => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(double value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
         /// <inheritdoc />
-        public int ValidateAndGetLength(byte value, NpgsqlParameter? parameter)   => ValidateAndGetLength((decimal)value, parameter);
+        public int ValidateAndGetLength(byte value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength((decimal)value, ref lengthCache, parameter);
 
-        /// <inheritdoc />
-        public override void Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
+        public override async Task Write(decimal value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
-            var weight = 0;
-            var groupCount = 0;
-            Span<short> groups = stackalloc short[MaxGroupCount];
+            if (buf.WriteSpaceLeft < (4 + MaxGroupCount) * sizeof(short))
+                await buf.Flush(async, cancellationToken);
 
-            var raw = new DecimalRaw(value);
-            if (raw.Low != 0 || raw.Mid != 0 || raw.High != 0)
+            WriteInner(new DecimalRaw(value), buf);
+
+            static void WriteInner(DecimalRaw raw, NpgsqlWriteBuffer buf)
             {
-                var scale = raw.Scale;
-                weight = -scale / MaxGroupScale - 1;
+                var weight = 0;
+                var groupCount = 0;
+                Span<short> groups = stackalloc short[MaxGroupCount];
 
-                uint remainder;
-                var scaleChunk = scale % MaxGroupScale;
-                if (scaleChunk > 0)
+                if (raw.Low != 0 || raw.Mid != 0 || raw.High != 0)
                 {
-                    var divisor = DecimalRaw.Powers10[scaleChunk];
-                    var multiplier = DecimalRaw.Powers10[MaxGroupScale - scaleChunk];
-                    remainder = DecimalRaw.Divide(ref raw, divisor) * multiplier;
+                    var scale = raw.Scale;
+                    weight = -scale / MaxGroupScale - 1;
 
-                    if (remainder != 0)
+                    uint remainder;
+                    var scaleChunk = scale % MaxGroupScale;
+                    if (scaleChunk > 0)
                     {
-                        weight--;
-                        goto WriteGroups;
+                        var divisor = DecimalRaw.Powers10[scaleChunk];
+                        var multiplier = DecimalRaw.Powers10[MaxGroupScale - scaleChunk];
+                        remainder = DecimalRaw.Divide(ref raw, divisor) * multiplier;
+
+                        if (remainder != 0)
+                        {
+                            weight--;
+                            goto WriteGroups;
+                        }
                     }
+
+                    while ((remainder = DecimalRaw.Divide(ref raw, MaxGroupSize)) == 0)
+                        weight++;
+
+                    WriteGroups:
+                    groups[groupCount++] = (short)remainder;
+
+                    while (raw.Low != 0 || raw.Mid != 0 || raw.High != 0)
+                        groups[groupCount++] = (short)DecimalRaw.Divide(ref raw, MaxGroupSize);
                 }
 
-                while ((remainder = DecimalRaw.Divide(ref raw, MaxGroupSize)) == 0)
-                    weight++;
+                buf.WriteInt16(groupCount);
+                buf.WriteInt16(groupCount + weight);
+                buf.WriteInt16(raw.Negative ? SignNegative : SignPositive);
+                buf.WriteInt16(raw.Scale);
 
-                WriteGroups:
-                groups[groupCount++] = (short)remainder;
-
-                while (raw.Low != 0 || raw.Mid != 0 || raw.High != 0)
-                    groups[groupCount++] = (short)DecimalRaw.Divide(ref raw, MaxGroupSize);
+                while (groupCount > 0)
+                    buf.WriteInt16(groups[--groupCount]);
             }
-
-            buf.WriteInt16(groupCount);
-            buf.WriteInt16(groupCount + weight);
-            buf.WriteInt16(raw.Negative ? SignNegative : SignPositive);
-            buf.WriteInt16(raw.Scale);
-
-            while (groupCount > 0)
-                buf.WriteInt16(groups[--groupCount]);
         }
 
         /// <inheritdoc />
-        public void Write(short value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)  => Write((decimal)value, buf, parameter);
+        public Task Write(short value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
         /// <inheritdoc />
-        public void Write(int value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)    => Write((decimal)value, buf, parameter);
+        public Task Write(int value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
         /// <inheritdoc />
-        public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)   => Write((decimal)value, buf, parameter);
+        public Task Write(long value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
         /// <inheritdoc />
-        public void Write(byte value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)   => Write((decimal)value, buf, parameter);
+        public Task Write(byte value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
         /// <inheritdoc />
-        public void Write(float value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)  => Write((decimal)value, buf, parameter);
+        public Task Write(float value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
         /// <inheritdoc />
-        public void Write(double value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter) => Write((decimal)value, buf, parameter);
+        public Task Write(double value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => Write((decimal)value, buf, lengthCache, parameter, async, cancellationToken);
+
+        static ushort[] FromBigInteger(BigInteger value)
+        {
+            var str = value.ToString(CultureInfo.InvariantCulture);
+            ushort[] result;
+            if (str == "0")
+            {
+                result = new ushort[4];
+            }
+            else
+            {
+                var negative = str[0] == '-';
+                var strLen = str.Length;
+                var numGroups = (strLen - (negative ? 1 : 0) + 3) / 4;
+
+                if (numGroups > 131072 / 4)
+                    throw new InvalidCastException("Cannot write a BigInteger with more than 131072 digits");
+
+                result = new ushort[4 + numGroups];
+
+                var strPos = strLen - numGroups * 4;
+
+                var firstDigit = 0;
+                for (var i = 0; i < 4; i++)
+                {
+                    if (strPos >= 0 && str[strPos] != '-')
+                        firstDigit = firstDigit * 10 + (str[strPos] - '0');
+                    strPos++;
+                }
+
+                result[4] = (ushort)firstDigit;
+
+                for (var i = 1; i < numGroups; i++)
+                {
+                    result[4 + i] = (ushort)((((str[strPos++] - '0') * 10 + (str[strPos++] - '0')) * 10 + (str[strPos++] - '0')) * 10 +
+                                             (str[strPos++] - '0'));
+
+                }
+
+                var lastNonZeroDigitPos = numGroups - 1;
+                while (result[4 + lastNonZeroDigitPos] == 0)
+                    lastNonZeroDigitPos--;
+
+                result[0] = (ushort)(lastNonZeroDigitPos + 1); // number of items in array
+                result[1] = (ushort)(numGroups - 1); // weight
+                result[2] = (ushort)(negative ? SignNegative : SignPositive);
+                result[3] = 0; // dscale
+            }
+
+            return result;
+        }
+
+        public int ValidateAndGetLength(BigInteger value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            var result = (ushort[]?)parameter?.ConvertedValue;
+            if (result == null)
+            {
+                result = FromBigInteger(value)!;
+                if (parameter != null)
+                    parameter.ConvertedValue = result;
+            }
+            return (4 + result[0]) * sizeof(ushort);
+        }
+
+        public async Task Write(BigInteger value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async,
+            CancellationToken cancellationToken = default)
+        {
+            var result = (ushort[])(parameter?.ConvertedValue ?? FromBigInteger(value))!;
+            var len = 4 + result[0];
+            var pos = 0;
+            while (len-- > 0)
+            {
+                if (buf.WriteSpaceLeft < sizeof(ushort))
+                    await buf.Flush(async, cancellationToken);
+                buf.WriteUInt16(result[pos++]);
+            }
+        }
 
         #endregion
     }

--- a/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NumericHandlers/NumericHandler.cs
@@ -237,6 +237,11 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
         /// <inheritdoc />
         public override int ValidateAndGetLength(decimal value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
+            if (lengthCache == null)
+                lengthCache = new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get();
+
             var groupCount = 0;
             var raw = new DecimalRaw(value);
             if (raw.Low != 0 || raw.Mid != 0 || raw.High != 0)
@@ -262,7 +267,7 @@ namespace Npgsql.Internal.TypeHandlers.NumericHandlers
                 }
             }
 
-            return 4 * sizeof(short) + groupCount * sizeof(short);
+            return lengthCache.Set((4 + groupCount) * sizeof(short));
         }
 
         /// <inheritdoc />

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Numerics;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -248,7 +249,7 @@ namespace Npgsql.TypeMapping
                     NpgsqlDbType = NpgsqlDbType.Numeric,
                     DbTypes = new[] { DbType.Decimal, DbType.VarNumeric },
                     InferredDbType = DbType.Decimal,
-                    ClrTypes = new[] { typeof(decimal) },
+                    ClrTypes = new[] { typeof(decimal), typeof(BigInteger) },
                     TypeHandlerFactory = new DefaultTypeHandlerFactory(typeof(NumericHandler))
                 }.Build());
 

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -85,7 +85,7 @@ namespace Npgsql.Tests.Types
 
         [Test]
         [TestCaseSource(nameof(ReadWriteCases))]
-        public async Task Read(string query, decimal expected)
+        public async Task ReadDecimal(string query, decimal expected)
         {
             using var conn = await OpenConnectionAsync();
             using var cmd = new NpgsqlCommand("SELECT " + query, conn);
@@ -96,7 +96,7 @@ namespace Npgsql.Tests.Types
 
         [Test]
         [TestCaseSource(nameof(ReadWriteCases))]
-        public async Task Write(string query, decimal expected)
+        public async Task WriteDecimal(string query, decimal expected)
         {
             using var conn = await OpenConnectionAsync();
             using var cmd = new NpgsqlCommand("SELECT @p, @p = " + query, conn);
@@ -162,21 +162,34 @@ namespace Npgsql.Tests.Types
 
         [Test]
         [TestCaseSource(nameof(ReadWriteCases))]
-        public async Task BigIntegerSupport(string query, decimal expected)
+        public async Task ReadBigInteger(string query, decimal expected)
         {
             if (decimal.Floor(expected) == expected)
             {
                 var bigInt = new BigInteger(expected);
                 using var conn = await OpenConnectionAsync();
-                using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
-                cmd.Parameters.AddWithValue("p1", bigInt);
-                cmd.Parameters.AddWithValue("p2", expected);
+                using var cmd = new NpgsqlCommand("SELECT " + query, conn);
                 using var rdr = await cmd.ExecuteReaderAsync();
                 await rdr.ReadAsync();
-                Assert.That(rdr.GetFieldValue<decimal>(0), Is.EqualTo(expected));
                 Assert.That(rdr.GetFieldValue<BigInteger>(0), Is.EqualTo(bigInt));
-                Assert.That(rdr.GetFieldValue<decimal>(1), Is.EqualTo(expected));
-                Assert.That(rdr.GetFieldValue<BigInteger>(1), Is.EqualTo(bigInt));
+            }
+        }
+
+
+        [Test]
+        [TestCaseSource(nameof(ReadWriteCases))]
+        public async Task WriteBigInteger(string query, decimal expected)
+        {
+            if (decimal.Floor(expected) == expected)
+            {
+                var bigInt = new BigInteger(expected);
+                using var conn = await OpenConnectionAsync();
+                using var cmd = new NpgsqlCommand("SELECT @p, @p = " + query, conn);
+                cmd.Parameters.AddWithValue("p", bigInt);
+                using var rdr = await cmd.ExecuteReaderAsync();
+                await rdr.ReadAsync();
+                Assert.That(rdr.GetFieldValue<BigInteger>(0), Is.EqualTo(bigInt));
+                Assert.That(rdr.GetFieldValue<bool>(1));
             }
         }
 

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -175,7 +175,6 @@ namespace Npgsql.Tests.Types
             }
         }
 
-
         [Test]
         [TestCaseSource(nameof(ReadWriteCases))]
         public async Task WriteBigInteger(string query, decimal expected)


### PR DESCRIPTION
Partial fix for #448.

Allows the reading/writing of numerics that don't have any fractional bits (but all fractional bits are zero is allowed).