### PR TITLE
Reduce nullable and array reflection and code generation

### DIFF
--- a/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
@@ -9,541 +9,540 @@ using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 
-namespace Npgsql.Internal.TypeHandlers
+namespace Npgsql.Internal.TypeHandlers;
+
+/// <summary>
+/// Non-generic base class for all type handlers which handle PostgreSQL arrays.
+/// Extend from <see cref="ArrayHandler{TElement}"/> instead.
+/// </summary>
+/// <remarks>
+/// https://www.postgresql.org/docs/current/static/arrays.html.
+///
+/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+/// Use it at your own risk.
+/// </remarks>
+public abstract class ArrayHandler : NpgsqlTypeHandler
 {
-    /// <summary>
-    /// Non-generic base class for all type handlers which handle PostgreSQL arrays.
-    /// Extend from <see cref="ArrayHandler{TElement}"/> instead.
-    /// </summary>
-    /// <remarks>
-    /// https://www.postgresql.org/docs/current/static/arrays.html.
-    ///
-    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-    /// Use it at your own risk.
-    /// </remarks>
-    public abstract class ArrayHandler : NpgsqlTypeHandler
+    private protected int LowerBound { get; } // The lower bound value sent to the backend when writing arrays. Normally 1 (the PG default) but is 0 for OIDVector.
+    private protected NpgsqlTypeHandler ElementHandler { get; }
+    private protected ArrayNullabilityMode ArrayNullabilityMode { get; }
+
+    /// <inheritdoc />
+    protected ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
+        : base(arrayPostgresType)
     {
-        private protected int LowerBound { get; } // The lower bound value sent to the backend when writing arrays. Normally 1 (the PG default) but is 0 for OIDVector.
-        private protected NpgsqlTypeHandler ElementHandler { get; }
-        private protected ArrayNullabilityMode ArrayNullabilityMode { get; }
+        LowerBound = lowerBound;
+        ElementHandler = elementHandler;
+        ArrayNullabilityMode = arrayNullabilityMode;
+    }
 
-        /// <inheritdoc />
-        protected ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
-            : base(arrayPostgresType)
-        {
-            LowerBound = lowerBound;
-            ElementHandler = elementHandler;
-            ArrayNullabilityMode = arrayNullabilityMode;
-        }
+    public override Type GetFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
+    public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
 
-        public override Type GetFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
-        public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
+    /// <inheritdoc />
+    public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
+        => throw new NotSupportedException();
 
-        /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
-            => throw new NotSupportedException();
+    /// <inheritdoc />
+    public override NpgsqlTypeHandler CreateRangeHandler(PostgresType pgRangeType)
+        => throw new NotSupportedException();
 
-        /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType pgRangeType)
-            => throw new NotSupportedException();
+    /// <inheritdoc />
+    public override NpgsqlTypeHandler CreateMultirangeHandler(PostgresMultirangeType pgMultirangeType)
+        => throw new NotSupportedException();
 
-        /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateMultirangeHandler(PostgresMultirangeType pgMultirangeType)
-            => throw new NotSupportedException();
+    #region Read
 
-        #region Read
+    /// <inheritdoc />
+    protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    {
+        if (ArrayTypeInfo<TRequestedArray>.IsArray)
+            return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
 
-        /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        {
-            if (ArrayTypeInfo<TRequestedArray>.IsArray)
-                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+        if (ListTypeInfo<TRequestedArray>.IsList)
+            return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
 
-            if (ListTypeInfo<TRequestedArray>.IsList)
-                return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
+        throw new InvalidCastException(fieldDescription == null
+            ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
+            : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
+        );
+    }
 
-            throw new InvalidCastException(fieldDescription == null
-                ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
-                : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
-            );
-        }
+    /// <summary>
+    /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+    /// </summary>
+    protected internal async ValueTask<object> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, bool readAsObject = false)
+    {
+        await buf.Ensure(12, async);
+        var dimensions = buf.ReadInt32();
+        var containsNulls = buf.ReadInt32() == 1;
+        buf.ReadUInt32(); // Element OID. Ignored.
 
-        /// <summary>
-        /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
-        /// </summary>
-        protected internal async ValueTask<object> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, bool readAsObject = false)
-        {
-            await buf.Ensure(12, async);
-            var dimensions = buf.ReadInt32();
-            var containsNulls = buf.ReadInt32() == 1;
-            buf.ReadUInt32(); // Element OID. Ignored.
-
-            var returnType = readAsObject
-                ? ArrayNullabilityMode switch
-                {
-                    ArrayNullabilityMode.Never => ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
-                        ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
-                        : typeof(TRequestedElement),
-                    ArrayNullabilityMode.Always => ElementTypeInfo<TRequestedElement>.NullableElementType,
-                    ArrayNullabilityMode.PerInstance => containsNulls
-                        ? ElementTypeInfo<TRequestedElement>.NullableElementType
-                        : typeof(TRequestedElement),
-                    _ => throw new ArgumentOutOfRangeException()
-                }
-                : ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
+        var returnType = readAsObject
+            ? ArrayNullabilityMode switch
+            {
+                ArrayNullabilityMode.Never => ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
                     ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
-                    : typeof(TRequestedElement);
-
-            if (dimensions == 0)
-                return expectedDimensions > 1
-                    ? Array.CreateInstance(returnType, new int[expectedDimensions])
-                    : returnType == typeof(TRequestedElement)
-                        ? Array.Empty<TRequestedElement>()
-                        : Array.CreateInstance(returnType, 0);
-
-            if (expectedDimensions > 0 && dimensions != expectedDimensions)
-                throw new InvalidOperationException($"Cannot read an array with {expectedDimensions} dimension(s) from an array with {dimensions} dimension(s)");
-
-            if (dimensions == 1 && returnType == typeof(TRequestedElement))
-            {
-                await buf.Ensure(8, async);
-                var arrayLength = buf.ReadInt32();
-
-                buf.ReadInt32(); // Lower bound
-
-                var oneDimensional = new TRequestedElement[arrayLength];
-                for (var i = 0; i < oneDimensional.Length; i++)
-                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
-
-                return oneDimensional;
+                    : typeof(TRequestedElement),
+                ArrayNullabilityMode.Always => ElementTypeInfo<TRequestedElement>.NullableElementType,
+                ArrayNullabilityMode.PerInstance => containsNulls
+                    ? ElementTypeInfo<TRequestedElement>.NullableElementType
+                    : typeof(TRequestedElement),
+                _ => throw new ArgumentOutOfRangeException()
             }
+            : ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
+                ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
+                : typeof(TRequestedElement);
 
-            var dimLengths = new int[dimensions];
-            await buf.Ensure(dimensions * 8, async);
+        if (dimensions == 0)
+            return expectedDimensions > 1
+                ? Array.CreateInstance(returnType, new int[expectedDimensions])
+                : returnType == typeof(TRequestedElement)
+                    ? Array.Empty<TRequestedElement>()
+                    : Array.CreateInstance(returnType, 0);
 
-            for (var i = 0; i < dimLengths.Length; i++)
-            {
-                dimLengths[i] = buf.ReadInt32();
-                buf.ReadInt32(); // Lower bound
-            }
+        if (expectedDimensions > 0 && dimensions != expectedDimensions)
+            throw new InvalidOperationException($"Cannot read an array with {expectedDimensions} dimension(s) from an array with {dimensions} dimension(s)");
 
-            var result = Array.CreateInstance(returnType, dimLengths);
-
-            // Either multidimensional arrays or arrays of nullable value types requested as object
-            // We can't avoid boxing here
-            var indices = new int[dimensions];
-            while (true)
-            {
-                await buf.Ensure(4, async);
-                var len = buf.ReadInt32();
-                var element = len == -1
-                    ? (object?)null
-                    : NullableHandler<TRequestedElement>.Exists
-                        ? await NullableHandler<TRequestedElement>.ReadAsync(ElementHandler, buf, len, async)
-                        : await ElementHandler.Read<TRequestedElement>(buf, len, async);
-
-                result.SetValue(element, indices);
-
-                // TODO: Overly complicated/inefficient...
-                indices[dimensions - 1]++;
-                for (var dim = dimensions - 1; dim >= 0; dim--)
-                {
-                    if (indices[dim] <= result.GetUpperBound(dim))
-                        continue;
-
-                    if (dim == 0)
-                        return result;
-
-                    for (var j = dim; j < dimensions; j++)
-                        indices[j] = result.GetLowerBound(j);
-                    indices[dim - 1]++;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
-        /// </summary>
-        protected internal async ValueTask<object> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
+        if (dimensions == 1 && returnType == typeof(TRequestedElement))
         {
-            await buf.Ensure(12, async);
-            var dimensions = buf.ReadInt32();
-            var containsNulls = buf.ReadInt32() == 1;
-            buf.ReadUInt32(); // Element OID. Ignored.
-
-            if (dimensions == 0)
-                return new List<TRequestedElement>();
-            if (dimensions > 1)
-                throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TRequestedElement).Name}>");
-            if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
-                throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
-
             await buf.Ensure(8, async);
-            var length = buf.ReadInt32();
-            buf.ReadInt32(); // We don't care about the lower bounds
+            var arrayLength = buf.ReadInt32();
 
-            var list = new List<TRequestedElement>(length);
-            for (var i = 0; i < length; i++)
-                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
-            return list;
+            buf.ReadInt32(); // Lower bound
+
+            var oneDimensional = new TRequestedElement[arrayLength];
+            for (var i = 0; i < oneDimensional.Length; i++)
+                oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
+
+            return oneDimensional;
         }
 
-        internal const string ReadNonNullableCollectionWithNullsExceptionMessage =
-            "Cannot read a non-nullable collection of elements because the returned array contains nulls. " +
-            "Call GetFieldValue with a nullable array instead.";
+        var dimLengths = new int[dimensions];
+        await buf.Ensure(dimensions * 8, async);
 
-        #endregion Read
-
-        #region Write
-
-        // Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
-        protected int ValidateAndGetLengthNonGeneric(ICollection value, ref NpgsqlLengthCache lengthCache)
+        for (var i = 0; i < dimLengths.Length; i++)
         {
-            var asMultidimensional = value as Array;
-            var dimensions = asMultidimensional?.Rank ?? 1;
+            dimLengths[i] = buf.ReadInt32();
+            buf.ReadInt32(); // Lower bound
+        }
 
-            // Leave empty slot for the entire array length, and go ahead an populate the element slots
-            var pos = lengthCache.Position;
-            var len =
-                4 +              // dimensions
-                4 +              // has_nulls (unused)
-                4 +              // type OID
-                dimensions * 8 + // number of dimensions * (length + lower bound)
-                4 * value.Count; // sum of element lengths
+        var result = Array.CreateInstance(returnType, dimLengths);
 
-            lengthCache.Set(0);
-            NpgsqlLengthCache? elemLengthCache = lengthCache;
+        // Either multidimensional arrays or arrays of nullable value types requested as object
+        // We can't avoid boxing here
+        var indices = new int[dimensions];
+        while (true)
+        {
+            await buf.Ensure(4, async);
+            var len = buf.ReadInt32();
+            var element = len == -1
+                ? (object?)null
+                : NullableHandler<TRequestedElement>.Exists
+                    ? await NullableHandler<TRequestedElement>.ReadAsync(ElementHandler, buf, len, async)
+                    : await ElementHandler.Read<TRequestedElement>(buf, len, async);
 
-            foreach (var element in value)
+            result.SetValue(element, indices);
+
+            // TODO: Overly complicated/inefficient...
+            indices[dimensions - 1]++;
+            for (var dim = dimensions - 1; dim >= 0; dim--)
             {
-                if (element is null)
+                if (indices[dim] <= result.GetUpperBound(dim))
                     continue;
 
-                try
-                {
-                    len += ElementHandler.ValidateObjectAndGetLength(element, ref elemLengthCache, null);
-                }
-                catch (Exception e)
-                {
-                    throw MixedTypesOrJaggedArrayException(e);
-                }
-            }
+                if (dim == 0)
+                    return result;
 
-            lengthCache.Lengths[pos] = len;
-            return len;
+                for (var j = dim; j < dimensions; j++)
+                    indices[j] = result.GetLowerBound(j);
+                indices[dim - 1]++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+    /// </summary>
+    protected internal async ValueTask<object> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
+    {
+        await buf.Ensure(12, async);
+        var dimensions = buf.ReadInt32();
+        var containsNulls = buf.ReadInt32() == 1;
+        buf.ReadUInt32(); // Element OID. Ignored.
+
+        if (dimensions == 0)
+            return new List<TRequestedElement>();
+        if (dimensions > 1)
+            throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TRequestedElement).Name}>");
+        if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
+            throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
+
+        await buf.Ensure(8, async);
+        var length = buf.ReadInt32();
+        buf.ReadInt32(); // We don't care about the lower bounds
+
+        var list = new List<TRequestedElement>(length);
+        for (var i = 0; i < length; i++)
+            list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
+        return list;
+    }
+
+    internal const string ReadNonNullableCollectionWithNullsExceptionMessage =
+        "Cannot read a non-nullable collection of elements because the returned array contains nulls. " +
+        "Call GetFieldValue with a nullable array instead.";
+
+    #endregion Read
+
+    #region Write
+
+    // Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
+    protected int ValidateAndGetLengthNonGeneric(ICollection value, ref NpgsqlLengthCache lengthCache)
+    {
+        var asMultidimensional = value as Array;
+        var dimensions = asMultidimensional?.Rank ?? 1;
+
+        // Leave empty slot for the entire array length, and go ahead an populate the element slots
+        var pos = lengthCache.Position;
+        var len =
+            4 +              // dimensions
+            4 +              // has_nulls (unused)
+            4 +              // type OID
+            dimensions * 8 + // number of dimensions * (length + lower bound)
+            4 * value.Count; // sum of element lengths
+
+        lengthCache.Set(0);
+        NpgsqlLengthCache? elemLengthCache = lengthCache;
+
+        foreach (var element in value)
+        {
+            if (element is null)
+                continue;
+
+            try
+            {
+                len += ElementHandler.ValidateObjectAndGetLength(element, ref elemLengthCache, null);
+            }
+            catch (Exception e)
+            {
+                throw MixedTypesOrJaggedArrayException(e);
+            }
         }
 
-        protected async Task WriteNonGeneric(ICollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
+        lengthCache.Lengths[pos] = len;
+        return len;
+    }
+
+    protected async Task WriteNonGeneric(ICollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
+    {
+        var asArray = value as Array;
+        var dimensions = asArray?.Rank ?? 1;
+
+        var len =
+            4 +               // ndim
+            4 +               // has_nulls
+            4 +               // element_oid
+            dimensions * 8;   // dim (4) + lBound (4)
+
+        if (buf.WriteSpaceLeft < len)
         {
-            var asArray = value as Array;
-            var dimensions = asArray?.Rank ?? 1;
+            await buf.Flush(async, cancellationToken);
+            Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
+        }
 
-            var len =
-                4 +               // ndim
-                4 +               // has_nulls
-                4 +               // element_oid
-                dimensions * 8;   // dim (4) + lBound (4)
-
-            if (buf.WriteSpaceLeft < len)
+        buf.WriteInt32(dimensions);
+        buf.WriteInt32(1);  // HasNulls=1. Not actually used by the backend.
+        buf.WriteUInt32(ElementHandler.PostgresType.OID);
+        if (asArray != null)
+        {
+            for (var i = 0; i < dimensions; i++)
             {
-                await buf.Flush(async, cancellationToken);
-                Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
-            }
-
-            buf.WriteInt32(dimensions);
-            buf.WriteInt32(1);  // HasNulls=1. Not actually used by the backend.
-            buf.WriteUInt32(ElementHandler.PostgresType.OID);
-            if (asArray != null)
-            {
-                for (var i = 0; i < dimensions; i++)
-                {
-                    buf.WriteInt32(asArray.GetLength(i));
-                    buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
-                }
-            }
-            else
-            {
-                buf.WriteInt32(value.Count);
+                buf.WriteInt32(asArray.GetLength(i));
                 buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
             }
-
-            foreach (var element in value)
-                await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async, cancellationToken);
         }
-
-        protected static Exception MixedTypesOrJaggedArrayException(Exception innerException)
-            => new("While trying to write an array, one of its elements failed validation. " +
-                   "You may be trying to mix types in a non-generic IList, or to write a jagged array.", innerException);
-
-        #endregion Write
-
-        #region Static generic caching helpers
-
-        internal static class ElementTypeInfo<TElement>
+        else
         {
-            public static readonly bool IsNonNullable =
-                typeof(TElement).IsValueType && default(TElement) is not null;
-
-            public static readonly Type NullableElementType = IsNonNullable
-                ? typeof(Nullable<>).MakeGenericType(typeof(TElement))
-                : typeof(TElement);
-        }
-
-        internal abstract class ArrayTypeInfo<TArray>
-        {
-            // ReSharper disable StaticMemberInGenericType
-            public static readonly Type? ElementType = typeof(TArray).IsArray ? typeof(TArray).GetElementType() : null;
-            // ReSharper restore StaticMemberInGenericType
-
-            public static bool IsArray => ElementType is not null;
-
-            static ArrayTypeInfo<TArray>? _derivedInstance;
-            static ArrayTypeInfo<TArray> DerivedInstance
-            {
-                get
-                {
-                    return _derivedInstance ?? CreateInstance();
-                    static ArrayTypeInfo<TArray> CreateInstance()
-                    {
-                        if (ElementType is null)
-                            return null!;
-
-                        _derivedInstance = (ArrayTypeInfo<TArray>?)Activator.CreateInstance(typeof(ArrayHandler<,>).MakeGenericType(typeof(TArray), ElementType), typeof(TArray).GetArrayRank());
-                        return _derivedInstance!;
-                    }
-                }
-            }
-
-            public static ValueTask<object> ReadArray(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false)
-                => DerivedInstance.Read(handler, buf, async, readAsObject);
-
-            protected abstract ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false);
-        }
-        internal abstract class ListTypeInfo<TList>
-        {
-            // ReSharper disable StaticMemberInGenericType
-            public static readonly Type? ElementType =
-                typeof(TList).IsGenericType && typeof(TList).GetGenericTypeDefinition() == typeof(List<>) ?
-                    typeof(TList).GetGenericArguments()[0] : null;
-            // ReSharper restore StaticMemberInGenericType
-
-            public static bool IsList => ElementType is not null;
-
-            static ListTypeInfo<TList>? _derivedInstance;
-            static ListTypeInfo<TList> DerivedInstance
-            {
-                get
-                {
-                    return _derivedInstance ?? CreateInstance();
-                    static ListTypeInfo<TList> CreateInstance()
-                    {
-                        if (ElementType is null)
-                            return null!;
-
-                        _derivedInstance = (ListTypeInfo<TList>?)Activator.CreateInstance(typeof(ListHandler<,>).MakeGenericType(typeof(TList), ElementType));
-                        return _derivedInstance!;
-                    }
-                }
-            }
-
-            public static ValueTask<object> ReadList(ArrayHandler handler, NpgsqlReadBuffer buf, bool async)
-                => DerivedInstance.Read(handler, buf, async);
-
-            protected abstract ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async);
-        }
-        #endregion Static generic caching helpers
-    }
-
-    /// <summary>
-    /// Base class for all type handlers which handle PostgreSQL arrays.
-    /// </summary>
-    /// <remarks>
-    /// https://www.postgresql.org/docs/current/static/arrays.html.
-    ///
-    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-    /// Use it at your own risk.
-    /// </remarks>
-    public class ArrayHandler<TElement> : ArrayHandler
-    {
-        /// <inheritdoc />
-        public ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
-            : base(arrayPostgresType, elementHandler, arrayNullabilityMode, lowerBound) {}
-
-        #region Read
-
-        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => await ReadArray<TElement>(buf, async, readAsObject: true);
-
-        #endregion
-
-        #region Write
-
-        static InvalidCastException CantWriteTypeException(Type type)
-            => new($"Can't write type '{type}' as an array of {typeof(TElement)}");
-
-        // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
-        // we must use the bang operator here to tell the compiler that a null value will never be returned.
-
-        /// <inheritdoc />
-        protected internal override int ValidateAndGetLengthCustom<TAny>([DisallowNull] TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => ValidateAndGetLength(value, ref lengthCache);
-
-        /// <inheritdoc />
-        public override int ValidateObjectAndGetLength(object? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value is null || value == DBNull.Value
-                ? 0
-                : ValidateAndGetLength(value!, ref lengthCache);
-
-        int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache)
-        {
-            lengthCache ??= new NpgsqlLengthCache(1);
-            if (lengthCache.IsPopulated)
-                return lengthCache.Get();
-            if (value is ICollection<TElement> generic)
-                return ValidateAndGetLengthGeneric(generic, ref lengthCache);
-            if (value is ICollection nonGeneric)
-                return ValidateAndGetLengthNonGeneric(nonGeneric, ref lengthCache);
-            throw CantWriteTypeException(value.GetType());
-        }
-
-        // Handle single-dimensional arrays and generic IList<T>
-        int ValidateAndGetLengthGeneric(ICollection<TElement> value, ref NpgsqlLengthCache lengthCache)
-        {
-            // Leave empty slot for the entire array length, and go ahead an populate the element slots
-            var pos = lengthCache.Position;
-            var len =
-                4 +              // dimensions
-                4 +              // has_nulls (unused)
-                4 +              // type OID
-                1 * 8 +          // number of dimensions (1) * (length + lower bound)
-                4 * value.Count; // sum of element lengths
-
-            lengthCache.Set(0);
-            var elemLengthCache = lengthCache;
-
-            foreach (var element in value)
-            {
-                if (element is null)
-                    continue;
-
-                try
-                {
-                    len += ElementHandler.ValidateAndGetLength(element, ref elemLengthCache, null);
-                }
-                catch (Exception e)
-                {
-                    throw MixedTypesOrJaggedArrayException(e);
-                }
-            }
-
-            lengthCache.Lengths[pos] = len;
-            return len;
-        }
-
-        protected override Task WriteWithLengthCustom<TAny>([DisallowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken)
-        {
-            buf.WriteInt32(ValidateAndGetLength(value, ref lengthCache, parameter));
-
-            if (value is ICollection<TElement> list)
-                return WriteGeneric(list, buf, lengthCache, async, cancellationToken);
-
-            if (value is ICollection nonGeneric)
-                return WriteNonGeneric(nonGeneric, buf, lengthCache, async, cancellationToken);
-
-            throw CantWriteTypeException(value.GetType());
-        }
-
-        // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
-        // us (need to handle many types of T, e.g. int[], int[,]...)
-        /// <inheritdoc />
-        public override Task WriteObjectWithLength(object? value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value is null || value is DBNull
-                ? WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
-                : WriteWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
-
-        async Task WriteGeneric(ICollection<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
-        {
-            var len =
-                4 +    // dimensions
-                4 +    // has_nulls (unused)
-                4 +    // type OID
-                1 * 8; // number of dimensions (1) * (length + lower bound)
-            if (buf.WriteSpaceLeft < len)
-            {
-                await buf.Flush(async, cancellationToken);
-                Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
-            }
-
-            buf.WriteInt32(1);
-            buf.WriteInt32(1); // has_nulls = 1. Not actually used by the backend.
-            buf.WriteUInt32(ElementHandler.PostgresType.OID);
             buf.WriteInt32(value.Count);
-            buf.WriteInt32(LowerBound); // We don't map .NET lower bounds to PG
-
-            foreach (var element in value)
-                await ElementHandler.WriteWithLength(element, buf, lengthCache, null, async, cancellationToken);
+            buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
         }
 
-        #endregion
+        foreach (var element in value)
+            await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async, cancellationToken);
     }
 
-    /// <remarks>
-    /// https://www.postgresql.org/docs/current/static/arrays.html
-    /// </remarks>
-    /// <typeparam name="TElement">The .NET type contained as an element within this array</typeparam>
-    /// <typeparam name="TElementPsv">The .NET provider-specific type contained as an element within this array</typeparam>
-    sealed class ArrayHandlerWithPsv<TElement, TElementPsv> : ArrayHandler<TElement>
-    {
-        public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
-            : base(arrayPostgresType, elementHandler, arrayNullabilityMode) { }
+    protected static Exception MixedTypesOrJaggedArrayException(Exception innerException)
+        => new("While trying to write an array, one of its elements failed validation. " +
+               "You may be trying to mix types in a non-generic IList, or to write a jagged array.", innerException);
 
-        protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    #endregion Write
+
+    #region Static generic caching helpers
+
+    internal static class ElementTypeInfo<TElement>
+    {
+        public static readonly bool IsNonNullable =
+            typeof(TElement).IsValueType && default(TElement) is not null;
+
+        public static readonly Type NullableElementType = IsNonNullable
+            ? typeof(Nullable<>).MakeGenericType(typeof(TElement))
+            : typeof(TElement);
+    }
+
+    internal abstract class ArrayTypeInfo<TArray>
+    {
+        // ReSharper disable StaticMemberInGenericType
+        public static readonly Type? ElementType = typeof(TArray).IsArray ? typeof(TArray).GetElementType() : null;
+        // ReSharper restore StaticMemberInGenericType
+
+        public static bool IsArray => ElementType is not null;
+
+        static ArrayTypeInfo<TArray>? _derivedInstance;
+        static ArrayTypeInfo<TArray> DerivedInstance
         {
-            if (ArrayTypeInfo<TRequestedArray>.IsArray)
+            get
             {
-                if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
-                    return (TRequestedArray)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank());
+                return _derivedInstance ?? CreateInstance();
+                static ArrayTypeInfo<TArray> CreateInstance()
+                {
+                    if (ElementType is null)
+                        return null!;
 
-                return (TRequestedArray)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+                    _derivedInstance = (ArrayTypeInfo<TArray>?)Activator.CreateInstance(typeof(ArrayHandler<,>).MakeGenericType(typeof(TArray), ElementType), typeof(TArray).GetArrayRank());
+                    return _derivedInstance!;
+                }
             }
-
-            // We evaluate List last to better support reflection free mode
-            // https://github.com/dotnet/runtimelab/blob/f2fd03035c1c02a0b904537b6f38906035f14689/docs/using-nativeaot/reflection-free-mode.md
-            if (ListTypeInfo<TRequestedArray>.IsList)
-            {
-                if (ListTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
-                    return (TRequestedArray)await ReadList<TElementPsv>(buf, async);
-
-                return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
-            }
-
-            throw new InvalidCastException(fieldDescription == null
-                ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
-                : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
-            );
         }
 
-        internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
+        public static ValueTask<object> ReadArray(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false)
+            => DerivedInstance.Read(handler, buf, async, readAsObject);
 
-        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => await ReadArray<TElementPsv>(buf, async, readAsObject: true);
+        protected abstract ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false);
     }
-
-    sealed class ArrayHandler<TArray, TElement> : ArrayHandler.ArrayTypeInfo<TArray>
+    internal abstract class ListTypeInfo<TList>
     {
-        readonly int _arrayRank;
-        public ArrayHandler(int arrayRank) => _arrayRank = arrayRank;
+        // ReSharper disable StaticMemberInGenericType
+        public static readonly Type? ElementType =
+            typeof(TList).IsGenericType && typeof(TList).GetGenericTypeDefinition() == typeof(List<>) ?
+                typeof(TList).GetGenericArguments()[0] : null;
+        // ReSharper restore StaticMemberInGenericType
 
-        protected override ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false)
-            => handler.ReadArray<TElement>(buf, async, _arrayRank, readAsObject);
+        public static bool IsList => ElementType is not null;
+
+        static ListTypeInfo<TList>? _derivedInstance;
+        static ListTypeInfo<TList> DerivedInstance
+        {
+            get
+            {
+                return _derivedInstance ?? CreateInstance();
+                static ListTypeInfo<TList> CreateInstance()
+                {
+                    if (ElementType is null)
+                        return null!;
+
+                    _derivedInstance = (ListTypeInfo<TList>?)Activator.CreateInstance(typeof(ListHandler<,>).MakeGenericType(typeof(TList), ElementType));
+                    return _derivedInstance!;
+                }
+            }
+        }
+
+        public static ValueTask<object> ReadList(ArrayHandler handler, NpgsqlReadBuffer buf, bool async)
+            => DerivedInstance.Read(handler, buf, async);
+
+        protected abstract ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async);
     }
+    #endregion Static generic caching helpers
+}
 
-    sealed class ListHandler<TList, TElement> : ArrayHandler.ListTypeInfo<TList>
+/// <summary>
+/// Base class for all type handlers which handle PostgreSQL arrays.
+/// </summary>
+/// <remarks>
+/// https://www.postgresql.org/docs/current/static/arrays.html.
+///
+/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+/// Use it at your own risk.
+/// </remarks>
+public class ArrayHandler<TElement> : ArrayHandler
+{
+    /// <inheritdoc />
+    public ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
+        : base(arrayPostgresType, elementHandler, arrayNullabilityMode, lowerBound) {}
+
+    #region Read
+
+    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        => await ReadArray<TElement>(buf, async, readAsObject: true);
+
+    #endregion
+
+    #region Write
+
+    static InvalidCastException CantWriteTypeException(Type type)
+        => new($"Can't write type '{type}' as an array of {typeof(TElement)}");
+
+    // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
+    // we must use the bang operator here to tell the compiler that a null value will never be returned.
+
+    /// <inheritdoc />
+    protected internal override int ValidateAndGetLengthCustom<TAny>([DisallowNull] TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => ValidateAndGetLength(value, ref lengthCache);
+
+    /// <inheritdoc />
+    public override int ValidateObjectAndGetLength(object? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => value is null || value == DBNull.Value
+            ? 0
+            : ValidateAndGetLength(value!, ref lengthCache);
+
+    int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache)
     {
-        protected override ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async) =>
-            handler.ReadList<TElement>(buf, async);
+        lengthCache ??= new NpgsqlLengthCache(1);
+        if (lengthCache.IsPopulated)
+            return lengthCache.Get();
+        if (value is ICollection<TElement> generic)
+            return ValidateAndGetLengthGeneric(generic, ref lengthCache);
+        if (value is ICollection nonGeneric)
+            return ValidateAndGetLengthNonGeneric(nonGeneric, ref lengthCache);
+        throw CantWriteTypeException(value.GetType());
     }
+
+    // Handle single-dimensional arrays and generic IList<T>
+    int ValidateAndGetLengthGeneric(ICollection<TElement> value, ref NpgsqlLengthCache lengthCache)
+    {
+        // Leave empty slot for the entire array length, and go ahead an populate the element slots
+        var pos = lengthCache.Position;
+        var len =
+            4 +              // dimensions
+            4 +              // has_nulls (unused)
+            4 +              // type OID
+            1 * 8 +          // number of dimensions (1) * (length + lower bound)
+            4 * value.Count; // sum of element lengths
+
+        lengthCache.Set(0);
+        var elemLengthCache = lengthCache;
+
+        foreach (var element in value)
+        {
+            if (element is null)
+                continue;
+
+            try
+            {
+                len += ElementHandler.ValidateAndGetLength(element, ref elemLengthCache, null);
+            }
+            catch (Exception e)
+            {
+                throw MixedTypesOrJaggedArrayException(e);
+            }
+        }
+
+        lengthCache.Lengths[pos] = len;
+        return len;
+    }
+
+    protected override Task WriteWithLengthCustom<TAny>([DisallowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken)
+    {
+        buf.WriteInt32(ValidateAndGetLength(value, ref lengthCache, parameter));
+
+        if (value is ICollection<TElement> list)
+            return WriteGeneric(list, buf, lengthCache, async, cancellationToken);
+
+        if (value is ICollection nonGeneric)
+            return WriteNonGeneric(nonGeneric, buf, lengthCache, async, cancellationToken);
+
+        throw CantWriteTypeException(value.GetType());
+    }
+
+    // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
+    // us (need to handle many types of T, e.g. int[], int[,]...)
+    /// <inheritdoc />
+    public override Task WriteObjectWithLength(object? value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        => value is null || value is DBNull
+            ? WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
+            : WriteWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
+
+    async Task WriteGeneric(ICollection<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
+    {
+        var len =
+            4 +    // dimensions
+            4 +    // has_nulls (unused)
+            4 +    // type OID
+            1 * 8; // number of dimensions (1) * (length + lower bound)
+        if (buf.WriteSpaceLeft < len)
+        {
+            await buf.Flush(async, cancellationToken);
+            Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
+        }
+
+        buf.WriteInt32(1);
+        buf.WriteInt32(1); // has_nulls = 1. Not actually used by the backend.
+        buf.WriteUInt32(ElementHandler.PostgresType.OID);
+        buf.WriteInt32(value.Count);
+        buf.WriteInt32(LowerBound); // We don't map .NET lower bounds to PG
+
+        foreach (var element in value)
+            await ElementHandler.WriteWithLength(element, buf, lengthCache, null, async, cancellationToken);
+    }
+
+    #endregion
+}
+
+/// <remarks>
+/// https://www.postgresql.org/docs/current/static/arrays.html
+/// </remarks>
+/// <typeparam name="TElement">The .NET type contained as an element within this array</typeparam>
+/// <typeparam name="TElementPsv">The .NET provider-specific type contained as an element within this array</typeparam>
+sealed class ArrayHandlerWithPsv<TElement, TElementPsv> : ArrayHandler<TElement>
+{
+    public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
+        : base(arrayPostgresType, elementHandler, arrayNullabilityMode) { }
+
+    protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    {
+        if (ArrayTypeInfo<TRequestedArray>.IsArray)
+        {
+            if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
+                return (TRequestedArray)await ReadArray<TElementPsv>(buf, async, typeof(TRequestedArray).GetArrayRank());
+
+            return (TRequestedArray)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+        }
+
+        // We evaluate List last to better support reflection free mode
+        // https://github.com/dotnet/runtimelab/blob/f2fd03035c1c02a0b904537b6f38906035f14689/docs/using-nativeaot/reflection-free-mode.md
+        if (ListTypeInfo<TRequestedArray>.IsList)
+        {
+            if (ListTypeInfo<TRequestedArray>.ElementType == typeof(TElementPsv))
+                return (TRequestedArray)await ReadList<TElementPsv>(buf, async);
+
+            return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
+        }
+
+        throw new InvalidCastException(fieldDescription == null
+            ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
+            : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
+        );
+    }
+
+    internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
+        => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
+
+    internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        => await ReadArray<TElementPsv>(buf, async, readAsObject: true);
+}
+
+sealed class ArrayHandler<TArray, TElement> : ArrayHandler.ArrayTypeInfo<TArray>
+{
+    readonly int _arrayRank;
+    public ArrayHandler(int arrayRank) => _arrayRank = arrayRank;
+
+    protected override ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async, bool readAsObject = false)
+        => handler.ReadArray<TElement>(buf, async, _arrayRank, readAsObject);
+}
+
+sealed class ListHandler<TList, TElement> : ArrayHandler.ListTypeInfo<TList>
+{
+    protected override ValueTask<object> Read(ArrayHandler handler, NpgsqlReadBuffer buf, bool async) =>
+        handler.ReadList<TElement>(buf, async);
 }

--- a/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
@@ -11,497 +11,498 @@ using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 
-namespace Npgsql.Internal.TypeHandlers;
-
-/// <summary>
-/// Non-generic base class for all type handlers which handle PostgreSQL arrays.
-/// Extend from <see cref="ArrayHandler{TElement}"/> instead.
-/// </summary>
-/// <remarks>
-/// https://www.postgresql.org/docs/current/static/arrays.html.
-///
-/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-/// Use it at your own risk.
-/// </remarks>
-public abstract class ArrayHandler : NpgsqlTypeHandler
+namespace Npgsql.Internal.TypeHandlers
 {
-    private protected int LowerBound { get; } // The lower bound value sent to the backend when writing arrays. Normally 1 (the PG default) but is 0 for OIDVector.
-    private protected NpgsqlTypeHandler ElementHandler { get; }
-    private protected ArrayNullabilityMode ArrayNullabilityMode { get; }
-
-    static readonly MethodInfo ReadArrayMethod = typeof(ArrayHandler).GetMethod(nameof(ReadArray), BindingFlags.NonPublic | BindingFlags.Instance)!;
-    static readonly MethodInfo ReadListMethod = typeof(ArrayHandler).GetMethod(nameof(ReadList), BindingFlags.NonPublic | BindingFlags.Instance)!;
-
-    /// <inheritdoc />
-    protected ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
-        : base(arrayPostgresType)
-    {
-        LowerBound = lowerBound;
-        ElementHandler = elementHandler;
-        ArrayNullabilityMode = arrayNullabilityMode;
-    }
-
-    public override Type GetFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
-    public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
-
-    /// <inheritdoc />
-    public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
-        => throw new NotSupportedException();
-
-    /// <inheritdoc />
-    public override NpgsqlTypeHandler CreateRangeHandler(PostgresType pgRangeType)
-        => throw new NotSupportedException();
-
-    /// <inheritdoc />
-    public override NpgsqlTypeHandler CreateMultirangeHandler(PostgresMultirangeType pgMultirangeType)
-        => throw new NotSupportedException();
-
-    #region Read
-
-    /// <inheritdoc />
-    protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-    {
-        if (ArrayTypeInfo<TRequestedArray>.IsArray)
-            return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async);
-
-        if (ArrayTypeInfo<TRequestedArray>.IsList)
-            return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async);
-
-        throw new InvalidCastException(fieldDescription == null
-            ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
-            : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
-        );
-    }
-
     /// <summary>
-    /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+    /// Non-generic base class for all type handlers which handle PostgreSQL arrays.
+    /// Extend from <see cref="ArrayHandler{TElement}"/> instead.
     /// </summary>
-    protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, bool readAsObject = false)
+    /// <remarks>
+    /// https://www.postgresql.org/docs/current/static/arrays.html.
+    ///
+    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+    /// Use it at your own risk.
+    /// </remarks>
+    public abstract class ArrayHandler : NpgsqlTypeHandler
     {
-        await buf.Ensure(12, async);
-        var dimensions = buf.ReadInt32();
-        var containsNulls = buf.ReadInt32() == 1;
-        buf.ReadUInt32(); // Element OID. Ignored.
+        private protected int LowerBound { get; } // The lower bound value sent to the backend when writing arrays. Normally 1 (the PG default) but is 0 for OIDVector.
+        private protected NpgsqlTypeHandler ElementHandler { get; }
+        private protected ArrayNullabilityMode ArrayNullabilityMode { get; }
 
-        var returnType = readAsObject
-            ? ArrayNullabilityMode switch
-            {
-                ArrayNullabilityMode.Never => ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
+        static readonly MethodInfo ReadArrayMethod = typeof(ArrayHandler).GetMethod(nameof(ReadArray), BindingFlags.NonPublic | BindingFlags.Instance)!;
+        static readonly MethodInfo ReadListMethod = typeof(ArrayHandler).GetMethod(nameof(ReadList), BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        /// <inheritdoc />
+        protected ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
+            : base(arrayPostgresType)
+        {
+            LowerBound = lowerBound;
+            ElementHandler = elementHandler;
+            ArrayNullabilityMode = arrayNullabilityMode;
+        }
+
+        public override Type GetFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
+        public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null) => typeof(Array);
+
+        /// <inheritdoc />
+        public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override NpgsqlTypeHandler CreateRangeHandler(PostgresType pgRangeType)
+            => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override NpgsqlTypeHandler CreateMultirangeHandler(PostgresMultirangeType pgMultirangeType)
+            => throw new NotSupportedException();
+
+        #region Read
+
+        /// <inheritdoc />
+        protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            if (ArrayTypeInfo<TRequestedArray>.IsArray)
+                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArrayFunc(this, buf, async);
+
+            if (ArrayTypeInfo<TRequestedArray>.IsList)
+                return await ArrayTypeInfo<TRequestedArray>.ReadListFunc(this, buf, async);
+
+            throw new InvalidCastException(fieldDescription == null
+                ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
+                : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
+            );
+        }
+
+        /// <summary>
+        /// Reads an array of element type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+        /// </summary>
+        protected async ValueTask<Array> ReadArray<TRequestedElement>(NpgsqlReadBuffer buf, bool async, int expectedDimensions = 0, bool readAsObject = false)
+        {
+            await buf.Ensure(12, async);
+            var dimensions = buf.ReadInt32();
+            var containsNulls = buf.ReadInt32() == 1;
+            buf.ReadUInt32(); // Element OID. Ignored.
+
+            var returnType = readAsObject
+                ? ArrayNullabilityMode switch
+                {
+                    ArrayNullabilityMode.Never => ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
+                        ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
+                        : typeof(TRequestedElement),
+                    ArrayNullabilityMode.Always => ElementTypeInfo<TRequestedElement>.NullableElementType,
+                    ArrayNullabilityMode.PerInstance => containsNulls
+                        ? ElementTypeInfo<TRequestedElement>.NullableElementType
+                        : typeof(TRequestedElement),
+                    _ => throw new ArgumentOutOfRangeException()
+                }
+                : ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
                     ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
-                    : typeof(TRequestedElement),
-                ArrayNullabilityMode.Always => ElementTypeInfo<TRequestedElement>.NullableElementType,
-                ArrayNullabilityMode.PerInstance => containsNulls
-                    ? ElementTypeInfo<TRequestedElement>.NullableElementType
-                    : typeof(TRequestedElement),
-                _ => throw new ArgumentOutOfRangeException()
-            }
-            : ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls
-                ? throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage)
-                : typeof(TRequestedElement);
+                    : typeof(TRequestedElement);
 
-        if (dimensions == 0)
-            return expectedDimensions > 1
-                ? Array.CreateInstance(returnType, new int[expectedDimensions])
-                : returnType == typeof(TRequestedElement)
-                    ? Array.Empty<TRequestedElement>()
-                    : Array.CreateInstance(returnType, 0);
+            if (dimensions == 0)
+                return expectedDimensions > 1
+                    ? Array.CreateInstance(returnType, new int[expectedDimensions])
+                    : returnType == typeof(TRequestedElement)
+                        ? Array.Empty<TRequestedElement>()
+                        : Array.CreateInstance(returnType, 0);
 
-        if (expectedDimensions > 0 && dimensions != expectedDimensions)
-            throw new InvalidOperationException($"Cannot read an array with {expectedDimensions} dimension(s) from an array with {dimensions} dimension(s)");
+            if (expectedDimensions > 0 && dimensions != expectedDimensions)
+                throw new InvalidOperationException($"Cannot read an array with {expectedDimensions} dimension(s) from an array with {dimensions} dimension(s)");
 
-        if (dimensions == 1 && returnType == typeof(TRequestedElement))
-        {
-            await buf.Ensure(8, async);
-            var arrayLength = buf.ReadInt32();
-
-            buf.ReadInt32(); // Lower bound
-
-            var oneDimensional = new TRequestedElement[arrayLength];
-            for (var i = 0; i < oneDimensional.Length; i++)
-                oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
-
-            return oneDimensional;
-        }
-
-        var dimLengths = new int[dimensions];
-        await buf.Ensure(dimensions * 8, async);
-
-        for (var i = 0; i < dimLengths.Length; i++)
-        {
-            dimLengths[i] = buf.ReadInt32();
-            buf.ReadInt32(); // Lower bound
-        }
-
-        var result = Array.CreateInstance(returnType, dimLengths);
-
-        // Either multidimensional arrays or arrays of nullable value types requested as object
-        // We can't avoid boxing here
-        var indices = new int[dimensions];
-        while (true)
-        {
-            await buf.Ensure(4, async);
-            var len = buf.ReadInt32();
-            var element = len == -1
-                ? (object?)null
-                : NullableHandler<TRequestedElement>.Exists
-                    ? await NullableHandler<TRequestedElement>.ReadAsync!(ElementHandler, buf, len, async)
-                    : await ElementHandler.Read<TRequestedElement>(buf, len, async);
-
-            result.SetValue(element, indices);
-
-            // TODO: Overly complicated/inefficient...
-            indices[dimensions - 1]++;
-            for (var dim = dimensions - 1; dim >= 0; dim--)
+            if (dimensions == 1 && returnType == typeof(TRequestedElement))
             {
-                if (indices[dim] <= result.GetUpperBound(dim))
+                await buf.Ensure(8, async);
+                var arrayLength = buf.ReadInt32();
+
+                buf.ReadInt32(); // Lower bound
+
+                var oneDimensional = new TRequestedElement[arrayLength];
+                for (var i = 0; i < oneDimensional.Length; i++)
+                    oneDimensional[i] = await ElementHandler.ReadWithLength<TRequestedElement>(buf, async);
+
+                return oneDimensional;
+            }
+
+            var dimLengths = new int[dimensions];
+            await buf.Ensure(dimensions * 8, async);
+
+            for (var i = 0; i < dimLengths.Length; i++)
+            {
+                dimLengths[i] = buf.ReadInt32();
+                buf.ReadInt32(); // Lower bound
+            }
+
+            var result = Array.CreateInstance(returnType, dimLengths);
+
+            // Either multidimensional arrays or arrays of nullable value types requested as object
+            // We can't avoid boxing here
+            var indices = new int[dimensions];
+            while (true)
+            {
+                await buf.Ensure(4, async);
+                var len = buf.ReadInt32();
+                var element = len == -1
+                    ? (object?)null
+                    : NullableHandler<TRequestedElement>.Exists
+                        ? await NullableHandler<TRequestedElement>.ReadAsync!(ElementHandler, buf, len, async)
+                        : await ElementHandler.Read<TRequestedElement>(buf, len, async);
+
+                result.SetValue(element, indices);
+
+                // TODO: Overly complicated/inefficient...
+                indices[dimensions - 1]++;
+                for (var dim = dimensions - 1; dim >= 0; dim--)
+                {
+                    if (indices[dim] <= result.GetUpperBound(dim))
+                        continue;
+
+                    if (dim == 0)
+                        return result;
+
+                    for (var j = dim; j < dimensions; j++)
+                        indices[j] = result.GetLowerBound(j);
+                    indices[dim - 1]++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+        /// </summary>
+        protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
+        {
+            await buf.Ensure(12, async);
+            var dimensions = buf.ReadInt32();
+            var containsNulls = buf.ReadInt32() == 1;
+            buf.ReadUInt32(); // Element OID. Ignored.
+
+            if (dimensions == 0)
+                return new List<TRequestedElement>();
+            if (dimensions > 1)
+                throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TRequestedElement).Name}>");
+            if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
+                throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
+
+            await buf.Ensure(8, async);
+            var length = buf.ReadInt32();
+            buf.ReadInt32(); // We don't care about the lower bounds
+
+            var list = new List<TRequestedElement>(length);
+            for (var i = 0; i < length; i++)
+                list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
+            return list;
+        }
+
+        internal const string ReadNonNullableCollectionWithNullsExceptionMessage =
+            "Cannot read a non-nullable collection of elements because the returned array contains nulls. " +
+            "Call GetFieldValue with a nullable array instead.";
+
+        #endregion Read
+
+        #region Write
+
+        // Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
+        protected int ValidateAndGetLengthNonGeneric(ICollection value, ref NpgsqlLengthCache lengthCache)
+        {
+            var asMultidimensional = value as Array;
+            var dimensions = asMultidimensional?.Rank ?? 1;
+
+            // Leave empty slot for the entire array length, and go ahead an populate the element slots
+            var pos = lengthCache.Position;
+            var len =
+                4 +              // dimensions
+                4 +              // has_nulls (unused)
+                4 +              // type OID
+                dimensions * 8 + // number of dimensions * (length + lower bound)
+                4 * value.Count; // sum of element lengths
+
+            lengthCache.Set(0);
+            NpgsqlLengthCache? elemLengthCache = lengthCache;
+
+            foreach (var element in value)
+            {
+                if (element is null)
                     continue;
 
-                if (dim == 0)
-                    return result;
+                try
+                {
+                    len += ElementHandler.ValidateObjectAndGetLength(element, ref elemLengthCache, null);
+                }
+                catch (Exception e)
+                {
+                    throw MixedTypesOrJaggedArrayException(e);
+                }
+            }
 
-                for (var j = dim; j < dimensions; j++)
-                    indices[j] = result.GetLowerBound(j);
-                indices[dim - 1]++;
+            lengthCache.Lengths[pos] = len;
+            return len;
+        }
+
+        protected async Task WriteNonGeneric(ICollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
+        {
+            var asArray = value as Array;
+            var dimensions = asArray?.Rank ?? 1;
+
+            var len =
+                4 +               // ndim
+                4 +               // has_nulls
+                4 +               // element_oid
+                dimensions * 8;   // dim (4) + lBound (4)
+
+            if (buf.WriteSpaceLeft < len)
+            {
+                await buf.Flush(async, cancellationToken);
+                Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
+            }
+
+            buf.WriteInt32(dimensions);
+            buf.WriteInt32(1);  // HasNulls=1. Not actually used by the backend.
+            buf.WriteUInt32(ElementHandler.PostgresType.OID);
+            if (asArray != null)
+            {
+                for (var i = 0; i < dimensions; i++)
+                {
+                    buf.WriteInt32(asArray.GetLength(i));
+                    buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
+                }
+            }
+            else
+            {
+                buf.WriteInt32(value.Count);
+                buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
+            }
+
+            foreach (var element in value)
+                await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async, cancellationToken);
+        }
+
+        protected static Exception MixedTypesOrJaggedArrayException(Exception innerException)
+            => new("While trying to write an array, one of its elements failed validation. " +
+                   "You may be trying to mix types in a non-generic IList, or to write a jagged array.", innerException);
+
+        #endregion Write
+
+        #region Static generic caching helpers
+
+        internal static class ElementTypeInfo<TElement>
+        {
+            public static readonly bool IsNonNullable =
+                typeof(TElement).IsValueType && Nullable.GetUnderlyingType(typeof(TElement)) is null;
+
+            public static readonly Type NullableElementType = IsNonNullable
+                ? typeof(Nullable<>).MakeGenericType(typeof(TElement))
+                : typeof(TElement);
+        }
+
+        internal static class ArrayTypeInfo<TArrayOrList>
+        {
+            // ReSharper disable StaticMemberInGenericType
+            public static readonly bool IsArray;
+            public static readonly bool IsList;
+            public static readonly Type? ElementType;
+
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>> ReadArrayFunc = default!;
+            public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>> ReadListFunc = default!;
+            // ReSharper restore StaticMemberInGenericType
+
+            static ArrayTypeInfo()
+            {
+                var type = typeof(TArrayOrList);
+                IsArray = type.IsArray;
+                IsList = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>);
+
+                ElementType = IsArray
+                    ? type.GetElementType()
+                    : IsList
+                        ? type.GetGenericArguments()[0]
+                        : null;
+
+                if (ElementType == null)
+                    return;
+
+                // Initialize delegates
+                var arrayHandlerParam = Expression.Parameter(typeof(ArrayHandler), "arrayHandler");
+                var bufferParam = Expression.Parameter(typeof(NpgsqlReadBuffer), "buf");
+                var asyncParam = Expression.Parameter(typeof(bool), "async");
+
+                if (IsArray)
+                {
+                    ReadArrayFunc = Expression
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>>>(
+                            Expression.Call(
+                                arrayHandlerParam,
+                                ReadArrayMethod.MakeGenericMethod(ElementType),
+                                bufferParam, asyncParam, Expression.Constant(type.GetArrayRank()), Expression.Constant(false, typeof(bool))),
+                            arrayHandlerParam, bufferParam, asyncParam)
+                        .Compile();
+                }
+
+                if (IsList)
+                {
+                    ReadListFunc = Expression
+                        .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>>>(
+                            Expression.Call(
+                                arrayHandlerParam,
+                                ReadListMethod.MakeGenericMethod(ElementType),
+                                bufferParam, asyncParam),
+                            arrayHandlerParam, bufferParam, asyncParam)
+                        .Compile();
+                }
             }
         }
+
+        #endregion Static generic caching helpers
     }
 
     /// <summary>
-    /// Reads a generic list containing elements of type <typeparamref name="TRequestedElement"/> from the given buffer <paramref name="buf"/>.
+    /// Base class for all type handlers which handle PostgreSQL arrays.
     /// </summary>
-    protected async ValueTask<List<TRequestedElement>> ReadList<TRequestedElement>(NpgsqlReadBuffer buf, bool async)
+    /// <remarks>
+    /// https://www.postgresql.org/docs/current/static/arrays.html.
+    ///
+    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+    /// Use it at your own risk.
+    /// </remarks>
+    public class ArrayHandler<TElement> : ArrayHandler
     {
-        await buf.Ensure(12, async);
-        var dimensions = buf.ReadInt32();
-        var containsNulls = buf.ReadInt32() == 1;
-        buf.ReadUInt32(); // Element OID. Ignored.
+        /// <inheritdoc />
+        public ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
+            : base(arrayPostgresType, elementHandler, arrayNullabilityMode, lowerBound) {}
 
-        if (dimensions == 0)
-            return new List<TRequestedElement>();
-        if (dimensions > 1)
-            throw new NotSupportedException($"Can't read multidimensional array as List<{typeof(TRequestedElement).Name}>");
-        if (ElementTypeInfo<TRequestedElement>.IsNonNullable && containsNulls)
-            throw new InvalidOperationException(ReadNonNullableCollectionWithNullsExceptionMessage);
+        #region Read
 
-        await buf.Ensure(8, async);
-        var length = buf.ReadInt32();
-        buf.ReadInt32(); // We don't care about the lower bounds
+        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => await ReadArray<TElement>(buf, async, readAsObject: true);
 
-        var list = new List<TRequestedElement>(length);
-        for (var i = 0; i < length; i++)
-            list.Add(await ElementHandler.ReadWithLength<TRequestedElement>(buf, async));
-        return list;
-    }
+        #endregion
 
-    internal const string ReadNonNullableCollectionWithNullsExceptionMessage =
-        "Cannot read a non-nullable collection of elements because the returned array contains nulls. " +
-        "Call GetFieldValue with a nullable array instead.";
+        #region Write
 
-    #endregion Read
+        static InvalidCastException CantWriteTypeException(Type type)
+            => new($"Can't write type '{type}' as an array of {typeof(TElement)}");
 
-    #region Write
+        // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
+        // we must use the bang operator here to tell the compiler that a null value will never be returned.
 
-    // Take care of multi-dimensional arrays and non-generic IList, we have no choice but to box/unbox
-    protected int ValidateAndGetLengthNonGeneric(ICollection value, ref NpgsqlLengthCache lengthCache)
-    {
-        var asMultidimensional = value as Array;
-        var dimensions = asMultidimensional?.Rank ?? 1;
+        /// <inheritdoc />
+        protected internal override int ValidateAndGetLengthCustom<TAny>([DisallowNull] TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => ValidateAndGetLength(value, ref lengthCache);
 
-        // Leave empty slot for the entire array length, and go ahead an populate the element slots
-        var pos = lengthCache.Position;
-        var len =
-            4 +              // dimensions
-            4 +              // has_nulls (unused)
-            4 +              // type OID
-            dimensions * 8 + // number of dimensions * (length + lower bound)
-            4 * value.Count; // sum of element lengths
+        /// <inheritdoc />
+        public override int ValidateObjectAndGetLength(object? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value is null || value == DBNull.Value
+                ? 0
+                : ValidateAndGetLength(value!, ref lengthCache);
 
-        lengthCache.Set(0);
-        NpgsqlLengthCache? elemLengthCache = lengthCache;
-
-        foreach (var element in value)
+        int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache)
         {
-            if (element is null)
-                continue;
-
-            try
-            {
-                len += ElementHandler.ValidateObjectAndGetLength(element, ref elemLengthCache, null);
-            }
-            catch (Exception e)
-            {
-                throw MixedTypesOrJaggedArrayException(e);
-            }
+            lengthCache ??= new NpgsqlLengthCache(1);
+            if (lengthCache.IsPopulated)
+                return lengthCache.Get();
+            if (value is ICollection<TElement> generic)
+                return ValidateAndGetLengthGeneric(generic, ref lengthCache);
+            if (value is ICollection nonGeneric)
+                return ValidateAndGetLengthNonGeneric(nonGeneric, ref lengthCache);
+            throw CantWriteTypeException(value.GetType());
         }
 
-        lengthCache.Lengths[pos] = len;
-        return len;
-    }
-
-    protected async Task WriteNonGeneric(ICollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
-    {
-        var asArray = value as Array;
-        var dimensions = asArray?.Rank ?? 1;
-
-        var len =
-            4 +               // ndim
-            4 +               // has_nulls
-            4 +               // element_oid
-            dimensions * 8;   // dim (4) + lBound (4)
-
-        if (buf.WriteSpaceLeft < len)
+        // Handle single-dimensional arrays and generic IList<T>
+        int ValidateAndGetLengthGeneric(ICollection<TElement> value, ref NpgsqlLengthCache lengthCache)
         {
-            await buf.Flush(async, cancellationToken);
-            Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
-        }
+            // Leave empty slot for the entire array length, and go ahead an populate the element slots
+            var pos = lengthCache.Position;
+            var len =
+                4 +              // dimensions
+                4 +              // has_nulls (unused)
+                4 +              // type OID
+                1 * 8 +          // number of dimensions (1) * (length + lower bound)
+                4 * value.Count; // sum of element lengths
 
-        buf.WriteInt32(dimensions);
-        buf.WriteInt32(1);  // HasNulls=1. Not actually used by the backend.
-        buf.WriteUInt32(ElementHandler.PostgresType.OID);
-        if (asArray != null)
-        {
-            for (var i = 0; i < dimensions; i++)
+            lengthCache.Set(0);
+            var elemLengthCache = lengthCache;
+
+            foreach (var element in value)
             {
-                buf.WriteInt32(asArray.GetLength(i));
-                buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
+                if (element is null)
+                    continue;
+
+                try
+                {
+                    len += ElementHandler.ValidateAndGetLength(element, ref elemLengthCache, null);
+                }
+                catch (Exception e)
+                {
+                    throw MixedTypesOrJaggedArrayException(e);
+                }
             }
+
+            lengthCache.Lengths[pos] = len;
+            return len;
         }
-        else
+
+        protected override Task WriteWithLengthCustom<TAny>([DisallowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken)
         {
+            buf.WriteInt32(ValidateAndGetLength(value, ref lengthCache, parameter));
+
+            if (value is ICollection<TElement> list)
+                return WriteGeneric(list, buf, lengthCache, async, cancellationToken);
+
+            if (value is ICollection nonGeneric)
+                return WriteNonGeneric(nonGeneric, buf, lengthCache, async, cancellationToken);
+
+            throw CantWriteTypeException(value.GetType());
+        }
+
+        // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
+        // us (need to handle many types of T, e.g. int[], int[,]...)
+        /// <inheritdoc />
+        public override Task WriteObjectWithLength(object? value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            => value is null || value is DBNull
+                ? WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
+                : WriteWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
+
+        async Task WriteGeneric(ICollection<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
+        {
+            var len =
+                4 +    // dimensions
+                4 +    // has_nulls (unused)
+                4 +    // type OID
+                1 * 8; // number of dimensions (1) * (length + lower bound)
+            if (buf.WriteSpaceLeft < len)
+            {
+                await buf.Flush(async, cancellationToken);
+                Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
+            }
+
+            buf.WriteInt32(1);
+            buf.WriteInt32(1); // has_nulls = 1. Not actually used by the backend.
+            buf.WriteUInt32(ElementHandler.PostgresType.OID);
             buf.WriteInt32(value.Count);
-            buf.WriteInt32(LowerBound);  // We don't map .NET lower bounds to PG
+            buf.WriteInt32(LowerBound); // We don't map .NET lower bounds to PG
+
+            foreach (var element in value)
+                await ElementHandler.WriteWithLength(element, buf, lengthCache, null, async, cancellationToken);
         }
 
-        foreach (var element in value)
-            await ElementHandler.WriteObjectWithLength(element, buf, lengthCache, null, async, cancellationToken);
+        #endregion
     }
 
-    protected static Exception MixedTypesOrJaggedArrayException(Exception innerException)
-        => new("While trying to write an array, one of its elements failed validation. " +
-               "You may be trying to mix types in a non-generic IList, or to write a jagged array.", innerException);
-
-    #endregion Write
-
-    #region Static generic caching helpers
-
-    internal static class ElementTypeInfo<TElement>
+    /// <remarks>
+    /// https://www.postgresql.org/docs/current/static/arrays.html
+    /// </remarks>
+    /// <typeparam name="TElement">The .NET type contained as an element within this array</typeparam>
+    /// <typeparam name="TElementPsv">The .NET provider-specific type contained as an element within this array</typeparam>
+    sealed class ArrayHandlerWithPsv<TElement, TElementPsv> : ArrayHandler<TElement>
     {
-        public static readonly bool IsNonNullable =
-            typeof(TElement).IsValueType && Nullable.GetUnderlyingType(typeof(TElement)) is null;
+        public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
+            : base(arrayPostgresType, elementHandler, arrayNullabilityMode) { }
 
-        public static readonly Type NullableElementType = IsNonNullable
-            ? typeof(Nullable<>).MakeGenericType(typeof(TElement))
-            : typeof(TElement);
+        internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
+            => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
+
+        internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => await ReadArray<TElementPsv>(buf, async, readAsObject: true);
     }
-
-    internal static class ArrayTypeInfo<TArrayOrList>
-    {
-        // ReSharper disable StaticMemberInGenericType
-        public static readonly bool IsArray;
-        public static readonly bool IsList;
-        public static readonly Type? ElementType;
-
-        public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>> ReadArrayFunc = default!;
-        public static readonly Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>> ReadListFunc = default!;
-        // ReSharper restore StaticMemberInGenericType
-
-        static ArrayTypeInfo()
-        {
-            var type = typeof(TArrayOrList);
-            IsArray = type.IsArray;
-            IsList = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>);
-
-            ElementType = IsArray
-                ? type.GetElementType()
-                : IsList
-                    ? type.GetGenericArguments()[0]
-                    : null;
-
-            if (ElementType == null)
-                return;
-
-            // Initialize delegates
-            var arrayHandlerParam = Expression.Parameter(typeof(ArrayHandler), "arrayHandler");
-            var bufferParam = Expression.Parameter(typeof(NpgsqlReadBuffer), "buf");
-            var asyncParam = Expression.Parameter(typeof(bool), "async");
-
-            if (IsArray)
-            {
-                ReadArrayFunc = Expression
-                    .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<Array>>>(
-                        Expression.Call(
-                            arrayHandlerParam,
-                            ReadArrayMethod.MakeGenericMethod(ElementType),
-                            bufferParam, asyncParam, Expression.Constant(type.GetArrayRank()), Expression.Constant(false, typeof(bool))),
-                        arrayHandlerParam, bufferParam, asyncParam)
-                    .Compile();
-            }
-
-            if (IsList)
-            {
-                ReadListFunc = Expression
-                    .Lambda<Func<ArrayHandler, NpgsqlReadBuffer, bool, ValueTask<TArrayOrList>>>(
-                        Expression.Call(
-                            arrayHandlerParam,
-                            ReadListMethod.MakeGenericMethod(ElementType),
-                            bufferParam, asyncParam),
-                        arrayHandlerParam, bufferParam, asyncParam)
-                    .Compile();
-            }
-        }
-    }
-
-    #endregion Static generic caching helpers
-}
-
-/// <summary>
-/// Base class for all type handlers which handle PostgreSQL arrays.
-/// </summary>
-/// <remarks>
-/// https://www.postgresql.org/docs/current/static/arrays.html.
-///
-/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-/// Use it at your own risk.
-/// </remarks>
-public class ArrayHandler<TElement> : ArrayHandler
-{
-    /// <inheritdoc />
-    public ArrayHandler(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode, int lowerBound = 1)
-        : base(arrayPostgresType, elementHandler, arrayNullabilityMode, lowerBound) {}
-
-    #region Read
-
-    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        => await ReadArray<TElement>(buf, async, readAsObject: true);
-
-    #endregion
-
-    #region Write
-
-    static InvalidCastException CantWriteTypeException(Type type)
-        => new($"Can't write type '{type}' as an array of {typeof(TElement)}");
-
-    // Since TAny isn't constrained to class? or struct (C# doesn't have a non-nullable constraint that doesn't limit us to either struct or class),
-    // we must use the bang operator here to tell the compiler that a null value will never be returned.
-
-    /// <inheritdoc />
-    protected internal override int ValidateAndGetLengthCustom<TAny>([DisallowNull] TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        => ValidateAndGetLength(value, ref lengthCache);
-
-    /// <inheritdoc />
-    public override int ValidateObjectAndGetLength(object? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        => value is null || value == DBNull.Value
-            ? 0
-            : ValidateAndGetLength(value!, ref lengthCache);
-
-    int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache)
-    {
-        lengthCache ??= new NpgsqlLengthCache(1);
-        if (lengthCache.IsPopulated)
-            return lengthCache.Get();
-        if (value is ICollection<TElement> generic)
-            return ValidateAndGetLengthGeneric(generic, ref lengthCache);
-        if (value is ICollection nonGeneric)
-            return ValidateAndGetLengthNonGeneric(nonGeneric, ref lengthCache);
-        throw CantWriteTypeException(value.GetType());
-    }
-
-    // Handle single-dimensional arrays and generic IList<T>
-    int ValidateAndGetLengthGeneric(ICollection<TElement> value, ref NpgsqlLengthCache lengthCache)
-    {
-        // Leave empty slot for the entire array length, and go ahead an populate the element slots
-        var pos = lengthCache.Position;
-        var len =
-            4 +              // dimensions
-            4 +              // has_nulls (unused)
-            4 +              // type OID
-            1 * 8 +          // number of dimensions (1) * (length + lower bound)
-            4 * value.Count; // sum of element lengths
-
-        lengthCache.Set(0);
-        var elemLengthCache = lengthCache;
-
-        foreach (var element in value)
-        {
-            if (element is null)
-                continue;
-
-            try
-            {
-                len += ElementHandler.ValidateAndGetLength(element, ref elemLengthCache, null);
-            }
-            catch (Exception e)
-            {
-                throw MixedTypesOrJaggedArrayException(e);
-            }
-        }
-
-        lengthCache.Lengths[pos] = len;
-        return len;
-    }
-
-    protected override Task WriteWithLengthCustom<TAny>([DisallowNull] TAny value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken)
-    {
-        buf.WriteInt32(ValidateAndGetLength(value, ref lengthCache, parameter));
-
-        if (value is ICollection<TElement> list)
-            return WriteGeneric(list, buf, lengthCache, async, cancellationToken);
-
-        if (value is ICollection nonGeneric)
-            return WriteNonGeneric(nonGeneric, buf, lengthCache, async, cancellationToken);
-
-        throw CantWriteTypeException(value.GetType());
-    }
-
-    // The default WriteObjectWithLength casts the type handler to INpgsqlTypeHandler<T>, but that's not sufficient for
-    // us (need to handle many types of T, e.g. int[], int[,]...)
-    /// <inheritdoc />
-    public override Task WriteObjectWithLength(object? value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        => value is null || value is DBNull
-            ? WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken)
-            : WriteWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
-
-    async Task WriteGeneric(ICollection<TElement> value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, bool async, CancellationToken cancellationToken = default)
-    {
-        var len =
-            4 +    // dimensions
-            4 +    // has_nulls (unused)
-            4 +    // type OID
-            1 * 8; // number of dimensions (1) * (length + lower bound)
-        if (buf.WriteSpaceLeft < len)
-        {
-            await buf.Flush(async, cancellationToken);
-            Debug.Assert(buf.WriteSpaceLeft >= len, "Buffer too small for header");
-        }
-
-        buf.WriteInt32(1);
-        buf.WriteInt32(1); // has_nulls = 1. Not actually used by the backend.
-        buf.WriteUInt32(ElementHandler.PostgresType.OID);
-        buf.WriteInt32(value.Count);
-        buf.WriteInt32(LowerBound); // We don't map .NET lower bounds to PG
-
-        foreach (var element in value)
-            await ElementHandler.WriteWithLength(element, buf, lengthCache, null, async, cancellationToken);
-    }
-
-    #endregion
-}
-
-/// <remarks>
-/// https://www.postgresql.org/docs/current/static/arrays.html
-/// </remarks>
-/// <typeparam name="TElement">The .NET type contained as an element within this array</typeparam>
-/// <typeparam name="TElementPsv">The .NET provider-specific type contained as an element within this array</typeparam>
-sealed class ArrayHandlerWithPsv<TElement, TElementPsv> : ArrayHandler<TElement>
-{
-    public ArrayHandlerWithPsv(PostgresType arrayPostgresType, NpgsqlTypeHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
-        : base(arrayPostgresType, elementHandler, arrayNullabilityMode) { }
-
-    internal override object ReadPsvAsObject(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-        => ReadPsvAsObject(buf, len, false, fieldDescription).GetAwaiter().GetResult();
-
-    internal override async ValueTask<object> ReadPsvAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        => await ReadArray<TElementPsv>(buf, async, readAsObject: true);
 }

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -272,12 +272,12 @@ namespace Npgsql.Internal.TypeHandlers
             if (ArrayTypeInfo<TRequestedArray>.IsArray)
             {
                 if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
-                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async);
+                    return (TRequestedArray)await ReadArray<BitArray>(buf, async);
 
                 if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
-                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async);
+                    return (TRequestedArray)await ReadArray<bool>(buf, async);
 
-                return (TRequestedArray)(object)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+                return (TRequestedArray)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
             }
 
             // We evaluate List last to better support reflection free mode

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -266,7 +266,31 @@ namespace Npgsql.Internal.TypeHandlers
         public BitStringArrayHandler(PostgresType postgresType, BitStringHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
             : base(postgresType, elementHandler, arrayNullabilityMode) {}
 
-        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        /// <inheritdoc />
+        protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
+            {
+                if (ArrayTypeInfo<TRequestedArray>.IsArray)
+                    return (TRequestedArray)(object)await ReadArray<BitArray>(buf, async);
+
+                if (ArrayTypeInfo<TRequestedArray>.IsList)
+                    return (TRequestedArray)await ReadList<BitArray>(buf, async);
+            }
+
+            if (ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
+            {
+                if (ArrayTypeInfo<TRequestedArray>.IsArray)
+                    return (TRequestedArray)(object)await ReadArray<bool>(buf, async);
+
+                if (ArrayTypeInfo<TRequestedArray>.IsList)
+                    return (TRequestedArray)await ReadList<bool>(buf, async);
+            }
+
+            return await base.ReadCustom<TRequestedArray>(buf, len, async, fieldDescription);
+        }
+
+        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
             => fieldDescription?.TypeModifier == 1
                 ? await ReadArray<bool>(buf, async)
                 : await ReadArray<BitArray>(buf, async);

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -9,299 +9,298 @@ using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 
-namespace Npgsql.Internal.TypeHandlers
+namespace Npgsql.Internal.TypeHandlers;
+
+/// <summary>
+/// A type handler for the PostgreSQL bit string data type.
+/// </summary>
+/// <remarks>
+/// See https://www.postgresql.org/docs/current/static/datatype-bit.html.
+///
+/// Note that for BIT(1), this handler will return a bool by default, to align with SQLClient
+/// (see discussion https://github.com/npgsql/npgsql/pull/362#issuecomment-59622101).
+///
+/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+/// Use it at your own risk.
+/// </remarks>
+public partial class BitStringHandler : NpgsqlTypeHandler<BitArray>,
+    INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
 {
-    /// <summary>
-    /// A type handler for the PostgreSQL bit string data type.
-    /// </summary>
-    /// <remarks>
-    /// See https://www.postgresql.org/docs/current/static/datatype-bit.html.
-    ///
-    /// Note that for BIT(1), this handler will return a bool by default, to align with SQLClient
-    /// (see discussion https://github.com/npgsql/npgsql/pull/362#issuecomment-59622101).
-    ///
-    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-    /// Use it at your own risk.
-    /// </remarks>
-    public partial class BitStringHandler : NpgsqlTypeHandler<BitArray>,
-        INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
+    public BitStringHandler(PostgresType pgType) : base(pgType) {}
+
+    public override Type GetFieldType(FieldDescription? fieldDescription = null)
+        => fieldDescription != null && fieldDescription.TypeModifier == 1 ? typeof(bool) : typeof(BitArray);
+
+    public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null)
+        => GetFieldType(fieldDescription);
+
+    // BitString requires a special array handler which returns bool or BitArray
+    /// <inheritdoc />
+    public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
+        => new BitStringArrayHandler(pgArrayType, this, arrayNullabilityMode);
+
+    #region Read
+
+    /// <inheritdoc />
+    public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
     {
-        public BitStringHandler(PostgresType pgType) : base(pgType) {}
-
-        public override Type GetFieldType(FieldDescription? fieldDescription = null)
-            => fieldDescription != null && fieldDescription.TypeModifier == 1 ? typeof(bool) : typeof(BitArray);
-
-        public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null)
-            => GetFieldType(fieldDescription);
-
-        // BitString requires a special array handler which returns bool or BitArray
-        /// <inheritdoc />
-        public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
-            => new BitStringArrayHandler(pgArrayType, this, arrayNullabilityMode);
-
-        #region Read
-
-        /// <inheritdoc />
-        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        {
-            await buf.Ensure(4, async);
-            var numBits = buf.ReadInt32();
-            var result = new BitArray(numBits);
-            var bytesLeft = len - 4;  // Remove leading number of bits
-            if (bytesLeft == 0)
-                return result;
-
-            var bitNo = 0;
-            while (true)
-            {
-                var iterationEndPos = bytesLeft > buf.ReadBytesLeft
-                    ? bytesLeft - buf.ReadBytesLeft
-                    : 1;
-
-                for (; bytesLeft > iterationEndPos; bytesLeft--)
-                {
-                    // ReSharper disable ShiftExpressionRealShiftCountIsZero
-                    var chunk = buf.ReadByte();
-                    result[bitNo++] = (chunk & (1 << 7)) != 0;
-                    result[bitNo++] = (chunk & (1 << 6)) != 0;
-                    result[bitNo++] = (chunk & (1 << 5)) != 0;
-                    result[bitNo++] = (chunk & (1 << 4)) != 0;
-                    result[bitNo++] = (chunk & (1 << 3)) != 0;
-                    result[bitNo++] = (chunk & (1 << 2)) != 0;
-                    result[bitNo++] = (chunk & (1 << 1)) != 0;
-                    result[bitNo++] = (chunk & (1 << 0)) != 0;
-                }
-
-                if (bytesLeft == 1)
-                    break;
-
-                Debug.Assert(buf.ReadBytesLeft == 0);
-                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
-            }
-
-            if (bitNo < result.Length)
-            {
-                var remainder = result.Length - bitNo;
-                await buf.Ensure(1, async);
-                var lastChunk = buf.ReadByte();
-                for (var i = 7; i >= 8 - remainder; i--)
-                    result[bitNo++] = (lastChunk & (1 << i)) != 0;
-            }
-
+        await buf.Ensure(4, async);
+        var numBits = buf.ReadInt32();
+        var result = new BitArray(numBits);
+        var bytesLeft = len - 4;  // Remove leading number of bits
+        if (bytesLeft == 0)
             return result;
-        }
 
-        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        var bitNo = 0;
+        while (true)
         {
-            if (len > 4 + 4)
-                throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
+            var iterationEndPos = bytesLeft > buf.ReadBytesLeft
+                ? bytesLeft - buf.ReadBytesLeft
+                : 1;
 
-            await buf.Ensure(4 + 4, async);
-
-            var numBits = buf.ReadInt32();
-            return numBits == 0
-                ? new BitVector32(0)
-                : new BitVector32(buf.ReadInt32());
-        }
-
-        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-        {
-            await buf.Ensure(5, async);
-            var bitLen = buf.ReadInt32();
-            if (bitLen != 1)
-                throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
-            var b = buf.ReadByte();
-            return (b & 128) != 0;
-        }
-
-        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-            => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
-
-        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => fieldDescription?.TypeModifier == 1
-                ? await Read<bool>(buf, len, async, fieldDescription)
-                : await Read<BitArray>(buf, len, async, fieldDescription);
-
-        #endregion
-
-        #region Write
-
-        /// <inheritdoc />
-        public override int ValidateAndGetLength(BitArray value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => 4 + (value.Length + 7) / 8;
-
-        /// <inheritdoc />
-        public int ValidateAndGetLength(BitVector32 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => value.Data == 0 ? 4 : 8;
-
-        /// <inheritdoc />
-        public int ValidateAndGetLength(bool value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-            => 5;
-
-        /// <inheritdoc />
-        public int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        {
-            if (value.Any(c => c != '0' && c != '1'))
-                throw new FormatException("Cannot interpret as ASCII BitString: " + value);
-            return 4 + (value.Length + 7) / 8;
-        }
-
-        /// <inheritdoc />
-        public override async Task Write(BitArray value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        {
-            // Initial bitlength byte
-            if (buf.WriteSpaceLeft < 4)
-                await buf.Flush(async, cancellationToken);
-            buf.WriteInt32(value.Length);
-
-            var byteLen = (value.Length + 7) / 8;
-            var pos = 0;
-            while (true)
+            for (; bytesLeft > iterationEndPos; bytesLeft--)
             {
-                var endPos = pos + Math.Min(byteLen - pos, buf.WriteSpaceLeft);
-                for (; pos < endPos; pos++)
-                {
-                    var bitPos = pos*8;
-                    var b = 0;
-                    for (var i = 0; i < Math.Min(8, value.Length - bitPos); i++)
-                        b += (value[bitPos + i] ? 1 : 0) << (8 - i - 1);
-                    buf.WriteByte((byte)b);
-                }
-
-                if (pos == byteLen)
-                    return;
-                await buf.Flush(async, cancellationToken);
-            }
-        }
-
-        /// <inheritdoc />
-        public async Task Write(BitVector32 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        {
-            if (buf.WriteSpaceLeft < 8)
-                await buf.Flush(async, cancellationToken);
-
-            if (value.Data == 0)
-                buf.WriteInt32(0);
-            else
-            {
-                buf.WriteInt32(32);
-                buf.WriteInt32(value.Data);
-            }
-        }
-
-        /// <inheritdoc />
-        public async Task Write(bool value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        {
-            if (buf.WriteSpaceLeft < 5)
-                await buf.Flush(async, cancellationToken);
-            buf.WriteInt32(1);
-            buf.WriteByte(value ? (byte)0x80 : (byte)0);
-        }
-
-        /// <inheritdoc />
-        public async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        {
-            // Initial bitlength byte
-            if (buf.WriteSpaceLeft < 4)
-                await buf.Flush(async, cancellationToken);
-            buf.WriteInt32(value.Length);
-
-            var pos = 0;
-            var byteLen = (value.Length + 7) / 8;
-            var bytePos = 0;
-
-            while (true)
-            {
-                var endBytePos = bytePos + Math.Min(byteLen - bytePos - 1, buf.WriteSpaceLeft);
-
-                for (; bytePos < endBytePos; bytePos++)
-                {
-                    var b = 0;
-                    b += (value[pos++] - '0') << 7;
-                    b += (value[pos++] - '0') << 6;
-                    b += (value[pos++] - '0') << 5;
-                    b += (value[pos++] - '0') << 4;
-                    b += (value[pos++] - '0') << 3;
-                    b += (value[pos++] - '0') << 2;
-                    b += (value[pos++] - '0') << 1;
-                    b += (value[pos++] - '0');
-                    buf.WriteByte((byte)b);
-                }
-
-                if (bytePos >= byteLen - 1)
-                    break;
-                await buf.Flush(async, cancellationToken);
+                // ReSharper disable ShiftExpressionRealShiftCountIsZero
+                var chunk = buf.ReadByte();
+                result[bitNo++] = (chunk & (1 << 7)) != 0;
+                result[bitNo++] = (chunk & (1 << 6)) != 0;
+                result[bitNo++] = (chunk & (1 << 5)) != 0;
+                result[bitNo++] = (chunk & (1 << 4)) != 0;
+                result[bitNo++] = (chunk & (1 << 3)) != 0;
+                result[bitNo++] = (chunk & (1 << 2)) != 0;
+                result[bitNo++] = (chunk & (1 << 1)) != 0;
+                result[bitNo++] = (chunk & (1 << 0)) != 0;
             }
 
-            if (pos < value.Length)
-            {
-                if (buf.WriteSpaceLeft < 1)
-                    await buf.Flush(async, cancellationToken);
+            if (bytesLeft == 1)
+                break;
 
-                var remainder = value.Length - pos;
-                var lastChunk = 0;
-                for (var i = 7; i >= 8 - remainder; i--)
-                    lastChunk += (value[pos++] - '0') << i;
-                buf.WriteByte((byte)lastChunk);
-            }
+            Debug.Assert(buf.ReadBytesLeft == 0);
+            await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
         }
 
-        #endregion
+        if (bitNo < result.Length)
+        {
+            var remainder = result.Length - bitNo;
+            await buf.Ensure(1, async);
+            var lastChunk = buf.ReadByte();
+            for (var i = 7; i >= 8 - remainder; i--)
+                result[bitNo++] = (lastChunk & (1 << i)) != 0;
+        }
+
+        return result;
     }
 
-    /// <summary>
-    /// A special handler for arrays of bit strings.
-    /// Differs from the standard array handlers in that it returns arrays of bool for BIT(1) and arrays
-    /// of BitArray otherwise (just like the scalar BitStringHandler does).
-    /// </summary>
-    /// <remarks>
-    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-    /// Use it at your own risk.
-    /// </remarks>
-    public class BitStringArrayHandler : ArrayHandler<BitArray>
+    async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
     {
-        /// <inheritdoc />
-        public BitStringArrayHandler(PostgresType postgresType, BitStringHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
-            : base(postgresType, elementHandler, arrayNullabilityMode) {}
+        if (len > 4 + 4)
+            throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
 
-        /// <inheritdoc />
-        protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        await buf.Ensure(4 + 4, async);
+
+        var numBits = buf.ReadInt32();
+        return numBits == 0
+            ? new BitVector32(0)
+            : new BitVector32(buf.ReadInt32());
+    }
+
+    async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+    {
+        await buf.Ensure(5, async);
+        var bitLen = buf.ReadInt32();
+        if (bitLen != 1)
+            throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
+        var b = buf.ReadByte();
+        return (b & 128) != 0;
+    }
+
+    ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
+
+    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        => fieldDescription?.TypeModifier == 1
+            ? await Read<bool>(buf, len, async, fieldDescription)
+            : await Read<BitArray>(buf, len, async, fieldDescription);
+
+    #endregion
+
+    #region Write
+
+    /// <inheritdoc />
+    public override int ValidateAndGetLength(BitArray value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => 4 + (value.Length + 7) / 8;
+
+    /// <inheritdoc />
+    public int ValidateAndGetLength(BitVector32 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => value.Data == 0 ? 4 : 8;
+
+    /// <inheritdoc />
+    public int ValidateAndGetLength(bool value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => 5;
+
+    /// <inheritdoc />
+    public int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+    {
+        if (value.Any(c => c != '0' && c != '1'))
+            throw new FormatException("Cannot interpret as ASCII BitString: " + value);
+        return 4 + (value.Length + 7) / 8;
+    }
+
+    /// <inheritdoc />
+    public override async Task Write(BitArray value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+    {
+        // Initial bitlength byte
+        if (buf.WriteSpaceLeft < 4)
+            await buf.Flush(async, cancellationToken);
+        buf.WriteInt32(value.Length);
+
+        var byteLen = (value.Length + 7) / 8;
+        var pos = 0;
+        while (true)
         {
-            if (ArrayTypeInfo<TRequestedArray>.IsArray)
+            var endPos = pos + Math.Min(byteLen - pos, buf.WriteSpaceLeft);
+            for (; pos < endPos; pos++)
             {
-                if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
-                    return (TRequestedArray)await ReadArray<BitArray>(buf, async);
-
-                if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
-                    return (TRequestedArray)await ReadArray<bool>(buf, async);
-
-                return (TRequestedArray)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+                var bitPos = pos*8;
+                var b = 0;
+                for (var i = 0; i < Math.Min(8, value.Length - bitPos); i++)
+                    b += (value[bitPos + i] ? 1 : 0) << (8 - i - 1);
+                buf.WriteByte((byte)b);
             }
 
-            // We evaluate List last to better support reflection free mode
-            // https://github.com/dotnet/runtimelab/blob/f2fd03035c1c02a0b904537b6f38906035f14689/docs/using-nativeaot/reflection-free-mode.md
-            if (ListTypeInfo<TRequestedArray>.IsList)
+            if (pos == byteLen)
+                return;
+            await buf.Flush(async, cancellationToken);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task Write(BitVector32 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+    {
+        if (buf.WriteSpaceLeft < 8)
+            await buf.Flush(async, cancellationToken);
+
+        if (value.Data == 0)
+            buf.WriteInt32(0);
+        else
+        {
+            buf.WriteInt32(32);
+            buf.WriteInt32(value.Data);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task Write(bool value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+    {
+        if (buf.WriteSpaceLeft < 5)
+            await buf.Flush(async, cancellationToken);
+        buf.WriteInt32(1);
+        buf.WriteByte(value ? (byte)0x80 : (byte)0);
+    }
+
+    /// <inheritdoc />
+    public async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+    {
+        // Initial bitlength byte
+        if (buf.WriteSpaceLeft < 4)
+            await buf.Flush(async, cancellationToken);
+        buf.WriteInt32(value.Length);
+
+        var pos = 0;
+        var byteLen = (value.Length + 7) / 8;
+        var bytePos = 0;
+
+        while (true)
+        {
+            var endBytePos = bytePos + Math.Min(byteLen - bytePos - 1, buf.WriteSpaceLeft);
+
+            for (; bytePos < endBytePos; bytePos++)
             {
-                if (ListTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
-                    return (TRequestedArray)await ReadList<BitArray>(buf, async);
-
-                if (ListTypeInfo<TRequestedArray>.ElementType == typeof(bool))
-                    return (TRequestedArray)await ReadList<bool>(buf, async);
-
-                return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
+                var b = 0;
+                b += (value[pos++] - '0') << 7;
+                b += (value[pos++] - '0') << 6;
+                b += (value[pos++] - '0') << 5;
+                b += (value[pos++] - '0') << 4;
+                b += (value[pos++] - '0') << 3;
+                b += (value[pos++] - '0') << 2;
+                b += (value[pos++] - '0') << 1;
+                b += (value[pos++] - '0');
+                buf.WriteByte((byte)b);
             }
 
-            throw new InvalidCastException(fieldDescription == null
-                ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
-                : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
-            );
+            if (bytePos >= byteLen - 1)
+                break;
+            await buf.Flush(async, cancellationToken);
         }
 
-        internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-            => fieldDescription?.TypeModifier == 1
-                ? await ReadArray<bool>(buf, async)
-                : await ReadArray<BitArray>(buf, async);
+        if (pos < value.Length)
+        {
+            if (buf.WriteSpaceLeft < 1)
+                await buf.Flush(async, cancellationToken);
+
+            var remainder = value.Length - pos;
+            var lastChunk = 0;
+            for (var i = 7; i >= 8 - remainder; i--)
+                lastChunk += (value[pos++] - '0') << i;
+            buf.WriteByte((byte)lastChunk);
+        }
     }
+
+    #endregion
+}
+
+/// <summary>
+/// A special handler for arrays of bit strings.
+/// Differs from the standard array handlers in that it returns arrays of bool for BIT(1) and arrays
+/// of BitArray otherwise (just like the scalar BitStringHandler does).
+/// </summary>
+/// <remarks>
+/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+/// Use it at your own risk.
+/// </remarks>
+public class BitStringArrayHandler : ArrayHandler<BitArray>
+{
+    /// <inheritdoc />
+    public BitStringArrayHandler(PostgresType postgresType, BitStringHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
+        : base(postgresType, elementHandler, arrayNullabilityMode) {}
+
+    /// <inheritdoc />
+    protected internal override async ValueTask<TRequestedArray> ReadCustom<TRequestedArray>(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    {
+        if (ArrayTypeInfo<TRequestedArray>.IsArray)
+        {
+            if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
+                return (TRequestedArray)await ReadArray<BitArray>(buf, async);
+
+            if(ArrayTypeInfo<TRequestedArray>.ElementType == typeof(bool))
+                return (TRequestedArray)await ReadArray<bool>(buf, async);
+
+            return (TRequestedArray)await ArrayTypeInfo<TRequestedArray>.ReadArray(this, buf, async);
+        }
+
+        // We evaluate List last to better support reflection free mode
+        // https://github.com/dotnet/runtimelab/blob/f2fd03035c1c02a0b904537b6f38906035f14689/docs/using-nativeaot/reflection-free-mode.md
+        if (ListTypeInfo<TRequestedArray>.IsList)
+        {
+            if (ListTypeInfo<TRequestedArray>.ElementType == typeof(BitArray))
+                return (TRequestedArray)await ReadList<BitArray>(buf, async);
+
+            if (ListTypeInfo<TRequestedArray>.ElementType == typeof(bool))
+                return (TRequestedArray)await ReadList<bool>(buf, async);
+
+            return (TRequestedArray)await ListTypeInfo<TRequestedArray>.ReadList(this, buf, async);
+        }
+
+        throw new InvalidCastException(fieldDescription == null
+            ? $"Can't cast database type to {typeof(TRequestedArray).Name}"
+            : $"Can't cast database type {fieldDescription.Handler.PgDisplayName} to {typeof(TRequestedArray).Name}"
+        );
+    }
+
+    internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        => fieldDescription?.TypeModifier == 1
+            ? await ReadArray<bool>(buf, async)
+            : await ReadArray<BitArray>(buf, async);
 }

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -299,7 +299,7 @@ public class BitStringArrayHandler : ArrayHandler<BitArray>
         );
     }
 
-    internal override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
         => fieldDescription?.TypeModifier == 1
             ? await ReadArray<bool>(buf, async)
             : await ReadArray<BitArray>(buf, async);

--- a/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/BitStringHandler.cs
@@ -9,265 +9,266 @@ using Npgsql.BackendMessages;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 
-namespace Npgsql.Internal.TypeHandlers;
-
-/// <summary>
-/// A type handler for the PostgreSQL bit string data type.
-/// </summary>
-/// <remarks>
-/// See https://www.postgresql.org/docs/current/static/datatype-bit.html.
-///
-/// Note that for BIT(1), this handler will return a bool by default, to align with SQLClient
-/// (see discussion https://github.com/npgsql/npgsql/pull/362#issuecomment-59622101).
-///
-/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-/// Use it at your own risk.
-/// </remarks>
-public partial class BitStringHandler : NpgsqlTypeHandler<BitArray>,
-    INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
+namespace Npgsql.Internal.TypeHandlers
 {
-    public BitStringHandler(PostgresType pgType) : base(pgType) {}
-
-    public override Type GetFieldType(FieldDescription? fieldDescription = null)
-        => fieldDescription != null && fieldDescription.TypeModifier == 1 ? typeof(bool) : typeof(BitArray);
-
-    public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null)
-        => GetFieldType(fieldDescription);
-
-    // BitString requires a special array handler which returns bool or BitArray
-    /// <inheritdoc />
-    public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
-        => new BitStringArrayHandler(pgArrayType, this, arrayNullabilityMode);
-
-    #region Read
-
-    /// <inheritdoc />
-    public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+    /// <summary>
+    /// A type handler for the PostgreSQL bit string data type.
+    /// </summary>
+    /// <remarks>
+    /// See https://www.postgresql.org/docs/current/static/datatype-bit.html.
+    ///
+    /// Note that for BIT(1), this handler will return a bool by default, to align with SQLClient
+    /// (see discussion https://github.com/npgsql/npgsql/pull/362#issuecomment-59622101).
+    ///
+    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+    /// Use it at your own risk.
+    /// </remarks>
+    public partial class BitStringHandler : NpgsqlTypeHandler<BitArray>,
+        INpgsqlTypeHandler<BitVector32>, INpgsqlTypeHandler<bool>, INpgsqlTypeHandler<string>
     {
-        await buf.Ensure(4, async);
-        var numBits = buf.ReadInt32();
-        var result = new BitArray(numBits);
-        var bytesLeft = len - 4;  // Remove leading number of bits
-        if (bytesLeft == 0)
+        public BitStringHandler(PostgresType pgType) : base(pgType) {}
+
+        public override Type GetFieldType(FieldDescription? fieldDescription = null)
+            => fieldDescription != null && fieldDescription.TypeModifier == 1 ? typeof(bool) : typeof(BitArray);
+
+        public override Type GetProviderSpecificFieldType(FieldDescription? fieldDescription = null)
+            => GetFieldType(fieldDescription);
+
+        // BitString requires a special array handler which returns bool or BitArray
+        /// <inheritdoc />
+        public override NpgsqlTypeHandler CreateArrayHandler(PostgresArrayType pgArrayType, ArrayNullabilityMode arrayNullabilityMode)
+            => new BitStringArrayHandler(pgArrayType, this, arrayNullabilityMode);
+
+        #region Read
+
+        /// <inheritdoc />
+        public override async ValueTask<BitArray> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+        {
+            await buf.Ensure(4, async);
+            var numBits = buf.ReadInt32();
+            var result = new BitArray(numBits);
+            var bytesLeft = len - 4;  // Remove leading number of bits
+            if (bytesLeft == 0)
+                return result;
+
+            var bitNo = 0;
+            while (true)
+            {
+                var iterationEndPos = bytesLeft > buf.ReadBytesLeft
+                    ? bytesLeft - buf.ReadBytesLeft
+                    : 1;
+
+                for (; bytesLeft > iterationEndPos; bytesLeft--)
+                {
+                    // ReSharper disable ShiftExpressionRealShiftCountIsZero
+                    var chunk = buf.ReadByte();
+                    result[bitNo++] = (chunk & (1 << 7)) != 0;
+                    result[bitNo++] = (chunk & (1 << 6)) != 0;
+                    result[bitNo++] = (chunk & (1 << 5)) != 0;
+                    result[bitNo++] = (chunk & (1 << 4)) != 0;
+                    result[bitNo++] = (chunk & (1 << 3)) != 0;
+                    result[bitNo++] = (chunk & (1 << 2)) != 0;
+                    result[bitNo++] = (chunk & (1 << 1)) != 0;
+                    result[bitNo++] = (chunk & (1 << 0)) != 0;
+                }
+
+                if (bytesLeft == 1)
+                    break;
+
+                Debug.Assert(buf.ReadBytesLeft == 0);
+                await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
+            }
+
+            if (bitNo < result.Length)
+            {
+                var remainder = result.Length - bitNo;
+                await buf.Ensure(1, async);
+                var lastChunk = buf.ReadByte();
+                for (var i = 7; i >= 8 - remainder; i--)
+                    result[bitNo++] = (lastChunk & (1 << i)) != 0;
+            }
+
             return result;
+        }
 
-        var bitNo = 0;
-        while (true)
+        async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         {
-            var iterationEndPos = bytesLeft > buf.ReadBytesLeft
-                ? bytesLeft - buf.ReadBytesLeft
-                : 1;
+            if (len > 4 + 4)
+                throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
 
-            for (; bytesLeft > iterationEndPos; bytesLeft--)
+            await buf.Ensure(4 + 4, async);
+
+            var numBits = buf.ReadInt32();
+            return numBits == 0
+                ? new BitVector32(0)
+                : new BitVector32(buf.ReadInt32());
+        }
+
+        async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+        {
+            await buf.Ensure(5, async);
+            var bitLen = buf.ReadInt32();
+            if (bitLen != 1)
+                throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
+            var b = buf.ReadByte();
+            return (b & 128) != 0;
+        }
+
+        ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
+            => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
+
+        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => fieldDescription?.TypeModifier == 1
+                ? await Read<bool>(buf, len, async, fieldDescription)
+                : await Read<BitArray>(buf, len, async, fieldDescription);
+
+        #endregion
+
+        #region Write
+
+        /// <inheritdoc />
+        public override int ValidateAndGetLength(BitArray value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => 4 + (value.Length + 7) / 8;
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(BitVector32 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => value.Data == 0 ? 4 : 8;
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(bool value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            => 5;
+
+        /// <inheritdoc />
+        public int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        {
+            if (value.Any(c => c != '0' && c != '1'))
+                throw new FormatException("Cannot interpret as ASCII BitString: " + value);
+            return 4 + (value.Length + 7) / 8;
+        }
+
+        /// <inheritdoc />
+        public override async Task Write(BitArray value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        {
+            // Initial bitlength byte
+            if (buf.WriteSpaceLeft < 4)
+                await buf.Flush(async, cancellationToken);
+            buf.WriteInt32(value.Length);
+
+            var byteLen = (value.Length + 7) / 8;
+            var pos = 0;
+            while (true)
             {
-                // ReSharper disable ShiftExpressionRealShiftCountIsZero
-                var chunk = buf.ReadByte();
-                result[bitNo++] = (chunk & (1 << 7)) != 0;
-                result[bitNo++] = (chunk & (1 << 6)) != 0;
-                result[bitNo++] = (chunk & (1 << 5)) != 0;
-                result[bitNo++] = (chunk & (1 << 4)) != 0;
-                result[bitNo++] = (chunk & (1 << 3)) != 0;
-                result[bitNo++] = (chunk & (1 << 2)) != 0;
-                result[bitNo++] = (chunk & (1 << 1)) != 0;
-                result[bitNo++] = (chunk & (1 << 0)) != 0;
+                var endPos = pos + Math.Min(byteLen - pos, buf.WriteSpaceLeft);
+                for (; pos < endPos; pos++)
+                {
+                    var bitPos = pos*8;
+                    var b = 0;
+                    for (var i = 0; i < Math.Min(8, value.Length - bitPos); i++)
+                        b += (value[bitPos + i] ? 1 : 0) << (8 - i - 1);
+                    buf.WriteByte((byte)b);
+                }
+
+                if (pos == byteLen)
+                    return;
+                await buf.Flush(async, cancellationToken);
             }
-
-            if (bytesLeft == 1)
-                break;
-
-            Debug.Assert(buf.ReadBytesLeft == 0);
-            await buf.Ensure(Math.Min(bytesLeft, buf.Size), async);
         }
 
-        if (bitNo < result.Length)
+        /// <inheritdoc />
+        public async Task Write(BitVector32 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
-            var remainder = result.Length - bitNo;
-            await buf.Ensure(1, async);
-            var lastChunk = buf.ReadByte();
-            for (var i = 7; i >= 8 - remainder; i--)
-                result[bitNo++] = (lastChunk & (1 << i)) != 0;
-        }
-
-        return result;
-    }
-
-    async ValueTask<BitVector32> INpgsqlTypeHandler<BitVector32>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-    {
-        if (len > 4 + 4)
-            throw new InvalidCastException("Can't read PostgreSQL bitstring with more than 32 bits into BitVector32");
-
-        await buf.Ensure(4 + 4, async);
-
-        var numBits = buf.ReadInt32();
-        return numBits == 0
-            ? new BitVector32(0)
-            : new BitVector32(buf.ReadInt32());
-    }
-
-    async ValueTask<bool> INpgsqlTypeHandler<bool>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-    {
-        await buf.Ensure(5, async);
-        var bitLen = buf.ReadInt32();
-        if (bitLen != 1)
-            throw new InvalidCastException("Can't convert a BIT(N) type to bool, only BIT(1)");
-        var b = buf.ReadByte();
-        return (b & 128) != 0;
-    }
-
-    ValueTask<string> INpgsqlTypeHandler<string>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
-        => throw new NotSupportedException("Only writing string to PostgreSQL bitstring is supported, no reading.");
-
-    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        => fieldDescription?.TypeModifier == 1
-            ? await Read<bool>(buf, len, async, fieldDescription)
-            : await Read<BitArray>(buf, len, async, fieldDescription);
-
-    #endregion
-
-    #region Write
-
-    /// <inheritdoc />
-    public override int ValidateAndGetLength(BitArray value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        => 4 + (value.Length + 7) / 8;
-
-    /// <inheritdoc />
-    public int ValidateAndGetLength(BitVector32 value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        => value.Data == 0 ? 4 : 8;
-
-    /// <inheritdoc />
-    public int ValidateAndGetLength(bool value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        => 5;
-
-    /// <inheritdoc />
-    public int ValidateAndGetLength(string value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-    {
-        if (value.Any(c => c != '0' && c != '1'))
-            throw new FormatException("Cannot interpret as ASCII BitString: " + value);
-        return 4 + (value.Length + 7) / 8;
-    }
-
-    /// <inheritdoc />
-    public override async Task Write(BitArray value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-    {
-        // Initial bitlength byte
-        if (buf.WriteSpaceLeft < 4)
-            await buf.Flush(async, cancellationToken);
-        buf.WriteInt32(value.Length);
-
-        var byteLen = (value.Length + 7) / 8;
-        var pos = 0;
-        while (true)
-        {
-            var endPos = pos + Math.Min(byteLen - pos, buf.WriteSpaceLeft);
-            for (; pos < endPos; pos++)
-            {
-                var bitPos = pos*8;
-                var b = 0;
-                for (var i = 0; i < Math.Min(8, value.Length - bitPos); i++)
-                    b += (value[bitPos + i] ? 1 : 0) << (8 - i - 1);
-                buf.WriteByte((byte)b);
-            }
-
-            if (pos == byteLen)
-                return;
-            await buf.Flush(async, cancellationToken);
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task Write(BitVector32 value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-    {
-        if (buf.WriteSpaceLeft < 8)
-            await buf.Flush(async, cancellationToken);
-
-        if (value.Data == 0)
-            buf.WriteInt32(0);
-        else
-        {
-            buf.WriteInt32(32);
-            buf.WriteInt32(value.Data);
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task Write(bool value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-    {
-        if (buf.WriteSpaceLeft < 5)
-            await buf.Flush(async, cancellationToken);
-        buf.WriteInt32(1);
-        buf.WriteByte(value ? (byte)0x80 : (byte)0);
-    }
-
-    /// <inheritdoc />
-    public async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-    {
-        // Initial bitlength byte
-        if (buf.WriteSpaceLeft < 4)
-            await buf.Flush(async, cancellationToken);
-        buf.WriteInt32(value.Length);
-
-        var pos = 0;
-        var byteLen = (value.Length + 7) / 8;
-        var bytePos = 0;
-
-        while (true)
-        {
-            var endBytePos = bytePos + Math.Min(byteLen - bytePos - 1, buf.WriteSpaceLeft);
-
-            for (; bytePos < endBytePos; bytePos++)
-            {
-                var b = 0;
-                b += (value[pos++] - '0') << 7;
-                b += (value[pos++] - '0') << 6;
-                b += (value[pos++] - '0') << 5;
-                b += (value[pos++] - '0') << 4;
-                b += (value[pos++] - '0') << 3;
-                b += (value[pos++] - '0') << 2;
-                b += (value[pos++] - '0') << 1;
-                b += (value[pos++] - '0');
-                buf.WriteByte((byte)b);
-            }
-
-            if (bytePos >= byteLen - 1)
-                break;
-            await buf.Flush(async, cancellationToken);
-        }
-
-        if (pos < value.Length)
-        {
-            if (buf.WriteSpaceLeft < 1)
+            if (buf.WriteSpaceLeft < 8)
                 await buf.Flush(async, cancellationToken);
 
-            var remainder = value.Length - pos;
-            var lastChunk = 0;
-            for (var i = 7; i >= 8 - remainder; i--)
-                lastChunk += (value[pos++] - '0') << i;
-            buf.WriteByte((byte)lastChunk);
+            if (value.Data == 0)
+                buf.WriteInt32(0);
+            else
+            {
+                buf.WriteInt32(32);
+                buf.WriteInt32(value.Data);
+            }
         }
+
+        /// <inheritdoc />
+        public async Task Write(bool value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        {
+            if (buf.WriteSpaceLeft < 5)
+                await buf.Flush(async, cancellationToken);
+            buf.WriteInt32(1);
+            buf.WriteByte(value ? (byte)0x80 : (byte)0);
+        }
+
+        /// <inheritdoc />
+        public async Task Write(string value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        {
+            // Initial bitlength byte
+            if (buf.WriteSpaceLeft < 4)
+                await buf.Flush(async, cancellationToken);
+            buf.WriteInt32(value.Length);
+
+            var pos = 0;
+            var byteLen = (value.Length + 7) / 8;
+            var bytePos = 0;
+
+            while (true)
+            {
+                var endBytePos = bytePos + Math.Min(byteLen - bytePos - 1, buf.WriteSpaceLeft);
+
+                for (; bytePos < endBytePos; bytePos++)
+                {
+                    var b = 0;
+                    b += (value[pos++] - '0') << 7;
+                    b += (value[pos++] - '0') << 6;
+                    b += (value[pos++] - '0') << 5;
+                    b += (value[pos++] - '0') << 4;
+                    b += (value[pos++] - '0') << 3;
+                    b += (value[pos++] - '0') << 2;
+                    b += (value[pos++] - '0') << 1;
+                    b += (value[pos++] - '0');
+                    buf.WriteByte((byte)b);
+                }
+
+                if (bytePos >= byteLen - 1)
+                    break;
+                await buf.Flush(async, cancellationToken);
+            }
+
+            if (pos < value.Length)
+            {
+                if (buf.WriteSpaceLeft < 1)
+                    await buf.Flush(async, cancellationToken);
+
+                var remainder = value.Length - pos;
+                var lastChunk = 0;
+                for (var i = 7; i >= 8 - remainder; i--)
+                    lastChunk += (value[pos++] - '0') << i;
+                buf.WriteByte((byte)lastChunk);
+            }
+        }
+
+        #endregion
     }
 
-    #endregion
-}
+    /// <summary>
+    /// A special handler for arrays of bit strings.
+    /// Differs from the standard array handlers in that it returns arrays of bool for BIT(1) and arrays
+    /// of BitArray otherwise (just like the scalar BitStringHandler does).
+    /// </summary>
+    /// <remarks>
+    /// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
+    /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
+    /// Use it at your own risk.
+    /// </remarks>
+    public class BitStringArrayHandler : ArrayHandler<BitArray>
+    {
+        /// <inheritdoc />
+        public BitStringArrayHandler(PostgresType postgresType, BitStringHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
+            : base(postgresType, elementHandler, arrayNullabilityMode) {}
 
-/// <summary>
-/// A special handler for arrays of bit strings.
-/// Differs from the standard array handlers in that it returns arrays of bool for BIT(1) and arrays
-/// of BitArray otherwise (just like the scalar BitStringHandler does).
-/// </summary>
-/// <remarks>
-/// The type handler API allows customizing Npgsql's behavior in powerful ways. However, although it is public, it
-/// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
-/// Use it at your own risk.
-/// </remarks>
-public class BitStringArrayHandler : ArrayHandler<BitArray>
-{
-    /// <inheritdoc />
-    public BitStringArrayHandler(PostgresType postgresType, BitStringHandler elementHandler, ArrayNullabilityMode arrayNullabilityMode)
-        : base(postgresType, elementHandler, arrayNullabilityMode) {}
-
-    public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
-        => fieldDescription?.TypeModifier == 1
-            ? await ReadArray<bool>(buf, async)
-            : await ReadArray<BitArray>(buf, async);
+        public override async ValueTask<object> ReadAsObject(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
+            => fieldDescription?.TypeModifier == 1
+                ? await ReadArray<bool>(buf, async)
+                : await ReadArray<BitArray>(buf, async);
+    }
 }

--- a/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
@@ -8,21 +9,14 @@ namespace Npgsql.Internal.TypeHandling;
 abstract class NullableHandler<T>
 {
     static NullableHandler<T>? _derivedInstance;
-    public static readonly Type? UnderlyingType = Nullable.GetUnderlyingType(typeof(T));
-    public static bool Exists => UnderlyingType != null;
+    public static bool Exists => default(T) is null && typeof(T).IsValueType;
 
     static NullableHandler<T> DerivedInstance
     {
         get
         {
-            return _derivedInstance ?? CreateInstance();
-            static NullableHandler<T> CreateInstance()
-            {
-                if (UnderlyingType is null)
-                    return null!;
-                _derivedInstance = (NullableHandler<T>?)Activator.CreateInstance(typeof(NullableHandler<,>).MakeGenericType(typeof(T), UnderlyingType));
-                return _derivedInstance!;
-            }
+            Debug.Assert(Exists);
+            return _derivedInstance ??= (NullableHandler<T>?)Activator.CreateInstance(typeof(NullableHandler<,>).MakeGenericType(typeof(T), typeof(T).GenericTypeArguments[0]))!;
         }
     }
 

--- a/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
@@ -6,64 +6,65 @@ using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 
 // ReSharper disable StaticMemberInGenericType
-namespace Npgsql.Internal.TypeHandling;
-
-delegate T ReadDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
-delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
-
-delegate int ValidateAndGetLengthDelegate<T>(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
-delegate Task WriteAsyncDelegate<T>(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default);
-
-static class NullableHandler<T>
+namespace Npgsql.Internal.TypeHandling
 {
-    public static readonly Type? UnderlyingType;
-    public static readonly ReadDelegate<T> Read = null!;
-    public static readonly ReadAsyncDelegate<T> ReadAsync = null!;
-    public static readonly ValidateAndGetLengthDelegate<T> ValidateAndGetLength = null!;
-    public static readonly WriteAsyncDelegate<T> WriteAsync = null!;
+    delegate T ReadDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
+    delegate ValueTask<T> ReadAsyncDelegate<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
 
-    public static bool Exists => UnderlyingType != null;
+    delegate int ValidateAndGetLengthDelegate<T>(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
+    delegate Task WriteAsyncDelegate<T>(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default);
 
-    static NullableHandler()
+    static class NullableHandler<T>
     {
-        UnderlyingType = Nullable.GetUnderlyingType(typeof(T));
+        public static readonly Type? UnderlyingType;
+        public static readonly ReadDelegate<T> Read = null!;
+        public static readonly ReadAsyncDelegate<T> ReadAsync = null!;
+        public static readonly ValidateAndGetLengthDelegate<T> ValidateAndGetLength = null!;
+        public static readonly WriteAsyncDelegate<T> WriteAsync = null!;
 
-        if (UnderlyingType == null)
-            return;
+        public static bool Exists => UnderlyingType != null;
 
-        Read = NullableHandler.CreateDelegate<ReadDelegate<T>>(UnderlyingType, NullableHandler.ReadMethod);
-        ReadAsync = NullableHandler.CreateDelegate<ReadAsyncDelegate<T>>(UnderlyingType, NullableHandler.ReadAsyncMethod);
-        ValidateAndGetLength = NullableHandler.CreateDelegate<ValidateAndGetLengthDelegate<T>>(UnderlyingType, NullableHandler.ValidateMethod);
-        WriteAsync = NullableHandler.CreateDelegate<WriteAsyncDelegate<T>>(UnderlyingType, NullableHandler.WriteAsyncMethod);
+        static NullableHandler()
+        {
+            UnderlyingType = Nullable.GetUnderlyingType(typeof(T));
+
+            if (UnderlyingType == null)
+                return;
+
+            Read = NullableHandler.CreateDelegate<ReadDelegate<T>>(UnderlyingType, NullableHandler.ReadMethod);
+            ReadAsync = NullableHandler.CreateDelegate<ReadAsyncDelegate<T>>(UnderlyingType, NullableHandler.ReadAsyncMethod);
+            ValidateAndGetLength = NullableHandler.CreateDelegate<ValidateAndGetLengthDelegate<T>>(UnderlyingType, NullableHandler.ValidateMethod);
+            WriteAsync = NullableHandler.CreateDelegate<WriteAsyncDelegate<T>>(UnderlyingType, NullableHandler.WriteAsyncMethod);
+        }
     }
-}
 
-static class NullableHandler
-{
-    internal static readonly MethodInfo ReadMethod = new ReadDelegate<int?>(Read<int>).Method.GetGenericMethodDefinition();
-    internal static readonly MethodInfo ReadAsyncMethod = new ReadAsyncDelegate<int?>(ReadAsync<int>).Method.GetGenericMethodDefinition();
-    internal static readonly MethodInfo ValidateMethod = new ValidateAndGetLengthDelegate<int?>(ValidateAndGetLength).Method.GetGenericMethodDefinition();
-    internal static readonly MethodInfo WriteAsyncMethod = new WriteAsyncDelegate<int?>(WriteAsync).Method.GetGenericMethodDefinition();
+    static class NullableHandler
+    {
+        internal static readonly MethodInfo ReadMethod = new ReadDelegate<int?>(Read<int>).Method.GetGenericMethodDefinition();
+        internal static readonly MethodInfo ReadAsyncMethod = new ReadAsyncDelegate<int?>(ReadAsync<int>).Method.GetGenericMethodDefinition();
+        internal static readonly MethodInfo ValidateMethod = new ValidateAndGetLengthDelegate<int?>(ValidateAndGetLength).Method.GetGenericMethodDefinition();
+        internal static readonly MethodInfo WriteAsyncMethod = new WriteAsyncDelegate<int?>(WriteAsync).Method.GetGenericMethodDefinition();
 
-    static T? Read<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription)
-        where T : struct
-        => handler.Read<T>(buffer, columnLength, fieldDescription);
+        static T? Read<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription)
+            where T : struct
+            => handler.Read<T>(buffer, columnLength, fieldDescription);
 
-    static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription)
-        where T : struct
-        => await handler.Read<T>(buffer, columnLength, async, fieldDescription);
+        static async ValueTask<T?> ReadAsync<T>(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription)
+            where T : struct
+            => await handler.Read<T>(buffer, columnLength, async, fieldDescription);
 
-    static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
-        where T : struct
-        => value.HasValue ? handler.ValidateAndGetLength(value.Value, ref lengthCache, parameter) : 0;
+        static int ValidateAndGetLength<T>(NpgsqlTypeHandler handler, T? value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+            where T : struct
+            => value.HasValue ? handler.ValidateAndGetLength(value.Value, ref lengthCache, parameter) : 0;
 
-    static Task WriteAsync<T>(NpgsqlTypeHandler handler, T? value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        where T : struct
-        => value.HasValue
-            ? handler.WriteWithLength(value.Value, buffer, lengthCache, parameter, async, cancellationToken)
-            : handler.WriteWithLength(DBNull.Value, buffer, lengthCache, parameter, async, cancellationToken);
+        static Task WriteAsync<T>(NpgsqlTypeHandler handler, T? value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+            where T : struct
+            => value.HasValue
+                ? handler.WriteWithLength(value.Value, buffer, lengthCache, parameter, async, cancellationToken)
+                : handler.WriteWithLength(DBNull.Value, buffer, lengthCache, parameter, async, cancellationToken);
 
-    internal static TDelegate CreateDelegate<TDelegate>(Type underlyingType, MethodInfo method)
-        where TDelegate : Delegate
-        => (TDelegate)method.MakeGenericMethod(underlyingType).CreateDelegate(typeof(TDelegate));
+        internal static TDelegate CreateDelegate<TDelegate>(Type underlyingType, MethodInfo method)
+            where TDelegate : Delegate
+            => (TDelegate)method.MakeGenericMethod(underlyingType).CreateDelegate(typeof(TDelegate));
+    }
 }

--- a/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
+++ b/src/Npgsql/Internal/TypeHandling/NullableHandler.cs
@@ -3,59 +3,58 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.BackendMessages;
 
-namespace Npgsql.Internal.TypeHandling
-{
-    abstract class NullableHandler<T>
-    {
-        static NullableHandler<T>? _derivedInstance;
-        public static readonly Type? UnderlyingType = Nullable.GetUnderlyingType(typeof(T));
-        public static bool Exists => UnderlyingType != null;
+namespace Npgsql.Internal.TypeHandling;
 
-        static NullableHandler<T> DerivedInstance
+abstract class NullableHandler<T>
+{
+    static NullableHandler<T>? _derivedInstance;
+    public static readonly Type? UnderlyingType = Nullable.GetUnderlyingType(typeof(T));
+    public static bool Exists => UnderlyingType != null;
+
+    static NullableHandler<T> DerivedInstance
+    {
+        get
         {
-            get
+            return _derivedInstance ?? CreateInstance();
+            static NullableHandler<T> CreateInstance()
             {
-                return _derivedInstance ?? CreateInstance();
-                static NullableHandler<T> CreateInstance()
-                {
-                    if (UnderlyingType is null)
-                        return null!;
-                    _derivedInstance = (NullableHandler<T>?)Activator.CreateInstance(typeof(NullableHandler<,>).MakeGenericType(typeof(T), UnderlyingType));
-                    return _derivedInstance!;
-                }
+                if (UnderlyingType is null)
+                    return null!;
+                _derivedInstance = (NullableHandler<T>?)Activator.CreateInstance(typeof(NullableHandler<,>).MakeGenericType(typeof(T), UnderlyingType));
+                return _derivedInstance!;
             }
         }
-
-        public static T Read(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null) =>
-            DerivedInstance.ReadImpl(handler, buffer, columnLength, fieldDescription);
-        public static ValueTask<T> ReadAsync(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription = null) =>
-            DerivedInstance.ReadAsyncImpl(handler, buffer, columnLength, async, fieldDescription);
-        public static int ValidateAndGetLength(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter) =>
-            DerivedInstance.ValidateAndGetLengthImpl(handler, value, ref lengthCache, parameter);
-        public static Task WriteAsync(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default) =>
-            DerivedInstance.WriteAsyncImpl(handler, value, buffer, lengthCache, parameter, async, cancellationToken);
-
-        protected abstract T ReadImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
-        protected abstract ValueTask<T> ReadAsyncImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
-        protected abstract int ValidateAndGetLengthImpl(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
-        protected abstract Task WriteAsyncImpl(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default);
     }
 
-    class NullableHandler<T, TUnderlying> : NullableHandler<T>
-        where TUnderlying : struct
-    {
-        protected override T ReadImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null)
-            => (T)(object)handler.Read<TUnderlying>(buffer, columnLength, fieldDescription);
+    public static T Read(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null) =>
+        DerivedInstance.ReadImpl(handler, buffer, columnLength, fieldDescription);
+    public static ValueTask<T> ReadAsync(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription = null) =>
+        DerivedInstance.ReadAsyncImpl(handler, buffer, columnLength, async, fieldDescription);
+    public static int ValidateAndGetLength(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter) =>
+        DerivedInstance.ValidateAndGetLengthImpl(handler, value, ref lengthCache, parameter);
+    public static Task WriteAsync(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default) =>
+        DerivedInstance.WriteAsyncImpl(handler, value, buffer, lengthCache, parameter, async, cancellationToken);
 
-        protected override async ValueTask<T> ReadAsyncImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription = null)
-            => (T)(object)await handler.Read<TUnderlying>(buffer, columnLength, async, fieldDescription);
+    protected abstract T ReadImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null);
+    protected abstract ValueTask<T> ReadAsyncImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLen, bool async, FieldDescription? fieldDescription = null);
+    protected abstract int ValidateAndGetLengthImpl(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter);
+    protected abstract Task WriteAsyncImpl(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default);
+}
 
-        protected override int ValidateAndGetLengthImpl(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter) =>
-            value != null ? handler.ValidateAndGetLength(((TUnderlying?)(object)value).Value, ref lengthCache, parameter) : 0;
+class NullableHandler<T, TUnderlying> : NullableHandler<T>
+    where TUnderlying : struct
+{
+    protected override T ReadImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, FieldDescription? fieldDescription = null)
+        => (T)(object)handler.Read<TUnderlying>(buffer, columnLength, fieldDescription);
 
-        protected override Task WriteAsyncImpl(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-            => value != null
-                ? handler.WriteWithLength(((TUnderlying?)(object)value).Value, buffer, lengthCache, parameter, async, cancellationToken)
-                : handler.WriteWithLength(DBNull.Value, buffer, lengthCache, parameter, async, cancellationToken);
-    }
+    protected override async ValueTask<T> ReadAsyncImpl(NpgsqlTypeHandler handler, NpgsqlReadBuffer buffer, int columnLength, bool async, FieldDescription? fieldDescription = null)
+        => (T)(object)await handler.Read<TUnderlying>(buffer, columnLength, async, fieldDescription);
+
+    protected override int ValidateAndGetLengthImpl(NpgsqlTypeHandler handler, T value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter) =>
+        value != null ? handler.ValidateAndGetLength(((TUnderlying?)(object)value).Value, ref lengthCache, parameter) : 0;
+
+    protected override Task WriteAsyncImpl(NpgsqlTypeHandler handler, T value, NpgsqlWriteBuffer buffer, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+        => value != null
+            ? handler.WriteWithLength(((TUnderlying?)(object)value).Value, buffer, lengthCache, parameter, async, cancellationToken)
+            : handler.WriteWithLength(DBNull.Value, buffer, lengthCache, parameter, async, cancellationToken);
 }


### PR DESCRIPTION
Tadah, as discussed.

Checks off `Array reader delegates` in https://github.com/npgsql/npgsql/issues/3300 and I also threw in reflectionless nullable for free 😄

I searched the codebase for `System.Reflection` and `System.Linq.Expressions` and the only ones left are for composites. Seems unavoidable, though we could expose some apis for users to hand npgsql the required composite code as an alternative to reflection.

