### PR TITLE
WIP on switching from NoSynchronizationContextScope to ConfigureAwait

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -4,6 +4,9 @@ root = false
 
 [*.cs]
 
+# Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = error
+
 # Constructor make noninheritable base class inheritable
 dotnet_diagnostic.RS0022.severity = none
 

--- a/src/Npgsql/GlobalSuppressions.cs
+++ b/src/Npgsql/GlobalSuppressions.cs
@@ -10,6 +10,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "We have several exception classes where this makes no sense")]
 [assembly: SuppressMessage("Design", "CA1710:Identifiers should have correct suffix", Justification = "Disagree")]
 [assembly: SuppressMessage("Design", "CA1707:Remove the underscores from member name", Justification = "Seems to cause some false positives on implicit/explicit cast operators, strange")]
-[assembly: SuppressMessage("Reliability", "CA2007:Do not directly await a Task", Justification = "Npgsql uses NoSynchronizationContextScope instead of ConfigureAwait(false)")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "All I/O methods are both sync and async, avoid clutter")]
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1893,10 +1893,7 @@ namespace Npgsql
 #else
         public Task<DataTable> GetSchemaAsync(string collectionName, string?[]? restrictions, CancellationToken cancellationToken = default)
 #endif
-        {
-            using (NoSynchronizationContextScope.Enter())
-                return NpgsqlSchema.GetSchema(this, collectionName, restrictions, async: true, cancellationToken);
-        }
+            => NpgsqlSchema.GetSchema(this, collectionName, restrictions, async: true, cancellationToken);
 
         #endregion Schema operations
 

--- a/src/Npgsql/NpgsqlDataAdapter.cs
+++ b/src/Npgsql/NpgsqlDataAdapter.cs
@@ -150,17 +150,17 @@ namespace Npgsql
             {
                 originalState = activeConnection.State;
                 if (ConnectionState.Closed == originalState)
-                    await activeConnection.Open(async, cancellationToken);
+                    await activeConnection.Open(async, cancellationToken).ConfigureAwait(false);;
 
-                var dataReader = await command.ExecuteReader(CommandBehavior.Default, async, cancellationToken);
+                var dataReader = await command.ExecuteReader(CommandBehavior.Default, async, cancellationToken).ConfigureAwait(false);;
                 try
                 {
-                    return await Fill(dataTable, dataReader, async, cancellationToken);
+                    return await Fill(dataTable, dataReader, async, cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
                     if (async)
-                        await dataReader.DisposeAsync();
+                        await dataReader.DisposeAsync().ConfigureAwait(false);
                     else
                         dataReader.Dispose();
                 }
@@ -193,7 +193,7 @@ namespace Npgsql
 
                 var values = new object[count];
 
-                while (async ? await dataReader.ReadAsync(cancellationToken) : dataReader.Read())
+                while (async ? await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false) : dataReader.Read())
                 {
                     dataReader.GetValues(values);
                     dataTable.LoadDataRow(values, true);

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -168,7 +168,7 @@ namespace Npgsql
 
             using var command = BuildCommand(conn, getDatabases, restrictions, "datname");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(databases, async, cancellationToken);
+            await adapter.Fill(databases, async, cancellationToken).ConfigureAwait(false);
 
             return databases;
         }
@@ -194,7 +194,7 @@ SELECT * FROM (
 
             using var command = BuildCommand(conn, getSchemata, restrictions, "catalog_name", "schema_name", "schema_owner");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(schemata, async, cancellationToken);
+            await adapter.Fill(schemata, async, cancellationToken).ConfigureAwait(false);
 
             return schemata;
         }
@@ -222,7 +222,7 @@ WHERE
 
             using var command = BuildCommand(conn, getTables, restrictions, false, "table_catalog", "table_schema", "table_name", "table_type");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(tables, async, cancellationToken);
+            await adapter.Fill(tables, async, cancellationToken).ConfigureAwait(false);;
 
             return tables;
         }
@@ -252,7 +252,7 @@ FROM information_schema.columns");
 
             using var command = BuildCommand(conn, getColumns, restrictions, "table_catalog", "table_schema", "table_name", "column_name");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(columns, async, cancellationToken);
+            await adapter.Fill(columns, async, cancellationToken).ConfigureAwait(false);;
 
             return columns;
         }
@@ -273,7 +273,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
 
             using var command = BuildCommand(conn, getViews, restrictions, false, "table_catalog", "table_schema", "table_name");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(views, async, cancellationToken);
+            await adapter.Fill(views, async, cancellationToken).ConfigureAwait(false);;
 
             return views;
         }
@@ -290,7 +290,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
 
             using var command = BuildCommand(conn, getUsers, restrictions, "usename");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(users, async, cancellationToken);
+            await adapter.Fill(users, async, cancellationToken).ConfigureAwait(false);;
 
             return users;
         }
@@ -323,7 +323,7 @@ WHERE
 
             using var command = BuildCommand(conn, getIndexes, restrictions, false, "current_database()", "n.nspname", "t.relname", "i.relname");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(indexes, async, cancellationToken);
+            await adapter.Fill(indexes, async, cancellationToken).ConfigureAwait(false);;
 
             return indexes;
         }
@@ -363,7 +363,7 @@ WHERE
 
             using var command = BuildCommand(conn, getIndexColumns, restrictions, false, "current_database()", "t_ns.nspname", "t.relname", "ix_cls.relname", "a.attname");
             using var adapter = new NpgsqlDataAdapter(command);
-            await adapter.Fill(indexColumns, async, cancellationToken);
+            await adapter.Fill(indexColumns, async, cancellationToken).ConfigureAwait(false);;
 
             return indexColumns;
         }
@@ -406,7 +406,7 @@ FROM
             using var adapter = new NpgsqlDataAdapter(command);
             var table = new DataTable(constraintType) { Locale = CultureInfo.InvariantCulture };
 
-            await adapter.Fill(table, async, cancellationToken);
+            await adapter.Fill(table, async, cancellationToken).ConfigureAwait(false);;
 
             return table;
         }
@@ -441,7 +441,7 @@ FROM pg_constraint c
             using var adapter = new NpgsqlDataAdapter(command);
             var table = new DataTable("ConstraintColumns") { Locale = CultureInfo.InvariantCulture };
 
-            await adapter.Fill(table, async, cancellationToken);
+            await adapter.Fill(table, async, cancellationToken).ConfigureAwait(false);;
 
             return table;
         }


### PR DESCRIPTION
This is incomplete, exploratory work which replaces our NoSynchronizationContextScope (at the public API level) with explicit ConfigureAwait everywhere (analyzer-enforced). For the sync-over-async case (writing messages in sync mode with batching), we simply pass down an additional syncOverAsync flag, which gets passed as the argument into ConfigureAwait; this ensures that SingleThreadSynchronizationContext is always used when in sync-over-async, and the thread-pool otherwise (ConfigureAwait(false)). Some comments:

* This has the advantage of the analyzer enforcing ConfigureAwait everywhere. Compare this to the current situation where we can forget (or mess up) to specify NoSynchronizationContextScope (this has happened once or twice).
* However, the code becomes considerably more verbose, with the syncOverAsync flag needing to be flowed into all write paths, including all type handlers.
* This should make the Orleans (and other TaskScheduler-related) problems go away - at least as long as sync-over-async isn't being used.

To be honest, if we didn't have the TaskScheduler issue, I'd rather just keep things the way they are - the code becomes significantly more verbose for no real reason (the couple issues we've had with messing up NoSynchronizationContextScope don't seem strong enough). There seem to be very little complaints/votes from people using Orleans, though on the other it does seem important for Npgsql to work correctly in all scenarios etc.

So I'm a little hesitant... @vonzshik @NinoFloris @Brar any opinions here?