### PR TITLE
Fix logging of command texts

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1536,25 +1536,29 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         NpgsqlBatchCommand TruncateStatementsToOne()
         {
+            NpgsqlBatchCommand statement;
             switch (InternalBatchCommands.Count)
             {
             case 0:
-                var statement = new NpgsqlBatchCommand();
+                statement = new NpgsqlBatchCommand();
                 InternalBatchCommands.Add(statement);
-                return statement;
+                break;
 
             case 1:
                 statement = InternalBatchCommands[0];
                 statement.Reset();
-                return statement;
+                break;
 
             default:
                 statement = InternalBatchCommands[0];
                 statement.Reset();
                 InternalBatchCommands.Clear();
                 InternalBatchCommands.Add(statement);
-                return statement;
+                break;
             }
+
+            statement.CommandText = CommandText;
+            return statement;
         }
 
         /// <summary>

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using Npgsql.Logging;
 
 namespace Npgsql
 {
@@ -462,6 +463,12 @@ namespace Npgsql
         SemiColon:
             _rewrittenSql.Append(sql.Slice(currTokenBeg, currCharOfs - currTokenBeg - 1));
             batchCommand.FinalCommandText = _rewrittenSql.ToString();
+
+            // Correctly assigning batchCommand.CommandText in presence of parameters would mean that we need a second StringBuilder to
+            // keep the split commands without rewritten parameters. Since the only current purpose is logging, this does not seem worthwhile.
+            if (parameters.Count == 0)
+                batchCommand.CommandText = batchCommand.FinalCommandText;
+
             while (currCharOfs < end)
             {
                 ch = sql[currCharOfs];
@@ -496,6 +503,12 @@ namespace Npgsql
         Finish:
             _rewrittenSql.Append(sql.Slice(currTokenBeg, end - currTokenBeg));
             batchCommand.FinalCommandText = _rewrittenSql.ToString();
+
+            // Correctly assigning batchCommand.CommandText in presence of parameters would mean that we need a second StringBuilder to
+            // keep the split commands without rewritten parameters. Since the only current purpose is logging, this does not seem worthwhile.
+            if (parameters.Count == 0)
+                batchCommand.CommandText = batchCommand.FinalCommandText;
+
             if (batchCommands is not null && batchCommands.Count > statementIndex + 1)
                 batchCommands.RemoveRange(statementIndex + 1, batchCommands.Count - (statementIndex + 1));
 


### PR DESCRIPTION
As mentioned offline, we have a problem where command texts no longer get logged because we log `NpgsqlBatchCommand.CommandText` but fail to set it in some instances.