### PR TITLE
Switch to SingleThreadSyncContext in Unprepare only in sync

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1008,7 +1008,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
             foreach (var statement in _statements.Where(s => s.IsPrepared))
             {
-                if (FlushOccurred)
+                if (!async && FlushOccurred)
                 {
                     async = true;
                     SynchronizationContext.SetSynchronizationContext(SingleThreadSynchronizationContext);


### PR DESCRIPTION
Fixes #3844 for 5.0
