### PR TITLE
Test reliability fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,15 +75,10 @@ jobs:
             sudo sed -i 's/#password_encryption = scram-sha-256/password_encryption = md5/' $PGDATA/postgresql.conf
           fi
           sudo -u postgres psql -c "CREATE USER npgsql_tests SUPERUSER PASSWORD 'npgsql_tests'"
-          sudo -u postgres psql -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
-          sudo -u postgres psql -c "CREATE EXTENSION citext" npgsql_tests
-          sudo -u postgres psql -c "CREATE EXTENSION hstore" npgsql_tests
-          sudo -u postgres psql -c "CREATE EXTENSION ltree" npgsql_tests
 
           # To disable PostGIS for prereleases (because it usually isn't available until late), surround with the following:
           if [ -z "${{ matrix.pg_prerelease }}" ]; then
             sudo apt-get install -qq postgresql-${{ matrix.pg_major }}-postgis-${{ env.postgis_version }}
-            sudo -u postgres psql -c "CREATE EXTENSION postgis" npgsql_tests
           fi
           
           if [ ${{ matrix.pg_major }} -ge 14 ]; then
@@ -167,11 +162,6 @@ jobs:
 
           # Configure test account
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests SUPERUSER LOGIN PASSWORD 'npgsql_tests'"
-          pgsql/bin/psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
-          pgsql/bin/psql -U postgres -c "CREATE EXTENSION citext" npgsql_tests
-          pgsql/bin/psql -U postgres -c "CREATE EXTENSION hstore" npgsql_tests
-          pgsql/bin/psql -U postgres -c "CREATE EXTENSION ltree" npgsql_tests
-          pgsql/bin/psql -U postgres -c "CREATE EXTENSION postgis" npgsql_tests
 
           # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
           if [ ${{ matrix.pg_major }} -ge 14 ]; then

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -2024,9 +2024,15 @@ namespace Npgsql
                     NpgsqlTimeout.Infinite,
                     async: false,
                     CancellationToken.None).GetAwaiter().GetResult();
+
             // Increment the change counter on the global type mapper. This will make conn.Open() pick up the
             // new DatabaseInfo and set up a new connection type mapper
             TypeMapping.GlobalTypeMapper.Instance.RecordChange();
+
+            if (Settings.Multiplexing)
+            {
+                ((MultiplexingConnectorPool)Pool).MultiplexingTypeMapper!.DatabaseInfo = connector.TypeMapper.DatabaseInfo;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The main point here is to make sure the tests reliably run without requiring any extra steps beyond creating a user; that means taking care of database creation and extension installation inside the tests.

* Create the database in the tests if it doesn't exist
* Clean up CommandBuilder tests, so they don't feel if types already exist in the database
* Make sure multiplexing properly picks up extensions that get installed as part of the tests.

@vonzshik I hope this stuff doesn't interfere with making our tests run in parallel...