### PR TITLE
Fixed possible deadlock when using ExecuteNonQueryAsync

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1004,7 +1004,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             using var reader = await ExecuteReaderAsync(CommandBehavior.Default, async, cancellationToken);
             while (async ? await reader.NextResultAsync(cancellationToken) : reader.NextResult()) ;
 
-            reader.Close();
+            await reader.Close(connectionClosing: false, async);
 
             return reader.RecordsAffected;
         }


### PR DESCRIPTION
The async parameter was not passed to the Close Method of the NpgsqlDataReader. This can cause a deadlock in the Cleanup Method of the DataReader because it is actively waiting for the completion of the "_sendTask".

I have tested this with Npgsql 4.1.9, PostgreSQL 10.3