### PR TITLE
Remove last public nullability-obliviousness

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1692,8 +1692,8 @@ namespace Npgsql
         #endregion IDictionary<string, object>
 
         #region ICustomTypeDescriptor
-#nullable disable
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+        /// <inheritdoc />
         protected override void GetProperties(Hashtable propertyDescriptors)
         {
             // Tweak which properties are exposed via TypeDescriptor. This affects the VS DDEX
@@ -1710,8 +1710,7 @@ namespace Npgsql
             foreach (var o in toRemove)
                 propertyDescriptors.Remove(o.DisplayName);
         }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-#nullable enable
+
         #endregion
 
         internal static readonly string[] EmptyStringArray = new string[0];

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -435,7 +435,6 @@ namespace NpgsqlTypes
             return new NpgsqlRange<T>(lower, lowerInclusive, lowerInfinite, upper, upperInclusive, upperInfinite);
         }
 
-#nullable disable
         /// <summary>
         /// Represents a type converter for <see cref="NpgsqlRange{T}" />.
         /// </summary>
@@ -450,23 +449,22 @@ namespace NpgsqlTypes
                     new TypeConverterAttribute(typeof(RangeTypeConverter)));
 
             /// <inheritdoc />
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
                 => sourceType == typeof(string);
 
             /// <inheritdoc />
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
                 => destinationType == typeof(string);
 
             /// <inheritdoc />
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
                 => value is string s ? Parse(s) : base.ConvertFrom(context, culture, value);
 
             /// <inheritdoc />
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-                => value.ToString();
+            public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+                => value is null ? string.Empty : value.ToString();
         }
     }
-#nullable restore
 
     /// <summary>
     /// Represents characteristics of range type boundaries.

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1900,7 +1900,7 @@ virtual Npgsql.NpgsqlDatabaseInfo.SupportsRangeTypes.get -> bool
 virtual Npgsql.NpgsqlDatabaseInfo.SupportsTransactions.get -> bool
 virtual Npgsql.NpgsqlDatabaseInfo.SupportsTransactions.set -> void
 virtual Npgsql.NpgsqlDatabaseInfo.SupportsUnlisten.get -> bool
-~override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) -> bool
-~override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) -> bool
-~override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) -> object
-~override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
+override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?


### PR DESCRIPTION
This removes the last `#nullable disable` from public APIs which weren't annotated in .NET 5.0, but were annotated in .NET 6.0.