### PR TITLE
Split TransactionScope test to isolate distributed transaction functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,6 @@ jobs:
           fi
 
           sudo sed -i 's/#ssl = off/ssl = on/' $PGDATA/postgresql.conf
-          sudo sed -i 's/#max_prepared_transactions = 0/max_prepared_transactions = 10/' $PGDATA/postgresql.conf
           if [ ${{ matrix.pg_major }} -ge 14 ]; then
             sudo sed -i 's/password_encryption = md5/password_encryption = scram-sha-256/' $PGDATA/postgresql.conf
           else
@@ -151,7 +150,7 @@ jobs:
           sed -i "s|#wal_sender_timeout =|wal_sender_timeout = 3s #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#synchronous_standby_names =|synchronous_standby_names = 'npgsql_test_sync_standby' #|" pgsql/PGDATA/postgresql.conf
           sed -i "s|#synchronous_commit =|synchronous_commit = local #|" pgsql/PGDATA/postgresql.conf
-          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10 -c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' start
+          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' start
           
           # Starting with PG14 the default password encryption mode is scram.
           # Changing it to md5 for compatability.
@@ -174,7 +173,7 @@ jobs:
             sed -i "s|#password_encryption = md5|password_encryption = scram-sha-256|" pgsql/PGDATA/postgresql.conf
           fi
 
-          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10 -c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' restart
+          pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c ssl=true -c ssl_cert_file=../server.crt -c ssl_key_file=../server.key' restart
 
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_scram SUPERUSER LOGIN PASSWORD 'npgsql_tests_scram'"
 

--- a/Npgsql.sln.DotSettings
+++ b/Npgsql.sln.DotSettings
@@ -102,6 +102,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=timetz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=UNLISTEN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unmap/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unpooled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unprepare/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unprepares/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=_0020Unprepare/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/test/Npgsql.Tests/DistributedTransactionTests.cs
+++ b/test/Npgsql.Tests/DistributedTransactionTests.cs
@@ -389,6 +389,37 @@ Exception {2}",
             }
         }
 
+        [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1737")]
+        public void Multiple_unpooled_connections_do_not_reuse()
+        {
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
+            {
+                Pooling = false,
+                Enlist = true
+            };
+
+            using var scope = new TransactionScope();
+
+            int processId;
+
+            using (var conn1 = OpenConnection(csb))
+            using (var cmd = new NpgsqlCommand("SELECT 1", conn1))
+            {
+                processId = conn1.ProcessID;
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var conn2 = OpenConnection(csb))
+            using (var cmd = new NpgsqlCommand("SELECT 1", conn2))
+            {
+                // The connection reuse optimization isn't implemented for unpooled connections (though it could be)
+                Assert.That(conn2.ProcessID, Is.Not.EqualTo(processId));
+                cmd.ExecuteNonQuery();
+            }
+
+            scope.Complete();
+        }
+
         #region Utilities
 
         void AssertNoPreparedTransactions()

--- a/test/Npgsql.Tests/SystemTransactionTests.cs
+++ b/test/Npgsql.Tests/SystemTransactionTests.cs
@@ -276,7 +276,7 @@ namespace Npgsql.Tests
         }
 
         [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1737")]
-        public void Bug1737()
+        public void Single_unpooled_connection()
         {
             var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
@@ -284,28 +284,14 @@ namespace Npgsql.Tests
                 Enlist = true
             };
 
-            // Case 1
-            using (var scope = new TransactionScope())
-            {
-                using (var conn = OpenConnection(csb))
-                using (var cmd = new NpgsqlCommand("SELECT 1", conn))
-                    cmd.ExecuteNonQuery();
-                scope.Complete();
-            }
 
-            // Case 2
-            using (var scope = new TransactionScope())
-            {
-                using (var conn1 = OpenConnection(csb))
-                using (var cmd = new NpgsqlCommand("SELECT 1", conn1))
-                    cmd.ExecuteNonQuery();
+            using var scope = new TransactionScope();
 
-                using (var conn2 = OpenConnection(csb))
-                using (var cmd = new NpgsqlCommand("SELECT 1", conn2))
-                    cmd.ExecuteNonQuery();
+            using (var conn = OpenConnection(csb))
+            using (var cmd = new NpgsqlCommand("SELECT 1", conn))
+                cmd.ExecuteNonQuery();
 
-                scope.Complete();
-            }
+            scope.Complete();
         }
 
         #region Utilities


### PR DESCRIPTION
We don't support the connection reuse optimization for unpooled connections, so opening two connections escalates to a distributed transaction. Move that part of the test to DistributedTransactionTests.

/cc @Brar
