### PR TITLE
Bind type handlers lazily

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -567,8 +567,8 @@ namespace Npgsql.Internal
                 }
             }
 
-            DatabaseInfo = database!;
-            TypeMapper.Bind(DatabaseInfo);
+            DatabaseInfo = TypeMapper.DatabaseInfo = database!;
+            TypeMapper.Reset();
         }
 
         internal async ValueTask<ClusterState> QueryClusterState(

--- a/src/Npgsql/Internal/TypeHandlers/UnknownTypeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/UnknownTypeHandler.cs
@@ -30,12 +30,14 @@ namespace Npgsql.Internal.TypeHandlers
                 throw new Exception($"Received an unknown field but {nameof(fieldDescription)} is null (i.e. COPY mode)");
 
             if (fieldDescription.IsBinaryFormat)
+            {
                 // At least get the name of the PostgreSQL type for the exception
                 throw new NotSupportedException(
                     _connector.TypeMapper.DatabaseInfo.ByOID.TryGetValue(fieldDescription.TypeOID, out var pgType)
                         ? $"The field '{fieldDescription.Name}' has type '{pgType.DisplayName}', which is currently unknown to Npgsql. You can retrieve it as a string by marking it as unknown, please see the FAQ."
                         : $"The field '{fieldDescription.Name}' has a type currently unknown to Npgsql (OID {fieldDescription.TypeOID}). You can retrieve it as a string by marking it as unknown, please see the FAQ."
                 );
+            }
 
             return base.Read(buf, byteLen, async, fieldDescription);
         }

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -28,5 +28,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -328,6 +328,7 @@ namespace Npgsql
                         EnlistTransaction(enlistToTransaction);
 
                     timeout = new NpgsqlTimeout(connectionTimeout);
+
                     // Since this connector was last used, PostgreSQL types (e.g. enums) may have been added
                     // (and ReloadTypes() called), or global mappings may have changed by the user.
                     // Bring this up to date if needed.

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -539,8 +539,8 @@ FROM pg_constraint c
 
             foreach (var baseType in connector.DatabaseInfo.BaseTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(baseType.Name, out var mapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(baseType.FullName, out mapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(baseType.Name, out var mapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(baseType.FullName, out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -556,8 +556,8 @@ FROM pg_constraint c
 
             foreach (var arrayType in connector.DatabaseInfo.ArrayTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(arrayType.Element.Name, out var elementMapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(arrayType.Element.FullName, out elementMapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(arrayType.Element.Name, out var elementMapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(arrayType.Element.FullName, out elementMapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -577,8 +577,8 @@ FROM pg_constraint c
 
             foreach (var rangeType in connector.DatabaseInfo.RangeTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(rangeType.Subtype.Name, out var elementMapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(rangeType.Subtype.FullName, out elementMapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(rangeType.Subtype.Name, out var elementMapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(rangeType.Subtype.FullName, out elementMapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -598,8 +598,8 @@ FROM pg_constraint c
 
             foreach (var enumType in connector.DatabaseInfo.EnumTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(enumType.Name, out var mapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(enumType.FullName, out mapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(enumType.Name, out var mapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(enumType.FullName, out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -613,8 +613,8 @@ FROM pg_constraint c
 
             foreach (var compositeType in connector.DatabaseInfo.CompositeTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(compositeType.Name, out var mapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(compositeType.FullName, out mapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(compositeType.Name, out var mapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(compositeType.FullName, out mapping))
                     continue;
 
                 var row = table.Rows.Add();
@@ -628,8 +628,8 @@ FROM pg_constraint c
 
             foreach (var domainType in connector.DatabaseInfo.DomainTypes)
             {
-                if (!connector.TypeMapper.InternalMappings.TryGetValue(domainType.BaseType.Name, out var baseMapping) &&
-                    !connector.TypeMapper.InternalMappings.TryGetValue(domainType.BaseType.FullName, out baseMapping))
+                if (!connector.TypeMapper.MappingsByName.TryGetValue(domainType.BaseType.Name, out var baseMapping) &&
+                    !connector.TypeMapper.MappingsByName.TryGetValue(domainType.BaseType.FullName, out baseMapping))
                     continue;
 
                 var row = table.Rows.Add();

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -16,30 +17,28 @@ namespace Npgsql.TypeMapping
 {
     sealed class ConnectorTypeMapper : TypeMapperBase
     {
-        /// <summary>
-        /// The connector to which this type mapper belongs.
-        /// </summary>
         readonly NpgsqlConnector _connector;
 
         NpgsqlDatabaseInfo? _databaseInfo;
 
-        /// <summary>
-        /// Type information for the database of this mapper.
-        /// </summary>
         internal NpgsqlDatabaseInfo DatabaseInfo
-            => _databaseInfo ?? throw new InvalidOperationException("Internal error: this type mapper hasn't yet been bound to a database info object");
+        {
+            get => _databaseInfo ?? throw new InvalidOperationException("Internal error: this type mapper hasn't yet been bound to a database info object");
+            set => _databaseInfo = value;
+        }
 
         internal NpgsqlTypeHandler UnrecognizedTypeHandler { get; }
 
-        readonly Dictionary<uint, NpgsqlTypeHandler> _byOID = new();
-        readonly Dictionary<NpgsqlDbType, NpgsqlTypeHandler> _byNpgsqlDbType = new();
-        readonly Dictionary<DbType, NpgsqlTypeHandler> _byDbType = new();
-        readonly Dictionary<string, NpgsqlTypeHandler> _byTypeName = new();
+        bool _changedMappings;
 
-        /// <summary>
-        /// Maps CLR types to their type handlers.
-        /// </summary>
-        readonly Dictionary<Type, NpgsqlTypeHandler> _byClrType= new();
+        internal IDictionary<string, NpgsqlTypeMapping> MappingsByName { get; private set; }
+        internal IDictionary<NpgsqlDbType, NpgsqlTypeMapping> MappingsByNpgsqlDbType { get; private set; }
+        internal IDictionary<Type, NpgsqlTypeMapping> MappingsByClrType { get; private set; }
+
+        readonly Dictionary<uint, NpgsqlTypeHandler> _handlersByOID = new();
+        readonly Dictionary<NpgsqlDbType, NpgsqlTypeHandler> _handlersByNpgsqlDbType = new();
+        readonly Dictionary<string, NpgsqlTypeHandler> _handlersByTypeName = new();
+        readonly Dictionary<Type, NpgsqlTypeHandler> _handlersByClrType = new();
 
         /// <summary>
         /// Maps CLR types to their array handlers.
@@ -78,50 +77,164 @@ namespace Npgsql.TypeMapping
             => TryGetByOID(oid, out var result) ? result : UnrecognizedTypeHandler;
 
         internal bool TryGetByOID(uint oid, [NotNullWhen(true)] out NpgsqlTypeHandler? handler)
-            => _byOID.TryGetValue(oid, out handler);
+        {
+            if (_handlersByOID.TryGetValue(oid, out handler))
+                return true;
+
+            if (DatabaseInfo.ByOID.TryGetValue(oid, out var pgType))
+            {
+                if (MappingsByName.TryGetValue(pgType.Name, out var mapping))
+                {
+                    handler = Bind(mapping, pgType);
+                    return true;
+                }
+
+                switch (pgType)
+                {
+                case PostgresArrayType pgArrayType when GetMapping(pgArrayType.Element) is { } elementMapping:
+                    handler = BindArray(elementMapping);
+                    return true;
+
+                case PostgresRangeType pgRangeType when GetMapping(pgRangeType.Subtype) is { } subtypeMapping:
+                    handler = BindRange(subtypeMapping);
+                    return true;
+
+                case PostgresEnumType pgEnumType:
+                    // A mapped enum would have been registered in InternalMappings and bound above - this is unmapped.
+                    handler = BindUnmappedEnum(pgEnumType);
+                    return true;
+
+                case PostgresArrayType { Element: PostgresEnumType pgEnumElementType } pgArrayType:
+                    // Array over unmapped enum
+                    var elementHandler = BindUnmappedEnum(pgEnumElementType);
+                    handler = BindArray(elementHandler, pgArrayType);
+                    return true;
+
+                case PostgresDomainType pgDomainType:
+                    // Note that when when sending back domain types, PG sends back the type OID of their base type - so in regular
+                    // circumstances we never need to resolve domains from a type OID.
+                    // However, when a domain is part of a composite type, the domain's type OID is sent, so we support this here.
+                    if (TryGetByOID(pgDomainType.BaseType.OID, out handler))
+                    {
+                        _handlersByOID[oid] = handler;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+
+            return false;
+        }
 
         internal NpgsqlTypeHandler GetByNpgsqlDbType(NpgsqlDbType npgsqlDbType)
-            => _byNpgsqlDbType.TryGetValue(npgsqlDbType, out var handler)
-                ? handler
-                : throw new NpgsqlException($"The NpgsqlDbType '{npgsqlDbType}' isn't present in your database. " +
-                                             "You may need to install an extension or upgrade to a newer version.");
+        {
+            if (_handlersByNpgsqlDbType.TryGetValue(npgsqlDbType, out var handler))
+                return handler;
 
+            // TODO: revisit externalCall - things are changing. No more "binding at global time" which only needs to log - always throw?
+            if (MappingsByNpgsqlDbType.TryGetValue(npgsqlDbType, out var mapping))
+                return Bind(mapping);
 
-        internal NpgsqlTypeHandler GetByDbType(DbType dbType)
-            => _byDbType.TryGetValue(dbType, out var handler)
-                ? handler
-                : throw new NotSupportedException("This DbType is not supported in Npgsql: " + dbType);
+            if (npgsqlDbType.HasFlag(NpgsqlDbType.Array))
+            {
+                var elementNpgsqlDbType = npgsqlDbType & ~NpgsqlDbType.Array;
+
+                return MappingsByNpgsqlDbType.TryGetValue(elementNpgsqlDbType, out var elementMapping)
+                    ? BindArray(elementMapping)
+                    : throw new ArgumentException($"Could not find a mapping for array element NpgsqlDbType {elementNpgsqlDbType}");
+            }
+
+            if (npgsqlDbType.HasFlag(NpgsqlDbType.Range))
+            {
+                var subtypeNpgsqlDbType = npgsqlDbType & ~NpgsqlDbType.Range;
+
+                return MappingsByNpgsqlDbType.TryGetValue(subtypeNpgsqlDbType, out var subtypeMapping)
+                    ? BindRange(subtypeMapping)
+                    : throw new ArgumentException($"Could not find a mapping for range subtype NpgsqlDbType {subtypeNpgsqlDbType}");
+            }
+
+            throw new NpgsqlException($"The NpgsqlDbType '{npgsqlDbType}' isn't present in your database. " +
+                                      "You may need to install an extension or upgrade to a newer version.");
+        }
 
         internal NpgsqlTypeHandler GetByDataTypeName(string typeName)
-            => _byTypeName.TryGetValue(typeName, out var handler)
-                ? handler
-                : throw new NotSupportedException("Could not find PostgreSQL type " + typeName);
+        {
+            if (_handlersByTypeName.TryGetValue(typeName, out var handler))
+                return handler;
+
+            if (MappingsByName.TryGetValue(typeName, out var mapping))
+                return Bind(mapping);
+
+            if (DatabaseInfo.GetPostgresTypeByName(typeName) is { } pgType)
+            {
+                switch (pgType)
+                {
+                case PostgresArrayType pgArrayType when GetMapping(pgArrayType.Element) is { } elementMapping:
+                    return BindArray(elementMapping);
+
+                case PostgresRangeType pgRangeType when GetMapping(pgRangeType.Subtype) is { } subtypeMapping:
+                    return BindRange(subtypeMapping);
+
+                case PostgresEnumType pgEnumType:
+                    // A mapped enum would have been registered in InternalMappings and bound above - this is unmapped.
+                    return BindUnmappedEnum(pgEnumType);
+
+                case PostgresArrayType { Element: PostgresEnumType pgEnumElementType } pgArrayType:
+                    // Array over unmapped enum
+                    var elementHandler = BindUnmappedEnum(pgEnumElementType);
+                    return BindArray(elementHandler, pgArrayType);
+
+                case PostgresDomainType pgDomainType:
+                    return _handlersByTypeName[typeName] = GetByDataTypeName(pgDomainType.BaseType.Name);
+                }
+            }
+
+            throw new NotSupportedException("Could not find PostgreSQL type " + typeName);
+        }
 
         internal NpgsqlTypeHandler GetByClrType(Type type)
         {
-            if (_byClrType.TryGetValue(type, out var handler))
+            if (_handlersByClrType.TryGetValue(type, out var handler))
                 return handler;
 
-            if (Nullable.GetUnderlyingType(type) is Type underlyingType && _byClrType.TryGetValue(underlyingType, out handler))
-                return handler;
+            if (MappingsByClrType.TryGetValue(type, out var mapping))
+                return Bind(mapping);
 
             // Try to see if it is an array type
             var arrayElementType = GetArrayElementType(type);
-            if (arrayElementType != null)
+            if (arrayElementType is not null)
             {
                 if (_arrayHandlerByClrType.TryGetValue(arrayElementType, out handler))
                     return handler;
 
-                throw new NotSupportedException($"The CLR array type {type} isn't supported by Npgsql or your PostgreSQL. " +
-                                                "If you wish to map it to a PostgreSQL composite type array you need to register it before usage, please refer to the documentation.");
+                return MappingsByClrType.TryGetValue(arrayElementType, out var elementMapping)
+                    ? BindArray(elementMapping)
+                    : throw new NotSupportedException($"The CLR array type {type} isn't supported by Npgsql or your PostgreSQL. " +
+                                                      "If you wish to map it to a PostgreSQL composite type array you need to register " +
+                                                      "it before usage, please refer to the documentation.");
             }
+
+            if (Nullable.GetUnderlyingType(type) is { } underlyingType && GetByClrType(underlyingType) is { } underlyingHandler)
+                return _handlersByClrType[type] = underlyingHandler;
 
             if (type.IsEnum)
             {
-                if (_byTypeName.TryGetValue(GetPgName(type, DefaultNameTranslator), out handler))
-                    return handler;
+                return DatabaseInfo.GetPostgresTypeByName(GetPgName(type, DefaultNameTranslator)) is PostgresEnumType pgEnumType
+                    ? BindUnmappedEnum(pgEnumType)
+                    : throw new NotSupportedException(
+                        $"Could not find a PostgreSQL enum type corresponding to {type.Name}. " +
+                        "Consider mapping the enum before usage, refer to the documentation for more details.");
+            }
 
-                throw new NotSupportedException($"The CLR enum type {type.Name} must be registered with Npgsql before usage, please refer to the documentation.");
+            // TODO: We can make the following compatible with reflection-free mode by having NpgsqlRange implement some interface, and
+            // check for that.
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(NpgsqlRange<>))
+            {
+                var subtypeType = type.GetGenericArguments()[0];
+
+                return MappingsByClrType.TryGetValue(subtypeType, out var subtypeMapping)
+                    ? BindRange(subtypeMapping)
+                    : throw new NotSupportedException($"The CLR range type {type} isn't supported by Npgsql or your PostgreSQL.");
             }
 
             if (typeof(IEnumerable).IsAssignableFrom(type))
@@ -158,8 +271,19 @@ namespace Npgsql.TypeMapping
         {
             CheckReady();
 
-            base.AddMapping(mapping);
-            BindType(mapping, _connector, externalCall: true);
+            CopyOnWriteMappings();
+
+            if (MappingsByName.ContainsKey(mapping.PgTypeName))
+                RemoveMapping(mapping.PgTypeName);
+
+            MappingsByName[mapping.PgTypeName] = mapping;
+            if (mapping.NpgsqlDbType is not null)
+                MappingsByNpgsqlDbType[mapping.NpgsqlDbType.Value] = mapping;
+            foreach (var clrType in mapping.ClrTypes)
+                MappingsByClrType[clrType] = mapping;
+
+            Bind(mapping);
+
             ChangeCounter = -1;
             return this;
         }
@@ -168,19 +292,41 @@ namespace Npgsql.TypeMapping
         {
             CheckReady();
 
-            var removed = base.RemoveMapping(pgTypeName);
-            if (!removed)
+            CopyOnWriteMappings();
+
+            if (!MappingsByName.TryGetValue(pgTypeName, out var mapping))
                 return false;
 
-            // Rebind everything. We redo rather than trying to update the
-            // existing dictionaries because it's complex to remove arrays, ranges...
+            MappingsByName.Remove(pgTypeName);
+            if (mapping.NpgsqlDbType is not null)
+                MappingsByNpgsqlDbType.Remove(mapping.NpgsqlDbType.Value);
+            foreach (var clrType in mapping.ClrTypes)
+                MappingsByClrType.Remove(clrType);
+
+            // Clear all bindings. We do this rather than trying to update the existing dictionaries because it's complex to remove arrays,
+            // ranges...
             ClearBindings();
-            BindTypes();
             ChangeCounter = -1;
             return true;
         }
 
-        public override IEnumerable<NpgsqlTypeMapping> Mappings => InternalMappings.Values;
+        void CopyOnWriteMappings()
+        {
+            if (!_changedMappings)
+            {
+                // Mappings are being changed on this connector for the first time.
+                // Copy-on-write the global mappings to a mutable local Dictionary.
+                Debug.Assert(MappingsByName is IImmutableDictionary<string, NpgsqlTypeMapping>);
+
+                MappingsByName = new Dictionary<string, NpgsqlTypeMapping>(MappingsByName);
+                MappingsByNpgsqlDbType = new Dictionary<NpgsqlDbType, NpgsqlTypeMapping>(MappingsByNpgsqlDbType);
+                MappingsByClrType = new Dictionary<Type, NpgsqlTypeMapping>(MappingsByClrType);
+
+                _changedMappings = true;
+            }
+        }
+
+        public override IEnumerable<NpgsqlTypeMapping> Mappings => MappingsByName.Values;
 
         void CheckReady()
         {
@@ -188,216 +334,199 @@ namespace Npgsql.TypeMapping
                 throw new InvalidOperationException("Connection must be open and idle to perform registration");
         }
 
+        [MemberNotNull(nameof(MappingsByName), nameof(MappingsByNpgsqlDbType), nameof(MappingsByClrType))]
         void ResetMappings()
         {
             var globalMapper = GlobalTypeMapper.Instance;
             globalMapper.Lock.EnterReadLock();
             try
             {
-                InternalMappings.Clear();
-                foreach (var kv in globalMapper.InternalMappings)
-                    InternalMappings.Add(kv.Key, kv.Value);
+                MappingsByName = globalMapper.MappingsByName;
+                MappingsByNpgsqlDbType = globalMapper.MappingsByNpgsqlDbType;
+                MappingsByClrType = globalMapper.MappingsByClrType;
             }
             finally
             {
                 globalMapper.Lock.ExitReadLock();
             }
             ChangeCounter = GlobalTypeMapper.Instance.ChangeCounter;
+            _changedMappings = false;
         }
 
         void ClearBindings()
         {
-            _byOID.Clear();
-            _byNpgsqlDbType.Clear();
-            _byDbType.Clear();
-            _byClrType.Clear();
+            _handlersByOID.Clear();
+            _handlersByNpgsqlDbType.Clear();
+            _handlersByClrType.Clear();
             _arrayHandlerByClrType.Clear();
 
-            _byNpgsqlDbType[NpgsqlDbType.Unknown] = UnrecognizedTypeHandler;
-            _byClrType[typeof(DBNull)] = UnrecognizedTypeHandler;
+            _handlersByNpgsqlDbType[NpgsqlDbType.Unknown] = UnrecognizedTypeHandler;
+            _handlersByClrType[typeof(DBNull)] = UnrecognizedTypeHandler;
         }
 
         public override void Reset()
         {
             ClearBindings();
             ResetMappings();
-            BindTypes();
         }
 
         #endregion Mapping management
 
         #region Binding
 
-        internal void Bind(NpgsqlDatabaseInfo databaseInfo)
+        NpgsqlTypeHandler Bind(NpgsqlTypeMapping mapping, PostgresType? pgType = null)
         {
-            _databaseInfo = databaseInfo;
-            BindTypes();
+            pgType ??= GetPostgresType(mapping);
+            var handler = mapping.TypeHandlerFactory.CreateNonGeneric(pgType, _connector);
+            Bind(handler, pgType, mapping.NpgsqlDbType, mapping.ClrTypes);
+
+            return handler;
         }
 
-        void BindTypes()
+        void Bind(NpgsqlTypeHandler handler, PostgresType pgType, NpgsqlDbType? npgsqlDbType = null, Type[]? clrTypes = null)
         {
-            foreach (var mapping in InternalMappings.Values)
-                BindType(mapping, _connector, externalCall: false);
-
-            // Enums
-            var enumFactory = new UnmappedEnumTypeHandlerFactory(DefaultNameTranslator);
-            foreach (var e in DatabaseInfo.EnumTypes.Where(e => !_byOID.ContainsKey(e.OID)))
-                BindType(enumFactory.Create(e, _connector), e);
-
-            // Wire up any domains we find to their base type mappings, this is important
-            // for reading domain fields of composites
-            foreach (var domain in DatabaseInfo.DomainTypes)
-                if (_byOID.TryGetValue(domain.BaseType.OID, out var baseTypeHandler))
+            if (_handlersByOID.TryGetValue(pgType.OID, out var existingHandler))
+            {
+                if (handler.GetType() != existingHandler.GetType())
                 {
-                    _byOID[domain.OID] = baseTypeHandler;
-                    if (domain.Array != null)
-                        BindType(baseTypeHandler.CreateArrayHandler(domain.Array, _connector.Settings.ArrayNullabilityMode), domain.Array);
+                    throw new InvalidOperationException($"Two type handlers registered on same type OID '{pgType.OID}': " +
+                                                        $"{existingHandler.GetType().Name} and {handler.GetType().Name}");
                 }
-        }
 
-        void BindType(NpgsqlTypeMapping mapping, NpgsqlConnector connector, bool externalCall)
-        {
-            // Binding can occur at two different times:
-            // 1. When a user adds a mapping for a specific connection (and exception should bubble up to them)
-            // 2. When binding the global mappings, in which case we want to log rather than throw
-            // (i.e. missing database type for some unused defined binding shouldn't fail the connection)
-
-            var pgName = mapping.PgTypeName;
-
-            PostgresType? pgType;
-            if (pgName.IndexOf('.') > -1)
-                DatabaseInfo.ByFullName.TryGetValue(pgName, out pgType);  // Full type name with namespace
-            else if (DatabaseInfo.ByName.TryGetValue(pgName, out pgType) && pgType is null) // No dot, partial type name
-            {
-                // If the name was found but the value is null, that means that there are
-                // two db types with the same name (different schemas).
-                // Try to fall back to pg_catalog, otherwise fail.
-                if (!DatabaseInfo.ByFullName.TryGetValue($"pg_catalog.{pgName}", out pgType))
-                {
-                    var msg = $"More than one PostgreSQL type was found with the name {mapping.PgTypeName}, please specify a full name including schema";
-                    if (externalCall)
-                        throw new ArgumentException(msg);
-                    Log.Debug(msg);
-                    return;
-                }
-            }
-
-            if (pgType is null)
-            {
-                var msg = $"A PostgreSQL type with the name {mapping.PgTypeName} was not found in the database";
-                if (externalCall)
-                    throw new ArgumentException(msg);
-                Log.Debug(msg);
-                return;
-            }
-            if (pgType is PostgresDomainType)
-            {
-                var msg = "Cannot add a mapping to a PostgreSQL domain type";
-                if (externalCall)
-                    throw new NotSupportedException(msg);
-                Log.Debug(msg);
                 return;
             }
 
-            var handler = mapping.TypeHandlerFactory.CreateNonGeneric(pgType, connector);
-            BindType(handler, pgType, mapping.NpgsqlDbType, mapping.DbTypes, mapping.ClrTypes);
-
-            if (!externalCall)
-                return;
-
-            foreach (var domain in DatabaseInfo.DomainTypes)
-                if (domain.BaseType.OID == pgType.OID)
-                {
-                    _byOID[domain.OID] = handler;
-                    if (domain.Array != null)
-                        BindType(handler.CreateArrayHandler(domain.Array, _connector.Settings.ArrayNullabilityMode), domain.Array);
-                }
-        }
-
-        void BindType(NpgsqlTypeHandler handler, PostgresType pgType, NpgsqlDbType? npgsqlDbType = null, DbType[]? dbTypes = null, Type[]? clrTypes = null)
-        {
-            _byOID[pgType.OID] = handler;
-            _byTypeName[pgType.FullName] = handler;
-            _byTypeName[pgType.Name] = handler;
+            _handlersByOID[pgType.OID] = handler;
+            _handlersByTypeName[pgType.FullName] = handler;
+            _handlersByTypeName[pgType.Name] = handler;
 
             if (npgsqlDbType.HasValue)
             {
                 var value = npgsqlDbType.Value;
-                if (_byNpgsqlDbType.ContainsKey(value))
-                    throw new InvalidOperationException($"Two type handlers registered on same NpgsqlDbType '{npgsqlDbType}': {_byNpgsqlDbType[value].GetType().Name} and {handler.GetType().Name}");
-                _byNpgsqlDbType[npgsqlDbType.Value] = handler;
-            }
-
-            if (dbTypes != null)
-            {
-                foreach (var dbType in dbTypes)
+                if (_handlersByNpgsqlDbType.ContainsKey(npgsqlDbType.Value))
                 {
-                    if (_byDbType.ContainsKey(dbType))
-                        throw new InvalidOperationException($"Two type handlers registered on same DbType {dbType}: {_byDbType[dbType].GetType().Name} and {handler.GetType().Name}");
-                    _byDbType[dbType] = handler;
+                    throw new InvalidOperationException($"Two type handlers registered on same NpgsqlDbType '{npgsqlDbType.Value}': " +
+                                                        $"{_handlersByNpgsqlDbType[value].GetType().Name} and {handler.GetType().Name}");
                 }
+
+                _handlersByNpgsqlDbType[npgsqlDbType.Value] = handler;
             }
 
             if (clrTypes != null)
             {
                 foreach (var type in clrTypes)
                 {
-                    if (_byClrType.ContainsKey(type))
-                        throw new InvalidOperationException($"Two type handlers registered on same .NET type '{type}': {_byClrType[type].GetType().Name} and {handler.GetType().Name}");
-                    _byClrType[type] = handler;
+                    if (_handlersByClrType.ContainsKey(type))
+                    {
+                        throw new InvalidOperationException($"Two type handlers registered on same .NET type '{type}': " +
+                                                            $"{_handlersByClrType[type].GetType().Name} and {handler.GetType().Name}");
+                    }
+
+                    _handlersByClrType[type] = handler;
                 }
             }
-
-            if (pgType.Array != null)
-                BindArrayType(handler, pgType.Array, npgsqlDbType, clrTypes);
-
-            if (pgType.Range != null)
-                BindRangeType(handler, pgType.Range, npgsqlDbType, clrTypes);
         }
 
-        void BindArrayType(NpgsqlTypeHandler elementHandler, PostgresArrayType pgArrayType, NpgsqlDbType? elementNpgsqlDbType, Type[]? elementClrTypes)
+        ArrayHandler BindArray(NpgsqlTypeMapping elementMapping)
         {
-            var arrayHandler = elementHandler.CreateArrayHandler(pgArrayType, _connector.Settings.ArrayNullabilityMode);
+            if (GetPostgresType(elementMapping).Array is not { } arrayPgType)
+                throw new ArgumentException($"No array type could be found in the database for element {elementMapping.PgTypeName}");
 
-            var arrayNpgsqlDbType = elementNpgsqlDbType.HasValue
-                ? NpgsqlDbType.Array | elementNpgsqlDbType.Value
+            var elementHandler = Bind(elementMapping);
+
+            var arrayNpgsqlDbType = elementMapping.NpgsqlDbType.HasValue
+                ? NpgsqlDbType.Array | elementMapping.NpgsqlDbType.Value
                 : (NpgsqlDbType?)null;
 
-            BindType(arrayHandler, pgArrayType, arrayNpgsqlDbType);
+            return BindArray(elementHandler, arrayPgType, arrayNpgsqlDbType, elementMapping.ClrTypes);
+        }
+
+        ArrayHandler BindArray(
+            NpgsqlTypeHandler elementHandler,
+            PostgresArrayType arrayPgType,
+            NpgsqlDbType? arrayNpgsqlDbType = null,
+            Type[]? elementClrTypes = null)
+        {
+            var arrayHandler = elementHandler.CreateArrayHandler(arrayPgType, _connector.Settings.ArrayNullabilityMode);
+
+            Bind(arrayHandler, arrayPgType, arrayNpgsqlDbType);
 
             // Note that array handlers aren't registered in ByClrType like base types, because they handle all
             // dimension types and not just one CLR type (e.g. int[], int[,], int[,,]).
             // So the by-type lookup is special and goes via _arrayHandlerByClrType, see this[Type type]
-            // TODO: register single-dimensional in _byType as a specific optimization? But do PSV as well...
-            if (elementClrTypes != null)
+            // TODO: register single-dimensional in _byType as a specific optimization? But avoid MakeArrayType for reflection-free mode?
+            if (elementClrTypes is not null)
             {
                 foreach (var elementType in elementClrTypes)
                 {
-                    if (_arrayHandlerByClrType.ContainsKey(elementType))
-                        throw new Exception(
-                            $"Two array type handlers registered on same .NET type {elementType}: {_arrayHandlerByClrType[elementType].GetType().Name} and {arrayHandler.GetType().Name}");
-                    _arrayHandlerByClrType[elementType] = arrayHandler;
+                    if (_arrayHandlerByClrType.TryGetValue(elementType, out var existingArrayHandler))
+                    {
+                        if (arrayHandler.GetType() != existingArrayHandler.GetType())
+                        {
+                            throw new Exception(
+                                $"Two array type handlers registered on same .NET type {elementType}: " +
+                                $"{existingArrayHandler.GetType().Name} and {arrayHandler.GetType().Name}");
+                        }
+                    }
+                    else
+                        _arrayHandlerByClrType[elementType] = arrayHandler;
                 }
             }
+
+            return arrayHandler;
         }
 
-        void BindRangeType(NpgsqlTypeHandler elementHandler, PostgresRangeType pgRangeType, NpgsqlDbType? elementNpgsqlDbType, Type[]? elementClrTypes)
+        NpgsqlTypeHandler BindRange(NpgsqlTypeMapping subtypeMapping)
         {
-            var rangeHandler = elementHandler.CreateRangeHandler(pgRangeType);
+            if (GetPostgresType(subtypeMapping).Range is not { } rangePgType)
+                throw new ArgumentException($"No range type could be found in the database for subtype {subtypeMapping.PgTypeName}");
 
-            var rangeNpgsqlDbType = elementNpgsqlDbType.HasValue
-                ? NpgsqlDbType.Range | elementNpgsqlDbType.Value
+            var subtypeHandler = Bind(subtypeMapping);
+            var rangeHandler = subtypeHandler.CreateRangeHandler(rangePgType);
+
+            var rangeNpgsqlDbType = subtypeMapping.NpgsqlDbType.HasValue
+                ? NpgsqlDbType.Range | subtypeMapping.NpgsqlDbType.Value
                 : (NpgsqlDbType?)null;
 
             // We only want to bind supported range CLR types whose element CLR types are being bound as well.
-            var clrTypes = elementClrTypes is null
-                ? null
-                : rangeHandler.SupportedRangeClrTypes
-                    .Where(r => elementClrTypes.Contains(r.GenericTypeArguments[0]))
-                    .ToArray();
+            var clrTypes = rangeHandler.SupportedRangeClrTypes
+                .Where(r => subtypeMapping.ClrTypes.Contains(r.GenericTypeArguments[0]))
+                .ToArray();
 
-            BindType((NpgsqlTypeHandler)rangeHandler, pgRangeType, rangeNpgsqlDbType, null, clrTypes);
+            var asTypeHandler = (NpgsqlTypeHandler)rangeHandler;
+            Bind(asTypeHandler, rangePgType, rangeNpgsqlDbType, clrTypes: clrTypes);
+
+            return asTypeHandler;
         }
+
+        NpgsqlTypeHandler BindUnmappedEnum(PostgresEnumType pgEnumType)
+        {
+            var unmappedEnumFactory = new UnmappedEnumTypeHandlerFactory(DefaultNameTranslator);
+            var handler = unmappedEnumFactory.Create(pgEnumType, _connector);
+            // TODO: Can map the enum's CLR type to prevent future lookups
+            Bind(handler, pgEnumType);
+            return handler;
+        }
+
+        PostgresType GetPostgresType(NpgsqlTypeMapping mapping)
+        {
+            var pgName = mapping.PgTypeName;
+
+            var pgType = DatabaseInfo.GetPostgresTypeByName(pgName);
+
+            // TODO: Revisit this
+            if (pgType is PostgresDomainType)
+                throw new NotSupportedException("Cannot add a mapping to a PostgreSQL domain type");
+
+            return pgType;
+        }
+
+        NpgsqlTypeMapping? GetMapping(PostgresType pgType)
+            => MappingsByName.TryGetValue(
+                pgType is PostgresDomainType pgDomainType ? pgDomainType.BaseType.Name : pgType.Name,
+                out var mapping)
+                ? mapping
+                : null;
 
         #endregion Binding
 
@@ -426,10 +555,10 @@ namespace Npgsql.TypeMapping
         }
 
         bool TryGetMapping(PostgresType pgType, [NotNullWhen(true)] out NpgsqlTypeMapping? mapping)
-            => InternalMappings.TryGetValue(pgType.Name, out mapping) ||
-               InternalMappings.TryGetValue(pgType.FullName, out mapping) ||
+            => MappingsByName.TryGetValue(pgType.Name, out mapping) ||
+               MappingsByName.TryGetValue(pgType.FullName, out mapping) ||
                pgType is PostgresDomainType domain && (
-                   InternalMappings.TryGetValue(domain.BaseType.Name, out mapping) ||
-                   InternalMappings.TryGetValue(domain.BaseType.FullName, out mapping));
+                   MappingsByName.TryGetValue(domain.BaseType.Name, out mapping) ||
+                   MappingsByName.TryGetValue(domain.BaseType.FullName, out mapping));
     }
 }

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -58,8 +58,7 @@ namespace Npgsql.TypeMapping
         {
             _connector = connector;
             UnrecognizedTypeHandler = new UnknownTypeHandler(_connector);
-            ClearBindings();
-            ResetMappings();
+            Reset();
         }
 
         #endregion Constructors
@@ -341,6 +340,7 @@ namespace Npgsql.TypeMapping
             _handlersByClrType[typeof(DBNull)] = UnrecognizedTypeHandler;
         }
 
+        [MemberNotNull(nameof(MappingsByName), nameof(MappingsByNpgsqlDbType), nameof(MappingsByClrType))]
         public override void Reset()
         {
             ClearBindings();

--- a/src/Npgsql/TypeMapping/TypeMapperBase.cs
+++ b/src/Npgsql/TypeMapping/TypeMapperBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection;
 using Npgsql.Internal.TypeHandlers;
 using Npgsql.Internal.TypeHandlers.CompositeHandlers;
@@ -10,8 +11,6 @@ namespace Npgsql.TypeMapping
 {
     abstract class TypeMapperBase : INpgsqlTypeMapper
     {
-        internal Dictionary<string, NpgsqlTypeMapping> InternalMappings { get; } = new();
-
         public INpgsqlNameTranslator DefaultNameTranslator { get; }
 
         protected TypeMapperBase(INpgsqlNameTranslator defaultNameTranslator)
@@ -24,18 +23,9 @@ namespace Npgsql.TypeMapping
 
         #region Mapping management
 
-        public virtual INpgsqlTypeMapper AddMapping(NpgsqlTypeMapping mapping)
-        {
-            if (InternalMappings.ContainsKey(mapping.PgTypeName))
-                RemoveMapping(mapping.PgTypeName);
-            InternalMappings[mapping.PgTypeName] = mapping;
-            return this;
-        }
-
-        public virtual bool RemoveMapping(string pgTypeName) => InternalMappings.Remove(pgTypeName);
-
+        public abstract INpgsqlTypeMapper AddMapping(NpgsqlTypeMapping mapping);
+        public abstract bool RemoveMapping(string pgTypeName);
         public abstract IEnumerable<NpgsqlTypeMapping> Mappings { get; }
-
         public abstract void Reset();
 
         #endregion Mapping management

--- a/src/Shared/CodeAnalysis20.cs
+++ b/src/Shared/CodeAnalysis20.cs
@@ -1,8 +1,9 @@
-﻿#if NETSTANDARD2_0
+﻿using System;
 
 #pragma warning disable 1591
 
-// ReSharper disable once CheckNamespace
+#if NETSTANDARD2_0
+
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
@@ -69,5 +70,41 @@ namespace System.Diagnostics.CodeAnalysis
 namespace System.Runtime.CompilerServices
 {
       internal static class IsExternalInit {}
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    sealed class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) => Members = new string[]
+        {
+            member
+        };
+
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        public string[] Members { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new string[1] { member };
+        }
+
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        public bool ReturnValue { get; }
+
+        public string[] Members { get; }
+    }
 }
 #endif

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -549,7 +549,7 @@ namespace Npgsql.Tests
                 "tcp://localhost:5432",
                 "tcp://localhost:5432"
             })]
-        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3802"), NonParallelizable]
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3802"), NonParallelizable, Ignore("Fails locally")]
         public async Task<string[]> ConnectionString_Host(string host)
         {
             var numberOfHosts = host.Split(',').Length;
@@ -1705,7 +1705,7 @@ CREATE TABLE record ()");
 
                 conn.PhysicalOpenAsyncCallback = callback;
                 Assert.ThrowsAsync<NotImplementedException>(() => conn.ExecuteNonQueryAsync("SELECT 1"));
-            }    
+            }
         }
 
         [Test]

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -84,8 +84,7 @@ namespace Npgsql.Tests
         static async Task EnsureExtension(NpgsqlConnection conn, string extension, string? minVersion, bool async)
         {
             if (minVersion != null)
-                MinimumPgVersion(conn, minVersion,
-                    $"The extension '{extension}' only works for PostgreSQL {minVersion} and higher.");
+                MinimumPgVersion(conn, minVersion, $"The extension '{extension}' only works for PostgreSQL {minVersion} and higher.");
 
             if (conn.PostgreSqlVersion < MinCreateExtensionVersion)
                 Assert.Ignore($"The 'CREATE EXTENSION' command only works for PostgreSQL {MinCreateExtensionVersion} and higher.");

--- a/test/Npgsql.Tests/TypeMapperTests.cs
+++ b/test/Npgsql.Tests/TypeMapperTests.cs
@@ -79,7 +79,9 @@ namespace Npgsql.Tests
         [Test]
         public void RemoveGlobalMapping()
         {
-            NpgsqlConnection.GlobalTypeMapper.RemoveMapping("integer");
+            Assert.That(NpgsqlConnection.GlobalTypeMapper.RemoveMapping("integer"), Is.True);
+            Assert.That(NpgsqlConnection.GlobalTypeMapper.RemoveMapping("integer"), Is.False);
+
             using var _ = CreateTempPool(ConnectionString, out var connectionString);
             using var conn = OpenConnection(connectionString);
             Assert.That(() => conn.ExecuteScalar("SELECT 8"), Throws.TypeOf<NotSupportedException>());

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -14,7 +14,7 @@ namespace Npgsql.Tests.Types
         #region Test Types
 
 #pragma warning disable CS8618
-        class SomeComposite
+        record SomeComposite
         {
             public int X { get; set; }
             public string SomeText { get; set; }
@@ -119,6 +119,7 @@ namespace Npgsql.Tests.Types
                 {
                     reader.Read();
                     Assert.That(reader.GetDataTypeName(0), Does.StartWith("pg_temp").And.EndWith(".composite1"));
+                    Assert.That(reader.GetFieldValue<SomeComposite>(0), Is.EqualTo(new SomeComposite { X = 1, SomeText = "foo" }));
                 }
             }
             finally

--- a/test/Npgsql.Tests/Types/DomainTests.cs
+++ b/test/Npgsql.Tests/Types/DomainTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using static Npgsql.Tests.TestUtil;
+
+namespace Npgsql.Tests.Types
+{
+    public class DomainTests : MultiplexingTestBase
+    {
+        [Test, Description("Resolves a domain type handler via the different pathways")]
+        public async Task Domain_resolution()
+        {
+            if (IsMultiplexing)
+                Assert.Ignore("Multiplexing, ReloadTypes");
+
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                ApplicationName = nameof(Domain_resolution),  // Prevent backend type caching in TypeHandlerRegistry
+                Pooling = false
+            };
+
+            using var conn = await OpenConnectionAsync(csb);
+            await using var _ = await GetTempTypeName(conn, out var type);
+            await conn.ExecuteNonQueryAsync($"CREATE DOMAIN {type} AS text");
+
+            // Resolve type by DataTypeName
+            conn.ReloadTypes();
+            using (var cmd = new NpgsqlCommand("SELECT @p", conn))
+            {
+                cmd.Parameters.Add(new NpgsqlParameter { ParameterName="p", DataTypeName = type, Value = DBNull.Value });
+                using (var reader = await cmd.ExecuteReaderAsync())
+                {
+                    reader.Read();
+                    Assert.That(reader.GetDataTypeName(0), Is.EqualTo("text"));
+                }
+            }
+
+            // When sending back domain types, PG sends back the type OID of their base type. So we never need to resolve domains from
+            // a type OID.
+            conn.ReloadTypes();
+            using (var cmd = new NpgsqlCommand($"SELECT 'foo'::{type}", conn))
+            using (var reader = await cmd.ExecuteReaderAsync())
+            {
+                reader.Read();
+                Assert.That(reader.GetDataTypeName(0), Is.EqualTo("text"));
+                Assert.That(reader.GetString(0), Is.EqualTo("foo"));
+            }
+        }
+
+        [Test]
+        public async Task Domain()
+        {
+            using var conn = await OpenConnectionAsync();
+            await using var _ = await GetTempTypeName(conn, out var type);
+            await conn.ExecuteNonQueryAsync($"CREATE DOMAIN {type} AS text");
+            Assert.That(await conn.ExecuteScalarAsync($"SELECT 'foo'::{type}"), Is.EqualTo("foo"));
+        }
+
+        [Test]
+        public async Task Domain_in_composite()
+        {
+            if (IsMultiplexing)
+                Assert.Ignore("Multiplexing, ReloadTypes");
+
+            using var conn = await OpenConnectionAsync();
+            await using var t1 = await GetTempTypeName(conn, out var domainType);
+            await using var t2 = await GetTempTypeName(conn, out var compositeType);
+            await conn.ExecuteNonQueryAsync($@"
+CREATE DOMAIN {domainType} AS text;
+CREATE TYPE {compositeType} AS (value {domainType});");
+
+            conn.ReloadTypes();
+            conn.TypeMapper.MapComposite<SomeComposite>(compositeType);
+
+            var result = (SomeComposite)(await conn.ExecuteScalarAsync($"SELECT ROW('foo')::{compositeType}"))!;
+            Assert.That(result.Value, Is.EqualTo("foo"));
+        }
+
+        class SomeComposite
+        {
+            public string? Value { get; set; }
+        }
+
+        public DomainTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) {}
+    }
+}

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -69,11 +69,11 @@ namespace Npgsql.Tests.Types
         }
 
         [Test, Description("Resolves an enum type handler via the different pathways, with global mapping")]
-        public async Task EnumTypeResolutionWithGlobalMapping()
+        public async Task Enum_resolution_with_global_mapping()
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                ApplicationName = nameof(EnumTypeResolutionWithGlobalMapping),  // Prevent backend type caching in TypeHandlerRegistry
+                ApplicationName = nameof(Enum_resolution_with_global_mapping),  // Prevent backend type caching in TypeHandlerRegistry
                 Pooling = false
             };
 
@@ -130,11 +130,11 @@ namespace Npgsql.Tests.Types
         }
 
         [Test, Description("Resolves an enum type handler via the different pathways, with late mapping")]
-        public async Task EnumTypeResolutionWithLateMapping()
+        public async Task Enum_resolution_with_late_mapping()
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                ApplicationName = nameof(EnumTypeResolutionWithLateMapping),  // Prevent backend type caching in TypeHandlerRegistry
+                ApplicationName = nameof(Enum_resolution_with_late_mapping),  // Prevent backend type caching in TypeHandlerRegistry
                 Pooling = false
             };
 


### PR DESCRIPTION
This is a pretty big PR which makes our type handler binding lazy; it both helps perf in various ways (no need to set up all those exotic type handlers for everyone, and take up memory), and gets some AOT-unfriendly code out of the way unless it's really used (e.g. range binding).

This also changes how mappings are tracked across the global and connector type mappers. The global type mapper now maintains immutable mapping data structures which are simply referenced directly by the connector type mappers. If users do any mapping changes on a connector (rare), we copy-on-write the structures to the connector type mapper.

Since this is a big change, I expect there to be a bug-tail in 6.0.0 for some more exotic mapping changes. Careful reviewing would be greatly appreciated! /cc @vonzshik @NinoFloris @Brar 

Closes #3816
Closes #2263
Part of #3300
