### PR TITLE
Move case insensitive lookup to use Ordinal comparison

### DIFF
--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -269,7 +269,7 @@ namespace Npgsql
                 // Case sensitive lookup failed, generate a case insensitive lookup
                 if (_lookupIgnoreCase == null)
                 {
-                    _lookupIgnoreCase = new Dictionary<string, int>(PGUtil.InvariantCaseIgnoringStringComparer);
+                    _lookupIgnoreCase = new Dictionary<string, int>(_internalList.Count, StringComparer.OrdinalIgnoreCase);
                     for (var i = 0 ; i < _internalList.Count ; i++)
                     {
                         var item = _internalList[i];

--- a/src/Npgsql/Util/PGUtil.cs
+++ b/src/Npgsql/Util/PGUtil.cs
@@ -118,8 +118,6 @@ namespace Npgsql.Util
 
         internal static readonly Task<bool> TrueTask = Task.FromResult(true);
         internal static readonly Task<bool> FalseTask = Task.FromResult(false);
-
-        internal static StringComparer InvariantCaseIgnoringStringComparer => StringComparer.InvariantCultureIgnoreCase;
     }
 
     enum FormatCode : short


### PR DESCRIPTION
Very simple fix to remove some slow comparisons.

I have another commit that removes the double lookup/loop entirely and reworks the lookup to stay in sync non-destructively, I think it's better to do that one in a follow-up PR (branch is here https://github.com/NinoFloris/npgsql/tree/enhancement/remove-double-lookup).