### PR TITLE
Fix connection string parsing for IPv6 host names.

### DIFF
--- a/src/Npgsql/ClusterStateCache.cs
+++ b/src/Npgsql/ClusterStateCache.cs
@@ -31,6 +31,8 @@ namespace Npgsql
         internal static void RemoveClusterState(string host, int port)
             => Clusters.TryRemove(new ClusterIdentifier(host, port), out _);
 
+        internal static void Clear()  => Clusters.Clear();
+
         readonly struct ClusterIdentifier : IEquatable<ClusterIdentifier>
         {
             readonly string _host;

--- a/src/Npgsql/MultiHostConnectorPool.cs
+++ b/src/Npgsql/MultiHostConnectorPool.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Npgsql.Netstandard20;
 
 namespace Npgsql
 {
@@ -34,11 +35,7 @@ namespace Npgsql
                     if (otherColon == -1 || portSeparator > ipv6End && otherColon < ipv6End)
                     {
                         var span = host.AsSpan();
-                        port = int.Parse(span.Slice(portSeparator + 1)
-#if NETSTANDARD2_0
-                                .ToString()
-#endif
-                        );
+                        port = span.Slice(portSeparator + 1).ParseInt();
                         host = span.Slice(0, portSeparator).ToString();
                     }
                 }

--- a/src/Npgsql/MultiHostConnectorPool.cs
+++ b/src/Npgsql/MultiHostConnectorPool.cs
@@ -26,11 +26,21 @@ namespace Npgsql
             {
                 var host = hosts[i].Trim();
                 var port = settings.Port;
-                var portSeparator = host.IndexOf(':');
+                var portSeparator = host.LastIndexOf(':');
                 if (portSeparator != -1)
                 {
-                    port = int.Parse(host.Substring(portSeparator + 1));
-                    host = host.Substring(0, portSeparator);
+                    var otherColon = host.LastIndexOf(':', portSeparator - 1);
+                    var ipv6End = host.LastIndexOf(']');
+                    if (otherColon == -1 || portSeparator > ipv6End && otherColon < ipv6End)
+                    {
+                        var span = host.AsSpan();
+                        port = int.Parse(span.Slice(portSeparator + 1)
+#if NETSTANDARD2_0
+                                .ToString()
+#endif
+                        );
+                        host = span.Slice(0, portSeparator).ToString();
+                    }
                 }
                 var poolSettings = settings.Clone();
                 poolSettings.Host = host;

--- a/src/Npgsql/Netstandard20/ReadOnlySpanOfCharExtensions.cs
+++ b/src/Npgsql/Netstandard20/ReadOnlySpanOfCharExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Npgsql.Netstandard20
+{
+    static class ReadOnlySpanOfCharExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ParseInt(this ReadOnlySpan<char> span)
+            => int.Parse(span
+#if NETSTANDARD2_0
+                    .ToString()
+#endif
+            );
+    }
+}

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -17,6 +17,7 @@ using System.Transactions;
 using Npgsql.Internal;
 using Npgsql.Logging;
 using Npgsql.NameTranslation;
+using Npgsql.Netstandard20;
 using Npgsql.TypeMapping;
 using Npgsql.Util;
 using NpgsqlTypes;
@@ -197,11 +198,7 @@ namespace Npgsql
                     if ((otherColon == -1 || portSeparator > ipv6End && otherColon < ipv6End))
                     {
                         var span = settings.Host.AsSpan();
-                        settings.Port = int.Parse(span.Slice(portSeparator + 1)
-#if NETSTANDARD2_0
-                                .ToString()
-#endif
-                        );
+                        settings.Port = span.Slice(portSeparator + 1).ParseInt();
                         settings.Host = span.Slice(0, portSeparator).ToString();
                     }
                 }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -190,17 +190,10 @@ namespace Npgsql
                     throw new NotSupportedException("Target Session Attributes other then Any is only supported with multiple hosts");
                 }
 
-                var portSeparator = settings.Host!.LastIndexOf(':');
-                if (portSeparator != -1 && !Path.IsPathRooted(settings.Host))
+                if (!Path.IsPathRooted(settings.Host) && NpgsqlConnectionStringBuilder.TrySplitHostPort(settings.Host!.AsSpan(), out var newHost, out var newPort))
                 {
-                    var otherColon = settings.Host!.LastIndexOf(':', portSeparator - 1);
-                    var ipv6End = settings.Host!.LastIndexOf(']');
-                    if ((otherColon == -1 || portSeparator > ipv6End && otherColon < ipv6End))
-                    {
-                        var span = settings.Host.AsSpan();
-                        settings.Port = span.Slice(portSeparator + 1).ParseInt();
-                        settings.Host = span.Slice(0, portSeparator).ToString();
-                    }
+                    settings.Host = newHost;
+                    settings.Port = newPort;
                 }
             }
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -548,12 +548,18 @@ namespace Npgsql.Tests
                 "tcp://localhost:5432",
                 "tcp://localhost:5432"
             })]
-        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3802")]
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3802"), NonParallelizable]
         public async Task<string[]> ConnectionString_Host(string host)
         {
             var numberOfHosts = host.Split(',').Length;
-            if (IsMultiplexing && numberOfHosts > 1)
-                throw new SuccessException("Multiple hosts in connection string is ignored for Multiplexing");
+            if (numberOfHosts > 1)
+            {
+                if (IsMultiplexing)
+                    throw new SuccessException("Multiple hosts in connection string is ignored for Multiplexing");
+                // We reset the cluster's state for multiple hosts
+                // Because other tests might have marked some of the hosts as disabled
+                ClusterStateCache.Clear();
+            }
 
             var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -537,12 +537,13 @@ namespace Npgsql.Tests
         [TestCase("[::1]:5432", ExpectedResult = new []{"tcp://[::1]:5432"})]
         [TestCase("localhost", ExpectedResult = new []{"tcp://localhost:5432"})]
         [TestCase("localhost:5432", ExpectedResult = new []{"tcp://localhost:5432"})]
-        [TestCase("127.0.0.1,127.0.0.1:5432,::1,[::1]:5432,localhost,localhost:5432",
+        [TestCase("127.0.0.1,127.0.0.1:5432,::1,[::1],[::1]:5432,localhost,localhost:5432",
             ExpectedResult = new []
             {
                 "tcp://127.0.0.1:5432",
                 "tcp://127.0.0.1:5432",
                 "tcp://::1:5432",
+                "tcp://[::1]:5432",
                 "tcp://[::1]:5432",
                 "tcp://localhost:5432",
                 "tcp://localhost:5432"
@@ -557,7 +558,7 @@ namespace Npgsql.Tests
             var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 Host = host,
-                LoadBalanceHosts = numberOfHosts > 1
+                MaxPoolSize = 1
             }.ConnectionString;
 
             var connections = new NpgsqlConnection?[numberOfHosts];

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -518,6 +518,9 @@ namespace Npgsql.Tests
         public void IntegrationTest([Values] bool loadBalancing, [Values] bool alwaysCheckHostState)
         {
             PoolManager.Reset();
+            // We reset the cluster's state for multiple hosts
+            // Because other tests might have marked some of the hosts as disabled
+            ClusterStateCache.Clear();
 
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {


### PR DESCRIPTION
This was broken by changes introduced with the multiple hosts feature.

While at it, add a pretty pointless allocation optimization using
ReadonlySpan<char>.

Fixes #3802
