### PR TITLE
Implement raw SQL mode for prepared, non-batched commands

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -139,6 +139,8 @@ namespace Npgsql.Internal
 
         internal PreparedStatementManager PreparedStatementManager;
 
+        internal SqlQueryParser SqlQueryParser { get; } = new();
+
         /// <summary>
         /// If the connector is currently in COPY mode, holds a reference to the importer/exporter object.
         /// Otherwise null.

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -482,7 +482,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             using (connector.StartUserAction())
             {
                 Log.Debug($"Deriving Parameters for query: {CommandText}", connector.Id);
-                ProcessRawQuery(connector.UseConformingStrings, deriveParameters: true);
+                ProcessRawQuery(connector, deriveParameters: true);
 
                 var sendTask = SendDeriveParameters(connector, false);
                 if (sendTask.IsFaulted)
@@ -581,7 +581,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             for (var i = 0; i < Parameters.Count; i++)
                 Parameters[i].Bind(connector.TypeMapper);
 
-            ProcessRawQuery(connector.UseConformingStrings, deriveParameters: false);
+            ProcessRawQuery(connector, deriveParameters: false);
             Log.Debug($"Preparing: {CommandText}", connector.Id);
 
             var needToPrepare = false;
@@ -740,7 +740,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         #region Query analysis
 
-        internal void ProcessRawQuery(bool standardConformingStrings, bool deriveParameters)
+        internal void ProcessRawQuery(NpgsqlConnector connector, bool deriveParameters)
         {
             if (string.IsNullOrEmpty(CommandText))
                 throw new InvalidOperationException("CommandText property has not been initialized");
@@ -748,23 +748,14 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             NpgsqlStatement statement;
             switch (CommandType) {
             case CommandType.Text:
-                var parser = new SqlQueryParser();
-                parser.ParseRawQuery(CommandText, _parameters, _statements, standardConformingStrings, deriveParameters);
+                connector.SqlQueryParser.ParseRawQuery(CommandText, _parameters, _statements, connector.UseConformingStrings, deriveParameters);
 
                 if (_statements.Count > 1 && _parameters.HasOutputParameters)
                     throw new NotSupportedException("Commands with multiple queries cannot have out parameters");
                 break;
 
             case CommandType.TableDirect:
-                if (_statements.Count == 0)
-                    statement = new NpgsqlStatement();
-                else
-                {
-                    statement = _statements[0];
-                    statement.Reset();
-                    _statements.Clear();
-                }
-                _statements.Add(statement);
+                statement = TruncateStatementsToOne();
                 statement.SQL = "SELECT * FROM " + CommandText;
                 break;
 
@@ -804,17 +795,9 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 }
                 sb.Append(')');
 
-                if (_statements.Count == 0)
-                    statement = new NpgsqlStatement();
-                else
-                {
-                    statement = _statements[0];
-                    statement.Reset();
-                    _statements.Clear();
-                }
+                statement = TruncateStatementsToOne();
                 statement.SQL = sb.ToString();
                 statement.InputParameters.AddRange(inputList);
-                _statements.Add(statement);
                 break;
             default:
                 throw new InvalidOperationException($"Internal Npgsql bug: unexpected value {CommandType} of enum {nameof(CommandType)}. Please file a bug.");
@@ -831,11 +814,29 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         void ValidateParameters(ConnectorTypeMapper typeMapper)
         {
+            Parameters.HasOutputParameters = false;
+
             for (var i = 0; i < Parameters.Count; i++)
             {
                 var p = Parameters[i];
-                if (!p.IsInputDirection)
+
+                switch (p.Direction)
+                {
+                case ParameterDirection.Input:
+                    break;
+                case ParameterDirection.InputOutput:
+                    Parameters.HasOutputParameters = true;
+                    break;
+                case ParameterDirection.Output:
+                    Parameters.HasOutputParameters = true;
                     continue;
+                case ParameterDirection.ReturnValue:
+                    continue;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(ParameterDirection),
+                        $"Unhandled {nameof(ParameterDirection)} value: {p.Direction}");
+                }
+
                 p.Bind(typeMapper);
                 p.LengthCache?.Clear();
                 p.ValidateAndGetLength();
@@ -1229,35 +1230,10 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                             break;
 
                         case false:
-                            ProcessRawQuery(connector.UseConformingStrings, deriveParameters: false);
-
                             if (connector.Settings.MaxAutoPrepare > 0)
-                            {
-                                var numPrepared = 0;
-                                foreach (var statement in _statements)
-                                {
-                                    // If this statement isn't prepared, see if it gets implicitly prepared.
-                                    // Note that this may return null (not enough usages for automatic preparation).
-                                    if (!statement.IsPrepared)
-                                        statement.PreparedStatement = connector.PreparedStatementManager.TryGetAutoPrepared(statement);
-                                    if (statement.PreparedStatement is PreparedStatement pStatement)
-                                    {
-                                        numPrepared++;
-                                        if (pStatement?.State == PreparedState.NotPrepared)
-                                        {
-                                            pStatement.State = PreparedState.BeingPrepared;
-                                            statement.IsPreparing = true;
-                                        }
-                                    }
-                                }
-
-                                if (numPrepared > 0)
-                                {
-                                    _connectorPreparedOn = connector;
-                                    if (numPrepared == _statements.Count)
-                                        NpgsqlEventSource.Log.CommandStartPrepared();
-                                }
-                            }
+                                AutoPrepare(connector);
+                            else
+                                ProcessRawQuery(connector, deriveParameters: false);
 
                             break;
                         }
@@ -1324,7 +1300,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     }
 
                     ValidateParameters(pool.MultiplexingTypeMapper!);
-                    ProcessRawQuery(standardConformingStrings: true, deriveParameters: false);
 
                     State = CommandState.InProgress;
 
@@ -1373,6 +1348,80 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 await Write(connector, async, cancellationToken2);
                 await connector.Flush(async, cancellationToken2);
                 CleanupSend();
+            }
+        }
+
+        internal void AutoPrepare(NpgsqlConnector connector)
+        {
+            var numPrepared = 0;
+
+            if (connector.PreparedStatementManager.BySql.TryGetValue(CommandText, out var cachedSqlEntry) &&
+                cachedSqlEntry.IsPrepared &&
+                !Parameters.HasOutputParameters &&
+                (Parameters.Count == 0 || Parameters[0].ParameterName.Length == 0))
+            {
+                // The SQL is prepared, and we're in positional parameter mode.
+                // This is the optimized mode, where we don't need to parse/rewrite the CommandText or reorder the
+                // parameters - just use them as is.
+                var statement = TruncateStatementsToOne();
+                statement.SQL = CommandText;
+                statement.InputParameters = Parameters.InternalList;
+
+                // We still do TryAutoPrepare to test parameter matching, update the last-used timestamp, etc.
+                TryAutoPrepare(statement, cachedSqlEntry);
+            }
+            else
+            {
+                // This is either the first time we're seeing this CommandText (in which case it may contain legacy
+                // batching), or we're in named parameter mode. Either way, we need to parse and possibly rewrite it.
+                ProcessRawQuery(connector, deriveParameters: false);
+
+                if (_statements.Count > 1)
+                {
+                    // Legacy batching mode (semicolon found in NpgsqlCommand.CommandText).
+                    // Enumerate over the statements we've parsed out above, and auto-prepare them.
+                    // Note that while the individual statements may get cached, the command as a whole isn't.
+                    Debug.Assert(cachedSqlEntry is null);
+
+                    foreach (var statement in _statements)
+                    {
+                        if (!connector.PreparedStatementManager.BySql.TryGetValue(statement.SQL, out cachedSqlEntry))
+                            cachedSqlEntry = connector.PreparedStatementManager.CreateAutoPrepareCandidate(statement.SQL);
+
+                        if (!statement.IsPrepared)
+                            TryAutoPrepare(statement, cachedSqlEntry);
+                    }
+                }
+                else
+                {
+                    // This is a single-statement command we haven't seen before.
+                    // Create a SQL cache entry for it.
+                    cachedSqlEntry ??= connector.PreparedStatementManager.CreateAutoPrepareCandidate(CommandText);
+
+                    TryAutoPrepare(_statements[0], cachedSqlEntry);
+                }
+            }
+
+            if (numPrepared > 0)
+            {
+                _connectorPreparedOn = connector;
+                if (numPrepared == _statements.Count)
+                    NpgsqlEventSource.Log.CommandStartPrepared();
+            }
+
+            void TryAutoPrepare(NpgsqlStatement statement, PreparedStatement cachedSqlEntry)
+            {
+                if (connector!.PreparedStatementManager.TryAutoPrepare(cachedSqlEntry, statement.InputParameters))
+                {
+                    numPrepared++;
+                    if (cachedSqlEntry.State == PreparedState.NotPrepared)
+                    {
+                        cachedSqlEntry.State = PreparedState.BeingPrepared;
+                        statement.IsPreparing = true;
+                    }
+
+                    statement.PreparedStatement = cachedSqlEntry;
+                }
             }
         }
 
@@ -1446,6 +1495,29 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         #endregion
 
         #region Misc
+
+        NpgsqlStatement TruncateStatementsToOne()
+        {
+            switch (_statements.Count)
+            {
+            case 0:
+                var statement = new NpgsqlStatement();
+                _statements.Add(statement);
+                return statement;
+
+            case 1:
+                statement = _statements[0];
+                statement.Reset();
+                return statement;
+
+            default:
+                statement = _statements[0];
+                statement.Reset();
+                _statements.Clear();
+                _statements.Add(statement);
+                return statement;
+            }
+        }
 
         /// <summary>
         /// Fixes up the text/binary flag on result columns.

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -581,9 +581,10 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             for (var i = 0; i < Parameters.Count; i++)
                 Parameters[i].Bind(connector.TypeMapper);
 
+            _connectorPreparedOn = connector;
+
             if (connector.PreparedStatementManager.BySql.TryGetValue(CommandText, out var preparedStatement) &&
                 preparedStatement.IsExplicit &&
-                // !Parameters.HasOutputParameters &&
                 (Parameters.Count == 0 || Parameters[0].ParameterName.Length == 0) &&
                 preparedStatement.DoParametersMatch(Parameters.InternalList))
             {
@@ -613,8 +614,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     needToPrepare = true;
                 }
             }
-
-            _connectorPreparedOn = connector;
 
             Log.Debug($"Preparing: {CommandText}", connector.Id);
 

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -79,12 +79,12 @@ namespace Npgsql
                     goto DoubleQuoted;
                 case ':':
                     if (lastChar != ':' && !positionalParameters)
-                        goto ParamStart;
+                        goto NamedParamStart;
                     else
                         break;
                 case '@':
                     if (lastChar != '@' && !positionalParameters)
-                        goto ParamStart;
+                        goto NamedParamStart;
                     else
                         break;
                 case ';':
@@ -109,7 +109,7 @@ namespace Npgsql
                     goto Finish;
             }
 
-        ParamStart:
+        NamedParamStart:
             if (currCharOfs < end)
             {
                 lastChar = ch;
@@ -119,14 +119,14 @@ namespace Npgsql
                     if (currCharOfs - 1 > currTokenBeg)
                         _rewrittenSql.Append(span.Slice(currTokenBeg, currCharOfs - 1 - currTokenBeg));
                     currTokenBeg = currCharOfs++ - 1;
-                    goto Param;
+                    goto NamedParam;
                 }
                 currCharOfs++;
                 goto NoneContinue;
             }
             goto Finish;
 
-        Param:
+        NamedParam:
             // We have already at least one character of the param name
             for (;;)
             {
@@ -433,8 +433,9 @@ namespace Npgsql
             return;
 
         Finish:
-            if (statementIndex == 0 && _rewrittenSql.Length == 0 && !parameters.HasOutputParameters)
+            if (positionalParameters)
             {
+                Debug.Assert(statementIndex == 0);
                 statement.SQL = sql;
                 statement.InputParameters = parameters.InternalList;
             }

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -106,38 +106,49 @@ namespace Npgsql.Tests
         public void Named_parameters()
         {
             using var conn = OpenConnectionAndUnprepare();
-            using var command = new NpgsqlCommand("SELECT @a, @b", conn);
-            command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
-            command.Parameters.Add(new NpgsqlParameter("b", 8));
-            command.Prepare();
-            command.Parameters[0].Value = 3;
-            command.Parameters[1].Value = 5;
-            using (var reader = command.ExecuteReader())
+
+            for (var i = 0; i < 2; i++)
             {
-                Assert.That(reader.Read(), Is.True);
-                Assert.That(reader.GetInt32(0), Is.EqualTo(3));
-                Assert.That(reader.GetInt64(1), Is.EqualTo(5));
+                using var command = new NpgsqlCommand("SELECT @a, @b", conn);
+                command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
+                command.Parameters.Add(new NpgsqlParameter("b", 8));
+                command.Prepare();
+                command.Parameters[0].Value = 3;
+                command.Parameters[1].Value = 5;
+                using (var reader = command.ExecuteReader())
+                {
+                    Assert.That(reader.Read(), Is.True);
+                    Assert.That(reader.GetInt32(0), Is.EqualTo(3));
+                    Assert.That(reader.GetInt64(1), Is.EqualTo(5));
+                }
+                if (i == 1)
+                    command.Unprepare();
             }
-            command.Unprepare();
         }
 
         [Test]
         public void Positional_parameters()
         {
             using var conn = OpenConnectionAndUnprepare();
-            using var command = new NpgsqlCommand("SELECT $1, $2", conn);
-            command.Parameters.Add(new NpgsqlParameter { DbType = DbType.Int32 });
-            command.Parameters.Add(new NpgsqlParameter { Value = 8 });
-            command.Prepare();
-            command.Parameters[0].Value = 3;
-            command.Parameters[1].Value = 5;
-            using (var reader = command.ExecuteReader())
+
+            for (var i = 0; i < 2; i++)
             {
-                Assert.That(reader.Read(), Is.True);
-                Assert.That(reader.GetInt32(0), Is.EqualTo(3));
-                Assert.That(reader.GetInt64(1), Is.EqualTo(5));
+                using var command = new NpgsqlCommand("SELECT $1, $2", conn);
+                command.Parameters.Add(new NpgsqlParameter { DbType = DbType.Int32 });
+                command.Parameters.Add(new NpgsqlParameter { Value = 8 });
+                command.Prepare();
+                command.Parameters[0].Value = 3;
+                command.Parameters[1].Value = 5;
+                using (var reader = command.ExecuteReader())
+                {
+                    Assert.That(reader.Read(), Is.True);
+                    Assert.That(reader.GetInt32(0), Is.EqualTo(3));
+                    Assert.That(reader.GetInt64(1), Is.EqualTo(5));
+                }
+
+                if (i == 1)
+                    command.Unprepare();
             }
-            command.Unprepare();
         }
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1207")]

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -103,12 +103,31 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        public void Parameters()
+        public void Named_parameters()
         {
             using var conn = OpenConnectionAndUnprepare();
             using var command = new NpgsqlCommand("SELECT @a, @b", conn);
             command.Parameters.Add(new NpgsqlParameter("a", DbType.Int32));
             command.Parameters.Add(new NpgsqlParameter("b", 8));
+            command.Prepare();
+            command.Parameters[0].Value = 3;
+            command.Parameters[1].Value = 5;
+            using (var reader = command.ExecuteReader())
+            {
+                Assert.That(reader.Read(), Is.True);
+                Assert.That(reader.GetInt32(0), Is.EqualTo(3));
+                Assert.That(reader.GetInt64(1), Is.EqualTo(5));
+            }
+            command.Unprepare();
+        }
+
+        [Test]
+        public void Positional_parameters()
+        {
+            using var conn = OpenConnectionAndUnprepare();
+            using var command = new NpgsqlCommand("SELECT $1, $2", conn);
+            command.Parameters.Add(new NpgsqlParameter { DbType = DbType.Int32 });
+            command.Parameters.Add(new NpgsqlParameter { Value = 8 });
             command.Prepare();
             command.Parameters[0].Value = 3;
             command.Parameters[1].Value = 5;

--- a/test/Npgsql.Tests/SqlQueryParserTests.cs
+++ b/test/Npgsql.Tests/SqlQueryParserTests.cs
@@ -63,18 +63,16 @@ namespace Npgsql.Tests
         }
 
         [Test]
-        [TestCase(@"SELECT :p, e'ab\'c:not_referenced'", TestName = "Estring")]
-        [TestCase(@"SELECT :p, /*/* -- nested comment :not_referenced /*/* *//*/ **/*/*/*/1", TestName = "BlockComment")]
-        [TestCase(@"SELECT :p,
--- Comment, @not_referenced and also :not_referenced
+        [TestCase(@"SELECT e'ab\'c:param'", TestName = "Estring")]
+        [TestCase(@"SELECT/*/* -- nested comment :int /*/* *//*/ **/*/*/*/1")]
+        [TestCase(@"SELECT 1,
+-- Comment, @param and also :param
 2", TestName = "LineComment")]
         public void ParamDoesntGetBound(string sql)
         {
-            _params.AddWithValue(":p", "foo");
-            _params.AddWithValue(":not_referenced", "foo");
+            _params.AddWithValue(":param", "foo");
             _parser.ParseRawQuery(sql, _params, _queries, standardConformingStrings: true);
-            var boundParameter = _queries.Single().InputParameters.Single();
-            Assert.That(boundParameter.ParameterName, Is.EqualTo(":p"));
+            Assert.That(_queries.Single().InputParameters, Is.Empty);
         }
 
         [Test]


### PR DESCRIPTION
Npgsql currently does SQL parsing/rewriting of user-provided SQL, for two reasons:

1. For legacy reasons, we support the named`@p` instead of the PostgreSQL positional native `$1`.
2. We support semicolon-batching, where CommandText contains semicolon. Since PG requires protocol messages to be per-statement, we need to split the SQL.

This is problematic for two reasons:
1. Performance: we have parsing/rewriting in the hot path. Even for prepared statements, we must perform the parsing before we can look up the statements in the internal SQL cache (since individual statements are cached, not the entire SQL with semicolons).
2. Correctness: a DB driver should not touch SQL, and writing a correct parser for PostgreSQL isn't trivial (e.g. detect semicolons, but not inside strings). In practice, we've had very little bug reports over the years.

This PR removes SQL parsing/rewriting for non-batched, prepared commands (explicit or auto): PostgreSQL's native parameter placeholders can be used (so $1 instead of @p). The same will be done for batched commands in a separate PR, as part of [implementing the new .NET batching API](https://github.com/dotnet/runtime/issues/28633).

Some notes:

* I used to think about raw mode as an opt-in flag. Here are some issues with that approach:
    * This isn't just a connection string parameter you turn on, since code creating commands has to be changed as well (different placeholders in SQL, etc), so layers like EF/Dapper would need to make changes to use this feature. At that point the connection string parameter becomes required - since EF wouldn't work with named parameters any more - so raw mode would somehow need to be turned on regardless of the connection string provided by the user (EF/Dapper don't typically touch/rewrite connection strings).
    * We could have an additional programmatic way to activate raw mode (e.g. some new boolean property on NpgsqlCommand), but that would be an Npgsql-specific API, so impossible to use in provider-agnostic code.
    * I generally hate adding behavior flags/parameters.
* After thinking about it, I ended up with a version that doesn't require an opt-in.
    * We automatically detect if we're in positional parameter mode by checking the first parameter's name. If it's empty, we're in positional mode.
    * When preparing a command (explicit or auto), we go through the existing SqlQueryParser. This tells us if we're in legacy batching mode. For legacy batching, only the individual statements get stored in PreparedStatementManager - never the full CommandText with semicolons.
    * The next time we execute the same command, if we found it in PreparedStatementManager we know there's no legacy batching. And if we're in positional mode (and have no output parameters), we can simply send the command's CommandText and Parameters as-is - no need to parse/rewrite any more.

* This means that we parse - but not for prepared commands which use positional parameters; this is new the hot path.
* This addresses the 1st point above (perf), but not the 2nd (completely remove the parsing/rewriting logic when using positional parameters). Since we haven't had any actual trouble with the parser, it seems reasonable.
* Breaking change: having an NpgsqlParameter which isn't referenced in the SQL no longer works (silly)

Part of #1042
Leads to #2317
