### PR TITLE
Very first work on trimming compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <VersionPrefix>6.0.0-preview7</VersionPrefix>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.SourceGenerators", "src\Npgsql.SourceGenerators\Npgsql.SourceGenerators.csproj", "{63026A19-60B8-4906-81CB-216F30E8094B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.TrimmingTests", "test\Npgsql.TrimmingTests\Npgsql.TrimmingTests.csproj", "{844EC023-21B8-448D-93AD-5F6857F15DFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,14 @@ Global
 		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|x86.ActiveCfg = Release|Any CPU
 		{63026A19-60B8-4906-81CB-216F30E8094B}.Release|x86.Build.0 = Release|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Debug|x86.Build.0 = Debug|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Release|x86.ActiveCfg = Release|Any CPU
+		{844EC023-21B8-448D-93AD-5F6857F15DFF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +159,7 @@ Global
 		{F7C53EBD-0075-474F-A083-419257D04080} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 		{63026A19-60B8-4906-81CB-216F30E8094B} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
+		{844EC023-21B8-448D-93AD-5F6857F15DFF} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/src/Npgsql/Internal/TypeHandlers/CompositeHandlers/CompositeHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/CompositeHandlers/CompositeHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -10,6 +11,32 @@ using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
+
+#region Trimming warning suppressions
+
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2046", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2080", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2026", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2090", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2087", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2055", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+[module: UnconditionalSuppressMessage(
+    "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.",
+    "IL2077", Scope = "type", Target = "Npgsql.Internal.TypeHandlers.CompositeHandlers.CompositeHandler")]
+
+#endregion
 
 namespace Npgsql.Internal.TypeHandlers.CompositeHandlers
 {

--- a/src/Npgsql/Internal/TypeHandlers/UnmappedEnumHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/UnmappedEnumHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -60,6 +61,7 @@ namespace Npgsql.Internal.TypeHandlers
         protected internal override int ValidateAndGetLengthCustom<TAny>(TAny value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
             => ValidateAndGetLength(value!, ref lengthCache, parameter);
 
+        [UnconditionalSuppressMessage("Unmapped enums currently aren't trimming-safe.", "IL2072")]
         int ValidateAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         {
             var type = value.GetType();
@@ -97,6 +99,7 @@ namespace Npgsql.Internal.TypeHandlers
             }
         }
 
+        [UnconditionalSuppressMessage("Unmapped enums currently aren't trimming-safe.", "IL2072")]
         internal Task Write(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
         {
             var type = value.GetType();
@@ -115,7 +118,7 @@ namespace Npgsql.Internal.TypeHandlers
 
         #region Misc
 
-        void Map(Type type)
+        void Map([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type)
         {
             Debug.Assert(_resolvedType != type);
 

--- a/src/Npgsql/Netstandard20/CodeAnalysis.cs
+++ b/src/Npgsql/Netstandard20/CodeAnalysis.cs
@@ -1,0 +1,74 @@
+#if !NET5_0_OR_GREATER
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+// ReSharper disable once CheckNamespace
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public string? Url { get; set; }
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    [Flags]
+    enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        PublicParameterlessConstructor = 0x0001,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        NonPublicConstructors = 0x0004,
+        PublicMethods = 0x0008,
+        NonPublicMethods = 0x0010,
+        PublicFields = 0x0020,
+        NonPublicFields = 0x0040,
+        PublicNestedTypes = 0x0080,
+        NonPublicNestedTypes = 0x0100,
+        PublicProperties = 0x0200,
+        NonPublicProperties = 0x0400,
+        PublicEvents = 0x0800,
+        NonPublicEvents = 0x1000,
+        Interfaces = 0x2000,
+        All = ~None
+    }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        public string Category { get; }
+        public string CheckId { get; }
+        public string? Scope { get; set; }
+        public string? Target { get; set; }
+        public string? MessageId { get; set; }
+        public string? Justification { get; set; }
+    }
+}
+#endif

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1492,6 +1492,7 @@ namespace Npgsql
         /// </param>
         /// <typeparam name="T">The .NET type to be mapped</typeparam>
         [Obsolete("Use NpgsqlConnection.TypeMapper.MapComposite() instead")]
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public void MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => TypeMapper.MapComposite<T>(pgName, nameTranslator);
 
@@ -1518,6 +1519,7 @@ namespace Npgsql
         /// </param>
         /// <typeparam name="T">The .NET type to be mapped</typeparam>
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.MapComposite() instead")]
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public static void MapCompositeGlobally<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => GlobalTypeMapper.MapComposite<T>(pgName, nameTranslator);
 
@@ -1533,6 +1535,7 @@ namespace Npgsql
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         [Obsolete("Use NpgsqlConnection.GlobalTypeMapper.UnmapComposite() instead")]
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public static void UnmapCompositeGlobally<T>(string pgName, INpgsqlNameTranslator? nameTranslator = null) where T : new()
             => GlobalTypeMapper.UnmapComposite<T>(pgName, nameTranslator);
 
@@ -1820,6 +1823,8 @@ namespace Npgsql
         /// <summary>
         /// Returns the supported collections
         /// </summary>
+        [UnconditionalSuppressMessage(
+            "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.", "IL2026")]
         public override DataTable GetSchema()
             => GetSchema("MetaDataCollections", null);
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -1931,12 +1932,16 @@ namespace Npgsql
         /// <summary>
         /// Returns a System.Data.DataTable that describes the column metadata of the DataReader.
         /// </summary>
+        [UnconditionalSuppressMessage(
+            "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.", "IL2026")]
         public override DataTable? GetSchemaTable()
             => GetSchemaTable(async: false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Asynchronously returns a System.Data.DataTable that describes the column metadata of the DataReader.
         /// </summary>
+        [UnconditionalSuppressMessage(
+            "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.", "IL2026")]
 #if NET5_0_OR_GREATER
         public override Task<DataTable?> GetSchemaTableAsync(CancellationToken cancellationToken = default)
 #else
@@ -1947,6 +1952,8 @@ namespace Npgsql
                 return GetSchemaTable(async: true, cancellationToken);
         }
 
+        [UnconditionalSuppressMessage(
+            "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.", "IL2026")]
         async Task<DataTable?> GetSchemaTable(bool async, CancellationToken cancellationToken = default)
         {
             if (FieldCount == 0) // No resultset

--- a/src/Npgsql/NpgsqlFactory.cs
+++ b/src/Npgsql/NpgsqlFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Npgsql.Logging;
 
@@ -68,7 +69,7 @@ namespace Npgsql
         /// </summary>
         /// <param name="serviceType">An object that specifies the type of service object to get.</param>
         /// <returns>A service object of type serviceType, or null if there is no service object of type serviceType.</returns>
-
+        [RequiresUnreferencedCode("Legacy EF5 method, not trimming-safe.")]
         public object? GetService(Type serviceType)
         {
             if (serviceType == null)

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -343,6 +343,7 @@ namespace Npgsql
         [DbProviderSpecificTypeProperty(true)]
         public NpgsqlDbType NpgsqlDbType
         {
+            [RequiresUnreferencedCodeAttribute("The NpgsqlDbType getter isn't trimming-safe")]
             get
             {
                 if (_npgsqlDbType.HasValue)

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -429,8 +429,8 @@ namespace NpgsqlTypes
                 string.Equals(upperSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(upperSegment, UpperInfinityLiteral, StringComparison.OrdinalIgnoreCase);
 
-            var lower = lowerInfinite ? default : (T)BoundConverter.ConvertFromString(lowerSegment);
-            var upper = upperInfinite ? default : (T)BoundConverter.ConvertFromString(upperSegment);
+            var lower = lowerInfinite ? default : (T)BoundConverter.ConvertFromString(lowerSegment)!;
+            var upper = upperInfinite ? default : (T)BoundConverter.ConvertFromString(upperSegment)!;
 
             return new NpgsqlRange<T>(lower, lowerInclusive, lowerInfinite, upper, upperInclusive, upperInfinite);
         }

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -199,6 +199,7 @@ namespace Npgsql.TypeMapping
         internal string? ToPgTypeName(Type type)
             => _typeToPgTypeName.TryGetValue(type, out var pgTypeName) ? pgTypeName : null;
 
+        [RequiresUnreferencedCodeAttribute("ToNpgsqlDbType uses interface-based reflection and isn't trimming-safe")]
         internal NpgsqlDbType ToNpgsqlDbType(Type type)
         {
             if (_typeToNpgsqlDbType.TryGetValue(type, out var npgsqlDbType))

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql.NameTranslation;
 using NpgsqlTypes;
 
@@ -98,6 +99,7 @@ namespace Npgsql.TypeMapping
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
         /// <typeparam name="T">The .NET type to be mapped</typeparam>
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         INpgsqlTypeMapper MapComposite<T>(
             string? pgName = null,
             INpgsqlNameTranslator? nameTranslator = null);
@@ -113,6 +115,7 @@ namespace Npgsql.TypeMapping
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         bool UnmapComposite<T>(
             string? pgName = null,
             INpgsqlNameTranslator? nameTranslator = null);
@@ -136,6 +139,7 @@ namespace Npgsql.TypeMapping
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         INpgsqlTypeMapper MapComposite(
             Type clrType,
             string? pgName = null,
@@ -153,6 +157,7 @@ namespace Npgsql.TypeMapping
         /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
         /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
         /// </param>
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         bool UnmapComposite(
             Type clrType,
             string? pgName = null,

--- a/src/Npgsql/TypeMapping/TypeMapperBase.cs
+++ b/src/Npgsql/TypeMapping/TypeMapperBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Npgsql.Internal.TypeHandlers;
 using Npgsql.Internal.TypeHandlers.CompositeHandlers;
@@ -69,9 +70,11 @@ namespace Npgsql.TypeMapping
 
         #region Composite mapping
 
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             => MapComposite(pgName, nameTranslator, typeof(T), t => new CompositeTypeHandlerFactory<T>(t));
 
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public INpgsqlTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             => MapComposite(pgName, nameTranslator, clrType, t => (NpgsqlTypeHandlerFactory)
                 Activator.CreateInstance(typeof(CompositeTypeHandlerFactory<>).MakeGenericType(clrType), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new object[] { t }, null)!);
@@ -94,9 +97,11 @@ namespace Npgsql.TypeMapping
                 .Build());
         }
 
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
             => UnmapComposite(typeof(T), pgName, nameTranslator);
 
+        [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
         public bool UnmapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         {
             if (pgName != null && string.IsNullOrWhiteSpace(pgName))

--- a/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj
+++ b/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>link</TrimMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Npgsql/Npgsql.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Remove="GitHubActionsTestLogger" />
+  </ItemGroup>
+</Project>

--- a/test/Npgsql.TrimmingTests/Program.cs
+++ b/test/Npgsql.TrimmingTests/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using Npgsql;
+
+var connectionString = Environment.GetEnvironmentVariable("NPGSQL_TEST_DB")
+                       ?? "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0";
+
+await using var conn = new NpgsqlConnection(connectionString);
+await conn.OpenAsync();
+await using var cmd = new NpgsqlCommand("SELECT 'Hello World'", conn);
+await using var reader = await cmd.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var value = reader.GetFieldValue<string>(0);
+    if (value != "Hello World")
+        throw new Exception($"Got {value} instead of the expected 'Hello World'");
+}


### PR DESCRIPTION
This is only a first step, more work is needed. Based on work by @NinoFloris in #3830 (thanks!)

* Annotate composite types as incompatible with trimming, while suppressing warnings for applications which don't use them.
* Create a very basic console test program for testing (#3820). We'll eventually run this in CI.

After this, the following issues still remain in Npgsql (for a trivial "hello world"-like program):

```
/home/roji/projects/npgsql/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs(258,21): Trim analysis error IL2060: Npgsql.Internal.TypeHandlers.ArrayHandler.ArrayTypeInfo<TArrayOrList>..cctor(): Call to 'System.Reflection.MethodInfo System.Reflection.MethodInfo::MakeGenericMethod(System.Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
/home/roji/projects/npgsql/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs(246,21): Trim analysis error IL2060: Npgsql.Internal.TypeHandlers.ArrayHandler.ArrayTypeInfo<TArrayOrList>..cctor(): Call to 'System.Reflection.MethodInfo System.Reflection.MethodInfo::MakeGenericMethod(System.Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
/home/roji/projects/npgsql/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs(247,13): Trim analysis error IL2070: Npgsql.TypeMapping.ConnectorTypeMapper.GetArrayElementType(Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Reflection.TypeInfo.ImplementedInterfaces.get'. The parameter 'type' of method 'Npgsql.TypeMapping.ConnectorTypeMapper.GetArrayElementType(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
/home/roji/projects/npgsql/src/Npgsql/Internal/TypeHandling/NullableHandler.cs(68,16): Trim analysis error IL2060: Npgsql.Internal.TypeHandling.NullableHandler.CreateDelegate<TDelegate>(Type,MethodInfo): Call to 'System.Reflection.MethodInfo System.Reflection.MethodInfo::MakeGenericMethod(System.Type[])' can not be statically analyzed. It's not possible to guarantee the availability of requirements of the generic method. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
```

These are related to array/nullable handling, which currently heavily relies on reflection and is being explored by @NinoFloris (see #3813).

Apart from this the following external linker warnings are generated (especially from System.Data), not sure if the plan is to handle those in .NET 6.0:

<details>
<summary>External linker warnings</summary>

```
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String,Func<AssemblyName,Assembly>,Func<Assembly,String,Boolean,Type>,Boolean,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String,Func<AssemblyName,Assembly>,Func<Assembly,String,Boolean,Type>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String,Boolean,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.ColumnTypeConverter.ConvertTo(ITypeDescriptorContext,CultureInfo,Object,Type): Using method 'System.Type.GetType(String,Func<AssemblyName,Assembly>,Func<Assembly,String,Boolean,Type>,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The type might be removed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.GetObjectData(SerializationInfo,StreamingContext): Using method 'System.Data.DataSet.SerializeDataSet(SerializationInfo,StreamingContext,SerializationFormat)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.GetSchema(): Using method 'System.Data.XmlTreeGen.Save(DataSet,XmlWriter)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.GetSchema(): Using method 'System.Data.DataSet.DataSet(SerializationInfo,StreamingContext,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.GetSchema(): Using method 'System.Data.DataSet.DataSet(SerializationInfo,StreamingContext)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.ReadXml(XmlReader): Using method 'System.Data.DataSet.ReadXmlSerializable(XmlReader)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.WriteXml(XmlWriter): Using method 'System.Data.DataSet.WriteXml(XmlWriter,XmlWriteMode)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.WriteXml(XmlWriter): Using method 'System.Data.DataSet.WriteXmlSchema(XmlWriter,SchemaFormat,Converter<Type,String>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.GetObjectData(SerializationInfo,StreamingContext): Using method 'System.Data.DataTable.SerializeDataTable(SerializationInfo,StreamingContext,Boolean,SerializationFormat)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.GetSchema(): Using method 'System.Data.XmlTreeGen.Save(DataTable,XmlWriter)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.ReadXml(XmlReader,XmlReadMode,Boolean): Using method 'System.Data.XmlDataLoader.LoadData(XmlReader)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.ReadXml(XmlReader,XmlReadMode,Boolean): Using method 'System.Data.DataTable.ReadXmlDiffgram(XmlReader)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.ReadXml(XmlReader,XmlReadMode,Boolean): Using method 'System.Data.DataTable.ReadXmlDiffgram(XmlReader)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.ReadXml(XmlReader,XmlReadMode,Boolean): Using method 'System.Data.DataTable.ReadXmlSchema(XmlReader,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.ReadXml(XmlReader,XmlReadMode,Boolean): Using method 'System.Data.DataTable.ReadXmlSchema(XmlReader,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.WriteXmlCore(XmlWriter): Using method 'System.Data.DataTable.WriteXmlSchema(XmlWriter,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.DataTable.WriteXmlCore(XmlWriter): Using method 'System.Data.DataTable.WriteXml(XmlWriter,XmlWriteMode,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Members from serialized types may be trimmed if not referenced directly. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.Common.DbConnectionStringBuilder.GetProperties(Hashtable): Using method 'System.ComponentModel.TypeDescriptor.GetProperties(Object,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. PropertyDescriptor's PropertyType cannot be statically discovered. The Type of component cannot be statically discovered. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Data.Common.DbConnectionStringBuilder.System.ComponentModel.ICustomTypeDescriptor.GetAttributes(): Using method 'System.ComponentModel.TypeDescriptor.GetAttributes(Object,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The Type of component cannot be statically discovered. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Linq.Expressions.Expression.Convert(Expression,Type): Using method 'System.Linq.Expressions.Expression.Convert(Expression,Type,MethodInfo)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Creating Expressions requires unreferenced code because the members being referenced by the Expression may be trimmed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
ILLink : Trim analysis error IL2026: System.Text.Json.Nodes.JsonNode.System.Dynamic.IDynamicMetaObjectProvider.GetMetaObject(Expression): Using method 'System.Text.Json.Nodes.JsonNode.CreateDynamicObject(Expression,JsonNode)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Using JsonNode instances as dynamic types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed. [/home/roji/projects/npgsql/test/Npgsql.TrimmingTests/Npgsql.TrimmingTests.csproj]
```
</details>

Part of #3300
Part of #3820
