### PR TITLE
Make ReplicationConnection.PostgreSqlVersion public

### DIFF
--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -219,25 +219,19 @@ namespace Npgsql.Internal
         /// </summary>
         protected static Version ParseServerVersion(string value)
         {
-            var versionString = value.AsSpan().TrimStart();
+            var versionString = value.TrimStart();
             for (var idx = 0; idx != versionString.Length; ++idx)
             {
                 var c = versionString[idx];
-                if (char.IsDigit(c) || c == '.')
-                    continue;
-
-                versionString = versionString.Slice(0, idx);
-                break;
+                if (!char.IsDigit(c) && c != '.')
+                {
+                    versionString = versionString.Substring(0, idx);
+                    break;
+                }
             }
-#if NETSTANDARD2_0 || NETSTANDARD2_1
-            if (!versionString.Contains(".".AsSpan(), StringComparison.Ordinal))
-                return new Version(versionString.ToString() + ".0");
-            return new Version(versionString.ToString());
-#else
-            if (!versionString.Contains('.'))
-                return new Version(string.Concat(versionString, ".0".AsSpan()));
-            return Version.Parse(versionString);
-#endif
+            if (!versionString.Contains("."))
+                versionString += ".0";
+            return new Version(versionString);
         }
 
         #endregion Misc

--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -229,9 +229,15 @@ namespace Npgsql.Internal
                 versionString = versionString.Slice(0, idx);
                 break;
             }
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+            if (!versionString.Contains(".".AsSpan(), StringComparison.Ordinal))
+                return new Version(versionString.ToString() + ".0");
+            return new Version(versionString.ToString());
+#else
             if (!versionString.Contains('.'))
                 return new Version(string.Concat(versionString, ".0".AsSpan()));
-            return new Version(versionString.ToString());
+            return Version.Parse(versionString);
+#endif
         }
 
         #endregion Misc

--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -32,19 +32,27 @@ namespace Npgsql.Internal
         /// The hostname of IP address of the database.
         /// </summary>
         public string Host { get; }
+
         /// <summary>
         /// The TCP port of the database.
         /// </summary>
         public int Port { get; }
+
         /// <summary>
         /// The database name.
         /// </summary>
         public string Name { get; }
+
         /// <summary>
         /// The version of the PostgreSQL database we're connected to, as reported in the "server_version" parameter.
         /// Exposed via <see cref="NpgsqlConnection.PostgreSqlVersion"/>.
         /// </summary>
         public Version Version { get; }
+
+        /// <summary>
+        /// The PostgreSQL version string as returned by the server_version option. Populated during loading.
+        /// </summary>
+        public string ServerVersion { get; }
 
         #endregion General database info
 
@@ -134,11 +142,28 @@ namespace Npgsql.Internal
         /// Initializes the instance of <see cref="NpgsqlDatabaseInfo"/>.
         /// </summary>
         protected NpgsqlDatabaseInfo(string host, int port, string databaseName, Version version)
+            : this(host, port, databaseName, version, version.ToString())
+        { }
+
+        /// <summary>
+        /// Initializes the instance of <see cref="NpgsqlDatabaseInfo"/>.
+        /// </summary>
+        protected NpgsqlDatabaseInfo(string host, int port, string databaseName, Version version, string serverVersion)
         {
             Host = host;
             Port = port;
             Name = databaseName;
             Version = version;
+            ServerVersion = serverVersion;
+        }
+
+        private protected NpgsqlDatabaseInfo(string host, int port, string databaseName, string serverVersion)
+        {
+            Host = host;
+            Port = port;
+            Name = databaseName;
+            ServerVersion = serverVersion;
+            Version = ParseServerVersion(serverVersion);
         }
 
         internal void ProcessTypes()
@@ -194,19 +219,19 @@ namespace Npgsql.Internal
         /// </summary>
         protected static Version ParseServerVersion(string value)
         {
-            var versionString = value.Trim();
+            var versionString = value.AsSpan().TrimStart();
             for (var idx = 0; idx != versionString.Length; ++idx)
             {
                 var c = versionString[idx];
-                if (!char.IsDigit(c) && c != '.')
-                {
-                    versionString = versionString.Substring(0, idx);
-                    break;
-                }
+                if (char.IsDigit(c) || c == '.')
+                    continue;
+
+                versionString = versionString.Slice(0, idx);
+                break;
             }
-            if (!versionString.Contains("."))
-                versionString += ".0";
-            return new Version(versionString);
+            if (!versionString.Contains('.'))
+                return new Version(string.Concat(versionString, ".0".AsSpan()));
+            return new Version(versionString.ToString());
         }
 
         #endregion Misc

--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -197,7 +197,7 @@ namespace Npgsql.Internal
             var versionString = value.Trim();
             for (var idx = 0; idx != versionString.Length; ++idx)
             {
-                var c = value[idx];
+                var c = versionString[idx];
                 if (!char.IsDigit(c) && c != '.')
                 {
                     versionString = versionString.Substring(0, idx);

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1009,8 +1009,12 @@ namespace Npgsql
         // TODO: We should probably move DatabaseInfo from each connector to the pool (but remember unpooled)
 
         /// <summary>
-        /// Version of the PostgreSQL backend.
+        /// The version of the PostgreSQL database we're connected to.
+        /// In case of a development or pre-release version this field will contain
+        /// the version of the next version to be released from this branch.
+        /// <remarks>
         /// This can only be called when there is an active connection.
+        /// </remarks>
         /// </summary>
         [Browsable(false)]
         public Version PostgreSqlVersion => CheckOpenAndRunInTemporaryScope(c => c.DatabaseInfo.Version);
@@ -1019,7 +1023,8 @@ namespace Npgsql
         /// PostgreSQL server version.
         /// This can only be called when there is an active connection.
         /// </summary>
-        public override string ServerVersion => PostgreSqlVersion.ToString();
+        public override string ServerVersion => CheckOpenAndRunInTemporaryScope(
+            c => c.DatabaseInfo.ServerVersion);
 
         /// <summary>
         /// Process id of backend server.

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1017,6 +1017,7 @@ namespace Npgsql
 
         /// <summary>
         /// PostgreSQL server version.
+        /// This can only be called when there is an active connection.
         /// </summary>
         public override string ServerVersion => PostgreSqlVersion.ToString();
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1009,19 +1009,25 @@ namespace Npgsql
         // TODO: We should probably move DatabaseInfo from each connector to the pool (but remember unpooled)
 
         /// <summary>
-        /// The version of the PostgreSQL database we're connected to.
+        /// The version of the PostgreSQL server we're connected to.
+        /// <remarks>
+        /// <p>
+        /// This can only be called when the connection is open.
+        /// </p>
+        /// <p>
         /// In case of a development or pre-release version this field will contain
         /// the version of the next version to be released from this branch.
-        /// <remarks>
-        /// This can only be called when there is an active connection.
+        /// </p>
         /// </remarks>
         /// </summary>
         [Browsable(false)]
         public Version PostgreSqlVersion => CheckOpenAndRunInTemporaryScope(c => c.DatabaseInfo.Version);
 
         /// <summary>
-        /// PostgreSQL server version.
-        /// This can only be called when there is an active connection.
+        /// The PostgreSQL server version as returned by the server_version option.
+        /// <remarks>
+        /// This can only be called when the connection is open.
+        /// </remarks>
         /// </summary>
         public override string ServerVersion => CheckOpenAndRunInTemporaryScope(
             c => c.DatabaseInfo.ServerVersion);

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -76,7 +76,7 @@ namespace Npgsql
         public virtual bool HasTypeCategory => Version.IsGreaterOrEqual(8, 4);
 
         internal PostgresDatabaseInfo(NpgsqlConnector conn)
-            : base(conn.Host!, conn.Port, conn.Database!, ParseServerVersion(conn.PostgresParameters["server_version"]))
+            : base(conn.Host!, conn.Port, conn.Database!, conn.PostgresParameters["server_version"])
         {
         }
 

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -37,6 +37,8 @@ Npgsql.NpgsqlConnectionStringBuilder.TargetSessionAttributes.set -> void
 Npgsql.NpgsqlCopyTextReader.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
+Npgsql.Replication.ReplicationConnection.PostgreSqlVersion.get -> System.Version!
+Npgsql.Replication.ReplicationConnection.ServerVersion.get -> string!
 Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override Npgsql.NpgsqlRawCopyStream.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -154,7 +154,17 @@ namespace Npgsql.Replication
 
         private protected abstract ReplicationMode ReplicationMode { get; }
 
-        internal Version PostgreSqlVersion => _npgsqlConnection.PostgreSqlVersion;
+        /// <summary>
+        /// Version of the PostgreSQL backend.
+        /// This can only be called when there is an active connection.
+        /// </summary>
+        public Version PostgreSqlVersion => _npgsqlConnection.PostgreSqlVersion;
+
+        /// <summary>
+        /// PostgreSQL server version.
+        /// This can only be called when there is an active connection.
+        /// </summary>
+        public string ServerVersion => _npgsqlConnection.ServerVersion;
 
         internal NpgsqlConnector Connector
             => _npgsqlConnection.Connector ??

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -155,14 +155,24 @@ namespace Npgsql.Replication
         private protected abstract ReplicationMode ReplicationMode { get; }
 
         /// <summary>
-        /// Version of the PostgreSQL backend.
-        /// This can only be called when there is an active connection.
+        /// The version of the PostgreSQL server we're connected to.
+        /// <remarks>
+        /// <p>
+        /// This can only be called when the connection is open.
+        /// </p>
+        /// <p>
+        /// In case of a development or pre-release version this field will contain
+        /// the version of the next version to be released from this branch.
+        /// </p>
+        /// </remarks>
         /// </summary>
         public Version PostgreSqlVersion => _npgsqlConnection.PostgreSqlVersion;
 
         /// <summary>
-        /// PostgreSQL server version.
-        /// This can only be called when there is an active connection.
+        /// The PostgreSQL server version as returned by the server_version option.
+        /// <remarks>
+        /// This can only be called when the connection is open.
+        /// </remarks>
         /// </summary>
         public string ServerVersion => _npgsqlConnection.ServerVersion;
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -657,6 +657,31 @@ namespace Npgsql.Tests
         }
 
         [Test]
+        public async Task PostgreSqlVersion_ServerVersion()
+        {
+            await using var c = new NpgsqlConnection(ConnectionString);
+
+            Assert.That(() => c.PostgreSqlVersion, Throws.InvalidOperationException
+                .With.Message.EqualTo("Connection is not open"));
+
+            Assert.That(() => c.ServerVersion, Throws.InvalidOperationException
+                .With.Message.EqualTo("Connection is not open"));
+
+            await c.OpenAsync();
+
+            var backendVersionString = (await c.ExecuteScalarAsync("SHOW server_version") as string)
+                !.Split(new []{' ', 'b'}, StringSplitOptions.RemoveEmptyEntries)[0].Trim() + ".0";
+            // The following assertion is not part of the proper test. It is included to make sure
+            // that a possible test failure isn't happening because we failed to extract the server
+            // version from the 'SHOW server_version' result
+            Assert.That(backendVersionString, Does.Match("^\\d{1,2}\\.\\d{1,2}(?:\\.\\d{1,2}(?:\\.\\d{1,2})?)?$"));
+            var backendVersion = Version.Parse(backendVersionString!);
+
+            Assert.That(c.PostgreSqlVersion, Is.EqualTo(backendVersion));
+            Assert.That(c.ServerVersion, Is.EqualTo(backendVersionString));
+        }
+
+        [Test]
         public void SetConnectionString()
         {
             using var conn = new NpgsqlConnection();

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -690,121 +690,42 @@ namespace Npgsql.Tests
         public void ParseVersionFails(string versionString)
             => Assert.That(() => TestDbInfo.ParseServerVersion(versionString), Throws.Exception);
 
-        [TestCaseSource(nameof(ParseVersionSucceedsData))]
-        public Version ParseVersionSucceeds(string versionString)
-            => TestDbInfo.ParseServerVersion(versionString);
-
-        static IEnumerable<TestCaseData> ParseVersionSucceedsData
-        {
-            get
-            {
-                yield return new TestCaseData("13.3")
-                    .Returns(new Version(13,3));
-
-                yield return new TestCaseData("13.3X")
-                    .Returns(new Version(13,3));
-
-                yield return new TestCaseData("9.6.4")
-                    .Returns(new Version(9,6,4));
-
-                yield return new TestCaseData("9.6.4X")
-                    .Returns(new Version(9,6,4));
-
-                yield return new TestCaseData("9.5alpha2")
-                    .Returns(new Version(9,5));
-
-                yield return new TestCaseData("9.5alpha2X")
-                    .Returns(new Version(9,5));
-
-                yield return new TestCaseData("9.5devel")
-                    .Returns(new Version(9,5));
-
-                yield return new TestCaseData("9.5develX")
-                    .Returns(new Version(9,5));
-
-                yield return new TestCaseData("9.5deveX")
-                    .Returns(new Version(9,5));
-
-                yield return new TestCaseData("9.4beta3")
-                    .Returns(new Version(9,4));
-
-                yield return new TestCaseData("9.4rc1")
-                    .Returns(new Version(9,4));
-
-                yield return new TestCaseData("9.4rc1X")
-                    .Returns(new Version(9,4));
-
-                yield return new TestCaseData("13devel")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13beta1")
-                    .Returns(new Version(13,0));
-
-                // The following should not occur as PostgreSQL version string in the wild these days but we support it.
-                yield return new TestCaseData("13")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13X")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13alpha1")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13alpha")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13alphX")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13beta")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13betX")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13rc1")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13rc")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData("13rX")
-                    .Returns(new Version(13,0));
-
-                yield return new TestCaseData(" 13.3")
-                    .Returns(new Version(13,3));
-
-                yield return new TestCaseData("99999.99999.99999.99999")
-                    .Returns(new Version(99999,99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999.99999X")
-                    .Returns(new Version(99999,99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999.99999devel")
-                    .Returns(new Version(99999,99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999devel")
-                    .Returns(new Version(99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999.99999alpha99999")
-                    .Returns(new Version(99999,99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999alpha99999")
-                    .Returns(new Version(99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999.99999beta99999")
-                    .Returns(new Version(99999,99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999beta99999")
-                    .Returns(new Version(99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999rc99999")
-                    .Returns(new Version(99999,99999,99999));
-
-                yield return new TestCaseData("99999.99999.99999.99999rc99999")
-                    .Returns(new Version(99999,99999,99999,99999));
-            }
-        }
+        [TestCase("13.3", ExpectedResult = "13.3")]
+        [TestCase("13.3X", ExpectedResult = "13.3")]
+        [TestCase("9.6.4", ExpectedResult = "9.6.4")]
+        [TestCase("9.6.4X", ExpectedResult = "9.6.4")]
+        [TestCase("9.5alpha2", ExpectedResult = "9.5")]
+        [TestCase("9.5alpha2X", ExpectedResult = "9.5")]
+        [TestCase("9.5devel", ExpectedResult = "9.5")]
+        [TestCase("9.5develX", ExpectedResult = "9.5")]
+        [TestCase("9.5deveX", ExpectedResult = "9.5")]
+        [TestCase("9.4beta3", ExpectedResult = "9.4")]
+        [TestCase("9.4rc1", ExpectedResult = "9.4")]
+        [TestCase("9.4rc1X", ExpectedResult = "9.4")]
+        [TestCase("13devel", ExpectedResult = "13.0")]
+        [TestCase("13beta1", ExpectedResult = "13.0")]
+        // The following should not occur as PostgreSQL version string in the wild these days but we support it.
+        [TestCase("13", ExpectedResult = "13.0")]
+        [TestCase("13X", ExpectedResult = "13.0")]
+        [TestCase("13alpha1", ExpectedResult = "13.0")]
+        [TestCase("13alpha", ExpectedResult = "13.0")]
+        [TestCase("13alphX", ExpectedResult = "13.0")]
+        [TestCase("13beta", ExpectedResult = "13.0")]
+        [TestCase("13betX", ExpectedResult = "13.0")]
+        [TestCase("13rc1", ExpectedResult = "13.0")]
+        [TestCase("13rc", ExpectedResult = "13.0")]
+        [TestCase("13rX", ExpectedResult = "13.0")]
+        [TestCase("99999.99999.99999.99999", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999.99999X", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999.99999devel", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999.99999alpha99999", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999alpha99999", ExpectedResult = "99999.99999.99999")]
+        [TestCase("99999.99999.99999.99999beta99999", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999beta99999", ExpectedResult = "99999.99999.99999")]
+        [TestCase("99999.99999.99999.99999rc99999", ExpectedResult = "99999.99999.99999.99999")]
+        [TestCase("99999.99999.99999rc99999", ExpectedResult = "99999.99999.99999")]
+        public string ParseVersionSucceeds(string versionString)
+            => TestDbInfo.ParseServerVersion(versionString).ToString();
 
         class TestDbInfo : NpgsqlDatabaseInfo
         {


### PR DESCRIPTION
Now that we have two versions of the Logical Streaming Replication
Protocol people may be interested in the backend version they are
connected to in order to adjust the requested protocol version.
Publicly exposing ReplicationConnection.PostgreSqlVersion will help
them to identify the backend version without having to open a separate
NpgsqlConnection.
