### PR TITLE
Implement raw SQL mode for prepared, non-batched commands (take 2)

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -139,6 +139,8 @@ namespace Npgsql.Internal
 
         internal PreparedStatementManager PreparedStatementManager;
 
+        internal SqlQueryParser SqlQueryParser { get; } = new();
+
         /// <summary>
         /// If the connector is currently in COPY mode, holds a reference to the importer/exporter object.
         /// Otherwise null.

--- a/src/Npgsql/MultiplexingConnectorPool.cs
+++ b/src/Npgsql/MultiplexingConnectorPool.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Channels;

--- a/src/Npgsql/MultiplexingConnectorPool.cs
+++ b/src/Npgsql/MultiplexingConnectorPool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Channels;
@@ -27,8 +28,6 @@ namespace Npgsql
 
         readonly ChannelReader<NpgsqlCommand>? _multiplexCommandReader;
         internal ChannelWriter<NpgsqlCommand>? MultiplexCommandWriter { get; }
-
-        const int WriteCoalescingDelayAdaptivityUs = 10;
 
         /// <summary>
         /// A pool-wide type mapper used when multiplexing. This is necessary because binding parameters
@@ -388,9 +387,9 @@ namespace Npgsql
 
             void FailWrite(NpgsqlConnector connector, Exception exception)
             {
-                // Note that all commands already passed validation before being enqueued. This means any error
-                // here is either an unrecoverable network issue (in which case we're already broken), or some other
-                // issue while writing (e.g. invalid UTF8 characters in the SQL query) - unrecoverable in any case.
+                // Note that all commands already passed validation. This means any error here is either an unrecoverable network issue
+                // (in which case we're already broken), or some other issue while writing (e.g. invalid UTF8 characters in the SQL query) -
+                // unrecoverable in any case.
 
                 // All commands enqueued in CommandsInFlightWriter will be drained by the reader and failed.
                 // Note that some of these commands where only written to the connector's buffer, but never

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -853,10 +853,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         {
             var hasOutputParameters = false;
 
-            for (var i = 0; i < Parameters.Count; i++)
+            foreach (var p in Parameters.InternalList)
             {
-                var p = Parameters[i];
-
                 Parameters.CalculatePlaceholderType(p);
 
                 switch (p.Direction)

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -582,9 +582,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 throw new NotSupportedException("Explicit preparation not supported with multiplexing");
             var connector = connection.Connector!;
 
-            for (var i = 0; i < Parameters.Count; i++)
+            foreach (var p in Parameters.InternalList)
             {
-                var p = Parameters[i];
                 Parameters.CalculatePlaceholderType(p);
                 p.Bind(connector.TypeMapper);
             }

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -662,7 +662,8 @@ namespace Npgsql
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException($"Unknown {nameof(PlaceholderType)} value: {PlaceholderType}");
+                    throw new ArgumentOutOfRangeException(
+                        nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {PlaceholderType}");
                 }
             }
             else
@@ -682,7 +683,8 @@ namespace Npgsql
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException($"Unknown {nameof(PlaceholderType)} value: {PlaceholderType}");
+                    throw new ArgumentOutOfRangeException(
+                        nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {PlaceholderType}");
                 }
             }
         }

--- a/src/Npgsql/NpgsqlStatement.cs
+++ b/src/Npgsql/NpgsqlStatement.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql.BackendMessages;
 
@@ -122,6 +123,7 @@ namespace Npgsql
                 InputParameters.Clear();
             else if (_inputParameters is not null)
                 _inputParameters = null; // We're pointing at a user's NpgsqlParameterCollection
+            Debug.Assert(_inputParameters is null || _inputParameters.Count == 0);
         }
 
         internal void ApplyCommandComplete(CommandCompleteMessage msg)

--- a/src/Npgsql/NpgsqlStatement.cs
+++ b/src/Npgsql/NpgsqlStatement.cs
@@ -117,8 +117,6 @@ namespace Npgsql
             OID = 0;
             PreparedStatement = null;
 
-            _ownedInputParameters?.Clear();
-
             if (ReferenceEquals(_inputParameters, _ownedInputParameters))
                 InputParameters.Clear();
             else if (_inputParameters is not null)

--- a/src/Npgsql/NpgsqlStatement.cs
+++ b/src/Npgsql/NpgsqlStatement.cs
@@ -116,6 +116,8 @@ namespace Npgsql
             OID = 0;
             PreparedStatement = null;
 
+            _ownedInputParameters?.Clear();
+
             if (ReferenceEquals(_inputParameters, _ownedInputParameters))
                 InputParameters.Clear();
             else if (_inputParameters is not null)

--- a/src/Npgsql/NpgsqlStatement.cs
+++ b/src/Npgsql/NpgsqlStatement.cs
@@ -124,6 +124,7 @@ namespace Npgsql
             else if (_inputParameters is not null)
                 _inputParameters = null; // We're pointing at a user's NpgsqlParameterCollection
             Debug.Assert(_inputParameters is null || _inputParameters.Count == 0);
+            Debug.Assert(_ownedInputParameters is null || _ownedInputParameters.Count == 0);
         }
 
         internal void ApplyCommandComplete(CommandCompleteMessage msg)

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -16,11 +16,8 @@ namespace Npgsql.Tests
 {
     public class CommandTests : MultiplexingTestBase
     {
-        #region Multiple Statements in a Command
+        #region Batching
 
-        /// <summary>
-        /// Tests various configurations of queries and non-queries within a multiquery
-        /// </summary>
         [Test]
         [TestCase(new[] { true }, TestName = "SingleQuery")]
         [TestCase(new[] { false }, TestName = "SingleNonQuery")]
@@ -540,13 +537,71 @@ namespace Npgsql.Tests
             Assert.That(reader.Read(), Is.False);
         }
 
+        #region Parameters
+
+        [Test]
+        public async Task Positional_parameter()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT $1", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer, Value = 8 });
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(8));
+        }
+
+        [Test]
+        public async Task Positional_parameters_arent_supported_with_legacy_batching()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT $1; SELECT $1", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Integer, Value = 8 });
+            Assert.That(async () => await cmd.ExecuteScalarAsync(), Throws.Exception.TypeOf<PostgresException>()
+                .With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.SyntaxError));
+        }
+
         [Test, Description("Makes sure writing an unset parameter isn't allowed")]
-        public async Task ParameterUnset()
+        public async Task Parameter_without_Value()
         {
             using var conn = await OpenConnectionAsync();
             using var cmd = new NpgsqlCommand("SELECT @p", conn);
             cmd.Parameters.Add(new NpgsqlParameter("@p", NpgsqlDbType.Integer));
             Assert.That(() => cmd.ExecuteScalarAsync(), Throws.Exception.TypeOf<InvalidCastException>());
+        }
+
+        [Test]
+        public async Task Unreferenced_named_parameter_works()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            cmd.Parameters.AddWithValue("not_used", 8);
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Unreferenced_positional_parameter_works()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { Value = 8 });
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Mixing_positional_and_named_parameters_is_not_supported()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT $1, @p", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { Value = 8 });
+            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = 9 });
+            Assert.That(() => cmd.ExecuteNonQueryAsync(), Throws.Exception.TypeOf<NotSupportedException>());
+        }
+
+        [Test]
+        public async Task Positional_output_parameters_are_not_supported()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT $1", conn);
+            cmd.Parameters.Add(new NpgsqlParameter { Value = 8, Direction = ParameterDirection.InputOutput });
+            Assert.That(() => cmd.ExecuteNonQueryAsync(), Throws.Exception.TypeOf<NotSupportedException>());
         }
 
         [Test]
@@ -606,6 +661,8 @@ namespace Npgsql.Tests
             Assert.That(reader.GetString(3), Is.EqualTo("foo"));
         }
 
+        #endregion Parameters
+
         [Test]
         public async Task CommandTextNotSet()
         {
@@ -654,9 +711,6 @@ namespace Npgsql.Tests
             Assert.That(cmd.ExecuteNonQueryAsync, Is.EqualTo(2));
 
             cmd.CommandText = $"INSERT INTO {table} (name) VALUES ('{new string('x', conn.Settings.WriteBufferSize)}')";
-            Assert.That(cmd.ExecuteNonQueryAsync, Is.EqualTo(1));
-
-            cmd.Parameters.AddWithValue("not_used", DBNull.Value);
             Assert.That(cmd.ExecuteNonQueryAsync, Is.EqualTo(1));
         }
 

--- a/test/Npgsql.Tests/PrepareTests.cs
+++ b/test/Npgsql.Tests/PrepareTests.cs
@@ -115,14 +115,15 @@ namespace Npgsql.Tests
                 command.Prepare();
                 command.Parameters[0].Value = 3;
                 command.Parameters[1].Value = 5;
+
                 using (var reader = command.ExecuteReader())
                 {
                     Assert.That(reader.Read(), Is.True);
                     Assert.That(reader.GetInt32(0), Is.EqualTo(3));
                     Assert.That(reader.GetInt64(1), Is.EqualTo(5));
                 }
-                if (i == 1)
-                    command.Unprepare();
+
+                command.Unprepare();
             }
         }
 
@@ -139,6 +140,7 @@ namespace Npgsql.Tests
                 command.Prepare();
                 command.Parameters[0].Value = 3;
                 command.Parameters[1].Value = 5;
+
                 using (var reader = command.ExecuteReader())
                 {
                     Assert.That(reader.Read(), Is.True);
@@ -146,8 +148,7 @@ namespace Npgsql.Tests
                     Assert.That(reader.GetInt64(1), Is.EqualTo(5));
                 }
 
-                if (i == 1)
-                    command.Unprepare();
+                command.Unprepare();
             }
         }
 


### PR DESCRIPTION
This is an alternative, simpler approach to #3834, because of perf issues in that attempt with multiplexing. The approach here does not tie together raw SQL mode to preparation, and simply uses the presence of positional parameters as an indication that raw mode is active. In the absence of any parameters, we parse/rewrite SQL as usual, since legacy semicolon batching may be in use (this unfortunately means that Fortunes does not work in raw mode). We may introduce a switch in the future to force raw mode, in which case the 0-param case would also not parse/rewrite.

Perf-wise, the longer the SQL and the more parameters are contained, the more this will be an improvement. 

Part of #1042
Leads to #2317

scenario                      | RPS
----------------------------- | ---
Fortunes before               | 480,589
Fortunes after                | 474,297
Single query named before     | 418,626
Single query named after      | 423,520
Single query positional after | 422,187
Multi query named before      | 25,143
Multi query named after       | 24,698
Multi query positional after  | 26,468

<details>
<summary>Detailed run results</summary>

### Fortunes Before (514001930d893be4566d5ec10b7f5309262d0839)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 38      |
| Cores usage (%)     | 1,072   |
| Working Set (MB)    | 44      |
| Build Time (ms)     | 1,692   |
| Start Time (ms)     | 338     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,695                           |
| Working Set (MB)      | 458                             |
| Private Memory (MB)   | 1,579                           |
| Build Time (ms)       | 2,574                           |
| Start Time (ms)       | 1,451                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 873        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 73         |
| Requests/sec           | 480,589    |
| Requests               | 57,718,341 |
| Mean latency (ms)      | 1.12       |
| Max latency (ms)       | 28.01      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 623.78     |
| Latency 50th (ms)      | 1.01       |
| Latency 75th (ms)      | 1.21       |
| Latency 90th (ms)      | 1.51       |
| Latency 99th (ms)      | 4.03       |
```

### Fortunes After (a453dc5f510874731a24394ab077384603a91ca6)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 38      |
| Cores usage (%)     | 1,056   |
| Working Set (MB)    | 47      |
| Build Time (ms)     | 1,679   |
| Start Time (ms)     | 340     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,695                           |
| Working Set (MB)      | 451                             |
| Private Memory (MB)   | 1,580                           |
| Build Time (ms)       | 2,576                           |
| Start Time (ms)       | 1,540                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 866        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 72         |
| Requests/sec           | 474,297    |
| Requests               | 56,961,560 |
| Mean latency (ms)      | 1.13       |
| Max latency (ms)       | 25.74      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 615.61     |
| Latency 50th (ms)      | 1.02       |
| Latency 75th (ms)      | 1.22       |
| Latency 90th (ms)      | 1.53       |
| Latency 99th (ms)      | 3.97       |
```

### Single Query named before (514001930d893be4566d5ec10b7f5309262d0839)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario single_query --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 35      |
| Cores usage (%)     | 986     |
| Working Set (MB)    | 46      |
| Build Time (ms)     | 1,755   |
| Start Time (ms)     | 348     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,685                           |
| Working Set (MB)      | 477                             |
| Private Memory (MB)   | 1,594                           |
| Build Time (ms)       | 3,748                           |
| Start Time (ms)       | 1,555                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 26         |
| Cores usage (%)        | 723        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 65         |
| Requests/sec           | 418,626    |
| Requests               | 50,276,778 |
| Mean latency (ms)      | 0.64       |
| Max latency (ms)       | 21.43      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 60.59      |
| Latency 50th (ms)      | 0.59       |
| Latency 75th (ms)      | 0.70       |
| Latency 90th (ms)      | 0.82       |
| Latency 99th (ms)      | 2.67       |
```

### Single Query named after (a453dc5f510874731a24394ab077384603a91ca6)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario single_query --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 35      |
| Cores usage (%)     | 987     |
| Working Set (MB)    | 46      |
| Build Time (ms)     | 1,722   |
| Start Time (ms)     | 363     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,679                           |
| Working Set (MB)      | 454                             |
| Private Memory (MB)   | 1,575                           |
| Build Time (ms)       | 2,620                           |
| Start Time (ms)       | 1,517                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 26         |
| Cores usage (%)        | 738        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 65         |
| Requests/sec           | 423,520    |
| Requests               | 50,864,574 |
| Mean latency (ms)      | 0.64       |
| Max latency (ms)       | 29.42      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 61.30      |
| Latency 50th (ms)      | 0.58       |
| Latency 75th (ms)      | 0.70       |
| Latency 90th (ms)      | 0.81       |
| Latency 99th (ms)      | 2.57       |
```

### Single Query positional after (a453dc5f510874731a24394ab077384603a91ca6)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario single_query --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit RawSql

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 35      |
| Cores usage (%)     | 991     |
| Working Set (MB)    | 46      |
| Build Time (ms)     | 1,739   |
| Start Time (ms)     | 337     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,681                           |
| Working Set (MB)      | 459                             |
| Private Memory (MB)   | 1,580                           |
| Build Time (ms)       | 2,624                           |
| Start Time (ms)       | 1,424                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 26         |
| Cores usage (%)        | 737        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 65         |
| Requests/sec           | 422,187    |
| Requests               | 50,695,518 |
| Mean latency (ms)      | 0.65       |
| Max latency (ms)       | 24.42      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 61.11      |
| Latency 50th (ms)      | 0.58       |
| Latency 75th (ms)      | 0.70       |
| Latency 90th (ms)      | 0.82       |
| Latency 99th (ms)      | 3.02       |
```

### Multi Query named before (514001930d893be4566d5ec10b7f5309262d0839)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario multiple_queries --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 41      |
| Cores usage (%)     | 1,162   |
| Working Set (MB)    | 47      |
| Build Time (ms)     | 1,772   |
| Start Time (ms)     | 348     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 75                              |
| Cores usage (%)       | 2,094                           |
| Working Set (MB)      | 469                             |
| Private Memory (MB)   | 1,467                           |
| Build Time (ms)       | 2,635                           |
| Start Time (ms)       | 1,697                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |           |
| ---------------------- | --------- |
| CPU Usage (%)          | 2         |
| Cores usage (%)        | 50        |
| Working Set (MB)       | 38        |
| Private Memory (MB)    | 358       |
| Start Time (ms)        | 0         |
| First Request (ms)     | 75        |
| Requests/sec           | 25,143    |
| Requests               | 3,019,710 |
| Mean latency (ms)      | 10.18     |
| Max latency (ms)       | 33.31     |
| Bad responses          | 0         |
| Socket errors          | 0         |
| Read throughput (MB/s) | 18.17     |
| Latency 50th (ms)      | 10.15     |
| Latency 75th (ms)      | 10.68     |
| Latency 90th (ms)      | 11.19     |
| Latency 99th (ms)      | 12.41     |
```

### Multi Query named after (a453dc5f510874731a24394ab077384603a91ca6)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario multiple_queries --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 39      |
| Cores usage (%)     | 1,087   |
| Working Set (MB)    | 47      |
| Build Time (ms)     | 1,702   |
| Start Time (ms)     | 339     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 73                              |
| Cores usage (%)       | 2,057                           |
| Working Set (MB)      | 455                             |
| Private Memory (MB)   | 1,556                           |
| Build Time (ms)       | 3,869                           |
| Start Time (ms)       | 1,610                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |           |
| ---------------------- | --------- |
| CPU Usage (%)          | 2         |
| Cores usage (%)        | 50        |
| Working Set (MB)       | 37        |
| Private Memory (MB)    | 358       |
| Start Time (ms)        | 0         |
| First Request (ms)     | 74        |
| Requests/sec           | 24,698    |
| Requests               | 2,966,221 |
| Mean latency (ms)      | 10.36     |
| Max latency (ms)       | 35.91     |
| Bad responses          | 0         |
| Socket errors          | 0         |
| Read throughput (MB/s) | 17.84     |
| Latency 50th (ms)      | 10.33     |
| Latency 75th (ms)      | 10.87     |
| Latency 90th (ms)      | 11.36     |
| Latency 99th (ms)      | 12.43     |
```

### Multi Query positional after (a453dc5f510874731a24394ab077384603a91ca6)

```
dotnet run -- --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario multiple_queries --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles Z:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit RawSql

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 41      |
| Cores usage (%)     | 1,147   |
| Working Set (MB)    | 47      |
| Build Time (ms)     | 1,715   |
| Start Time (ms)     | 370     |
| Published Size (KB) | 914,279 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 74                              |
| Cores usage (%)       | 2,069                           |
| Working Set (MB)      | 452                             |
| Private Memory (MB)   | 1,440                           |
| Build Time (ms)       | 2,643                           |
| Start Time (ms)       | 1,627                           |
| Published Size (KB)   | 91,126                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.7.21317.2+0aa82c3 |
| .NET Runtime Version  | 6.0.0-preview.7.21317.7+eb7b3db |


| load                   |           |
| ---------------------- | --------- |
| CPU Usage (%)          | 2         |
| Cores usage (%)        | 52        |
| Working Set (MB)       | 37        |
| Private Memory (MB)    | 358       |
| Start Time (ms)        | 0         |
| First Request (ms)     | 75        |
| Requests/sec           | 26,468    |
| Requests               | 3,178,564 |
| Mean latency (ms)      | 9.67      |
| Max latency (ms)       | 31.76     |
| Bad responses          | 0         |
| Socket errors          | 0         |
| Read throughput (MB/s) | 19.12     |
| Latency 50th (ms)      | 9.65      |
| Latency 75th (ms)      | 10.16     |
| Latency 90th (ms)      | 10.64     |
| Latency 99th (ms)      | 11.68     |
```

</details>

