### PR TITLE
Remove double loop/lookup and rework lookup synchronization

### DIFF
--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -246,6 +246,7 @@ namespace Npgsql
             get => _name;
             set
             {
+                var oldTrimmedName = TrimmedName;
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (value == null)
                     _name = TrimmedName = string.Empty;
@@ -254,7 +255,7 @@ namespace Npgsql
                 else
                     _name = TrimmedName = value;
 
-                Collection?.ReflectListMutationInLookup(this);
+                Collection?.ChangeParameterName(this, oldTrimmedName);
             }
         }
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -259,7 +259,7 @@ namespace Npgsql
             }
         }
 
-        internal bool IsPositionalParameter => ReferenceEquals(ParameterName, "");
+        internal bool IsPositional => ReferenceEquals(ParameterName, "");
 
         #endregion Name
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -254,7 +254,7 @@ namespace Npgsql
                 else
                     _name = TrimmedName = value;
 
-                Collection?.InvalidateHashLookups();
+                Collection?.ReflectListMutationInLookup(this);
             }
         }
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -247,7 +247,6 @@ namespace Npgsql
             set
             {
                 var oldName = _name;
-                var oldTrimmedName = TrimmedName;
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (value == null)
                     _name = TrimmedName = string.Empty;
@@ -256,11 +255,11 @@ namespace Npgsql
                 else
                     _name = TrimmedName = value;
 
-                Collection?.ChangeParameterName(this, oldName, oldTrimmedName);
+                Collection?.ChangeParameterName(this, oldName);
             }
         }
 
-        internal bool IsPositionalParameter => ParameterName == "";
+        internal bool IsPositionalParameter => ReferenceEquals(ParameterName, "");
 
         #endregion Name
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -246,6 +246,7 @@ namespace Npgsql
             get => _name;
             set
             {
+                var oldName = _name;
                 var oldTrimmedName = TrimmedName;
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (value == null)
@@ -255,9 +256,11 @@ namespace Npgsql
                 else
                     _name = TrimmedName = value;
 
-                Collection?.ChangeParameterName(this, oldTrimmedName);
+                Collection?.ChangeParameterName(this, oldName, oldTrimmedName);
             }
         }
+
+        internal bool IsPositionalParameter => ParameterName == "";
 
         #endregion Name
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -247,6 +247,7 @@ namespace Npgsql
             set
             {
                 var oldName = _name;
+                var oldTrimmedName = TrimmedName;
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (value == null)
                     _name = TrimmedName = string.Empty;
@@ -255,11 +256,11 @@ namespace Npgsql
                 else
                     _name = TrimmedName = value;
 
-                Collection?.ChangeParameterName(this, oldName);
+                Collection?.ChangeParameterName(this, oldName, oldTrimmedName);
             }
         }
 
-        internal bool IsPositional => ReferenceEquals(ParameterName, "");
+        internal bool IsPositional => ParameterName.Length == 0;
 
         #endregion Name
 

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using NpgsqlTypes;
 
@@ -87,12 +88,15 @@ namespace Npgsql
                     for (var i = 0; i < indices.Values.Count; i++)
                     {
                         var value = indices.Values[i];
-                        indices.Values[i] = index <= value ? value - 1 : value;
+                        Debug.Assert(index != value, "Values should not contain duplicates.");
+                        indices.Values[i] = index < value ? value - 1 : value;
                     }
                 }
-                else if (index <= indices.Value)
+                else
                 {
-                    indices = new MultiValue(indices.Value - 1);
+                    Debug.Assert(index != indices.Value, "Values should not contain duplicates.");
+                    if (index < indices.Value)
+                        indices = new MultiValue(indices.Value - 1);
                 }
 
                 _lookup[name] = indices;

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -120,7 +120,7 @@ namespace Npgsql
 
             if (!ReferenceEquals(oldName, ""))
                 LookupRemove(oldName, index);
-            if (parameter.IsPositionalParameter)
+            if (parameter.IsPositional)
                 LookupAdd(parameter.ParameterName, index);
         }
 
@@ -218,7 +218,7 @@ namespace Npgsql
 
             _internalList.Add(value);
             value.Collection = this;
-            if (!value.IsPositionalParameter)
+            if (!value.IsPositional)
                 LookupAdd(value.ParameterName, _internalList.Count - 1);
             return value;
         }
@@ -576,7 +576,7 @@ namespace Npgsql
 
             _internalList.Insert(index, item);
             item.Collection = this;
-            if (!item.IsPositionalParameter)
+            if (!item.IsPositional)
                 LookupInsert(item.ParameterName, index);
         }
 
@@ -605,7 +605,7 @@ namespace Npgsql
                 _internalList.RemoveAt(index);
                 if (!LookupEnabled)
                     LookupClear();
-                if (!item.IsPositionalParameter)
+                if (!item.IsPositional)
                     LookupRemove(item.ParameterName, index);
                 item.Collection = null;
                 return true;

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -120,7 +120,7 @@ namespace Npgsql
 
             if (!ReferenceEquals(oldName, ""))
                 LookupRemove(oldName, index);
-            if (parameter.IsPositional)
+            if (!parameter.IsPositional)
                 LookupAdd(parameter.ParameterName, index);
         }
 

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -751,16 +751,6 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public async Task CaseInsensitiveParameterNames()
-        {
-            using var conn = await OpenConnectionAsync();
-            using var command = new NpgsqlCommand("select :p1", conn);
-            command.Parameters.Add(new NpgsqlParameter("P1", NpgsqlDbType.Integer)).Value = 5;
-            var result = await command.ExecuteScalarAsync();
-            Assert.AreEqual(5, result);
-        }
-
-        [Test]
         public async Task TestBug1006158OutputParameters()
         {
             using var conn = await OpenConnectionAsync();

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -877,6 +877,40 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public void IndexOf_falls_back_to_first_insensitive_match([Values] bool manyParams)
+        {
+            using var command = new NpgsqlCommand();
+            var parameters = command.Parameters;
+
+            parameters.Add(new NpgsqlParameter("foo", 8));
+            parameters.Add(new NpgsqlParameter("bar", 8));
+            parameters.Add(new NpgsqlParameter("BAR", 8));
+            Assert.That(parameters, Has.Count.LessThan(ParameterCollectionLookupThreshold));
+
+            if (manyParams)
+                for (var i = 0; i < ParameterCollectionLookupThreshold; i++)
+                    parameters.Add(new NpgsqlParameter($"p{i}", i));
+
+            Assert.That(parameters.IndexOf("Bar"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void IndexOf_prefers_case_sensitive_match([Values] bool manyParams)
+        {
+            using var command = new NpgsqlCommand();
+            var parameters = command.Parameters;
+
+            parameters.Add(new NpgsqlParameter("FOO", 8));
+            parameters.Add(new NpgsqlParameter("foo", 8));
+            Assert.That(parameters, Has.Count.LessThan(ParameterCollectionLookupThreshold));
+
+            if (manyParams)
+                for (var i = 0; i < ParameterCollectionLookupThreshold; i++)
+                    parameters.Add(new NpgsqlParameter($"p{i}", i));
+
+            Assert.That(parameters.IndexOf("foo"), Is.EqualTo(1));
+        }
+        [Test]
         public void NpgsqlParameterCloneTest()
         {
             var param = new NpgsqlParameter();

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -899,6 +899,17 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public void PositionalParameterLookupReturnsFirstMatch([Values(LookupThreshold, LookupThreshold - 2)] int count)
+        {
+            using var command = new NpgsqlCommand();
+            var parameters = command.Parameters;
+            for (var i = 0; i < count; i++)
+                parameters.Add(new NpgsqlParameter("", i));
+
+            Assert.That(command.Parameters.IndexOf(""), Is.EqualTo(0));
+        }
+
+        [Test]
         public void IndexOf_falls_back_to_first_insensitive_match([Values] bool manyParams)
         {
             if (_compatMode == CompatMode.CaseSensitive)

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -9,6 +9,8 @@ using System.Data.Common;
 
 namespace Npgsql.Tests
 {
+    // This test class has global effects on case sensitive matching in param collection.
+    [NonParallelizable]
     [TestFixture(CompatMode.CaseSensitive)]
     [TestFixture(CompatMode.CaseInsensitive)]
     public class NpgsqlParameterTest : TestBase

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -820,6 +820,8 @@ namespace Npgsql.Tests
             // Test whether we can still find the last added parameter, and if its index is correctly shifted in the lookup.
             Assert.IsTrue(command.Parameters.IndexOf("p02") == count - 1);
             Assert.IsTrue(command.Parameters.IndexOf("P02") == count - 1);
+            // And finally test whether other parameters were also correctly shifted.
+            Assert.IsTrue(command.Parameters.IndexOf("p03") == 1);
         }
 
         [Test]
@@ -869,6 +871,9 @@ namespace Npgsql.Tests
             Assert.IsTrue(command.Parameters.IndexOf("ParameteR02") == 0);
             // This name does not exist so we expect the first case insensitive match to be returned.
             Assert.IsTrue(command.Parameters.IndexOf("ParaMeteR02") == 0);
+
+            // And finally test whether other parameters were also correctly shifted.
+            Assert.IsTrue(command.Parameters.IndexOf("parameter03") == 3);
         }
 
         [Test]

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -946,6 +946,25 @@ namespace Npgsql.Tests
 
             Assert.That(parameters.IndexOf("foo"), Is.EqualTo(1));
         }
+
+        [Test]
+        public void IndexOfMatchesAllParameterSyntaxes()
+        {
+            using var command = new NpgsqlCommand();
+            var parameters = command.Parameters;
+
+            parameters.Add(new NpgsqlParameter("@foo0", 8));
+            parameters.Add(new NpgsqlParameter(":foo1", 8));
+            parameters.Add(new NpgsqlParameter("foo2", 8));
+
+            for (var i = 0; i < parameters.Count; i++)
+            {
+                Assert.That(parameters.IndexOf("foo" + i), Is.EqualTo(i));
+                Assert.That(parameters.IndexOf("@foo" + i), Is.EqualTo(i));
+                Assert.That(parameters.IndexOf(":foo" + i), Is.EqualTo(i));
+            }
+        }
+
         [Test]
         public void NpgsqlParameterCloneTest()
         {


### PR DESCRIPTION
Here is the other cleanup @roji. ReflectListMutationInLookup is a bit messy but having it intrusive like this provides much better results under a repeated add + indexof/contains call pattern. For new/cleared instances not building two lookups helps as well. 

In general IndexOf will be much faster for unknown parameters, though for known parameters this probably regresses some small percentage due to always doing OrdinalIgnoreCase comparisons. (I could do a BDN on Ordinal vs OrdinalIgnoreCase if we want to be sure)