### PR TITLE
Add helper to conditionally ignore tests that fail because of a feature that is not supported by the backend and use it for xml

### DIFF
--- a/test/Npgsql.Tests/SystemTransactionTests.cs
+++ b/test/Npgsql.Tests/SystemTransactionTests.cs
@@ -278,43 +278,33 @@ namespace Npgsql.Tests
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1737")]
         public void Bug1737()
         {
-            try
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
-                {
-                    Pooling = false,
-                    Enlist = true
-                };
+                Pooling = false,
+                Enlist = true
+            };
 
-                // Case 1
-                using (var scope = new TransactionScope())
-                {
-                    using (var conn = OpenConnection(csb))
-                    using (var cmd = new NpgsqlCommand("SELECT 1", conn))
-                        cmd.ExecuteNonQuery();
-                    scope.Complete();
-                }
-
-                // Case 2
-                using (var scope = new TransactionScope())
-                {
-                    using (var conn1 = OpenConnection(csb))
-                    using (var cmd = new NpgsqlCommand("SELECT 1", conn1))
-                        cmd.ExecuteNonQuery();
-
-                    using (var conn2 = OpenConnection(csb))
-                    using (var cmd = new NpgsqlCommand("SELECT 1", conn2))
-                        cmd.ExecuteNonQuery();
-
-                    scope.Complete();
-                }
+            // Case 1
+            using (var scope = new TransactionScope())
+            {
+                using (var conn = OpenConnection(csb))
+                using (var cmd = new NpgsqlCommand("SELECT 1", conn))
+                    cmd.ExecuteNonQuery();
+                scope.Complete();
             }
-            catch (TransactionAbortedException e) when (e.InnerException is PostgresException { SqlState: "55000"/*object_not_in_prerequisite_state*/ })
+
+            // Case 2
+            using (var scope = new TransactionScope())
             {
-                throw new IgnoreException(
-                    "Prepared transactions are disabled. " +
-                    "You need to set max_prepared_transactions to a value " +
-                    "greater than zero in your postgresql.conf to enable them.");
+                using (var conn1 = OpenConnection(csb))
+                using (var cmd = new NpgsqlCommand("SELECT 1", conn1))
+                    cmd.ExecuteNonQuery();
+
+                using (var conn2 = OpenConnection(csb))
+                using (var cmd = new NpgsqlCommand("SELECT 1", conn2))
+                    cmd.ExecuteNonQuery();
+
+                scope.Complete();
             }
         }
 

--- a/test/Npgsql.Tests/Types/TextTests.cs
+++ b/test/Npgsql.Tests/Types/TextTests.cs
@@ -229,35 +229,28 @@ namespace Npgsql.Tests.Types
         [Test]
         public async Task Xml()
         {
-            try
-            {
-                using var conn = await OpenConnectionAsync();
-                using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
-                const string expected = "<root>foo</root>";
-                var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Xml);
-                var p2 = new NpgsqlParameter("p2", DbType.Xml);
-                Assert.That(p1.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Xml));
-                Assert.That(p2.DbType, Is.EqualTo(DbType.Xml));
-                cmd.Parameters.Add(p1);
-                cmd.Parameters.Add(p2);
-                p1.Value = p2.Value = expected;
-                using var reader = await cmd.ExecuteReaderAsync();
-                reader.Read();
+            await using var conn = await OpenConnectionAsync();
+            await IgnoreIfFeatureNotSupportedAsync(conn, "SELECT '<x>t</x>'::xml::text");
 
-                for (var i = 0; i < cmd.Parameters.Count; i++)
-                {
-                    Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(string)));
-                    Assert.That(reader.GetDataTypeName(i), Is.EqualTo("xml"));
-                    Assert.That(reader.GetString(i), Is.EqualTo(expected));
-                    Assert.That(reader.GetFieldValue<string>(i), Is.EqualTo(expected));
-                    Assert.That(reader.GetValue(i), Is.EqualTo(expected));
-                }
-            }
-            catch (PostgresException e) when (e.SqlState == "0A000"/*feature_not_supported*/)
+            using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
+            const string expected = "<root>foo</root>";
+            var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Xml);
+            var p2 = new NpgsqlParameter("p2", DbType.Xml);
+            Assert.That(p1.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Xml));
+            Assert.That(p2.DbType, Is.EqualTo(DbType.Xml));
+            cmd.Parameters.Add(p1);
+            cmd.Parameters.Add(p2);
+            p1.Value = p2.Value = expected;
+            await using var reader = await cmd.ExecuteReaderAsync();
+            reader.Read();
+
+            for (var i = 0; i < cmd.Parameters.Count; i++)
             {
-                throw new IgnoreException(
-                    "The XML data type is not supported by your database." +
-                    " You need to rebuild PostgreSQL using --with-libxml to enable this test.");
+                Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(string)));
+                Assert.That(reader.GetDataTypeName(i), Is.EqualTo("xml"));
+                Assert.That(reader.GetString(i), Is.EqualTo(expected));
+                Assert.That(reader.GetFieldValue<string>(i), Is.EqualTo(expected));
+                Assert.That(reader.GetValue(i), Is.EqualTo(expected));
             }
         }
 


### PR DESCRIPTION
When preparing my system to write tests for the replication PR I noticed
that the test suite fails on my self-built PostgreSQL instance with
default settings because it is lacking features (xml) or has them
disabled by default (prepared transations).
This PR makes us ignore the tests in case of excepions that come
from the fact that the features are missing.