### PR TITLE
Add wrapper for LastAppliedLsn and LastFlushedLsn setters to ReplicationConnection

### DIFF
--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -37,6 +37,7 @@ Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.set -> void
 Npgsql.NpgsqlCopyTextReader.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
+Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedLsn, NpgsqlTypes.NpgsqlLogSequenceNumber lastFlushedLsn) -> void
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override Npgsql.NpgsqlRawCopyStream.DisposeAsync() -> System.Threading.Tasks.ValueTask
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -37,7 +37,7 @@ Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.set -> void
 Npgsql.NpgsqlCopyTextReader.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
-Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedLsn, NpgsqlTypes.NpgsqlLogSequenceNumber lastFlushedLsn) -> void
+Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override Npgsql.NpgsqlRawCopyStream.DisposeAsync() -> System.Threading.Tasks.ValueTask
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -116,7 +116,6 @@ namespace Npgsql.Replication
         public NpgsqlLogSequenceNumber LastFlushedLsn
         {
             get => (NpgsqlLogSequenceNumber)unchecked((ulong)Interlocked.Read(ref _lastFlushedLsn));
-            [Obsolete("Setting this property is deprecated and the setter will be removed in a future release. Please use the SetStatus() method instead.")]
             set => Interlocked.Exchange(ref _lastFlushedLsn, unchecked((long)(ulong)value));
         }
 
@@ -126,7 +125,6 @@ namespace Npgsql.Replication
         public NpgsqlLogSequenceNumber LastAppliedLsn
         {
             get => (NpgsqlLogSequenceNumber)unchecked((ulong)Interlocked.Read(ref _lastAppliedLsn));
-            [Obsolete("Setting this property is deprecated and the setter will be removed in a future release. Please use the SetStatus() method instead.")]
             set => Interlocked.Exchange(ref _lastAppliedLsn, unchecked((long)(ulong)value));
         }
 
@@ -541,21 +539,26 @@ namespace Npgsql.Replication
         }
 
         /// <summary>
-        /// Sets the current status of the replication as it is interpreted by the consuming client. The values supplied
-        /// in <see paramref="lastAppliedLsn" />  and <see paramref="lastFlushedLsn" />will be sent to the server with the
-        /// next status update which will happen upon server request, upon expiration of <see cref="WalReceiverStatusInterval"/>
+        /// Sets the current status of the replication as it is interpreted by the consuming client. The value supplied
+        /// in <see paramref="lastAppliedAndFlushedLsn" /> will be sent to the server via <see cref="LastAppliedLsn"/> and
+        /// <see cref="LastFlushedLsn"/> with the next status update.
+        /// <para>
+        /// A status update which will happen upon server request, upon expiration of <see cref="WalReceiverStatusInterval"/>
         /// our upon an enforced status update via <see cref="SendStatusUpdate"/>, whichever happens first.
+        /// If you want the value you set here to be pushed to the server immediately (e. g. in synchronous replication scenarios),
+        /// call <see cref="SendStatusUpdate"/> after calling this method.
+        /// </para>
         /// </summary>
         /// <remarks>
-        /// If you want the values you set here to be pushed to the server immediately (e. g. in synchronous replication scenarios)
-        /// call <see cref="SendStatusUpdate"/> after calling this method.
+        /// This is a convenience method setting both <see cref="LastAppliedLsn"/> and <see cref="LastFlushedLsn"/> in one operation.
+        /// You can use it if your application processes replication messages in  a way that doesn't care about the difference between
+        /// writing a message and flushing it to a permanent storage medium.
         /// </remarks>
-        /// <param name="lastAppliedLsn">The location of the last WAL byte + 1 applied (e. g. written to disk) in the standby.</param>
-        /// <param name="lastFlushedLsn">The location of the last WAL byte + 1 flushed to disk in the standby.</param>
-        public void SetReplicationStatus(NpgsqlLogSequenceNumber lastAppliedLsn, NpgsqlLogSequenceNumber lastFlushedLsn)
+        /// <param name="lastAppliedAndFlushedLsn">The location of the last WAL byte + 1 applied (e. g. processed or written to disk) and flushed to disk in the standby.</param>
+        public void SetReplicationStatus(NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn)
         {
-            Interlocked.Exchange(ref _lastAppliedLsn, unchecked((long)(ulong)lastAppliedLsn));
-            Interlocked.Exchange(ref _lastFlushedLsn, unchecked((long)(ulong)lastFlushedLsn));
+            Interlocked.Exchange(ref _lastAppliedLsn, unchecked((long)(ulong)lastAppliedAndFlushedLsn));
+            Interlocked.Exchange(ref _lastFlushedLsn, unchecked((long)(ulong)lastAppliedAndFlushedLsn));
         }
 
         /// <summary>

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -116,6 +116,7 @@ namespace Npgsql.Replication
         public NpgsqlLogSequenceNumber LastFlushedLsn
         {
             get => (NpgsqlLogSequenceNumber)unchecked((ulong)Interlocked.Read(ref _lastFlushedLsn));
+            [Obsolete("Setting this property is deprecated and the setter will be removed in a future release. Please use the SetStatus() method instead.")]
             set => Interlocked.Exchange(ref _lastFlushedLsn, unchecked((long)(ulong)value));
         }
 
@@ -125,6 +126,7 @@ namespace Npgsql.Replication
         public NpgsqlLogSequenceNumber LastAppliedLsn
         {
             get => (NpgsqlLogSequenceNumber)unchecked((ulong)Interlocked.Read(ref _lastAppliedLsn));
+            [Obsolete("Setting this property is deprecated and the setter will be removed in a future release. Please use the SetStatus() method instead.")]
             set => Interlocked.Exchange(ref _lastAppliedLsn, unchecked((long)(ulong)value));
         }
 
@@ -536,6 +538,24 @@ namespace Npgsql.Replication
 
                 completionSource.SetResult(0);
             }
+        }
+
+        /// <summary>
+        /// Sets the current status of the replication as it is interpreted by the consuming client. The values supplied
+        /// in <see paramref="lastAppliedLsn" />  and <see paramref="lastFlushedLsn" />will be sent to the server with the
+        /// next status update which will happen upon server request, upon expiration of <see cref="WalReceiverStatusInterval"/>
+        /// our upon an enforced status update via <see cref="SendStatusUpdate"/>, whichever happens first.
+        /// </summary>
+        /// <remarks>
+        /// If you want the values you set here to be pushed to the server immediately (e. g. in synchronous replication scenarios)
+        /// call <see cref="SendStatusUpdate"/> after calling this method.
+        /// </remarks>
+        /// <param name="lastAppliedLsn">The location of the last WAL byte + 1 applied (e. g. written to disk) in the standby.</param>
+        /// <param name="lastFlushedLsn">The location of the last WAL byte + 1 flushed to disk in the standby.</param>
+        public void SetReplicationStatus(NpgsqlLogSequenceNumber lastAppliedLsn, NpgsqlLogSequenceNumber lastFlushedLsn)
+        {
+            Interlocked.Exchange(ref _lastAppliedLsn, unchecked((long)(ulong)lastAppliedLsn));
+            Interlocked.Exchange(ref _lastFlushedLsn, unchecked((long)(ulong)lastFlushedLsn));
         }
 
         /// <summary>

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -336,14 +336,14 @@ namespace Npgsql.Tests.Replication
                     Assert.That(result, Is.Null); // Not committed yet because we still didn't report fsync yet
 
                     // Report last applied LSN
-                    rc.SetReplicationStatus(commitLsn, rc.LastFlushedLsn);
+                    rc.LastAppliedLsn = commitLsn;
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     result = await c.ExecuteScalarAsync($"SELECT name FROM {tableName} ORDER BY id DESC LIMIT 1;");
                     Assert.That(result, Is.Null); // Not committed yet because we still didn't report fsync yet
 
                     // Report last flushed LSN
-                    rc.SetReplicationStatus(commitLsn, commitLsn);
+                    rc.LastFlushedLsn = commitLsn;
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     await insertTask;
@@ -372,7 +372,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(result, Is.EqualTo(value1String)); // Not committed yet because we still didn't report apply yet
 
                     // Report last applied LSN
-                    rc.SetReplicationStatus(commitLsn, rc.LastFlushedLsn);
+                    rc.LastAppliedLsn = commitLsn;
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     await insertTask;

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -336,14 +336,14 @@ namespace Npgsql.Tests.Replication
                     Assert.That(result, Is.Null); // Not committed yet because we still didn't report fsync yet
 
                     // Report last applied LSN
-                    rc.LastAppliedLsn = commitLsn;
+                    rc.SetReplicationStatus(commitLsn, rc.LastFlushedLsn);
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     result = await c.ExecuteScalarAsync($"SELECT name FROM {tableName} ORDER BY id DESC LIMIT 1;");
                     Assert.That(result, Is.Null); // Not committed yet because we still didn't report fsync yet
 
                     // Report last flushed LSN
-                    rc.LastFlushedLsn = commitLsn;
+                    rc.SetReplicationStatus(commitLsn, commitLsn);
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     await insertTask;
@@ -372,7 +372,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(result, Is.EqualTo(value1String)); // Not committed yet because we still didn't report apply yet
 
                     // Report last applied LSN
-                    rc.LastAppliedLsn = commitLsn;
+                    rc.SetReplicationStatus(commitLsn, rc.LastFlushedLsn);
                     await rc.SendStatusUpdate(CancellationToken.None);
 
                     await insertTask;


### PR DESCRIPTION
After discussion in #3534 it became clear that the current API is less
than ideal for two reasons:

1. Setting those two properties has (intended) side effects because it
   influences what is sent back to the server as feedback. Setting
   properties for side effects is not a typical or recommended API and
   is hard to discover and understand in it's consequences.

2. It isn't clear from the API that you *should always* set both values
   because both of them will be reported back to the server and have
   consequences there.

Instead of those two setters this commit adds a new method
SetReplicationStatus() which enforces setting both values at the same
time and is easier to discover, use and document.