### PR TITLE
Always clear read buffer after SSL negotiation

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -794,13 +794,14 @@ namespace Npgsql.Internal
                             throw new NpgsqlException("Exception while performing SSL handshake", e);
                         }
 
-                        ReadBuffer.Clear();  // Reset to empty after reading single SSL char
                         ReadBuffer.Underlying = _stream;
                         WriteBuffer.Underlying = _stream;
                         IsSecure = true;
                         Log.Trace("SSL negotiation successful");
                         break;
                     }
+
+                    ReadBuffer.Clear();  // Reset to empty after reading single SSL char
                 }
 
                 Log.Trace($"Socket connected to {Host}:{Port}");


### PR DESCRIPTION
Fixes the assertion failure described in https://github.com/npgsql/npgsql/issues/3839#issue-921233995.

Tracked down by @vonzshik.