### PR TITLE
Fix SingleThreadSynchronizationContext

### DIFF
--- a/src/Npgsql/SingleThreadSynchronizationContext.cs
+++ b/src/Npgsql/SingleThreadSynchronizationContext.cs
@@ -49,6 +49,8 @@ namespace Npgsql
 
         void WorkLoop()
         {
+            SetSynchronizationContext(this);
+
             try
             {
                 while (true)


### PR DESCRIPTION
To have its own thread use itself as the context.

Fixes #3856
