### PR TITLE
Improve WriteStringChunked logic for dealing with Unicode characters outside the basic multilingual plane

### DIFF
--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -500,7 +500,7 @@ namespace Npgsql.Internal
         internal void WriteStringChunked(char[] chars, int charIndex, int charCount,
                                          bool flush, out int charsUsed, out bool completed)
         {
-            if (WriteSpaceLeft < _textEncoder.GetByteCount(chars, charIndex, Math.Min(2, charCount), flush: false))
+            if (WriteSpaceLeft < _textEncoder.GetByteCount(chars, charIndex, char.IsHighSurrogate(chars[charIndex]) ? 2 : 1, flush: false))
             {
                 charsUsed = 0;
                 completed = false;
@@ -520,7 +520,7 @@ namespace Npgsql.Internal
             fixed (char* sPtr = s)
             fixed (byte* bufPtr = Buffer)
             {
-                if (WriteSpaceLeft < _textEncoder.GetByteCount(sPtr + charIndex, Math.Min(2, charCount), flush: false))
+                if (WriteSpaceLeft < _textEncoder.GetByteCount(sPtr + charIndex, char.IsHighSurrogate(*(sPtr + charIndex)) ? 2 : 1, flush: false))
                 {
                     charsUsed = 0;
                     completed = false;


### PR DESCRIPTION
Off the back of https://github.com/npgsql/npgsql/pull/3734#issuecomment-851323762, I think this logic is more correct and makes it more obvious _why_ the count is conditional

 - if we are on a high surrogate, need to find the byte count for both surrogates
 - if we are not on a high surrogate, only need to check there is space to encode a single char (we can't be on a low surrogate, that would have required us to encode only the high surrogate on the last pass, which is not possible)