### PR TITLE
Fix stackoverflow in ReplicationConnection

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -178,7 +178,7 @@ namespace Npgsql.Replication
 
         internal NpgsqlConnector Connector
             => _npgsqlConnection.Connector ??
-               throw new InvalidOperationException($"The {Connector} property can only be used when there is an active connection");
+               throw new InvalidOperationException($"The {nameof(Connector)} property can only be used when there is an active connection");
 
         /// <summary>
         /// Gets or sets the wait time before terminating the attempt  to execute a command and generating an error.
@@ -205,13 +205,13 @@ namespace Npgsql.Replication
         /// The client encoding for the connection
         /// This can only be called when there is an active connection.
         /// </summary>
-        public Encoding Encoding => _npgsqlConnection.Connector?.TextEncoding ?? throw new InvalidOperationException($"The {Encoding} property can only be used when there is an active connection");
+        public Encoding Encoding => _npgsqlConnection.Connector?.TextEncoding ?? throw new InvalidOperationException($"The {nameof(Encoding)} property can only be used when there is an active connection");
 
         /// <summary>
         /// Process id of backend server.
         /// This can only be called when there is an active connection.
         /// </summary>
-        public int ProcessID => _npgsqlConnection.Connector?.BackendProcessId ?? throw new InvalidOperationException($"The {ProcessID} property can only be used when there is an active connection");
+        public int ProcessID => _npgsqlConnection.Connector?.BackendProcessId ?? throw new InvalidOperationException($"The {nameof(ProcessID)} property can only be used when there is an active connection");
 
         #endregion Properties
 


### PR DESCRIPTION
When connection is not opened and you call `StartReplication` currently it crashes application with stackoverflow. It happens because in `ReplicationConnection` properties when `_npgsqlconnection.Connector` is `null` exception should be throwed, but instead of `nameof(Property)` was used just `Property` for exception message, so it loopbacks.

This small PR fixed this.