### PR TITLE
Add typname condition to invoke composite index

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -154,7 +154,7 @@ FROM (
     LEFT JOIN pg_class AS elemcls ON (elemcls.oid = elemtyp.typrelid)
     LEFT JOIN pg_proc AS elemproc ON elemproc.oid = elemtyp.typreceive
 ) AS typ_and_elem_type
-JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
+JOIN pg_namespace AS ns ON (typname = typname AND ns.oid = typnamespace)
 WHERE
     typtype IN ('b', 'r', 'e', 'd') OR -- Base, range, enum, domain
     (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR -- User-defined free-standing composites (not table composites) by default
@@ -169,7 +169,7 @@ ORDER BY ord;
 -- Load field definitions for (free-standing) composite types
 SELECT typ.oid, att.attname, att.atttypid
 FROM pg_type AS typ
-JOIN pg_namespace AS ns ON (ns.oid = typ.typnamespace)
+JOIN pg_namespace AS ns ON (typ.typname = typ.typname AND ns.oid = typ.typnamespace)
 JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
 JOIN pg_attribute AS att ON (att.attrelid = typ.typrelid)
 WHERE


### PR DESCRIPTION
Change prompted by this [comment](https://github.com/npgsql/npgsql/issues/3095#issuecomment-846451614)

The type loading issue seems to stem from the fact that the `pg_type.typnamespace` is second in a composite index with `pg_type.typname` being first. These changes encourage the database engine to use the defined index. Running explain with these change reduced the execution cost to less than 1K from over 10K. 

Tested and confirm with the following simple code (using Dapper as ORM):
```
const string connString = "Server=;Port=5432;Database=;User Id=;Password=;";

Console.WriteLine("Creating connection");
using (var conn = new NpgsqlConnection(connString))
{
    Console.WriteLine("Getting IS tables");
    conn.Execute("SELECT * FROM information_schema.tables;");
}
            
Console.WriteLine("Done!");
```

Against AWS Aurora Postgres, the current Npgsql version (v5.0.5) times out. With changes, code completes. 