### PR TITLE
Always write non-first batched statements asynchronously

### DIFF
--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -172,18 +172,11 @@ namespace Npgsql.Internal
             //NpgsqlEventSource.Log.RequestFailed();
 
             WritePosition = 0;
-            if (CurrentCommand != null)
-            {
-                CurrentCommand.FlushOccurred = true;
-                CurrentCommand = null;
-            }
             if (_copyMode)
                 WriteCopyDataHeader();
         }
 
         internal void Flush() => Flush(false).GetAwaiter().GetResult();
-
-        internal NpgsqlCommand? CurrentCommand { get; set; }
 
         #endregion
 

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -1048,7 +1048,7 @@ LANGUAGE 'plpgsql' VOLATILE;";
         }
 
         [Test, Description("Makes sure that Npgsql doesn't attempt to send all data before the user can start reading. That would cause a deadlock.")]
-        public async Task ReadWriteDeadlock()
+        public async Task Batched_big_statements_do_not_deadlock()
         {
             // We're going to send a large multistatement query that would exhaust both the client's and server's
             // send and receive buffers (assume 64k per buffer).
@@ -1066,6 +1066,22 @@ LANGUAGE 'plpgsql' VOLATILE;";
                 Assert.That(reader.GetString(0), Is.EqualTo(data));
                 reader.NextResult();
             }
+        }
+
+        [Test, Timeout(10000)]
+        public void Batched_small_then_big_statements_do_not_deadlock_in_sync_io()
+        {
+            if (IsMultiplexing)
+                return; // Multiplexing, sync I/O
+
+            // This makes sure we switch to async writing for batches, starting from the 2nd statement at the latest.
+            // Otherwise, a small first first statement followed by a huge big one could cause us to deadlock, as we're stuck
+            // synchronously sending the 2nd statement while PG is stuck sending the results of the 1st.
+            using var conn = OpenConnection();
+            var data = new string('x', 5_000_000);
+            using var cmd = new NpgsqlCommand("SELECT generate_series(1, 500000); SELECT @p", conn);
+            cmd.Parameters.AddWithValue("p", NpgsqlDbType.Text, data);
+            cmd.ExecuteNonQuery();
         }
 
         [Test]


### PR DESCRIPTION
To avoid deadlocking.

Fixes #3846
