### PR TITLE
Fix logging of command texts

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1584,7 +1584,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             sb.AppendLine("Executing statement(s):");
             foreach (var s in InternalBatchCommands)
             {
-                sb.Append("\t").AppendLine(s.CommandText);
+                sb.Append("\t").AppendLine(s.FinalCommandText);
                 var p = s.Parameters.InternalList;
                 if (p.Count > 0 && (NpgsqlLogManager.IsParameterLoggingEnabled || connector.Settings.LogParameters))
                 {


### PR DESCRIPTION
This makes NpgsqlCommand log the FinalCommandText that is actually
sent to the backend instead of the CommandText that would represent
the original value before rewriting and splitting.
