### PR TITLE
Use Scriban in source generator

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
+    <PackageVersion Include="Scriban.Signed" Version="3.7.0 " />
 
     <!-- Plugins -->
     <PackageVersion Include="NetTopologySuite.IO.PostGIS" Version="2.1.0" />

--- a/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
+++ b/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
@@ -9,5 +9,22 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+
+        <!-- For this and the below, see https://github.com/dotnet/roslyn/discussions/47517#discussioncomment-64145 -->
+        <PackageReference Include="Scriban.Signed" GeneratePathProperty="true" PrivateAssets="all" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
+    </PropertyGroup>
+
+    <Target Name="GetDependencyTargetPaths">
+        <ItemGroup>
+            <TargetPathWithTargetPlatformMoniker Include="$(PKGScriban_Signed)\lib\netstandard2.0\Scriban.Signed.dll" IncludeRuntimeDependency="false" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup>
+        <EmbeddedResource Include="TypeHandler.snbtxt" />
     </ItemGroup>
 </Project>

--- a/src/Npgsql.SourceGenerators/TypeHandler.snbtxt
+++ b/src/Npgsql.SourceGenerators/TypeHandler.snbtxt
@@ -1,0 +1,38 @@
+{{ for using in usings }}
+using {{ using }};
+{{ end }}
+
+#nullable enable
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable RS0016 // Add public types and members to the declared API
+#pragma warning disable 618 // Member is obsolete
+
+namespace {{ namespace }}
+{
+    partial class {{ type_name }}
+    {
+        {{ validate_access }} override int ValidateObjectAndGetLength(object value, {{ is_simple ? "" : "ref NpgsqlLengthCache? lengthCache, " }} NpgsqlParameter? parameter)
+            => value switch
+            {
+                {{ for interface in interfaces }}
+                {{ interface.handled_type }} converted => (({{ interface.name }})this).ValidateAndGetLength(converted, {{ is_simple ? "" : "ref lengthCache, " }}parameter),
+                {{ end }}
+
+                DBNull => -1,
+                null => -1,
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type {{ type_name }}")
+            };
+
+        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value switch
+            {
+                {{ for interface in interfaces }}
+                {{ interface.handled_type }} converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),
+                {{ end }}
+
+                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
+                _ => throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type {{ type_name }}")
+            };
+    }
+}

--- a/src/Npgsql.SourceGenerators/TypeHandlerSourceGenerator.cs
+++ b/src/Npgsql.SourceGenerators/TypeHandlerSourceGenerator.cs
@@ -6,6 +6,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Scriban;
+using Scriban.Runtime;
 
 namespace Npgsql.SourceGenerators
 {
@@ -48,8 +50,6 @@ namespace Npgsql.SourceGenerators
 
             void AugmentTypeHandler(INamedTypeSymbol typeSymbol, ClassDeclarationSyntax classDeclarationSyntax, bool isSimple)
             {
-                var typeName = FormatTypeName(typeSymbol);
-
                 var usings = new HashSet<string>(
                     new[]
                     {
@@ -61,67 +61,27 @@ namespace Npgsql.SourceGenerators
                         .Where(u => u.Alias is null)
                         .Select(u => u.Name.ToString())));
 
-                var ns = typeSymbol.ContainingNamespace.ToDisplayString();
-
                 var interfaces = typeSymbol.AllInterfaces
                     .Where(i => i.OriginalDefinition.Equals(isSimple ? simpleTypeHandlerInterfaceSymbol : typeHandlerInterfaceSymbol,
                                     SymbolEqualityComparer.Default) &&
                                 !i.TypeArguments[0].IsAbstract);
 
-                var validateAccess = isSimple ? "protected" : "public";
-                var validationDispatchLines = interfaces.Select(i =>
-                    $"{FormatTypeName(i.TypeArguments[0])} converted => (({FormatTypeName(i)})this).ValidateAndGetLength(converted, {(isSimple ? "" : "ref lengthCache, ")}parameter),");
+                var template = Template.Parse(EmbeddedResource.GetContent("TypeHandler.snbtxt"), "TypeHandler.snbtxt");
+                var output = template.Render(new
+                {
+                    Usings = usings,
+                    TypeName = FormatTypeName(typeSymbol),
+                    Namespace = typeSymbol.ContainingNamespace.ToDisplayString(),
+                    IsSimple = isSimple,
+                    ValidateAccess = isSimple ? "protected" : "public",
+                    Interfaces = interfaces.Select(i => new
+                    {
+                        Name = FormatTypeName(i),
+                        HandledType = FormatTypeName(i.TypeArguments[0]),
+                    })
+                });
 
-                var writeDispatchLines = interfaces.Select(i =>
-                    $"{FormatTypeName(i.TypeArguments[0])} converted => WriteWithLengthInternal(converted, buf, lengthCache, parameter, async, cancellationToken),");
-
-                var sourceBuilder = new StringBuilder();
-
-                foreach (var usingNamespace in usings.OrderBy(n => n))
-                    sourceBuilder.Append("using ").Append(usingNamespace).AppendLine(";");
-
-                sourceBuilder.Append($@"
-
-#nullable enable
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable RS0016 // Add public types and members to the declared API
-#pragma warning disable 618 // Member is obsolete
-
-namespace {ns}
-{{
-    partial class {typeName}
-    {{
-        {validateAccess} override int ValidateObjectAndGetLength(object value, {(isSimple ? "" : "ref NpgsqlLengthCache? lengthCache, ")}NpgsqlParameter? parameter)
-            => value switch
-            {{");
-                foreach (var line in validationDispatchLines)
-                    sourceBuilder.Append(@$"
-                {line}");
-
-                sourceBuilder.Append($@"
-
-                DBNull => -1,
-                null => -1,
-                _ => throw new InvalidCastException($""Can't write CLR type {{value.GetType()}} with handler type {typeName}"")
-            }};
-
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value switch
-            {{");
-                foreach (var line in writeDispatchLines)
-                    sourceBuilder.Append(@$"
-                {line}");
-
-                sourceBuilder.Append($@"
-
-                DBNull => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                null => WriteWithLengthInternal(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken),
-                _ => throw new InvalidCastException($""Can't write CLR type {{value.GetType()}} with handler type {typeName}"")
-            }};
-    }}
-}}");
-
-                context.AddSource(typeSymbol.Name + ".Generated.cs", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
+                context.AddSource(typeSymbol.Name + ".Generated.cs", SourceText.From(output, Encoding.UTF8));
             }
 
             static string FormatTypeName(ITypeSymbol typeSymbol)


### PR DESCRIPTION
Instead of ugly string interpolation with StringBuilder, this uses the Scriban templating engine for much better code generation.

This is a "clean-up" PR - no functional change. Prepares the way for other changes.