### PR TITLE
Replication changes for PostgreSQL 14 / Npgsql 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           fi
           sudo sed -i 's/#wal_level =/wal_level = logical #/' $PGDATA/postgresql.conf
           sudo sed -i 's/#max_wal_senders =/max_wal_senders = 50 #/' $PGDATA/postgresql.conf
+          sudo sed -i 's/#logical_decoding_work_mem =/logical_decoding_work_mem = 64kB #/' $PGDATA/postgresql.conf
           sudo sed -i 's/#wal_sender_timeout =/wal_sender_timeout = 3s #/' $PGDATA/postgresql.conf
           sudo sed -i "s/#synchronous_standby_names =/synchronous_standby_names = 'npgsql_test_sync_standby' #/" $PGDATA/postgresql.conf
           sudo sed -i "s/#synchronous_commit =/synchronous_commit = local #/" $PGDATA/postgresql.conf
@@ -147,6 +148,7 @@ jobs:
           sed -i "s|#unix_socket_directories = ''|unix_socket_directories = '$SOCKET_DIR'|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#wal_level =|wal_level = logical #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#max_wal_senders =|max_wal_senders = 50 #|" pgsql/PGDATA/postgresql.conf
+          sed -i "s|#logical_decoding_work_mem =|logical_decoding_work_mem = 64kB #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#wal_sender_timeout =|wal_sender_timeout = 3s #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#synchronous_standby_names =|synchronous_standby_names = 'npgsql_test_sync_standby' #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#synchronous_commit =|synchronous_commit = local #|" pgsql/PGDATA/postgresql.conf

--- a/Npgsql.sln.DotSettings
+++ b/Npgsql.sln.DotSettings
@@ -91,6 +91,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOEXPORT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pgoutput/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pgpass/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PGTZ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgis/@EntryIndexedValue">True</s:Boolean>
@@ -98,6 +99,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pregenerated/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=P_0020keepaliv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resultset/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subtransaction/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=timestamptz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=timetz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=UNLISTEN/@EntryIndexedValue">True</s:Boolean>

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -41,12 +41,16 @@ Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
 Npgsql.Replication.ReplicationConnection.PostgreSqlVersion.get -> System.Version!
 Npgsql.Replication.ReplicationConnection.ServerVersion.get -> string!
+*REMOVED*Npgsql.Replication.PgOutput.Messages.BeginMessage.TransactionXid.get -> uint
 *REMOVED*Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.ReadOnlyMemory<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
 Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.Collections.Immutable.ImmutableArray<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
 Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage
 Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionalPgOutputReplicationMessage() -> void
 Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionXid.get -> uint?
 *REMOVED*Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> uint[]!
+Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage
+Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage.TransactionChangingPgOutputReplicationMessage() -> void
+Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage.TransactionXid.get -> uint
 Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> System.Collections.Immutable.ImmutableArray<uint>
 Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
 *REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
@@ -58,7 +62,7 @@ Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.MessageLsn.get -> Np
 Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Prefix.get -> string!
 Npgsql.Replication.PgOutput.Messages.StreamAbortMessage
 Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.StreamAbortMessage() -> void
-Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.SubtransactionXid.get -> uint?
+Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.SubtransactionXid.get -> uint
 Npgsql.Replication.PgOutput.Messages.StreamCommitMessage
 Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.CommitLsn.get -> NpgsqlTypes.NpgsqlLogSequenceNumber
 Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.Flags.get -> byte

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -43,15 +43,15 @@ Npgsql.Replication.ReplicationConnection.PostgreSqlVersion.get -> System.Version
 Npgsql.Replication.ReplicationConnection.ServerVersion.get -> string!
 *REMOVED*Npgsql.Replication.PgOutput.Messages.BeginMessage.TransactionXid.get -> uint
 *REMOVED*Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.ReadOnlyMemory<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
-Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.Collections.Immutable.ImmutableArray<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
-Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage
-Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionalPgOutputReplicationMessage() -> void
-Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionXid.get -> uint?
+Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.Collections.Generic.IReadOnlyList<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>!
+Npgsql.Replication.PgOutput.Messages.TransactionalMessage
+Npgsql.Replication.PgOutput.Messages.TransactionalMessage.TransactionalMessage() -> void
+Npgsql.Replication.PgOutput.Messages.TransactionalMessage.TransactionXid.get -> uint?
 *REMOVED*Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> uint[]!
-Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage
-Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage.TransactionChangingPgOutputReplicationMessage() -> void
-Npgsql.Replication.PgOutput.Messages.TransactionChangingPgOutputReplicationMessage.TransactionXid.get -> uint
-Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> System.Collections.Immutable.ImmutableArray<uint>
+Npgsql.Replication.PgOutput.Messages.TransactionControlMessage
+Npgsql.Replication.PgOutput.Messages.TransactionControlMessage.TransactionControlMessage() -> void
+Npgsql.Replication.PgOutput.Messages.TransactionControlMessage.TransactionXid.get -> uint
+Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> System.Collections.Generic.IReadOnlyList<uint>!
 Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
 *REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
 Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -41,9 +41,46 @@ Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
 Npgsql.Replication.ReplicationConnection.PostgreSqlVersion.get -> System.Version!
 Npgsql.Replication.ReplicationConnection.ServerVersion.get -> string!
+*REMOVED*Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.ReadOnlyMemory<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
+Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.Collections.Immutable.ImmutableArray<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
+Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage
+Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionalPgOutputReplicationMessage() -> void
+Npgsql.Replication.PgOutput.Messages.TransactionalPgOutputReplicationMessage.TransactionXid.get -> uint?
+*REMOVED*Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> uint[]!
+Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> System.Collections.Immutable.ImmutableArray<uint>
 Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Data.get -> System.IO.Stream!
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Flags.get -> byte
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.LogicalDecodingMessage() -> void
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.MessageLsn.get -> NpgsqlTypes.NpgsqlLogSequenceNumber
+Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Prefix.get -> string!
+Npgsql.Replication.PgOutput.Messages.StreamAbortMessage
+Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.StreamAbortMessage() -> void
+Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.SubtransactionXid.get -> uint?
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.CommitLsn.get -> NpgsqlTypes.NpgsqlLogSequenceNumber
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.Flags.get -> byte
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.StreamCommitMessage() -> void
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.TransactionCommitTimestamp.get -> System.DateTime
+Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.TransactionEndLsn.get -> NpgsqlTypes.NpgsqlLogSequenceNumber
+Npgsql.Replication.PgOutput.Messages.StreamStartMessage
+Npgsql.Replication.PgOutput.Messages.StreamStartMessage.StreamSegmentIndicator.get -> byte
+Npgsql.Replication.PgOutput.Messages.StreamStartMessage.StreamStartMessage() -> void
+Npgsql.Replication.PgOutput.Messages.StreamStopMessage
+Npgsql.Replication.PgOutput.Messages.StreamStopMessage.StreamStopMessage() -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.Messages.get -> bool?
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null) -> void
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override Npgsql.NpgsqlRawCopyStream.DisposeAsync() -> System.Threading.Tasks.ValueTask
+override Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Clone() -> Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage!
+override Npgsql.Replication.PgOutput.Messages.StreamAbortMessage.Clone() -> Npgsql.Replication.PgOutput.Messages.StreamAbortMessage!
+override Npgsql.Replication.PgOutput.Messages.StreamCommitMessage.Clone() -> Npgsql.Replication.PgOutput.Messages.StreamCommitMessage!
+override Npgsql.Replication.PgOutput.Messages.StreamStartMessage.Clone() -> Npgsql.Replication.PgOutput.Messages.StreamStartMessage!
+override Npgsql.Replication.PgOutput.Messages.StreamStopMessage.Clone() -> Npgsql.Replication.PgOutput.Messages.StreamStopMessage!
 override NpgsqlTypes.NpgsqlTsQuery.Equals(object? obj) -> bool
 override NpgsqlTypes.NpgsqlTsQuery.GetHashCode() -> int
 *REMOVED*static Npgsql.NpgsqlDatabaseInfo.ParseServerVersion(string! value) -> System.Version!

--- a/src/Npgsql/Replication/PgOutput/Messages/BeginMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/BeginMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol begin message
     /// </summary>
-    public sealed class BeginMessage : PgOutputReplicationMessage
+    public sealed class BeginMessage : TransactionChangingPgOutputReplicationMessage
     {
         /// <summary>
         /// The final LSN of the transaction.
@@ -19,20 +19,12 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// </summary>
         public DateTime TransactionCommitTimestamp { get; private set; }
 
-        /// <summary>
-        /// Xid of the transaction.
-        /// </summary>
-        public uint TransactionXid { get; private set; }
-
         internal BeginMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
             NpgsqlLogSequenceNumber transactionFinalLsn, DateTime transactionCommitTimestamp, uint transactionXid)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             TransactionFinalLsn = transactionFinalLsn;
             TransactionCommitTimestamp = transactionCommitTimestamp;
-            TransactionXid = transactionXid;
-
             return this;
         }
 

--- a/src/Npgsql/Replication/PgOutput/Messages/BeginMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/BeginMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol begin message
     /// </summary>
-    public sealed class BeginMessage : TransactionChangingPgOutputReplicationMessage
+    public sealed class BeginMessage : TransactionControlMessage
     {
         /// <summary>
         /// The final LSN of the transaction.

--- a/src/Npgsql/Replication/PgOutput/Messages/DeleteMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/DeleteMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Abstract base class for Logical Replication Protocol delete message types.
     /// </summary>
-    public abstract class DeleteMessage : PgOutputReplicationMessage
+    public abstract class DeleteMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.
@@ -14,12 +14,10 @@ namespace Npgsql.Replication.PgOutput.Messages
         public uint RelationId { get; private set; }
 
         private protected DeleteMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId)
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
-
             return this;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/DeleteMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/DeleteMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Abstract base class for Logical Replication Protocol delete message types.
     /// </summary>
-    public abstract class DeleteMessage : TransactionalPgOutputReplicationMessage
+    public abstract class DeleteMessage : TransactionalMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.

--- a/src/Npgsql/Replication/PgOutput/Messages/FullDeleteMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/FullDeleteMessage.cs
@@ -14,12 +14,10 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> OldRow { get; private set; } = default!;
 
         internal FullDeleteMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId, ReadOnlyMemory<TupleData> oldRow)
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId, ReadOnlyMemory<TupleData> oldRow)
         {
-            base.Populate(walStart, walEnd, serverClock, relationId);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid, relationId);
             OldRow = oldRow;
-
             return this;
         }
 
@@ -31,7 +29,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new FullDeleteMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, OldRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, OldRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/FullUpdateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/FullUpdateMessage.cs
@@ -14,13 +14,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> OldRow { get; private set; } = default!;
 
         internal FullUpdateMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId,
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
             ReadOnlyMemory<TupleData> newRow, ReadOnlyMemory<TupleData> oldRow)
         {
-            base.Populate(walStart, walEnd, serverClock, relationId, newRow);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid, relationId, newRow);
             OldRow = oldRow;
-
             return this;
         }
 
@@ -32,7 +30,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new FullUpdateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, NewRow.ToArray(), OldRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.ToArray(), OldRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/IndexUpdateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/IndexUpdateMessage.cs
@@ -14,13 +14,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> KeyRow { get; private set; } = default!;
 
         internal IndexUpdateMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId,
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
             ReadOnlyMemory<TupleData> newRow, ReadOnlyMemory<TupleData> keyRow)
         {
-            base.Populate(walStart, walEnd, serverClock, relationId, newRow);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid, relationId, newRow);
             KeyRow = keyRow;
-
             return this;
         }
 
@@ -32,7 +30,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new IndexUpdateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, NewRow.ToArray(), KeyRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.ToArray(), KeyRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol insert message
     /// </summary>
-    public sealed class InsertMessage : TransactionalPgOutputReplicationMessage
+    public sealed class InsertMessage : TransactionalMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.

--- a/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol insert message
     /// </summary>
-    public sealed class InsertMessage : PgOutputReplicationMessage
+    public sealed class InsertMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.
@@ -19,14 +19,12 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> NewRow { get; private set; } = default!;
 
         internal InsertMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId,
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
             ReadOnlyMemory<TupleData> newRow)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
             NewRow = newRow;
-
             return this;
         }
 
@@ -38,7 +36,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new InsertMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, NewRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/KeyDeleteMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/KeyDeleteMessage.cs
@@ -14,13 +14,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> KeyRow { get; private set; } = default!;
 
         internal KeyDeleteMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId,
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
             ReadOnlyMemory<TupleData> keyRow)
         {
-            base.Populate(walStart, walEnd, serverClock, relationId);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid, relationId);
             KeyRow = keyRow;
-
             return this;
         }
 
@@ -32,7 +30,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new KeyDeleteMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, KeyRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, KeyRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/LogicalDecodingMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/LogicalDecodingMessage.cs
@@ -7,7 +7,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol logical decoding message
     /// </summary>
-    public sealed class LogicalDecodingMessage : TransactionalPgOutputReplicationMessage
+    public sealed class LogicalDecodingMessage : TransactionalMessage
     {
         /// <summary>
         /// Flags; Either 0 for no flags or 1 if the logical decoding message is transactional.

--- a/src/Npgsql/Replication/PgOutput/Messages/LogicalDecodingMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/LogicalDecodingMessage.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using NpgsqlTypes;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Logical Replication Protocol logical decoding message
+    /// </summary>
+    public sealed class LogicalDecodingMessage : TransactionalPgOutputReplicationMessage
+    {
+        /// <summary>
+        /// Flags; Either 0 for no flags or 1 if the logical decoding message is transactional.
+        /// </summary>
+        public byte Flags { get; private set; }
+
+        /// <summary>
+        /// The LSN of the logical decoding message.
+        /// </summary>
+        public NpgsqlLogSequenceNumber MessageLsn { get; private set; }
+
+        /// <summary>
+        /// The prefix of the logical decoding message.
+        /// </summary>
+        public string Prefix { get; private set; } = default!;
+
+        /// <summary>
+        /// The content of the logical decoding message.
+        /// </summary>
+        public Stream Data { get; private set; } = default!;
+
+        internal LogicalDecodingMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
+            uint? transactionXid, byte flags, NpgsqlLogSequenceNumber messageLsn, string prefix, Stream data)
+        {
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
+            Flags = flags;
+            MessageLsn = messageLsn;
+            Prefix = prefix;
+            Data = data;
+            return this;
+        }
+
+        /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override LogicalDecodingMessage Clone()
+#else
+        public override PgOutputReplicationMessage Clone()
+#endif
+        {
+            var clone = new LogicalDecodingMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Flags, MessageLsn, Prefix, Data);
+            return clone;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
@@ -8,7 +8,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol relation message
     /// </summary>
-    public sealed class RelationMessage : TransactionalPgOutputReplicationMessage
+    public sealed class RelationMessage : TransactionalMessage
     {
         /// <summary>
         /// ID of the relation.
@@ -33,11 +33,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// Relation columns
         /// </summary>
-        public ImmutableArray<Column> Columns { get; private set; } = default!;
+        public IReadOnlyList<Column> Columns { get; private set; } = ReadonlyArrayBuffer<Column>.Empty!;
 
         internal RelationMessage Populate(
             NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId, string ns,
-            string relationName, char relationReplicaIdentitySetting, ImmutableArray<Column> columns)
+            string relationName, char relationReplicaIdentitySetting, ReadonlyArrayBuffer<Column> columns)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
@@ -56,7 +56,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new RelationMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, Columns);
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, ((ReadonlyArrayBuffer<Column>)Columns).Clone());
             return clone;
         }
 

--- a/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
@@ -1,13 +1,14 @@
 ﻿using NpgsqlTypes;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {
     /// <summary>
     /// Logical Replication Protocol relation message
     /// </summary>
-    public sealed class RelationMessage : PgOutputReplicationMessage
+    public sealed class RelationMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// ID of the relation.
@@ -32,20 +33,18 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// Relation columns
         /// </summary>
-        public ReadOnlyMemory<Column> Columns { get; private set; } = default!;
+        public ImmutableArray<Column> Columns { get; private set; } = default!;
 
         internal RelationMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId, string ns,
-            string relationName, char relationReplicaIdentitySetting, ReadOnlyMemory<Column> columns)
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId, string ns,
+            string relationName, char relationReplicaIdentitySetting, ImmutableArray<Column> columns)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
             Namespace = ns;
             RelationName = relationName;
             RelationReplicaIdentitySetting = relationReplicaIdentitySetting;
             Columns = columns;
-
             return this;
         }
 
@@ -57,7 +56,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new RelationMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, Columns.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, Columns);
             return clone;
         }
 

--- a/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
@@ -33,11 +33,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// Relation columns
         /// </summary>
-        public IReadOnlyList<Column> Columns { get; private set; } = ReadonlyArrayBuffer<Column>.Empty!;
+        public IReadOnlyList<Column> Columns { get; private set; } = ReadOnlyArrayBuffer<Column>.Empty!;
 
         internal RelationMessage Populate(
             NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId, string ns,
-            string relationName, char relationReplicaIdentitySetting, ReadonlyArrayBuffer<Column> columns)
+            string relationName, char relationReplicaIdentitySetting, ReadOnlyArrayBuffer<Column> columns)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
@@ -56,7 +56,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new RelationMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, ((ReadonlyArrayBuffer<Column>)Columns).Clone());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, Namespace, RelationName, RelationReplicaIdentitySetting, ((ReadOnlyArrayBuffer<Column>)Columns).Clone());
             return clone;
         }
 

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
@@ -1,0 +1,36 @@
+﻿using NpgsqlTypes;
+using System;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Logical Replication Protocol stream abort message
+    /// </summary>
+    public sealed class StreamAbortMessage : TransactionalPgOutputReplicationMessage
+    {
+        /// <summary>
+        /// Xid of the subtransaction (will be same as xid of the transaction for top-level transactions).
+        /// </summary>
+        public uint? SubtransactionXid { get; private set; }
+
+        internal StreamAbortMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
+            uint? transactionXid, uint? subtransactionXid)
+        {
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
+            SubtransactionXid = subtransactionXid;
+            return this;
+        }
+
+        /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override StreamAbortMessage Clone()
+#else
+        public override PgOutputReplicationMessage Clone()
+#endif
+        {
+            var clone = new StreamAbortMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, SubtransactionXid);
+            return clone;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream abort message
     /// </summary>
-    public sealed class StreamAbortMessage : TransactionChangingPgOutputReplicationMessage
+    public sealed class StreamAbortMessage : TransactionControlMessage
     {
         /// <summary>
         /// Xid of the subtransaction (will be same as xid of the transaction for top-level transactions).

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
@@ -6,15 +6,15 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream abort message
     /// </summary>
-    public sealed class StreamAbortMessage : TransactionalPgOutputReplicationMessage
+    public sealed class StreamAbortMessage : TransactionChangingPgOutputReplicationMessage
     {
         /// <summary>
         /// Xid of the subtransaction (will be same as xid of the transaction for top-level transactions).
         /// </summary>
-        public uint? SubtransactionXid { get; private set; }
+        public uint SubtransactionXid { get; private set; }
 
         internal StreamAbortMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
-            uint? transactionXid, uint? subtransactionXid)
+            uint transactionXid, uint subtransactionXid)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             SubtransactionXid = subtransactionXid;

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
@@ -1,0 +1,54 @@
+﻿using NpgsqlTypes;
+using System;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Logical Replication Protocol stream commit message
+    /// </summary>
+    public sealed class StreamCommitMessage : TransactionalPgOutputReplicationMessage
+    {
+        /// <summary>
+        /// Flags; currently unused (must be 0).
+        /// </summary>
+        public byte Flags { get; private set; }
+
+        /// <summary>
+        /// The LSN of the commit.
+        /// </summary>
+        public NpgsqlLogSequenceNumber CommitLsn { get; private set; }
+
+        /// <summary>
+        /// The end LSN of the transaction.
+        /// </summary>
+        public NpgsqlLogSequenceNumber TransactionEndLsn { get; private set; }
+
+        /// <summary>
+        /// Commit timestamp of the transaction.
+        /// </summary>
+        public DateTime TransactionCommitTimestamp { get; private set; }
+
+        internal StreamCommitMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
+            uint? transactionXid, byte flags, NpgsqlLogSequenceNumber commitLsn, NpgsqlLogSequenceNumber transactionEndLsn, DateTime transactionCommitTimestamp)
+        {
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
+            Flags = flags;
+            CommitLsn = commitLsn;
+            TransactionEndLsn = transactionEndLsn;
+            TransactionCommitTimestamp = transactionCommitTimestamp;
+            return this;
+        }
+
+        /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override StreamCommitMessage Clone()
+#else
+        public override PgOutputReplicationMessage Clone()
+#endif
+        {
+            var clone = new StreamCommitMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Flags, CommitLsn, TransactionEndLsn, TransactionCommitTimestamp);
+            return clone;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream commit message
     /// </summary>
-    public sealed class StreamCommitMessage : TransactionChangingPgOutputReplicationMessage
+    public sealed class StreamCommitMessage : TransactionControlMessage
     {
         /// <summary>
         /// Flags; currently unused (must be 0).

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamCommitMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream commit message
     /// </summary>
-    public sealed class StreamCommitMessage : TransactionalPgOutputReplicationMessage
+    public sealed class StreamCommitMessage : TransactionChangingPgOutputReplicationMessage
     {
         /// <summary>
         /// Flags; currently unused (must be 0).
@@ -29,7 +29,7 @@ namespace Npgsql.Replication.PgOutput.Messages
         public DateTime TransactionCommitTimestamp { get; private set; }
 
         internal StreamCommitMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
-            uint? transactionXid, byte flags, NpgsqlLogSequenceNumber commitLsn, NpgsqlLogSequenceNumber transactionEndLsn, DateTime transactionCommitTimestamp)
+            uint transactionXid, byte flags, NpgsqlLogSequenceNumber commitLsn, NpgsqlLogSequenceNumber transactionEndLsn, DateTime transactionCommitTimestamp)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             Flags = flags;

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
@@ -1,0 +1,36 @@
+﻿using NpgsqlTypes;
+using System;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Logical Replication Protocol stream start message
+    /// </summary>
+    public sealed class StreamStartMessage : TransactionalPgOutputReplicationMessage
+    {
+        /// <summary>
+        /// A value of 1 indicates this is the first stream segment for this XID, 0 for any other stream segment.
+        /// </summary>
+        public byte StreamSegmentIndicator { get; private set; }
+
+        internal StreamStartMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
+            uint? transactionXid, byte streamSegmentIndicator)
+        {
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
+            StreamSegmentIndicator = streamSegmentIndicator;
+            return this;
+        }
+
+        /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override StreamStartMessage Clone()
+#else
+        public override PgOutputReplicationMessage Clone()
+#endif
+        {
+            var clone = new StreamStartMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, StreamSegmentIndicator);
+            return clone;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream start message
     /// </summary>
-    public sealed class StreamStartMessage : TransactionalPgOutputReplicationMessage
+    public sealed class StreamStartMessage : TransactionChangingPgOutputReplicationMessage
     {
         /// <summary>
         /// A value of 1 indicates this is the first stream segment for this XID, 0 for any other stream segment.
@@ -14,7 +14,7 @@ namespace Npgsql.Replication.PgOutput.Messages
         public byte StreamSegmentIndicator { get; private set; }
 
         internal StreamStartMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
-            uint? transactionXid, byte streamSegmentIndicator)
+            uint transactionXid, byte streamSegmentIndicator)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             StreamSegmentIndicator = streamSegmentIndicator;

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamStartMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol stream start message
     /// </summary>
-    public sealed class StreamStartMessage : TransactionChangingPgOutputReplicationMessage
+    public sealed class StreamStartMessage : TransactionControlMessage
     {
         /// <summary>
         /// A value of 1 indicates this is the first stream segment for this XID, 0 for any other stream segment.

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamStopMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamStopMessage.cs
@@ -1,0 +1,29 @@
+﻿using NpgsqlTypes;
+using System;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Logical Replication Protocol stream stop message
+    /// </summary>
+    public sealed class StreamStopMessage : PgOutputReplicationMessage
+    {
+        internal new StreamStopMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock)
+        {
+            base.Populate(walStart, walEnd, serverClock);
+            return this;
+        }
+
+        /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override StreamStopMessage Clone()
+#else
+        public override PgOutputReplicationMessage Clone()
+#endif
+        {
+            var clone = new StreamStopMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock);
+            return clone;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/TransactionChangingPgOutputReplicationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TransactionChangingPgOutputReplicationMessage.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NpgsqlTypes;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// The common base class for all replication messages
+    /// that set the transation xid of a transaction
+    /// </summary>
+    public abstract class TransactionChangingPgOutputReplicationMessage : PgOutputReplicationMessage
+    {
+        /// <summary>
+        /// Xid of the transaction.
+        /// </summary>
+        public uint TransactionXid { get; private set; }
+
+        private protected void Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint transactionXid)
+        {
+            base.Populate(walStart, walEnd, serverClock);
+
+            TransactionXid = transactionXid;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/TransactionControlMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TransactionControlMessage.cs
@@ -4,10 +4,9 @@ using NpgsqlTypes;
 namespace Npgsql.Replication.PgOutput.Messages
 {
     /// <summary>
-    /// The common base class for all replication messages
-    /// that set the transation xid of a transaction
+    /// The common base class for all replication messages that set the transaction xid of a transaction
     /// </summary>
-    public abstract class TransactionChangingPgOutputReplicationMessage : PgOutputReplicationMessage
+    public abstract class TransactionControlMessage : PgOutputReplicationMessage
     {
         /// <summary>
         /// Xid of the transaction.

--- a/src/Npgsql/Replication/PgOutput/Messages/TransactionalMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TransactionalMessage.cs
@@ -4,10 +4,9 @@ using NpgsqlTypes;
 namespace Npgsql.Replication.PgOutput.Messages
 {
     /// <summary>
-    /// The common base class for all streaming replication messages
-    /// that can be part of a streaming transaction (protocol V2)
+    /// The common base class for all streaming replication messages that can be part of a streaming transaction (protocol V2)
     /// </summary>
-    public abstract class TransactionalPgOutputReplicationMessage : PgOutputReplicationMessage
+    public abstract class TransactionalMessage : PgOutputReplicationMessage
     {
         /// <summary>
         /// Xid of the transaction (only present for streamed transactions).

--- a/src/Npgsql/Replication/PgOutput/Messages/TransactionalPgOutputReplicationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TransactionalPgOutputReplicationMessage.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NpgsqlTypes;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// The common base class for all streaming replication messages
+    /// that can be part of a streaming transaction (protocol V2)
+    /// </summary>
+    public abstract class TransactionalPgOutputReplicationMessage : PgOutputReplicationMessage
+    {
+        /// <summary>
+        /// Xid of the transaction (only present for streamed transactions).
+        /// </summary>
+        public uint? TransactionXid { get; private set; }
+
+        private protected void Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid)
+        {
+            base.Populate(walStart, walEnd, serverClock);
+
+            TransactionXid = transactionXid;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
@@ -17,11 +17,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// IDs of the relations corresponding to the ID in the relation message.
         /// </summary>
-        public IReadOnlyList<uint> RelationIds { get; private set; } = ReadonlyArrayBuffer<uint>.Empty;
+        public IReadOnlyList<uint> RelationIds { get; private set; } = ReadOnlyArrayBuffer<uint>.Empty;
 
         internal TruncateMessage Populate(
             NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, TruncateOptions options,
-            ReadonlyArrayBuffer<uint> relationIds)
+            ReadOnlyArrayBuffer<uint> relationIds)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             Options = options;
@@ -37,7 +37,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new TruncateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Options, ((ReadonlyArrayBuffer<uint>)RelationIds).Clone());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Options, ((ReadOnlyArrayBuffer<uint>)RelationIds).Clone());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
@@ -1,12 +1,13 @@
 ﻿using NpgsqlTypes;
 using System;
+using System.Collections.Immutable;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {
     /// <summary>
     /// Logical Replication Protocol truncate message
     /// </summary>
-    public sealed class TruncateMessage : PgOutputReplicationMessage
+    public sealed class TruncateMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// Option flags for TRUNCATE
@@ -16,17 +17,15 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// IDs of the relations corresponding to the ID in the relation message.
         /// </summary>
-        public uint[] RelationIds { get; private set; } = default!;
+        public ImmutableArray<uint> RelationIds { get; private set; } = ImmutableArray<uint>.Empty;
 
         internal TruncateMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, TruncateOptions options,
-            uint[] relationIds)
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, TruncateOptions options,
+            ImmutableArray<uint> relationIds)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             Options = options;
             RelationIds = relationIds;
-
             return this;
         }
 
@@ -38,7 +37,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new TruncateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, Options, RelationIds); // TODO: RelationIds...
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Options, RelationIds);
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TruncateMessage.cs
@@ -1,13 +1,13 @@
 ﻿using NpgsqlTypes;
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {
     /// <summary>
     /// Logical Replication Protocol truncate message
     /// </summary>
-    public sealed class TruncateMessage : TransactionalPgOutputReplicationMessage
+    public sealed class TruncateMessage : TransactionalMessage
     {
         /// <summary>
         /// Option flags for TRUNCATE
@@ -17,11 +17,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// IDs of the relations corresponding to the ID in the relation message.
         /// </summary>
-        public ImmutableArray<uint> RelationIds { get; private set; } = ImmutableArray<uint>.Empty;
+        public IReadOnlyList<uint> RelationIds { get; private set; } = ReadonlyArrayBuffer<uint>.Empty;
 
         internal TruncateMessage Populate(
             NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, TruncateOptions options,
-            ImmutableArray<uint> relationIds)
+            ReadonlyArrayBuffer<uint> relationIds)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             Options = options;
@@ -37,7 +37,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new TruncateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Options, RelationIds);
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, Options, ((ReadonlyArrayBuffer<uint>)RelationIds).Clone());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/TypeMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TypeMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol type message
     /// </summary>
-    public sealed class TypeMessage : TransactionalPgOutputReplicationMessage
+    public sealed class TypeMessage : TransactionalMessage
     {
         /// <summary>
         /// ID of the data type.

--- a/src/Npgsql/Replication/PgOutput/Messages/TypeMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TypeMessage.cs
@@ -6,7 +6,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <summary>
     /// Logical Replication Protocol type message
     /// </summary>
-    public sealed class TypeMessage : PgOutputReplicationMessage
+    public sealed class TypeMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// ID of the data type.
@@ -24,14 +24,12 @@ namespace Npgsql.Replication.PgOutput.Messages
         public string Name { get; private set; } = string.Empty;
 
         internal TypeMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint typeId, string ns, string name)
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint typeId, string ns, string name)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             TypeId = typeId;
             Namespace = ns;
             Name = name;
-
             return this;
         }
 
@@ -43,7 +41,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new TypeMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TypeId, Namespace, Name);
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, TypeId, Namespace, Name);
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
@@ -10,7 +10,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <remarks>
     /// This is the base type of all update messages containing only the tuples for the new row.
     /// </remarks>
-    public class UpdateMessage : PgOutputReplicationMessage
+    public class UpdateMessage : TransactionalPgOutputReplicationMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.
@@ -23,14 +23,12 @@ namespace Npgsql.Replication.PgOutput.Messages
         public ReadOnlyMemory<TupleData> NewRow { get; private set; }
 
         internal UpdateMessage Populate(
-            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint relationId,
+            NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
             ReadOnlyMemory<TupleData> newRow)
         {
-            base.Populate(walStart, walEnd, serverClock);
-
+            base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
             NewRow = newRow;
-
             return this;
         }
 
@@ -42,7 +40,7 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new UpdateMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, RelationId, NewRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.ToArray());
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
@@ -10,7 +10,7 @@ namespace Npgsql.Replication.PgOutput.Messages
     /// <remarks>
     /// This is the base type of all update messages containing only the tuples for the new row.
     /// </remarks>
-    public class UpdateMessage : TransactionalPgOutputReplicationMessage
+    public class UpdateMessage : TransactionalMessage
     {
         /// <summary>
         /// ID of the relation corresponding to the ID in the relation message.

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql.Internal;
 using Npgsql.Internal.TypeHandlers.DateTimeHandlers;
 using Npgsql.Replication.Internal;
 using Npgsql.Replication.PgOutput.Messages;
@@ -21,6 +24,7 @@ namespace Npgsql.Replication.PgOutput
         #region Cached messages
 
         readonly BeginMessage _beginMessage = new();
+        readonly LogicalDecodingMessage _logicalDecodingMessage = new();
         readonly CommitMessage _commitMessage = new();
         readonly FullDeleteMessage _fullDeleteMessage = new();
         readonly FullUpdateMessage _fullUpdateMessage = new();
@@ -32,10 +36,15 @@ namespace Npgsql.Replication.PgOutput
         readonly TruncateMessage _truncateMessage = new();
         readonly TypeMessage _typeMessage = new();
         readonly UpdateMessage _updateMessage = new();
+        readonly StreamStartMessage _streamStartMessage = new();
+        readonly StreamStopMessage _streamStopMessage = new();
+        readonly StreamCommitMessage _streamCommitMessage = new();
+        readonly StreamAbortMessage _streamAbortMessage = new();
+        readonly ImmutableArray<RelationMessage.Column>.Builder _relationMessageColumns = ImmutableArray.CreateBuilder<RelationMessage.Column>();
+        readonly ImmutableArray<uint>.Builder _truncateMessageRelationIds = ImmutableArray.CreateBuilder<uint>();
 
         TupleData[] _tupleDataArray1 = Array.Empty<TupleData>();
         TupleData[] _tupleDataArray2 = Array.Empty<TupleData>();
-        RelationMessage.Column[] _relationalMessageColumns = Array.Empty<RelationMessage.Column>();
 
         #endregion
 
@@ -67,7 +76,7 @@ namespace Npgsql.Replication.PgOutput
             var stream = _connection.StartLogicalReplication(
                 _slot, cancellationToken, _walLocation, _options.GetOptionPairs(), bypassingStream: true);
             var buf = _connection.Connector!.ReadBuffer;
-
+            var inStreamingTransaction = false;
             await foreach (var xLogData in stream.WithCancellation(cancellationToken))
             {
                 await buf.EnsureAsync(1);
@@ -77,52 +86,75 @@ namespace Npgsql.Replication.PgOutput
                 case BackendReplicationMessageCode.Begin:
                 {
                     await buf.EnsureAsync(20);
-                    yield return _beginMessage.Populate(
-                        xLogData.WalStart,
-                        xLogData.WalEnd,
-                        xLogData.ServerClock,
-                        new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
-                        TimestampHandler.FromPostgresTimestamp(buf.ReadInt64()),
-                        buf.ReadUInt32()
-                    );
+                    yield return _beginMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
+                        transactionFinalLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        transactionCommitTimestamp: TimestampHandler.FromPostgresTimestamp(buf.ReadInt64()),
+                        transactionXid: buf.ReadUInt32());
+                    continue;
+                }
+                case BackendReplicationMessageCode.Message:
+                {
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(14);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(10);
+                        transactionXid = null;
+                    }
+
+                    var flags = buf.ReadByte();
+                    var messageLsn = new NpgsqlLogSequenceNumber(buf.ReadUInt64());
+                    var prefix = await buf.ReadNullTerminatedString(async: true, cancellationToken);
+                    await buf.EnsureAsync(4);
+                    var length = buf.ReadUInt32();
+                    var data = (NpgsqlReadBuffer.ColumnStream)xLogData.Data;
+                    data.Init(checked((int)length), false);
+                    yield return _logicalDecodingMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                        flags, messageLsn, prefix, data);
                     continue;
                 }
                 case BackendReplicationMessageCode.Commit:
                 {
                     await buf.EnsureAsync(25);
-                    yield return _commitMessage.Populate(
-                        xLogData.WalStart,
-                        xLogData.WalEnd,
-                        xLogData.ServerClock,
-                        buf.ReadByte(),
-                        new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
-                        new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
-                        TimestampHandler.FromPostgresTimestamp(buf.ReadInt64())
-                    );
+                    yield return _commitMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, buf.ReadByte(),
+                        commitLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        transactionEndLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        transactionCommitTimestamp: TimestampHandler.FromPostgresTimestamp(buf.ReadInt64()));
                     continue;
                 }
                 case BackendReplicationMessageCode.Origin:
                 {
                     await buf.EnsureAsync(9);
-                    yield return _originMessage.Populate(
-                        xLogData.WalStart,
-                        xLogData.WalEnd,
-                        xLogData.ServerClock,
-                        new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
-                        await buf.ReadNullTerminatedString(async: true, cancellationToken));
+                    yield return _originMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
+                        originCommitLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        originName: await buf.ReadNullTerminatedString(async: true, cancellationToken));
                     continue;
                 }
                 case BackendReplicationMessageCode.Relation:
                 {
-                    await buf.EnsureAsync(6);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(10);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(6);
+                        transactionXid = null;
+                    }
+
                     var relationId = buf.ReadUInt32();
                     var ns = await buf.ReadNullTerminatedString(async: true, cancellationToken);
                     var relationName = await buf.ReadNullTerminatedString(async: true, cancellationToken);
                     await buf.EnsureAsync(3);
                     var relationReplicaIdentitySetting = (char)buf.ReadByte();
                     var numColumns = buf.ReadUInt16();
-                    if (numColumns > _relationalMessageColumns.Length)
-                        _relationalMessageColumns = new RelationMessage.Column[numColumns];
+                    _relationMessageColumns.Capacity = numColumns;
                     for (var i = 0; i < numColumns; i++)
                     {
                         await buf.EnsureAsync(2);
@@ -131,47 +163,72 @@ namespace Npgsql.Replication.PgOutput
                         await buf.EnsureAsync(8);
                         var dateTypeId = buf.ReadUInt32();
                         var typeModifier = buf.ReadInt32();
-                        _relationalMessageColumns[i] = new RelationMessage.Column(flags, columnName, dateTypeId, typeModifier);
+                        _relationMessageColumns.Add(new RelationMessage.Column(flags, columnName, dateTypeId, typeModifier));
                     }
 
-                    yield return _relationMessage.Populate(
-                        xLogData.WalStart,
-                        xLogData.WalEnd,
-                        xLogData.ServerClock,
-                        relationId,
-                        ns,
-                        relationName,
-                        relationReplicaIdentitySetting,
-                        new ReadOnlyMemory<RelationMessage.Column>(_relationalMessageColumns, 0, numColumns)
-                    );
-
+                    yield return _relationMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                        relationId, ns, relationName, relationReplicaIdentitySetting,
+                        columns: _relationMessageColumns.MoveToImmutable());
                     continue;
                 }
                 case BackendReplicationMessageCode.Type:
                 {
-                    await buf.EnsureAsync(5);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(9);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(5);
+                        transactionXid = null;
+                    }
+
                     var typeId = buf.ReadUInt32();
                     var ns = await buf.ReadNullTerminatedString(async: true, cancellationToken);
                     var name = await buf.ReadNullTerminatedString(async: true, cancellationToken);
-                    yield return _typeMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, typeId, ns, name);
-
+                    yield return _typeMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid, typeId, ns,
+                        name);
                     continue;
                 }
                 case BackendReplicationMessageCode.Insert:
                 {
-                    await buf.EnsureAsync(7);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(11);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(7);
+                        transactionXid = null;
+                    }
+
                     var relationId = buf.ReadUInt32();
                     var tupleDataType = (TupleType)buf.ReadByte();
                     Debug.Assert(tupleDataType == TupleType.NewTuple);
                     var numColumns = buf.ReadUInt16();
                     var newRow = await ReadTupleDataAsync(ref _tupleDataArray1, numColumns);
-                    yield return _insertMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, relationId, newRow);
-
+                    yield return _insertMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                        relationId, newRow);
                     continue;
                 }
                 case BackendReplicationMessageCode.Update:
                 {
-                    await buf.EnsureAsync(7);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(11);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(7);
+                        transactionXid = null;
+                    }
+
                     var relationId = buf.ReadUInt32();
                     var tupleType = (TupleType)buf.ReadByte();
                     var numColumns = buf.ReadUInt16();
@@ -184,8 +241,8 @@ namespace Npgsql.Replication.PgOutput
                         Debug.Assert(tupleType == TupleType.NewTuple);
                         numColumns = buf.ReadUInt16();
                         var newRow = await ReadTupleDataAsync(ref _tupleDataArray2, numColumns);
-                        yield return _indexUpdateMessage.Populate(xLogData.WalStart, xLogData.WalEnd,
-                            xLogData.ServerClock, relationId, newRow, keyRow);
+                        yield return _indexUpdateMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                            relationId, newRow, keyRow);
                         continue;
                     case TupleType.OldTuple:
                         var oldRow = await ReadTupleDataAsync(ref _tupleDataArray1, numColumns);
@@ -194,13 +251,13 @@ namespace Npgsql.Replication.PgOutput
                         Debug.Assert(tupleType == TupleType.NewTuple);
                         numColumns = buf.ReadUInt16();
                         newRow = await ReadTupleDataAsync(ref _tupleDataArray2, numColumns);
-                        yield return _fullUpdateMessage.Populate(xLogData.WalStart, xLogData.WalEnd,
-                            xLogData.ServerClock, relationId, newRow, oldRow);
+                        yield return _fullUpdateMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                            relationId, newRow, oldRow);
                         continue;
                     case TupleType.NewTuple:
                         newRow = await ReadTupleDataAsync(ref _tupleDataArray1, numColumns);
-                        yield return _updateMessage.Populate(xLogData.WalStart, xLogData.WalEnd,
-                            xLogData.ServerClock, relationId, newRow);
+                        yield return _updateMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                            relationId, newRow);
                         continue;
                     default:
                         throw new NotSupportedException($"The tuple type '{tupleType}' is not supported.");
@@ -208,19 +265,30 @@ namespace Npgsql.Replication.PgOutput
                 }
                 case BackendReplicationMessageCode.Delete:
                 {
-                    await buf.EnsureAsync(7);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(11);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(7);
+                        transactionXid = null;
+                    }
+
                     var relationId = buf.ReadUInt32();
                     var tupleDataType = (TupleType)buf.ReadByte();
                     var numColumns = buf.ReadUInt16();
                     switch (tupleDataType)
                     {
                     case TupleType.Key:
-                        yield return _keyDeleteMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
-                            relationId, await ReadTupleDataAsync(ref _tupleDataArray1, numColumns));
+                        yield return _keyDeleteMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                            relationId, keyRow: await ReadTupleDataAsync(ref _tupleDataArray1, numColumns));
                         continue;
                     case TupleType.OldTuple:
-                        yield return _fullDeleteMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
-                            relationId, await ReadTupleDataAsync(ref _tupleDataArray1, numColumns));
+                        yield return _fullDeleteMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                            relationId, oldRow: await ReadTupleDataAsync(ref _tupleDataArray1, numColumns));
                         continue;
                     default:
                         throw new NotSupportedException($"The tuple type '{tupleDataType}' is not supported.");
@@ -228,18 +296,60 @@ namespace Npgsql.Replication.PgOutput
                 }
                 case BackendReplicationMessageCode.Truncate:
                 {
-                    await buf.EnsureAsync(9);
+                    uint? transactionXid;
+                    if (inStreamingTransaction)
+                    {
+                        await buf.EnsureAsync(9);
+                        transactionXid = buf.ReadUInt32();
+                    }
+                    else
+                    {
+                        await buf.EnsureAsync(5);
+                        transactionXid = null;
+                    }
+
                     // Don't dare to truncate more than 2147483647 tables at once!
                     var numRels = checked((int)buf.ReadUInt32());
                     var truncateOptions = (TruncateOptions)buf.ReadByte();
-                    var relationIds = new uint[numRels];
-                    await buf.EnsureAsync(checked(numRels * 4));
+                    _truncateMessageRelationIds.Capacity = numRels;
+                    for (var i = 0L; i < numRels; i++)
+                    {
+                        await buf.EnsureAsync(4);
+                        _truncateMessageRelationIds.Add(buf.ReadUInt32());
+                    }
 
-                    for (var i = 0; i < numRels; i++)
-                        relationIds[i] = buf.ReadUInt32();
-
-                    yield return _truncateMessage.Populate(
-                        xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, truncateOptions, relationIds);
+                    yield return _truncateMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
+                        truncateOptions, relationIds: _truncateMessageRelationIds.MoveToImmutable());
+                    continue;
+                }
+                case BackendReplicationMessageCode.StreamStart:
+                {
+                    await buf.EnsureAsync(5);
+                    inStreamingTransaction = true;
+                    yield return _streamStartMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
+                        transactionXid: buf.ReadUInt32(), streamSegmentIndicator: buf.ReadByte());
+                    continue;
+                }
+                case BackendReplicationMessageCode.StreamStop:
+                {
+                    inStreamingTransaction = false;
+                    yield return _streamStopMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock);
+                    continue;
+                }
+                case BackendReplicationMessageCode.StreamCommit:
+                {
+                    await buf.EnsureAsync(29);
+                    yield return _streamCommitMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
+                        transactionXid: buf.ReadUInt32(), flags: buf.ReadByte(), commitLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        transactionEndLsn: new NpgsqlLogSequenceNumber(buf.ReadUInt64()),
+                        transactionCommitTimestamp: TimestampHandler.FromPostgresTimestamp(buf.ReadInt64()));
+                    continue;
+                }
+                case BackendReplicationMessageCode.StreamAbort:
+                {
+                    await buf.EnsureAsync(8);
+                    yield return _streamAbortMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock,
+                        transactionXid: buf.ReadUInt32(), subtransactionXid: buf.ReadUInt32());
                     continue;
                 }
                 default:
@@ -288,6 +398,7 @@ namespace Npgsql.Replication.PgOutput
         enum BackendReplicationMessageCode : byte
         {
             Begin = (byte)'B',
+            Message = (byte)'M',
             Commit = (byte)'C',
             Origin = (byte)'O',
             Relation = (byte)'R',
@@ -295,7 +406,11 @@ namespace Npgsql.Replication.PgOutput
             Insert = (byte)'I',
             Update = (byte)'U',
             Delete = (byte)'D',
-            Truncate = (byte)'T'
+            Truncate = (byte)'T',
+            StreamStart = (byte)'S',
+            StreamStop = (byte)'E',
+            StreamCommit = (byte)'c',
+            StreamAbort = (byte)'A',
         }
 
         enum TupleType : byte

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -40,8 +40,8 @@ namespace Npgsql.Replication.PgOutput
         readonly StreamStopMessage _streamStopMessage = new();
         readonly StreamCommitMessage _streamCommitMessage = new();
         readonly StreamAbortMessage _streamAbortMessage = new();
-        readonly ReadonlyArrayBuffer<RelationMessage.Column> _relationMessageColumns = new();
-        readonly ReadonlyArrayBuffer<uint> _truncateMessageRelationIds = new();
+        readonly ReadOnlyArrayBuffer<RelationMessage.Column> _relationMessageColumns = new();
+        readonly ReadOnlyArrayBuffer<uint> _truncateMessageRelationIds = new();
 
         TupleData[] _tupleDataArray1 = Array.Empty<TupleData>();
         TupleData[] _tupleDataArray2 = Array.Empty<TupleData>();

--- a/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
+++ b/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
@@ -7,14 +7,14 @@ namespace Npgsql.Replication.PgOutput
 {
     class ReadOnlyArrayBuffer<T> : IReadOnlyList<T>
     {
-        public static readonly ReadonlyArrayBuffer<T> Empty = new(Array.Empty<T>());
+        public static readonly ReadOnlyArrayBuffer<T> Empty = new(Array.Empty<T>());
         T[] _items;
         int _size;
 
-        public ReadonlyArrayBuffer()
+        public ReadOnlyArrayBuffer()
             => _items = Array.Empty<T>();
 
-        ReadonlyArrayBuffer(T[] items)
+        ReadOnlyArrayBuffer(T[] items)
         {
             _items = items;
             _size = items.Length;
@@ -48,7 +48,7 @@ namespace Npgsql.Replication.PgOutput
             internal set => _items[index] = value;
         }
 
-        public ReadonlyArrayBuffer<T> Clone()
+        public ReadOnlyArrayBuffer<T> Clone()
         {
             var newItems = new T[_size];
             if (_size > 0)

--- a/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
+++ b/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
@@ -5,7 +5,7 @@ using Npgsql.Replication.PgOutput.Messages;
 
 namespace Npgsql.Replication.PgOutput
 {
-    class ReadonlyArrayBuffer<T> : IReadOnlyList<T>
+    class ReadOnlyArrayBuffer<T> : IReadOnlyList<T>
     {
         public static readonly ReadonlyArrayBuffer<T> Empty = new(Array.Empty<T>());
         T[] _items;
@@ -44,7 +44,7 @@ namespace Npgsql.Replication.PgOutput
 
         public T this[int index]
         {
-            get => index >= _size ? throw new IndexOutOfRangeException() : _items[index];
+            get => index < _size ? _items[index] : throw new IndexOutOfRangeException();
             internal set => _items[index] = value;
         }
 

--- a/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
+++ b/src/Npgsql/Replication/PgOutput/ReadonlyArrayBuffer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Npgsql.Replication.PgOutput.Messages;
+
+namespace Npgsql.Replication.PgOutput
+{
+    class ReadonlyArrayBuffer<T> : IReadOnlyList<T>
+    {
+        public static readonly ReadonlyArrayBuffer<T> Empty = new(Array.Empty<T>());
+        T[] _items;
+        int _size;
+
+        public ReadonlyArrayBuffer()
+            => _items = Array.Empty<T>();
+
+        ReadonlyArrayBuffer(T[] items)
+        {
+            _items = items;
+            _size = items.Length;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var i = 0; i < _size; i++)
+            {
+                yield return _items[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public int Count
+        {
+            get => _size;
+            internal set
+            {
+                if (_items.Length < value)
+                    _items = new T[value];
+
+                _size = value;
+            }
+        }
+
+        public T this[int index]
+        {
+            get => index >= _size ? throw new IndexOutOfRangeException() : _items[index];
+            internal set => _items[index] = value;
+        }
+
+        public ReadonlyArrayBuffer<T> Clone()
+        {
+            var newItems = new T[_size];
+            if (_size > 0)
+                Array.Copy(_items, newItems, _size);
+            return new(newItems);
+        }
+    }
+}

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -101,7 +101,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -161,7 +161,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -217,7 +217,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('i'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -274,7 +274,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('f'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -333,7 +333,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -389,7 +389,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('i'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -443,7 +443,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('f'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -506,7 +506,7 @@ namespace Npgsql.Tests.Replication
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
-                    Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
+                    Assert.That(relMsg.Columns.Count, Is.EqualTo(2));
                     Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
                     Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
@@ -514,7 +514,7 @@ namespace Npgsql.Tests.Replication
                     var truncateMsg = await NextMessage<TruncateMessage>(messages);
                     Assert.That(truncateMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(truncateMsg.Options, Is.EqualTo(truncateOptionFlags));
-                    Assert.That(truncateMsg.RelationIds.Length, Is.EqualTo(1));
+                    Assert.That(truncateMsg.RelationIds.Count, Is.EqualTo(1));
 
                     // Remaining inserts
                     // Since the inserts run in the same transaction as the truncate, we'll

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,13 +12,51 @@ using Npgsql.Replication.PgOutput.Messages;
 
 namespace Npgsql.Tests.Replication
 {
+    [TestFixture(ProtocolVersion.V1, ReplicationDataMode.DefaultReplicationDataMode, TransactionMode.DefaultTransactionMode)]
+    //[TestFixture(ProtocolVersion.V1, ReplicationDataMode.BinaryReplicationDataMode, TransactionMode.DefaultTransactionMode)]
+    [TestFixture(ProtocolVersion.V2, ReplicationDataMode.DefaultReplicationDataMode, TransactionMode.StreamingTransactionMode)]
+    // We currently don't execute all possible combinations of settings for efficiency reasons because they don't
+    // interact in the current implementation.
+    // Feel free to uncomment some or all of the following lines if the implementation changed or you suspect a
+    // problem with some combination.
+    // [TestFixture(ProtocolVersion.V1, ReplicationDataMode.TextReplicationDataMode, TransactionMode.NonStreamingTransactionMode)]
+    // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.DefaultReplicationDataMode, TransactionMode.DefaultTransactionMode)]
+    // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.TextReplicationDataMode, TransactionMode.NonStreamingTransactionMode)]
+    // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.BinaryReplicationDataMode, TransactionMode.DefaultTransactionMode)]
+    // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.BinaryReplicationDataMode, TransactionMode.StreamingTransactionMode)]
     public class PgOutputReplicationTests : SafeReplicationTestBase<LogicalReplicationConnection>
     {
+        readonly ulong _protocolVersion;
+        readonly bool? _binary;
+        readonly bool? _streaming;
+
+        bool IsBinary => _binary ?? false;
+        bool IsStreaming => _streaming ?? false;
+
+        public PgOutputReplicationTests(ProtocolVersion protocolVersion, ReplicationDataMode dataMode, TransactionMode transactionMode)
+        {
+            _protocolVersion = (ulong)protocolVersion;
+            _binary = dataMode == ReplicationDataMode.BinaryReplicationDataMode
+                ? true
+                : dataMode == ReplicationDataMode.TextReplicationDataMode
+                    ? false
+                    : null;
+            _streaming = transactionMode == TransactionMode.StreamingTransactionMode
+                ? true
+                : transactionMode == TransactionMode.NonStreamingTransactionMode
+                    ? false
+                    : null;
+        }
+
         [Test]
         public Task CreateReplicationSlot()
             => SafeReplicationTest(
                 async (slotName, _) =>
                 {
+                    // There's nothing special here when streaming so only execute once
+                    if (IsStreaming)
+                        return;
+
                     await using var c = await OpenConnectionAsync();
                     await using var rc = await OpenReplicationConnectionAsync();
                     var options = await rc.CreatePgOutputReplicationSlot(slotName);
@@ -34,48 +74,57 @@ namespace Npgsql.Tests.Replication
 
         [Test(Description = "Tests whether INSERT commands get replicated as Logical Replication Protocol Messages")]
         public Task Insert()
-            => SafeReplicationTest(
+            => SafePgOutputReplicationTest(
                 async (slotName, tableName, publicationName) =>
                 {
                     await using var c = await OpenConnectionAsync();
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"INSERT INTO {tableName} (name) VALUES ('val1'), ('val2')");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"INSERT INTO {tableName} VALUES (1, 'val1'), (2, 'val2');
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(3, 15000) s(i);");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Insert first value
                     var insertMsg = await NextMessage<InsertMessage>(messages);
+                    Assert.That(insertMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(insertMsg.NewRow.Length, Is.EqualTo(2));
                     Assert.That(insertMsg.NewRow.Span[0].Value, Is.EqualTo("1"));
                     Assert.That(insertMsg.NewRow.Span[1].Value, Is.EqualTo("val1"));
 
                     // Insert second value
                     insertMsg = await NextMessage<InsertMessage>(messages);
+                    Assert.That(insertMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(insertMsg.NewRow.Length, Is.EqualTo(2));
                     Assert.That(insertMsg.NewRow.Span[0].Value, Is.EqualTo("2"));
                     Assert.That(insertMsg.NewRow.Span[1].Value, Is.EqualTo("val2"));
 
+                    // Remaining inserts
+                    for (var insertCount = 0; insertCount < 14998; insertCount++)
+                        await NextMessage<InsertMessage>(messages);
+
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -88,39 +137,47 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 async (slotName, tableName, publicationName) =>
                 {
                     await using var c = await OpenConnectionAsync();
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"UPDATE {tableName} SET name='val1' WHERE name='val'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"UPDATE {tableName} SET name='val1_updated' WHERE id = 1;
+                                                    UPDATE {tableName} SET name = md5(name) WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Update
                     var updateMsg = await NextMessage<UpdateMessage>(messages);
+                    Assert.That(updateMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(updateMsg.NewRow.Length, Is.EqualTo(2));
                     Assert.That(updateMsg.NewRow.Span[0].Value, Is.EqualTo("1"));
-                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1"));
+                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1_updated"));
+
+                    // Remaining updates
+                    for (var updateCount = 0; updateCount < 14999; updateCount++)
+                        await NextMessage<UpdateMessage>(messages);
 
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -134,44 +191,52 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 {
                     await using var c = await OpenConnectionAsync();
                     var indexName = $"i_{tableName.Substring(2)}";
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-CREATE UNIQUE INDEX {indexName} ON {tableName} (name);
-ALTER TABLE {tableName} REPLICA IDENTITY USING INDEX {indexName};
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    CREATE UNIQUE INDEX {indexName} ON {tableName} (name);
+                                                    ALTER TABLE {tableName} REPLICA IDENTITY USING INDEX {indexName};
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"UPDATE {tableName} SET name='val1' WHERE name='val'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"UPDATE {tableName} SET name='val1_updated' WHERE id = 1;
+                                                    UPDATE {tableName} SET name = md5(name) WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('i'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Update
                     var updateMsg = await NextMessage<IndexUpdateMessage>(messages);
+                    Assert.That(updateMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(updateMsg.KeyRow!.Length, Is.EqualTo(2));
                     Assert.That(updateMsg.KeyRow!.Span[0].Value, Is.Null);
-                    Assert.That(updateMsg.KeyRow!.Span[1].Value, Is.EqualTo("val"));
+                    Assert.That(updateMsg.KeyRow!.Span[1].Value, Is.EqualTo("val1"));
                     Assert.That(updateMsg.NewRow.Length, Is.EqualTo(2));
                     Assert.That(updateMsg.NewRow.Span[0].Value, Is.EqualTo("1"));
-                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1"));
+                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1_updated"));
+
+                    // Remaining updates
+                    for (var updateCount = 0; updateCount < 14999; updateCount++)
+                        await NextMessage<IndexUpdateMessage>(messages);
 
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -184,43 +249,51 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 async (slotName, tableName, publicationName) =>
                 {
                     await using var c = await OpenConnectionAsync();
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-ALTER TABLE {tableName} REPLICA IDENTITY FULL;
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    ALTER TABLE {tableName} REPLICA IDENTITY FULL;
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"UPDATE {tableName} SET name='val1' WHERE name='val'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"UPDATE {tableName} SET name='val1_updated' WHERE id = 1;
+                                                    UPDATE {tableName} SET name = md5(name) WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('f'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Update
                     var updateMsg = await NextMessage<FullUpdateMessage>(messages);
+                    Assert.That(updateMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(updateMsg.OldRow!.Length, Is.EqualTo(2));
                     Assert.That(updateMsg.OldRow!.Span[0].Value, Is.EqualTo("1"));
-                    Assert.That(updateMsg.OldRow!.Span[1].Value, Is.EqualTo("val"));
+                    Assert.That(updateMsg.OldRow!.Span[1].Value, Is.EqualTo("val1"));
                     Assert.That(updateMsg.NewRow.Length, Is.EqualTo(2));
                     Assert.That(updateMsg.NewRow.Span[0].Value, Is.EqualTo("1"));
-                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1"));
+                    Assert.That(updateMsg.NewRow.Span[1].Value, Is.EqualTo("val1_updated"));
+
+                    // Remaining updates
+                    for (var updateCount = 0; updateCount < 14999; updateCount++)
+                        await NextMessage<FullUpdateMessage>(messages);
 
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     Assert.That(async () => await messages.MoveNextAsync(), Throws.Exception.AssignableTo<OperationCanceledException>()
@@ -236,39 +309,47 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 async (slotName, tableName, publicationName) =>
                 {
                     await using var c = await OpenConnectionAsync();
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"DELETE FROM {tableName} WHERE name='val2'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"DELETE FROM {tableName} WHERE id = 1;
+                                                    DELETE FROM {tableName} WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Delete
                     var deleteMsg = await NextMessage<KeyDeleteMessage>(messages);
+                    Assert.That(deleteMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(deleteMsg.KeyRow!.Length, Is.EqualTo(2));
-                    Assert.That(deleteMsg.KeyRow.Span[0].Value, Is.EqualTo("2"));
+                    Assert.That(deleteMsg.KeyRow.Span[0].Value, Is.EqualTo("1"));
                     Assert.That(deleteMsg.KeyRow.Span[1].Value, Is.Null);
 
+                    // Remaining deletes
+                    for (var deleteCount = 0; deleteCount < 14999; deleteCount++)
+                        await NextMessage<KeyDeleteMessage>(messages);
+
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -282,41 +363,49 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 {
                     await using var c = await OpenConnectionAsync();
                     var indexName = $"i_{tableName.Substring(2)}";
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-CREATE UNIQUE INDEX {indexName} ON {tableName} (name);
-ALTER TABLE {tableName} REPLICA IDENTITY USING INDEX {indexName};
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    CREATE UNIQUE INDEX {indexName} ON {tableName} (name);
+                                                    ALTER TABLE {tableName} REPLICA IDENTITY USING INDEX {indexName};
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"DELETE FROM {tableName} WHERE name='val2'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"DELETE FROM {tableName} WHERE id = 1;
+                                                    DELETE FROM {tableName} WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('i'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Delete
                     var deleteMsg = await NextMessage<KeyDeleteMessage>(messages);
+                    Assert.That(deleteMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(deleteMsg.KeyRow!.Length, Is.EqualTo(2));
                     Assert.That(deleteMsg.KeyRow.Span[0].Value, Is.Null);
-                    Assert.That(deleteMsg.KeyRow.Span[1].Value, Is.EqualTo("val2"));
+                    Assert.That(deleteMsg.KeyRow.Span[1].Value, Is.EqualTo("val1"));
+
+                    // Remaining deletes
+                    for (var deleteCount = 0; deleteCount < 14999; deleteCount++)
+                        await NextMessage<KeyDeleteMessage>(messages);
 
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -329,40 +418,48 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 async (slotName, tableName, publicationName) =>
                 {
                     await using var c = await OpenConnectionAsync();
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-ALTER TABLE {tableName} REPLICA IDENTITY FULL;
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    ALTER TABLE {tableName} REPLICA IDENTITY FULL;
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
-                    await c.ExecuteNonQueryAsync($"DELETE FROM {tableName} WHERE name='val2'");
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"DELETE FROM {tableName} WHERE id = 1;
+                                                    DELETE FROM {tableName} WHERE id > 1");
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('f'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Delete
                     var deleteMsg = await NextMessage<FullDeleteMessage>(messages);
+                    Assert.That(deleteMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(deleteMsg.OldRow!.Length, Is.EqualTo(2));
-                    Assert.That(deleteMsg.OldRow.Span[0].Value, Is.EqualTo("2"));
-                    Assert.That(deleteMsg.OldRow.Span[1].Value, Is.EqualTo("val2"));
+                    Assert.That(deleteMsg.OldRow.Span[0].Value, Is.EqualTo("1"));
+                    Assert.That(deleteMsg.OldRow.Span[1].Value, Is.EqualTo("val1"));
+
+                    // Remaining deletes
+                    for (var deleteCount = 0; deleteCount < 14999; deleteCount++)
+                        await NextMessage<FullDeleteMessage>(messages);
 
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -380,11 +477,9 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                 {
                     await using var c = await OpenConnectionAsync();
                     TestUtil.MinimumPgVersion(c, "11.0", "Replication of TRUNCATE commands was introduced in PostgreSQL 11");
-                    await c.ExecuteNonQueryAsync(@$"
-CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
-INSERT INTO {tableName} (name) VALUES ('val'), ('val2');
-CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
-");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, name TEXT NOT NULL);
+                                                    INSERT INTO {tableName} (name) VALUES ('val1');
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
                     var rc = await OpenReplicationConnectionAsync();
                     var slot = await rc.CreatePgOutputReplicationSlot(slotName);
                     StringBuilder sb = new StringBuilder("TRUNCATE TABLE ").Append(tableName);
@@ -392,31 +487,43 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                         sb.Append(" RESTART IDENTITY");
                     if (truncateOptionFlags.HasFlag(TruncateOptions.Cascade))
                         sb.Append(" CASCADE");
+                    sb.Append($"; INSERT INTO {tableName} (name) SELECT 'val' || i::text FROM generate_series(1, 15000) s(i);");
+
+                    await using var tran = await c.BeginTransactionAsync();
                     await c.ExecuteNonQueryAsync(sb.ToString());
+                    await tran.CommitAsync();
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     // Begin Transaction
-                    _ = await NextMessage<BeginMessage>(messages);
+                    var transactionXid = await AssertTransactionStart(messages);
 
                     // Relation
                     var relMsg = await NextMessage<RelationMessage>(messages);
+                    Assert.That(relMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(relMsg.RelationReplicaIdentitySetting, Is.EqualTo('d'));
                     Assert.That(relMsg.Namespace, Is.EqualTo("public"));
                     Assert.That(relMsg.RelationName, Is.EqualTo(tableName));
                     Assert.That(relMsg.Columns.Length, Is.EqualTo(2));
-                    Assert.That(relMsg.Columns.Span[0].ColumnName, Is.EqualTo("id"));
-                    Assert.That(relMsg.Columns.Span[1].ColumnName, Is.EqualTo("name"));
+                    Assert.That(relMsg.Columns[0].ColumnName, Is.EqualTo("id"));
+                    Assert.That(relMsg.Columns[1].ColumnName, Is.EqualTo("name"));
 
                     // Truncate
                     var truncateMsg = await NextMessage<TruncateMessage>(messages);
+                    Assert.That(truncateMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                     Assert.That(truncateMsg.Options, Is.EqualTo(truncateOptionFlags));
                     Assert.That(truncateMsg.RelationIds.Length, Is.EqualTo(1));
 
+                    // Remaining inserts
+                    // Since the inserts run in the same transaction as the truncate, we'll
+                    // get a RelationMessage after every StreamStartMessage
+                    for (var insertCount = 0; insertCount < 15000; insertCount++)
+                        await NextMessage<InsertMessage>(messages, expectRelationMessage: true);
+
                     // Commit Transaction
-                    _ = await NextMessage<CommitMessage>(messages);
+                    await AssertTransactionCommit(messages);
 
                     streamingCts.Cancel();
                     await AssertReplicationCancellation(messages);
@@ -438,7 +545,7 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     await c.ExecuteNonQueryAsync($"INSERT INTO {tableName} (name) VALUES ('value 1'), ('value 2');");
 
                     using var streamingCts = new CancellationTokenSource();
-                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, new PgOutputReplicationOptions(publicationName), streamingCts.Token))
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
                         .GetAsyncEnumerator();
 
                     await NextMessage<BeginMessage>(messages);
@@ -446,10 +553,191 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     await rc.DisposeAsync();
                 }, nameof(DisposeWhileReplicating));
 
-        async ValueTask<TExpected> NextMessage<TExpected>(IAsyncEnumerator<PgOutputReplicationMessage> enumerator)
+        [TestCase(true)]
+        [TestCase(false)]
+        [Test(Description = "Tests whether logical decoding messages get replicated as Logical Replication Protocol Messages on PostgreSQL 14 and above")]
+        public Task LogicalDecodingMessage(bool writeMessages)
+            => SafeReplicationTest(
+                async (slotName, tableName, publicationName) =>
+                {
+                    const string prefix = "My test Prefix";
+                    const string transactionalMessage = "A transactional message";
+                    const string nonTransactionalMessage = "A non-transactional message";
+                    await using var c = await OpenConnectionAsync();
+                    TestUtil.MinimumPgVersion(c, "14.0", "Replication of logical decoding messages was introduced in PostgreSQL 14");
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (id INT PRIMARY KEY, name TEXT NOT NULL);
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
+                    var rc = await OpenReplicationConnectionAsync();
+                    var slot = await rc.CreatePgOutputReplicationSlot(slotName);
+
+                    await using var tran = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"SELECT pg_logical_emit_message(true, '{prefix}', '{transactionalMessage}');
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(1, 15000) s(i);", tran);
+                    await tran.CommitAsync();
+
+                    await using var tran2 = await c.BeginTransactionAsync();
+                    await c.ExecuteNonQueryAsync(@$"SELECT pg_logical_emit_message(false, '{prefix}', '{nonTransactionalMessage}');
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(15001, 15010) s(i);
+                                                    SELECT pg_logical_emit_message(true, '{prefix}', '{transactionalMessage}');
+                                                    INSERT INTO {tableName} SELECT i, 'val' || i::text FROM generate_series(15011, 30000) s(i);
+                                                    SELECT pg_logical_emit_message(false, '{prefix}', '{nonTransactionalMessage}');
+                                                    ", tran2);
+                    await tran2.RollbackAsync();
+                    await c.ExecuteNonQueryAsync(@$"SELECT pg_switch_wal();");
+
+                    using var streamingCts = new CancellationTokenSource();
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot,
+                            GetOptions(publicationName, writeMessages), streamingCts.Token))
+                        .GetAsyncEnumerator();
+
+                    // Begin Transaction 1
+                    var transactionXid = await AssertTransactionStart(messages);
+
+                    // LogicalDecodingMessage
+                    if (writeMessages)
+                    {
+                        var msg = await NextMessage<LogicalDecodingMessage>(messages);
+                        Assert.That(msg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
+                        Assert.That(msg.Flags, Is.EqualTo(1));
+                        Assert.That(msg.Prefix, Is.EqualTo(prefix));
+                        Assert.That(msg.Data.Length, Is.EqualTo(transactionalMessage.Length));
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                    }
+
+                    // Relation
+                    await NextMessage<RelationMessage>(messages);
+
+                    // Inserts
+                    for (var insertCount = 0; insertCount < 15000; insertCount++)
+                        await NextMessage<InsertMessage>(messages);
+
+                    // Commit Transaction 1
+                    await AssertTransactionCommit(messages);
+
+                    // LogicalDecodingMessage 1 (non-transactional)
+                    if (writeMessages)
+                    {
+                        var msg = await NextMessage<LogicalDecodingMessage>(messages);
+                        Assert.That(msg.TransactionXid, Is.Null);
+                        Assert.That(msg.Flags, Is.EqualTo(0));
+                        Assert.That(msg.Prefix, Is.EqualTo(prefix));
+                        Assert.That(msg.Data.Length, Is.EqualTo(nonTransactionalMessage.Length));
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                    }
+
+                    if (IsStreaming)
+                    {
+                        // Begin Transaction 2
+                        transactionXid = await AssertTransactionStart(messages);
+
+                        // Relation
+                        await NextMessage<RelationMessage>(messages);
+
+                        // Inserts
+                        for (var insertCount = 0; insertCount < 10; insertCount++)
+                            await NextMessage<InsertMessage>(messages);
+
+                        // LogicalDecodingMessage 2 (transactional)
+                        if (writeMessages)
+                        {
+                            var msg = await NextMessage<LogicalDecodingMessage>(messages);
+                            Assert.That(msg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
+                            Assert.That(msg.Flags, Is.EqualTo(1));
+                            Assert.That(msg.Prefix, Is.EqualTo(prefix));
+                            Assert.That(msg.Data.Length, Is.EqualTo(transactionalMessage.Length));
+                            var buffer = new MemoryStream();
+                            await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                            Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                        }
+
+                        // Further inserts
+                        // We don't try to predict how many insert messages we get here
+                        // since the streaming transaction will most likely abort before
+                        // we reach the expected number
+                        while (await messages.MoveNextAsync() && messages.Current is InsertMessage
+                                   || messages.Current is StreamStopMessage
+                                   && await messages.MoveNextAsync()
+                                   && messages.Current is StreamStartMessage
+                                   && await messages.MoveNextAsync()
+                                   && messages.Current is InsertMessage)
+                        {
+                            // Ignore
+                        }
+                    }
+                    else if (writeMessages)
+                        await messages.MoveNextAsync();
+
+                    // LogicalDecodingMessage 3 (non-transactional)
+                    if (writeMessages)
+                    {
+                        var msg = (LogicalDecodingMessage)messages.Current;
+                        Assert.That(msg.TransactionXid, Is.Null);
+                        Assert.That(msg.Flags, Is.EqualTo(0));
+                        Assert.That(msg.Prefix, Is.EqualTo(prefix));
+                        Assert.That(msg.Data.Length, Is.EqualTo(nonTransactionalMessage.Length));
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                        if (IsStreaming)
+                            await messages.MoveNextAsync();
+                    }
+
+                    // Rollback Transaction 2
+                    if (IsStreaming)
+                        Assert.That(messages.Current, Is.TypeOf<StreamAbortMessage>());
+
+                    streamingCts.Cancel();
+                    await AssertReplicationCancellation(messages);
+                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
+                }, $"{GetObjectName(nameof(LogicalDecodingMessage))}_m_{BoolToChar(writeMessages)}");
+
+        async Task<uint?> AssertTransactionStart(IAsyncEnumerator<PgOutputReplicationMessage> messages)
+        {
+            Assert.True(await messages.MoveNextAsync());
+            if (IsStreaming)
+            {
+                Assert.That(messages.Current, Is.TypeOf<StreamStartMessage>());
+                var streamStartMessage = (messages.Current as StreamStartMessage)!;
+                return streamStartMessage.TransactionXid;
+            }
+            Assert.That(messages.Current, Is.TypeOf<BeginMessage>());
+            var beginMessage = (messages.Current as BeginMessage)!;
+            return beginMessage.TransactionXid;
+        }
+
+        async Task AssertTransactionCommit(IAsyncEnumerator<PgOutputReplicationMessage> messages)
+        {
+            Assert.True(await messages.MoveNextAsync());
+            if (IsStreaming)
+            {
+                Assert.That(messages.Current, Is.TypeOf<StreamStopMessage>());
+                Assert.True(await messages.MoveNextAsync());
+                Assert.That(messages.Current, Is.TypeOf<StreamCommitMessage>());
+            }
+            else
+                Assert.That(messages.Current, Is.TypeOf<CommitMessage>());
+        }
+
+        async ValueTask<TExpected> NextMessage<TExpected>(IAsyncEnumerator<PgOutputReplicationMessage> enumerator, bool expectRelationMessage = false)
             where TExpected : PgOutputReplicationMessage
         {
             Assert.True(await enumerator.MoveNextAsync());
+            if (IsStreaming && enumerator.Current is StreamStopMessage)
+            {
+                Assert.True(await enumerator.MoveNextAsync());
+                Assert.That(enumerator.Current, Is.TypeOf<StreamStartMessage>());
+                Assert.True(await enumerator.MoveNextAsync());
+                if (expectRelationMessage)
+                {
+                    Assert.That(enumerator.Current, Is.TypeOf<RelationMessage>());
+                    Assert.True(await enumerator.MoveNextAsync());
+                }
+            }
+
             Assert.That(enumerator.Current, Is.TypeOf<TExpected>());
             return (TExpected)enumerator.Current!;
         }
@@ -485,6 +773,27 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
             }
         }
 
+        PgOutputReplicationOptions GetOptions(string publicationName, bool? messages = null)
+            => new(publicationName, _protocolVersion, _binary, _streaming, messages);
+
+        Task SafePgOutputReplicationTest(Func<string, string, string, Task> testAction, [CallerMemberName] string memberName = "")
+            => SafeReplicationTest(testAction, GetObjectName(memberName));
+
+        string GetObjectName(string memberName)
+        {
+            var sb = new StringBuilder(memberName)
+                .Append("_v").Append(_protocolVersion);
+            if (_binary.HasValue)
+                sb.Append("_b_").Append(BoolToChar(_binary.Value));
+            if (_streaming.HasValue)
+                sb.Append("_s_").Append(BoolToChar(_streaming.Value));
+            return sb.ToString();
+        }
+
+        static char BoolToChar(bool value)
+            => value ? 't' : 'f';
+
+
         protected override string Postfix => "pgoutput_l";
 
         [OneTimeSetUp]
@@ -492,6 +801,30 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
         {
             await using var c = await OpenConnectionAsync();
             TestUtil.MinimumPgVersion(c, "10.0", "The Logical Replication Protocol (via pgoutput plugin) was introduced in PostgreSQL 10");
+            if (_protocolVersion > 1)
+                TestUtil.MinimumPgVersion(c, "14.0", "Logical Streaming Replication Protocol version 2 was introduced in PostgreSQL 14");
+            if (IsBinary)
+                TestUtil.MinimumPgVersion(c, "14.0", "Sending replication values in binary representation was introduced in PostgreSQL 14");
+            if (IsStreaming)
+                TestUtil.MinimumPgVersion(c, "14.0", "Streaming of in-progress transactions was introduced in PostgreSQL 14");
+        }
+
+        public enum ProtocolVersion : ulong
+        {
+            V1 = 1UL,
+            V2 = 2UL,
+        }
+        public enum ReplicationDataMode
+        {
+            DefaultReplicationDataMode,
+            TextReplicationDataMode,
+            BinaryReplicationDataMode,
+        }
+        public enum TransactionMode
+        {
+            DefaultTransactionMode,
+            NonStreamingTransactionMode,
+            StreamingTransactionMode,
         }
     }
 }

--- a/test/Npgsql.Tests/Replication/SafeReplicationTestBase.cs
+++ b/test/Npgsql.Tests/Replication/SafeReplicationTestBase.cs
@@ -46,7 +46,7 @@ namespace Npgsql.Tests.Replication
             return c;
         }
 
-        private protected static async Task AssertReplicationCancellation<T>(IAsyncEnumerator<T> enumerator)
+        private protected static async Task AssertReplicationCancellation<T>(IAsyncEnumerator<T> enumerator, bool streamingStarted = true)
         {
             try
             {
@@ -57,7 +57,7 @@ namespace Npgsql.Tests.Replication
             }
             catch (Exception e)
             {
-                Assert.That(e, CurrentServerVersion >= Pg10Version
+                Assert.That(e, streamingStarted && CurrentServerVersion >= Pg10Version
                     ? Is.AssignableTo<OperationCanceledException>()
                         .With.InnerException.InstanceOf<PostgresException>()
                         .And.InnerException.Property(nameof(PostgresException.SqlState))


### PR DESCRIPTION
This PR contains replication changes for PostgreSQL 14 including Logical Replication Protocol version 2.
It adds:

- [X] Support for [streaming of in-progress transactions](https://github.com/postgres/postgres/commit/464824323e57dc4b397e8b05854d779908b55304)
- [X] Support for [logical decoding messages](https://github.com/postgres/postgres/commit/ac4645c0157fc5fcef0af8ff571512aa284a2cec)
- ~Support for [logical replication data in binary format](https://github.com/postgres/postgres/commit/9de77b5453130242654ff0b30a551c9c862ed661)~ [This will follow in a separate PR]
- [X] Tests

Since this PR targets Npgsql 6 and it is the first revision of the Npgsql logical replication API which we had considered as somewhat instable up to now, I also plan to introduce a few breaking changes .

As first breaking change, this commit changes RelationMessage.Columns and TruncateMessage.RelationIds to use ImmutableArray<T>.