### PR TITLE
Unbind the transaction for unpooled connections

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -787,7 +787,11 @@ namespace Npgsql
                 else
                 {
                     if (_pool == null)
+                    {
+                        // We're already doing the same in the NpgsqlConnector.Reset for pooled connections
+                        connector.Transaction?.UnbindIfNecessary();
                         connector.Close();
+                    }
                     else
                     {
                         // Clear the buffer, roll back any pending transaction and prepend a reset message if needed


### PR DESCRIPTION
Fixes #3686

No point in merging in 6.0 as the bug is not reproducible there due to the pool never being null, but instead an UnpooledConnectorSource. We might have to do something about this.