### PR TITLE
Initial working binary replication

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -193,7 +193,7 @@ namespace Npgsql.Internal
                 => DisposeAsync(disposing: true, async: true);
 #endif
 
-            async ValueTask DisposeAsync(bool disposing, bool async)
+            internal async ValueTask DisposeAsync(bool disposing, bool async)
             {
                 if (IsDisposed || !disposing)
                     return;

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -27,7 +27,7 @@ namespace Npgsql.Internal
 
         internal readonly NpgsqlConnector Connector;
 
-        internal Stream Underlying { private get; set; }
+        internal Stream Underlying { get; set; }
 
         readonly Socket? _underlyingSocket;
 
@@ -541,9 +541,7 @@ namespace Npgsql.Internal
 
         public Stream GetStream(int len, bool canSeek)
         {
-            if (_columnStream == null)
-                _columnStream = new ColumnStream(Connector);
-
+            _columnStream ??= new ColumnStream(Connector);
             _columnStream.Init(len, canSeek);
             return _columnStream;
         }

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -99,7 +99,7 @@ namespace Npgsql
                 intDateTimes == "on";
 
             IsRedshift = conn.Settings.ServerCompatibilityMode == ServerCompatibilityMode.Redshift;
-            _types = await LoadBackendTypes(conn, timeout, async);
+            _types = await LoadBackendTypes(conn, timeout, async, conn.Settings.ReplicationMode != ReplicationMode.Off);
         }
 
         /// <summary>
@@ -112,13 +112,19 @@ namespace Npgsql
         /// For arrays and ranges, join in the element OID and type (to filter out arrays of unhandled
         /// types).
         /// </remarks>
-        static string GenerateLoadTypesQuery(bool withRange, bool withMultirange, bool loadTableComposites)
+        static string GenerateLoadTypesQuery(bool withRange, bool withMultirange, bool loadTableComposites, bool addComments =
+#if DEBUG
+                true
+#else
+            false
+#endif
+        )
             => $@"
 SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid
-FROM (
+FROM ({(addComments ? @"
     -- Arrays have typtype=b - this subquery identifies them by their typreceive and converts their typtype to a
     -- We first do this for the type (innerest-most subquery), and then for its element type
-    -- This also returns the array element, range subtype and domain base type as elemtypoid
+    -- This also returns the array element, range subtype and domain base type as elemtypoid" : string.Empty)}
     SELECT
         typ.oid, typ.typnamespace, typ.typname, typ.typtype, typ.typrelid, typ.typnotnull, typ.relkind,
         elemtyp.oid AS elemtypoid, elemtyp.typname AS elemtypname, elemcls.relkind AS elemrelkind,
@@ -132,56 +138,88 @@ FROM (
                 {(withMultirange ? "WHEN typ.typtype='m' THEN (SELECT rngtypid FROM pg_range WHERE rngmultitypid = typ.oid)" : "")}
                 WHEN typ.typtype='d' THEN typ.typbasetype
             END AS elemtypoid
-        FROM pg_type AS typ
-        LEFT JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
-        LEFT JOIN pg_proc AS proc ON proc.oid = typ.typreceive
-        {(withRange ? "LEFT JOIN pg_range ON (pg_range.rngtypid = typ.oid)" : "")}
+        FROM pg_catalog.pg_type AS typ
+        LEFT JOIN pg_catalog.pg_class AS cls ON (cls.oid = typ.typrelid)
+        LEFT JOIN pg_catalog.pg_proc AS proc ON proc.oid = typ.typreceive
+        {(withRange ? "LEFT JOIN pg_catalog.pg_range AS rng ON (rng.rngtypid = typ.oid)" : "")}
     ) AS typ
-    LEFT JOIN pg_type AS elemtyp ON elemtyp.oid = elemtypoid
-    LEFT JOIN pg_class AS elemcls ON (elemcls.oid = elemtyp.typrelid)
-    LEFT JOIN pg_proc AS elemproc ON elemproc.oid = elemtyp.typreceive
+    LEFT JOIN pg_catalog.pg_type AS elemtyp ON elemtyp.oid = elemtypoid
+    LEFT JOIN pg_catalog.pg_class AS elemcls ON (elemcls.oid = elemtyp.typrelid)
+    LEFT JOIN pg_catalog.pg_proc AS elemproc ON elemproc.oid = elemtyp.typreceive
 ) AS t
-JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
+JOIN pg_catalog.pg_namespace AS ns ON (ns.oid = typnamespace)
 WHERE
-    typtype IN ('b', 'r', 'm', 'e', 'd') OR -- Base, range, multirange, enum, domain
-    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR -- User-defined free-standing composites (not table composites) by default
-    (typtype = 'p' AND typname IN ('record', 'void')) OR -- Some special supported pseudo-types
-    (typtype = 'a' AND (  -- Array of...
-        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR -- Array of base, range, multirange, enum, domain
-        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR -- Arrays of special supported pseudo-types
-        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")}) -- Array of user-defined free-standing composites (not table composites) by default
+    typtype IN ('b', 'r', 'm', 'e', 'd') OR{(addComments ? " -- Base, range, multirange, enum, domain" : string.Empty)}
+    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR{(addComments ? " -- User-defined free-standing composites (not table composites) by default" : string.Empty)}
+    (typtype = 'p' AND typname IN ('record', 'void')) OR{(addComments ? " -- Some special supported pseudo-types" : string.Empty)}
+    (typtype = 'a' AND ({(addComments ? "  -- Array of..." : string.Empty)}
+        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR{(addComments ? " -- Array of base, range, multirange, enum, domain" : string.Empty)}
+        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR{(addComments ? " -- Arrays of special supported pseudo-types" : string.Empty)}
+        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")}){(addComments ? " -- Array of user-defined free-standing composites (not table composites) by default" : string.Empty)}
     ))
 ORDER BY CASE
-       WHEN typtype IN ('b', 'e', 'p') THEN 0           -- First base types, enums, pseudo-types
-       WHEN typtype = 'r' THEN 1                        -- Ranges after
-       WHEN typtype = 'm' THEN 2                        -- Multiranges after
-       WHEN typtype = 'c' THEN 3                        -- Composites after
-       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4 -- Domains over non-arrays after
-       WHEN typtype = 'a' THEN 5                        -- Arrays after
-       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6  -- Domains over arrays last
-END;";
+       WHEN typtype IN ('b', 'e', 'p') THEN 0{(addComments ? "           -- First base types, enums, pseudo-types" : string.Empty)}
+       WHEN typtype = 'r' THEN 1{(addComments ? "                        -- Ranges after" : string.Empty)}
+       WHEN typtype = 'm' THEN 2{(addComments ? "                        -- Multiranges after" : string.Empty)}
+       WHEN typtype = 'c' THEN 3{(addComments ? "                        -- Composites after" : string.Empty)}
+       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4{(addComments ? " -- Domains over non-arrays after" : string.Empty)}
+       WHEN typtype = 'a' THEN 5{(addComments ? "                        -- Arrays before" : string.Empty)}
+       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6{(addComments ? "  -- Domains over arrays last" : string.Empty)}
+END;
+"
+#if NET6_0_OR_GREATER
+                .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
 
-        static string GenerateLoadCompositeTypesQuery(bool loadTableComposites)
-            => $@"
--- Load field definitions for (free-standing) composite types
+        static string GenerateLoadCompositeTypesQuery(bool loadTableComposites, bool addComments =
+#if DEBUG
+                true
+#else
+            false
+#endif
+        )
+            => $@"{(addComments ? @"
+-- Load field definitions for (free-standing) composite types" : string.Empty)}
 SELECT typ.oid, att.attname, att.atttypid
-FROM pg_type AS typ
-JOIN pg_namespace AS ns ON (ns.oid = typ.typnamespace)
-JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
-JOIN pg_attribute AS att ON (att.attrelid = typ.typrelid)
+FROM pg_catalog.pg_type AS typ
+JOIN pg_catalog.pg_namespace AS ns ON (ns.oid = typ.typnamespace)
+JOIN pg_catalog.pg_class AS cls ON (cls.oid = typ.typrelid)
+JOIN pg_catalog.pg_attribute AS att ON (att.attrelid = typ.typrelid)
 WHERE
   (typ.typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "cls.relkind='c'")}) AND
-  attnum > 0 AND     -- Don't load system attributes
+  attnum > 0 AND{(addComments ? "     -- Don't load system attributes" : string.Empty)}
   NOT attisdropped
-ORDER BY typ.oid, att.attnum;";
+ORDER BY typ.oid, att.attnum;
+"
+#if NET6_0_OR_GREATER
+                .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
 
-        static string GenerateLoadEnumFieldsQuery(bool withEnumSortOrder)
-            => $@"
--- Load enum fields
+        static string GenerateLoadEnumFieldsQuery(bool withEnumSortOrder, bool addComments =
+#if DEBUG
+                true
+#else
+            false
+#endif
+        )
+            => $@"{(addComments ? @"
+-- Load enum fields" : string.Empty)}
 SELECT pg_type.oid, enumlabel
-FROM pg_enum
-JOIN pg_type ON pg_type.oid=enumtypid
-ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
+FROM pg_catalog.pg_enum
+JOIN pg_catalog.pg_type ON pg_type.oid=enumtypid
+ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};
+"
+#if NET6_0_OR_GREATER
+                .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
+
+        const string VersionQuery = "SELECT pg_catalog.version();\n";
 
         /// <summary>
         /// Loads type information from the backend specified by <paramref name="conn"/>.
@@ -189,211 +227,268 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
         /// <param name="conn">The database connection.</param>
         /// <param name="timeout">The timeout while loading types from the backend.</param>
         /// <param name="async">True to load types asynchronously.</param>
+        /// <param name="isReplicationConnection">True if this is a replication connection.</param>
         /// <returns>
         /// A collection of types loaded from the backend.
         /// </returns>
         /// <exception cref="TimeoutException" />
         /// <exception cref="ArgumentOutOfRangeException">Unknown typtype for type '{internalName}' in pg_type: {typeChar}.</exception>
-        internal async Task<List<PostgresType>> LoadBackendTypes(NpgsqlConnector conn, NpgsqlTimeout timeout, bool async)
+        internal async Task<List<PostgresType>> LoadBackendTypes(NpgsqlConnector conn, NpgsqlTimeout timeout, bool async,
+            bool isReplicationConnection)
         {
-            var commandTimeout = 0;  // Default to infinity
-            if (timeout.IsSet)
-                commandTimeout = (int)timeout.CheckAndGetTimeLeft().TotalSeconds;
-
-            var batchQuery = new StringBuilder()
-                .AppendLine("SELECT version();")
-                .AppendLine(GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites))
-                .AppendLine(GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites));
-
-            if (SupportsEnumTypes)
-                batchQuery.AppendLine(GenerateLoadEnumFieldsQuery(HasEnumSortOrder));
-
+            Dictionary<uint, PostgresType> byOID;
             timeout.CheckAndApply(conn);
-            await conn.WriteQuery(batchQuery.ToString(), async);
-            await conn.Flush(async);
-            var byOID = new Dictionary<uint, PostgresType>();
-            var buf = conn.ReadBuffer;
 
-            // First read the PostgreSQL version
-            Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
-
-            // We read the message in non-sequential mode which buffers the whole message.
-            // There is no need to ensure data within the message boundaries
-            Expect<DataRowMessage>(await conn.ReadMessage(async), conn);
-            buf.Skip(2); // Column count
-            LongVersion = ReadNonNullableString(buf);
-            Expect<CommandCompleteMessage>(await conn.ReadMessage(async), conn);
-
-            // Then load the types
-            Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
-            IBackendMessage msg;
-            while (true)
+            // The Lexer/Parser of replication connections is pretty picky and somewhat flawed.
+            // Currently (2021-08-20) it does not support
+            // - SQL batches containing multiple commands
+            // - The <CR> ('\r') in Windows or Mac newlines
+            // - Comments are dangerous (they work in some places but don't in others)
+            if (isReplicationConnection)
             {
-                msg = await conn.ReadMessage(async);
-                if (msg is not DataRowMessage)
-                    break;
+                var q = VersionQuery;
+                await conn.WriteQuery(q, async);
+                await conn.Flush(async);
+                LongVersion = await LoadVersionString(conn, async);
+                Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
-                buf.Skip(2); // Column count
-                var nspname = ReadNonNullableString(buf);
-                var oid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
-                Debug.Assert(oid != 0);
-                var typname = ReadNonNullableString(buf);
-                var typtype = ReadNonNullableString(buf)[0];
-                var typnotnull = ReadNonNullableString(buf)[0] == 't';
-                var len = buf.ReadInt32();
-                var elemtypoid = len == -1 ? 0 : uint.Parse(buf.ReadString(len), NumberFormatInfo.InvariantInfo);
+                q = GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites, addComments: false);
+                await conn.WriteQuery(q, async);
+                await conn.Flush(async);
+                byOID = await LoadTypes(conn, async);
+                Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
-                switch (typtype)
+                q = GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites, false);
+                await conn.WriteQuery(q, async);
+                await conn.Flush(async);
+                await LoadCompositeTypes(conn, byOID, async);
+                Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
+
+                if (SupportsEnumTypes)
                 {
-                case 'b': // Normal base type
-                    var baseType = new PostgresBaseType(nspname, typname, oid);
-                    byOID[baseType.OID] = baseType;
-                    continue;
-
-                case 'a': // Array
-                {
-                    Debug.Assert(elemtypoid > 0);
-                    if (!byOID.TryGetValue(elemtypoid, out var elementPostgresType))
-                    {
-                        Log.Trace($"Array type '{typname}' refers to unknown element with OID {elemtypoid}, skipping", conn.Id);
-                        continue;
-                    }
-
-                    var arrayType = new PostgresArrayType(nspname, typname, oid, elementPostgresType);
-                    byOID[arrayType.OID] = arrayType;
-                    continue;
-                }
-
-                case 'r': // Range
-                {
-                    Debug.Assert(elemtypoid > 0);
-                    if (!byOID.TryGetValue(elemtypoid, out var subtypePostgresType))
-                    {
-                        Log.Trace($"Range type '{typname}' refers to unknown subtype with OID {elemtypoid}, skipping", conn.Id);
-                        continue;
-                    }
-
-                    var rangeType = new PostgresRangeType(nspname, typname, oid, subtypePostgresType);
-                    byOID[rangeType.OID] = rangeType;
-                    continue;
-                }
-
-                case 'm': // Multirange
-                    Debug.Assert(elemtypoid > 0);
-                    if (!byOID.TryGetValue(elemtypoid, out var type))
-                    {
-                        Log.Trace($"Multirange type '{typname}' refers to unknown range with OID {elemtypoid}, skipping", conn.Id);
-                        continue;
-                    }
-
-                    if (type is not PostgresRangeType rangePostgresType)
-                    {
-                        Log.Trace($"Multirange type '{typname}' refers to non-range type {type.Name}, skipping",
-                            conn.Id);
-                        continue;
-                    }
-
-                    var multirangeType = new PostgresMultirangeType(nspname, typname, oid, rangePostgresType);
-                    byOID[multirangeType.OID] = multirangeType;
-                    continue;
-
-                case 'e': // Enum
-                    var enumType = new PostgresEnumType(nspname, typname, oid);
-                    byOID[enumType.OID] = enumType;
-                    continue;
-
-                case 'c': // Composite
-                    var compositeType = new PostgresCompositeType(nspname, typname, oid);
-                    byOID[compositeType.OID] = compositeType;
-                    continue;
-
-                case 'd': // Domain
-                    Debug.Assert(elemtypoid > 0);
-                    if (!byOID.TryGetValue(elemtypoid, out var basePostgresType))
-                    {
-                        Log.Trace($"Domain type '{typname}' refers to unknown base type with OID {elemtypoid}, skipping", conn.Id);
-                        continue;
-                    }
-
-                    var domainType = new PostgresDomainType(nspname, typname, oid, basePostgresType, typnotnull);
-                    byOID[domainType.OID] = domainType;
-                    continue;
-
-                case 'p': // pseudo-type (record, void)
-                    goto case 'b'; // Hack this as a base type
-
-                default:
-                    throw new ArgumentOutOfRangeException($"Unknown typtype for type '{typname}' in pg_type: {typtype}");
+                    q = GenerateLoadEnumFieldsQuery(HasEnumSortOrder, false);
+                    await conn.WriteQuery(q, async);
+                    await conn.Flush(async);
+                    await LoadEnums(conn, byOID, async);
+                    Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
                 }
             }
-            Expect<CommandCompleteMessage>(msg, conn);
-
-            // Then load the composite type fields
-            Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
-
-            var currentOID = uint.MaxValue;
-            PostgresCompositeType? currentComposite = null;
-            var skipCurrent = false;
-
-            while (true)
+            else
             {
-                msg = await conn.ReadMessage(async);
-                if (msg is not DataRowMessage)
-                    break;
+                var batchQuery = new StringBuilder()
+                    .Append(VersionQuery)
+                    .Append(GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites))
+                    .Append(GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites));
 
-                buf.Skip(2); // Column count
-                var oid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
-                var attname = ReadNonNullableString(buf);
-                var atttypid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
+                if (SupportsEnumTypes)
+                    batchQuery.Append(GenerateLoadEnumFieldsQuery(HasEnumSortOrder));
 
-                if (oid != currentOID)
-                {
-                    currentOID = oid;
+                await conn.WriteQuery(batchQuery.ToString(), async);
+                await conn.Flush(async);
 
-                    if (!byOID.TryGetValue(oid, out var type))  // See #2020
-                    {
-                        Log.Warn($"Skipping composite type with OID {oid} which was not found in pg_type");
-                        byOID.Remove(oid);
-                        skipCurrent = true;
-                        continue;
-                    }
+                LongVersion = await LoadVersionString(conn, async);
+                byOID = await LoadTypes(conn, async);
+                await LoadCompositeTypes(conn, byOID, async);
+                if (SupportsEnumTypes)
+                    await LoadEnums(conn, byOID, async);
 
-                    currentComposite = type as PostgresCompositeType;
-                    if (currentComposite == null)
-                    {
-                        Log.Warn($"Type {type.Name} was referenced as a composite type but is a {type.GetType()}");
-                        byOID.Remove(oid);
-                        skipCurrent = true;
-                        continue;
-                    }
-
-                    skipCurrent = false;
-                }
-
-                if (skipCurrent)
-                    continue;
-
-                if (!byOID.TryGetValue(atttypid, out var fieldType))  // See #2020
-                {
-                    Log.Warn($"Skipping composite type {currentComposite!.DisplayName} with field {attname} with type OID {atttypid}, which could not be resolved to a PostgreSQL type.");
-                    byOID.Remove(oid);
-                    skipCurrent = true;
-                    continue;
-                }
-
-                currentComposite!.MutableFields.Add(new PostgresCompositeType.Field(attname, fieldType));
+                Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
             }
-            Expect<CommandCompleteMessage>(msg, conn);
 
-            if (SupportsEnumTypes)
+            return byOID.Values.ToList();
+
+            // Read the PostgreSQL version
+            static async Task<string> LoadVersionString(NpgsqlConnector conn, bool async)
             {
-                // Then load the enum fields
+                var buf = conn.ReadBuffer;
                 Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
+                Expect<DataRowMessage>(await conn.ReadMessage(async), conn);
+                buf.Skip(2); // Column count
+                var version = ReadNonNullableString(buf);
+                Expect<CommandCompleteMessage>(await conn.ReadMessage(async), conn);
+                return version;
+            }
 
-                currentOID = uint.MaxValue;
+            // Load the types
+            static async Task<Dictionary<uint, PostgresType>> LoadTypes(NpgsqlConnector conn, bool async)
+            {
+                var buf = conn.ReadBuffer;
+                var byOID = new Dictionary<uint, PostgresType>();
+                IBackendMessage msg = Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
+                while (true)
+                {
+                    msg = await conn.ReadMessage(async);
+                    if (msg is not DataRowMessage)
+                        break;
+
+                    buf.Skip(2); // Column count
+                    var nspname = ReadNonNullableString(buf);
+                    var oid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
+                    Debug.Assert(oid != 0);
+                    var typname = ReadNonNullableString(buf);
+                    var typtype = ReadNonNullableString(buf)[0];
+                    var typnotnull = ReadNonNullableString(buf)[0] == 't';
+                    var len = buf.ReadInt32();
+                    var elemtypoid = len == -1 ? 0 : uint.Parse(buf.ReadString(len), NumberFormatInfo.InvariantInfo);
+
+                    switch (typtype)
+                    {
+                    case 'b': // Normal base type
+                        var baseType = new PostgresBaseType(nspname, typname, oid);
+                        byOID[baseType.OID] = baseType;
+                        continue;
+
+                    case 'a': // Array
+                    {
+                        Debug.Assert(elemtypoid > 0);
+                        if (!byOID.TryGetValue(elemtypoid, out var elementPostgresType))
+                        {
+                            Log.Trace($"Array type '{typname}' refers to unknown element with OID {elemtypoid}, skipping", conn.Id);
+                            continue;
+                        }
+
+                        var arrayType = new PostgresArrayType(nspname, typname, oid, elementPostgresType);
+                        byOID[arrayType.OID] = arrayType;
+                        continue;
+                    }
+
+                    case 'r': // Range
+                    {
+                        Debug.Assert(elemtypoid > 0);
+                        if (!byOID.TryGetValue(elemtypoid, out var subtypePostgresType))
+                        {
+                            Log.Trace($"Range type '{typname}' refers to unknown subtype with OID {elemtypoid}, skipping", conn.Id);
+                            continue;
+                        }
+
+                        var rangeType = new PostgresRangeType(nspname, typname, oid, subtypePostgresType);
+                        byOID[rangeType.OID] = rangeType;
+                        continue;
+                    }
+
+                    case 'm': // Multirange
+                        Debug.Assert(elemtypoid > 0);
+                        if (!byOID.TryGetValue(elemtypoid, out var type))
+                        {
+                            Log.Trace($"Multirange type '{typname}' refers to unknown range with OID {elemtypoid}, skipping", conn.Id);
+                            continue;
+                        }
+
+                        if (type is not PostgresRangeType rangePostgresType)
+                        {
+                            Log.Trace($"Multirange type '{typname}' refers to non-range type {type.Name}, skipping",
+                                conn.Id);
+                            continue;
+                        }
+
+                        var multirangeType = new PostgresMultirangeType(nspname, typname, oid, rangePostgresType);
+                        byOID[multirangeType.OID] = multirangeType;
+                        continue;
+
+                    case 'e': // Enum
+                        var enumType = new PostgresEnumType(nspname, typname, oid);
+                        byOID[enumType.OID] = enumType;
+                        continue;
+
+                    case 'c': // Composite
+                        var compositeType = new PostgresCompositeType(nspname, typname, oid);
+                        byOID[compositeType.OID] = compositeType;
+                        continue;
+
+                    case 'd': // Domain
+                        Debug.Assert(elemtypoid > 0);
+                        if (!byOID.TryGetValue(elemtypoid, out var basePostgresType))
+                        {
+                            Log.Trace($"Domain type '{typname}' refers to unknown base type with OID {elemtypoid}, skipping",
+                                conn.Id);
+                            continue;
+                        }
+
+                        var domainType = new PostgresDomainType(nspname, typname, oid, basePostgresType, typnotnull);
+                        byOID[domainType.OID] = domainType;
+                        continue;
+
+                    case 'p': // pseudo-type (record, void)
+                        goto case 'b'; // Hack this as a base type
+
+                    default:
+                        throw new ArgumentOutOfRangeException($"Unknown typtype for type '{typname}' in pg_type: {typtype}");
+                    }
+                }
+
+                Expect<CommandCompleteMessage>(msg, conn);
+                return byOID;
+            }
+
+            // Load the composite type fields
+            static async Task LoadCompositeTypes(NpgsqlConnector conn, Dictionary<uint, PostgresType> byOID, bool async)
+            {
+                var buf = conn.ReadBuffer;
+                var currentOID = uint.MaxValue;
+                PostgresCompositeType? currentComposite = null;
+                var skipCurrent = false;
+                IBackendMessage msg = Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
+                while (true)
+                {
+                    msg = await conn.ReadMessage(async);
+                    if (msg is not DataRowMessage)
+                        break;
+
+                    buf.Skip(2); // Column count
+                    var oid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
+                    var attname = ReadNonNullableString(buf);
+                    var atttypid = uint.Parse(ReadNonNullableString(buf), NumberFormatInfo.InvariantInfo);
+
+                    if (oid != currentOID)
+                    {
+                        currentOID = oid;
+
+                        if (!byOID.TryGetValue(oid, out var type)) // See #2020
+                        {
+                            Log.Warn($"Skipping composite type with OID {oid} which was not found in pg_type");
+                            byOID.Remove(oid);
+                            skipCurrent = true;
+                            continue;
+                        }
+
+                        currentComposite = type as PostgresCompositeType;
+                        if (currentComposite == null)
+                        {
+                            Log.Warn($"Type {type.Name} was referenced as a composite type but is a {type.GetType()}");
+                            byOID.Remove(oid);
+                            skipCurrent = true;
+                            continue;
+                        }
+
+                        skipCurrent = false;
+                    }
+
+                    if (skipCurrent)
+                        continue;
+
+                    if (!byOID.TryGetValue(atttypid, out var fieldType)) // See #2020
+                    {
+                        Log.Warn(
+                            $"Skipping composite type {currentComposite!.DisplayName} with field {attname} with type OID {atttypid}, which could not be resolved to a PostgreSQL type.");
+                        byOID.Remove(oid);
+                        skipCurrent = true;
+                        continue;
+                    }
+
+                    currentComposite!.MutableFields.Add(new PostgresCompositeType.Field(attname, fieldType));
+                }
+
+                Expect<CommandCompleteMessage>(msg, conn);
+            }
+
+            // Load the enum fields
+            static async Task LoadEnums(NpgsqlConnector conn, Dictionary<uint, PostgresType> byOID, bool async)
+            {
+                var buf = conn.ReadBuffer;
+                var currentOID = uint.MaxValue;
                 PostgresEnumType? currentEnum = null;
-                skipCurrent = false;
-
+                var skipCurrent = false;
+                IBackendMessage msg = Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
                 while (true)
                 {
                     msg = await conn.ReadMessage(async);
@@ -407,7 +502,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                     {
                         currentOID = oid;
 
-                        if (!byOID.TryGetValue(oid, out var type))  // See #2020
+                        if (!byOID.TryGetValue(oid, out var type)) // See #2020
                         {
                             Log.Warn($"Skipping enum type with OID {oid} which was not found in pg_type");
                             byOID.Remove(oid);
@@ -432,11 +527,9 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
 
                     currentEnum!.MutableLabels.Add(enumlabel);
                 }
+
                 Expect<CommandCompleteMessage>(msg, conn);
             }
-
-            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
-            return byOID.Values.ToList();
 
             static string ReadNonNullableString(NpgsqlReadBuffer buffer)
                 => buffer.ReadString(buffer.ReadInt32());

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -80,6 +80,26 @@ Npgsql.PostgresTypes.PostgresMultirangeType.Subrange.get -> Npgsql.PostgresTypes
 Npgsql.PostgresTypes.PostgresRangeType.Multirange.get -> Npgsql.PostgresTypes.PostgresMultirangeType?
 Npgsql.PhysicalOpenAsyncCallback
 Npgsql.PhysicalOpenCallback
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetBoolean(int i) -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetByte(int i) -> byte
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetBytes(int i, long fieldoffset, byte[]? buffer, int bufferoffset, int length) -> long
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetChar(int i) -> char
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) -> long
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetDateTime(int i) -> System.DateTime
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetDecimal(int i) -> decimal
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetDouble(int i) -> double
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetFloat(int i) -> float
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetGuid(int i) -> System.Guid
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetInt16(int i) -> short
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetInt32(int i) -> int
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetInt64(int i) -> long
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetString(int i) -> string!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetValue(int i) -> object!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetValues(object![]! values) -> int
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.this[int i].get -> object!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.this[string! name].get -> object!
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.GetBytes(long fieldoffset, byte[]? buffer, int bufferoffset, int length) -> long
+Npgsql.Replication.PgOutput.Messages.UnchangedToasted
 Npgsql.Replication.ReplicationConnection.PostgreSqlVersion.get -> System.Version!
 Npgsql.Replication.ReplicationConnection.ServerVersion.get -> string!
 *REMOVED*Npgsql.Replication.PgOutput.Messages.BeginMessage.TransactionXid.get -> uint
@@ -93,8 +113,38 @@ Npgsql.Replication.PgOutput.Messages.TransactionControlMessage
 Npgsql.Replication.PgOutput.Messages.TransactionControlMessage.TransactionControlMessage() -> void
 Npgsql.Replication.PgOutput.Messages.TransactionControlMessage.TransactionXid.get -> uint
 Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> System.Collections.Generic.IReadOnlyList<uint>!
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.Messages.BeginMessage.TransactionXid.get -> uint
+*REMOVED*Npgsql.Replication.PgOutput.Messages.RelationMessage.Columns.get -> System.ReadOnlyMemory<Npgsql.Replication.PgOutput.Messages.RelationMessage.Column>
+Npgsql.Replication.PgOutput.Messages.InsertMessage.CloneAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Npgsql.Replication.PgOutput.Messages.InsertMessage!>!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.FieldCount.get -> int
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<Npgsql.Replication.PgOutput.Messages.ReplicationTuple!>!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetData(int i) -> System.Data.IDataReader!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetDataTypeName(int i) -> string!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetEnumerator() -> System.Collections.Generic.IEnumerator<Npgsql.Replication.PgOutput.Messages.ReplicationTuple!>!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetFieldType(int i) -> System.Type!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetFieldValue<T>(int ordinal) -> T
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetFieldValueAsync<T>(int ordinal, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetName(int i) -> string!
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.GetOrdinal(string! name) -> int
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.IsDBNull(int i) -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord.IsUnchangedToastedValue(int i) -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.GetStream() -> System.IO.Stream!
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.GetFieldValue<T>() -> T
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.GetFieldValueAsync<T>(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.IsBinaryValue.get -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.IsDBNull.get -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.IsTextValue.get -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.IsUnchangedToastedValue.get -> bool
+Npgsql.Replication.PgOutput.Messages.ReplicationTuple.ReplicationTuple() -> void
+*REMOVED*Npgsql.Replication.PgOutput.Messages.TruncateMessage.RelationIds.get -> uint[]!
+Npgsql.Replication.PgOutput.Messages.TupleDataKind.BinaryValue = 98 -> Npgsql.Replication.PgOutput.Messages.TupleDataKind
 Npgsql.Replication.ReplicationConnection.SetReplicationStatus(NpgsqlTypes.NpgsqlLogSequenceNumber lastAppliedAndFlushedLsn) -> void
 *REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion = 1, bool? binary = null, bool? streaming = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.Messages.InsertMessage.NewRow.get -> System.ReadOnlyMemory<Npgsql.Replication.PgOutput.Messages.TupleData>
+Npgsql.Replication.PgOutput.Messages.InsertMessage.NewRow.get -> Npgsql.Replication.PgOutput.Messages.ReplicationDataRecord!
 Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage
 Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Data.get -> System.IO.Stream!
 Npgsql.Replication.PgOutput.Messages.LogicalDecodingMessage.Flags.get -> byte
@@ -161,6 +211,7 @@ NpgsqlTypes.NpgsqlInterval.Time.get -> long
 NpgsqlTypes.NpgsqlInterval.Equals(NpgsqlTypes.NpgsqlInterval other) -> bool
 override NpgsqlTypes.NpgsqlInterval.Equals(object? obj) -> bool
 override NpgsqlTypes.NpgsqlInterval.GetHashCode() -> int
+Npgsql.Replication.ReplicationConnection.TypeMapper.get -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 NpgsqlTypes.NpgsqlTsQuery.Write(System.Text.StringBuilder! stringBuilder) -> void
 override Npgsql.NpgsqlBatch.Cancel() -> void
 override Npgsql.NpgsqlBatch.CreateDbBatchCommand() -> System.Data.Common.DbBatchCommand!
@@ -317,3 +368,4 @@ NpgsqlTypes.NpgsqlDbType.Xid8 = 64 -> NpgsqlTypes.NpgsqlDbType
 *REMOVED*Npgsql.NpgsqlStatement.StatementType.get -> Npgsql.StatementType
 *REMOVED*override Npgsql.NpgsqlStatement.ToString() -> string!
 *REMOVED*Npgsql.PostgresException.Statement.get -> Npgsql.NpgsqlStatement?
+static readonly Npgsql.Replication.PgOutput.Messages.UnchangedToasted.Value -> Npgsql.Replication.PgOutput.Messages.UnchangedToasted!

--- a/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/InsertMessage.cs
@@ -1,5 +1,7 @@
 ﻿using NpgsqlTypes;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {
@@ -16,11 +18,11 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// <summary>
         /// Columns representing the new row.
         /// </summary>
-        public ReadOnlyMemory<TupleData> NewRow { get; private set; } = default!;
+        public ReplicationDataRecord NewRow { get; private set; } = default!;
 
         internal InsertMessage Populate(
             NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock, uint? transactionXid, uint relationId,
-            ReadOnlyMemory<TupleData> newRow)
+            ReplicationDataRecord newRow)
         {
             base.Populate(walStart, walEnd, serverClock, transactionXid);
             RelationId = relationId;
@@ -36,7 +38,21 @@ namespace Npgsql.Replication.PgOutput.Messages
 #endif
         {
             var clone = new InsertMessage();
-            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.ToArray());
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, NewRow.Clone(async: false).GetAwaiter().GetResult());
+            return clone;
+        }
+
+        /// <summary>
+        /// Returns a buffered clone of this <see cref="InsertMessage"/>, which can be accessed after other replication messages have been retrieved.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
+        /// </param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task<InsertMessage> CloneAsync(CancellationToken cancellationToken = default)
+        {
+            var clone = new InsertMessage();
+            clone.Populate(WalStart, WalEnd, ServerClock, TransactionXid, RelationId, await NewRow.Clone(async: true, cancellationToken));
             return clone;
         }
     }

--- a/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/RelationMessage.cs
@@ -1,7 +1,6 @@
 ﻿using NpgsqlTypes;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {

--- a/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecord.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecord.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.Internal;
+
+#pragma warning disable 1591
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    public sealed class ReplicationDataRecord : IDataRecord, IAsyncEnumerable<ReplicationTuple>, IEnumerable
+    {
+        readonly NpgsqlReadBuffer _readBuffer;
+        readonly ReplicationDataRecordEnumerator _dataRecordEnumerator;
+        RowDescriptionMessage _tableInfo = default!;
+
+        internal ReplicationDataRecord(NpgsqlReadBuffer readBuffer)
+        {
+            _readBuffer = readBuffer;
+            _dataRecordEnumerator = new ReplicationDataRecordEnumerator(readBuffer);
+        }
+        
+        public int FieldCount { get; private set; }
+
+        public object this[string name]
+            => GetFieldValue<object>(GetOrdinal(name), async: false).GetAwaiter().GetResult();
+
+        public object this[int i]
+            => GetFieldValue<object>(i, async: false).GetAwaiter().GetResult();
+
+        public bool GetBoolean(int i)
+            => GetFieldValue<bool>(i, async: false).GetAwaiter().GetResult();
+
+        public byte GetByte(int i)
+            => GetFieldValue<byte>(i, async: false).GetAwaiter().GetResult();
+
+        public long GetBytes(int i, long fieldoffset, byte[]? buffer, int bufferoffset, int length)
+        {
+            SetPosition(i, async: false).GetAwaiter().GetResult();
+            return _dataRecordEnumerator.Current.GetBytes(fieldoffset, buffer, bufferoffset, length);
+        }
+
+        public char GetChar(int i)
+            => GetFieldValue<char>(i, async: false).GetAwaiter().GetResult();
+
+        public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length)
+        {
+            SetPosition(i, async: false).GetAwaiter().GetResult();
+            return _dataRecordEnumerator.Current.GetChars(fieldoffset, buffer, bufferoffset, length);
+        }
+
+        public IDataReader GetData(int i)
+            => GetFieldValue<IDataReader>(i, async: false).GetAwaiter().GetResult();
+
+        public DateTime GetDateTime(int i)
+            => GetFieldValue<DateTime>(i, async: false).GetAwaiter().GetResult();
+
+        public decimal GetDecimal(int i)
+            => GetFieldValue<decimal>(i, async: false).GetAwaiter().GetResult();
+
+        public double GetDouble(int i)
+            => GetFieldValue<double>(i, async: false).GetAwaiter().GetResult();
+
+        public float GetFloat(int i)
+            => GetFieldValue<float>(i, async: false).GetAwaiter().GetResult();
+
+        public Guid GetGuid(int i)
+            => GetFieldValue<Guid>(i, async: false).GetAwaiter().GetResult();
+
+        public short GetInt16(int i)
+            => GetFieldValue<short>(i, async: false).GetAwaiter().GetResult();
+
+        public int GetInt32(int i)
+            => GetFieldValue<int>(i, async: false).GetAwaiter().GetResult();
+
+        public long GetInt64(int i)
+            => GetFieldValue<long>(i, async: false).GetAwaiter().GetResult();
+
+        public string GetString(int i)
+            => GetFieldValue<string>(i, async: false).GetAwaiter().GetResult();
+
+        public object GetValue(int i)
+            => GetFieldValue<object>(i, async: false).GetAwaiter().GetResult();
+
+        public int GetValues(object[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            if (_dataRecordEnumerator.CurrentFieldIndex > -1)
+            {
+                if (_dataRecordEnumerator.IsBuffered)
+                    _dataRecordEnumerator.Reset();
+                else
+                    throw new InvalidOperationException(
+                        $"You can only access unbuffered {nameof(ReplicationDataRecord)} tuples sequentially.");
+            }
+
+            var i = 0;
+
+            for (; i < values.Length && _dataRecordEnumerator.MoveNext(); i++)
+                values[i] = _dataRecordEnumerator.Current.GetFieldValue<object>();
+
+            return i;
+        }
+
+        public string GetDataTypeName(int i)
+            => _tableInfo[i].Handler.PostgresType.DisplayName;
+
+        public Type GetFieldType(int i)
+            => _tableInfo[i].Handler.GetFieldType();
+
+        public string GetName(int i)
+            => _tableInfo[i].Name;
+
+        public int GetOrdinal(string name)
+            => _tableInfo.TryGetFieldIndex(name, out var i) ? i : throw new Exception(); // ToDo: Investigate type and message
+
+        /// <inheritdoc/>
+        /// <exception cref="InvalidOperationException"></exception>
+        public bool IsDBNull(int i)
+        {
+            SetPosition(i, async: false).GetAwaiter().GetResult();
+            return _dataRecordEnumerator.Current.IsDBNull;
+        }
+
+        /// <summary>
+        /// Return whether the specified field is set to an unchanged toasted value
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns><see langword="true"/> if the specified field is set to an unchanged toasted value; otherwise, <see langword="false"/></returns>
+        /// <exception cref="IndexOutOfRangeException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        public bool IsUnchangedToastedValue(int i)
+        {
+            SetPosition(i, async: false).GetAwaiter().GetResult();
+            return _dataRecordEnumerator.Current.IsUnchangedToastedValue;
+        }
+
+        public T GetFieldValue<T> (int ordinal)
+            => GetFieldValue<T>(ordinal, async: false).GetAwaiter().GetResult();
+
+        public ValueTask<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken = default)
+            => GetFieldValue<T>(ordinal, async: true, cancellationToken);
+
+        ValueTask<T> GetFieldValue<T>(int ordinal, bool async, CancellationToken cancellationToken = default)
+        {
+            using (NoSynchronizationContextScope.Enter())
+                return GetFieldValueInternal(ordinal, async, cancellationToken);
+
+            async ValueTask<T> GetFieldValueInternal(int ordinal, bool async, CancellationToken cancellationToken)
+            {
+                await SetPosition(ordinal, async: true);
+                return await _dataRecordEnumerator.Current.GetFieldValue<T>(async, cancellationToken);
+            }
+        }
+
+        private async ValueTask SetPosition(int ordinal, bool async)
+        {
+            if (!CheckIndex(ordinal)) do
+            {
+                // ReSharper disable once MethodHasAsyncOverload
+                if (!await _dataRecordEnumerator.MoveNext(async))
+                    throw new InvalidOperationException(
+                        $"You can only access unbuffered {nameof(ReplicationDataRecord)} tuples sequentially.");
+            } while (ordinal > _dataRecordEnumerator.CurrentFieldIndex);
+        }
+
+        private bool CheckIndex(int ordinal)
+        {
+            if (ordinal < 0 || ordinal >= FieldCount)
+                throw new IndexOutOfRangeException();
+
+            if (ordinal < _dataRecordEnumerator.CurrentFieldIndex)
+            {
+                if (_dataRecordEnumerator.IsBuffered)
+                {
+                    _dataRecordEnumerator.Reset();
+                    return false;
+                }
+                else
+                    throw new InvalidOperationException(
+                        $"You can only access unbuffered {nameof(ReplicationDataRecord)} tuples sequentially.");
+            }
+            return true;
+        }
+
+        public IEnumerator<ReplicationTuple> GetEnumerator()
+            => _dataRecordEnumerator;
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => _dataRecordEnumerator;
+
+        public IAsyncEnumerator<ReplicationTuple> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => _dataRecordEnumerator.SetCancellationToken(cancellationToken);
+
+        internal async ValueTask<ReplicationDataRecord> Clone(bool async, CancellationToken cancellationToken = default)
+        {
+            Stream? inputStream = null;
+            try
+            {
+                _dataRecordEnumerator.SetCancellationToken(cancellationToken);
+                if (_dataRecordEnumerator.CurrentFieldIndex > -1)
+                    throw new InvalidOperationException(
+                        $"Cloning a {nameof(ReplicationDataRecord)} is not supported after starting to read its fields.");
+
+                var bufferStream = new MemoryStream();
+                // ReSharper disable once MethodHasAsyncOverload
+                while (async && await _dataRecordEnumerator.MoveNextAsync() || _dataRecordEnumerator.MoveNext())
+                {
+                    if (_dataRecordEnumerator.Current.IsDBNull)
+                        bufferStream.WriteByte((byte)TupleDataKind.Null);
+                    else if (_dataRecordEnumerator.Current.IsUnchangedToastedValue)
+                        bufferStream.WriteByte((byte)TupleDataKind.UnchangedToastedValue);
+                    else
+                    {
+                        if (_dataRecordEnumerator.Current.IsTextValue)
+                            bufferStream.WriteByte((byte)TupleDataKind.TextValue);
+                        else if (_dataRecordEnumerator.Current.IsBinaryValue)
+                            bufferStream.WriteByte((byte)TupleDataKind.BinaryValue);
+
+                        bufferStream.Write(BitConverter.GetBytes(BitConverter.IsLittleEndian
+                            ? BinaryPrimitives.ReverseEndianness(_dataRecordEnumerator.Current.Length)
+                            : _dataRecordEnumerator.Current.Length));
+                        inputStream = _dataRecordEnumerator.Current.GetStream();
+                        if (async)
+                            await inputStream.CopyToAsync(bufferStream, 8192, cancellationToken);
+                        else
+                            // ReSharper disable once MethodHasAsyncOverloadWithCancellation
+                            inputStream.CopyTo(bufferStream);
+                    }
+                }
+
+                bufferStream.Position = 0;
+                // Hack: Abuse a NpgsqlReadBuffer as buffer. This currently costs at least 4096 bytes per row + the MemoryStream content!
+                var readBuffer = new NpgsqlReadBuffer(_readBuffer.Connector, bufferStream, null, MinBufferLength(bufferStream.Length),
+                    _readBuffer.Connector.TextEncoding, _readBuffer.Connector.RelaxedTextEncoding, usePool: true);
+
+                // This copies everything from the stream to the internal read buffer in order to make
+                // streams returned from NpgsqlReadBuffer seekable
+                await readBuffer.Ensure(checked((int)bufferStream.Length), async, false);
+
+                return new ReplicationDataRecord(readBuffer).Init((ushort)FieldCount, _tableInfo);
+            }
+            finally
+            {
+                if (async)
+                {
+#if NETSTANDARD2_0
+                    inputStream?.Dispose();
+#else
+                    if (inputStream != null)
+                        await inputStream.DisposeAsync();
+#endif
+                    await _dataRecordEnumerator.DisposeAsync();
+                }
+                else
+                {
+                    // ReSharper disable MethodHasAsyncOverload
+                    inputStream?.Dispose();
+                    _dataRecordEnumerator.Dispose();
+                    // ReSharper restore MethodHasAsyncOverload
+                }
+            }
+
+        }
+
+        static int MinBufferLength(long actualBufferLength)
+            => actualBufferLength > NpgsqlReadBuffer.MinimumSize
+                ? checked((int)actualBufferLength)
+                : NpgsqlReadBuffer.MinimumSize;
+
+        internal ReplicationDataRecord Init(ushort fieldCount, RowDescriptionMessage tableInfo)
+        {
+            // Hack: Set AttemptPostgresCancellation back to true on the connector in case it has been left at false (e. g. by GetStream())
+            _readBuffer.Connector.StartNestedCancellableOperation().Dispose();
+
+            FieldCount = fieldCount;
+            _tableInfo = tableInfo;
+            _dataRecordEnumerator.Init(fieldCount, tableInfo);
+            return this;
+        }
+
+        internal async Task Cleanup()
+            => await _dataRecordEnumerator.DisposeAsync();
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecordEnumerator.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecordEnumerator.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.Internal;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    sealed class ReplicationDataRecordEnumerator : IAsyncEnumerator<ReplicationTuple>, IEnumerator<ReplicationTuple>
+    {
+        readonly NpgsqlReadBuffer _readBuffer;
+        ReplicationTuple? _current;
+        bool _disposed;
+        CancellationToken _cancellationToken;
+        int _currentFieldIndex = -1;
+        int _fieldCount;
+        RowDescriptionMessage _tableInfo = default!;
+
+        internal ReplicationDataRecordEnumerator(NpgsqlReadBuffer readBuffer)
+            => _readBuffer = readBuffer;
+
+        // Hack: Detect buffering by looking at the underlying stream
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+        internal bool IsBuffered => _readBuffer.Underlying is MemoryStream;
+
+        internal int CurrentFieldIndex => _currentFieldIndex;
+
+        public ReplicationTuple Current => _disposed
+            ? throw new ObjectDisposedException(nameof(ReplicationDataRecordEnumerator))
+            : _current ?? throw new InvalidOperationException();
+
+        object IEnumerator.Current => Current;
+
+        public ValueTask<bool> MoveNextAsync()
+            => MoveNext(async: true);
+
+        public bool MoveNext()
+            => MoveNext(async: false).GetAwaiter().GetResult();
+
+        internal ValueTask<bool> MoveNext(bool async)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(null);
+
+            using (NoSynchronizationContextScope.Enter())
+                return MoveNextInternal(async);
+
+            async ValueTask<bool> MoveNextInternal(bool async)
+            {
+                if(_current is null)
+                    _current = new();
+                else
+                    await _current.Cleanup(async, _cancellationToken);
+
+                _currentFieldIndex++;
+
+                if (_currentFieldIndex >= _fieldCount)
+                    return false;
+
+                using var tokenRegistration = IsBuffered
+                    ? default
+                    : _readBuffer.Connector.StartNestedCancellableOperation(_cancellationToken);
+
+                await _readBuffer.Ensure(1, async);
+                var kind = (TupleDataKind)_readBuffer.ReadByte();
+                switch (kind)
+                {
+                case TupleDataKind.Null:
+                case TupleDataKind.UnchangedToastedValue:
+                    _current.Init(_readBuffer, 0, kind, _tableInfo[_currentFieldIndex]);
+                    break;
+                case TupleDataKind.TextValue:
+                case TupleDataKind.BinaryValue:
+                    await _readBuffer.Ensure(4, async);
+                    var len = _readBuffer.ReadInt32();
+                    _current.Init(_readBuffer, len, kind, _tableInfo[_currentFieldIndex]);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+                }
+                return true;
+            }
+        }
+
+        public void Reset()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(ReplicationDataRecordEnumerator));
+            if (IsBuffered)
+            {
+                Debug.Assert(_readBuffer.Underlying.CanSeek);
+                _currentFieldIndex = -1;
+                _readBuffer.ReadPosition = 0;
+                _readBuffer.Underlying.Position = 0;
+            }
+            else if (_currentFieldIndex > -1)
+                throw new InvalidOperationException("Resetting streaming enumerators is not supported.");
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed) while (MoveNext()) { /* Do nothing, just iterate the enumerator */ }
+            _disposed = true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed) while (await MoveNextAsync()) { /* Do nothing, just iterate the enumerator */ }
+            _disposed = true;
+        }
+
+        internal void Init(int fieldCount, RowDescriptionMessage tableInfo)
+        {
+            _disposed = false;
+            _current = null;
+            _currentFieldIndex = -1;
+            _fieldCount = fieldCount;
+            _tableInfo = tableInfo;
+        }
+
+        internal ReplicationDataRecordEnumerator SetCancellationToken(CancellationToken cancellationToken)
+        {
+            _cancellationToken = cancellationToken;
+            return this;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/ReplicationTuple.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/ReplicationTuple.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Data;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql.BackendMessages;
+using Npgsql.Internal;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.Util;
+
+#pragma warning disable 1591
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    public sealed class ReplicationTuple
+    {
+        internal int Length { get; private set; }
+        int _startPosition;
+        TupleDataKind _tupleDataKind;
+        NpgsqlReadBuffer _readBuffer = default!;
+        FieldDescription _fieldDescription = new() { FormatCode = FormatCode.Binary };
+        NpgsqlReadBuffer.ColumnStream? _stream;
+        Decoder? _decoder;
+
+        // ReSharper disable once InconsistentNaming
+        public bool IsDBNull => _tupleDataKind == TupleDataKind.Null;
+
+        public bool IsUnchangedToastedValue => _tupleDataKind == TupleDataKind.UnchangedToastedValue;
+
+        public bool IsBinaryValue => _tupleDataKind == TupleDataKind.BinaryValue;
+
+        public bool IsTextValue => _tupleDataKind == TupleDataKind.TextValue;
+
+        bool IsBuffered => _readBuffer.Underlying is MemoryStream;
+
+
+        public T GetFieldValue<T>()
+            => GetFieldValue<T>(async: false).GetAwaiter().GetResult();
+
+        public ValueTask<T> GetFieldValueAsync<T>(CancellationToken cancellationToken = default)
+            => GetFieldValue<T>(async: true, cancellationToken);
+
+        internal ValueTask<T> GetFieldValue<T>(bool async, CancellationToken cancellationToken = default)
+        {
+            using (NoSynchronizationContextScope.Enter())
+                return GetValueInternal(async, cancellationToken);
+
+            async ValueTask<T> GetValueInternal(bool async, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    if (_readBuffer.ReadPosition != _startPosition)
+                    {
+                        await Cleanup(async, cancellationToken);
+                        if (IsBuffered)
+                            _readBuffer.ReadPosition -= Length;
+                        else
+                            throw new NpgsqlException("You can't read an unbuffered tuple twice.");
+                    }
+
+                    switch (_tupleDataKind)
+                    {
+                    case TupleDataKind.TextValue:
+                    {
+                        if (typeof(T) != typeof(object) && typeof(T).IsAssignableFrom(typeof(Stream)))
+                            return (T)(object)GetStreamInternal();
+
+                        if (!typeof(T).IsAssignableFrom(typeof(string)))
+                            throw new NotSupportedException(
+                                "Npgsql does not support converting tuple data in text format to types that are not assignable from string.");
+
+                        using var tokenRegistration = IsBuffered
+                            ? default
+                            : _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken);
+                        await _readBuffer.Ensure(Length, async);
+
+                        return (T)(object)_readBuffer.ReadString(Length);
+                    }
+                    case TupleDataKind.BinaryValue:
+                    {
+                        if (typeof(T) != typeof(object))
+                        {
+                            if (typeof(T).IsAssignableFrom(typeof(Stream)))
+                                return (T)(object)GetStreamInternal();
+                            if (typeof(T).IsAssignableFrom(typeof(IDataReader)))
+                            {
+                                // ToDo: NpgsqlNestedDataReader
+                                throw new NotSupportedException();
+                            }
+                        }
+
+                        using var tokenRegistration = IsBuffered
+                            ? default
+                            : _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken);
+                        await _readBuffer.Ensure(Length, async);
+
+                        return NullableHandler<T>.Exists
+                            ? NullableHandler<T>.Read(_fieldDescription.Handler, _readBuffer, Length, _fieldDescription)
+                            : typeof(T) == typeof(object)
+                                ? (T)_fieldDescription.Handler.ReadAsObject(_readBuffer, Length, _fieldDescription)
+                                : _fieldDescription.Handler.Read<T>(_readBuffer, Length, _fieldDescription);
+                    }
+                    case TupleDataKind.Null:
+                    {
+                        if (NullableHandler<T>.Exists)
+                            return default!;
+
+                        if (typeof(T) == typeof(object) || typeof(T) == typeof(DBNull))
+                            return (T)(object)DBNull.Value;
+
+                        throw new InvalidOperationException($"You can not convert {nameof(DBNull)} to {nameof(T)}.");
+                    }
+                    case TupleDataKind.UnchangedToastedValue:
+                    {
+                        if (typeof(T) == typeof(object) || typeof(T) == typeof(UnchangedToasted))
+                            return (T)(object)UnchangedToasted.Value;
+
+                        throw new InvalidOperationException("You can not access an unchanged toasted value.");
+                    }
+                    default:
+                        throw new NpgsqlException(
+                            $"Unexpected {nameof(TupleDataKind)} with value '{_tupleDataKind}'. Please report this as bug.");
+                    }
+                }
+                catch
+                {
+                    if (_readBuffer.Connector.State != ConnectorState.Broken)
+                    {
+                        var bytesRead = _readBuffer.ReadPosition - _startPosition;
+                        var remainingBytes = Length - bytesRead;
+                        if (remainingBytes > 0)
+                            await _readBuffer.Skip(remainingBytes, async);
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        public Stream GetStream()
+            => GetFieldValue<Stream>();
+
+        Stream GetStreamInternal()
+            => _stream ??= (NpgsqlReadBuffer.ColumnStream)_readBuffer.GetStream(Length, IsBuffered);
+
+        public long GetBytes(long fieldoffset, byte[]? buffer, int bufferoffset, int length)
+        {
+            _readBuffer.Skip(fieldoffset, false).GetAwaiter().GetResult();
+            var bytesRead = _readBuffer.ReadPosition - _startPosition;
+            var remainingBytes = Length - bytesRead;
+            var len = Math.Min(remainingBytes, length);
+
+            if (buffer != null)
+            {
+                _readBuffer.Ensure(len, async: false).GetAwaiter().GetResult();
+                Array.Copy(_readBuffer.Buffer, _readBuffer.ReadPosition, buffer, bufferoffset, len);
+            }
+
+            return len;
+        }
+
+        internal long GetChars(long fieldoffset, char[]? buffer, int bufferoffset, int length)
+        {
+            _decoder ??= _readBuffer.TextEncoding.GetDecoder();
+            _readBuffer.Skip(fieldoffset, false).GetAwaiter().GetResult();
+            var bytesRead = _readBuffer.ReadPosition - _startPosition;
+            var remainingBytes = Length - bytesRead;
+            var len = Math.Min(remainingBytes, length);
+            _readBuffer.Ensure(len, async: false).GetAwaiter().GetResult();
+
+            return buffer == null
+                ? _decoder.GetCharCount(_readBuffer.Buffer, _readBuffer.ReadPosition, len)
+                : _decoder.GetChars(_readBuffer.Buffer, _readBuffer.ReadPosition, len, buffer, bufferoffset);
+        }
+
+        internal void Init(NpgsqlReadBuffer readBuffer, int length, TupleDataKind kind, FieldDescription fieldDescription)
+        {
+            _readBuffer = readBuffer;
+            Length = length;
+            _startPosition = readBuffer.ReadPosition;
+            _tupleDataKind = kind;
+            _fieldDescription = fieldDescription;
+        }
+
+        internal async Task Cleanup(bool async, CancellationToken cancellationToken = default)
+        {
+            _decoder?.Reset();
+            // Always dispose the stream if one has been requested to signal that it is
+            // no longer usable. This also skips unconsumed bytes in the buffer.
+            if (_stream != null)
+            {
+                await _stream.DisposeAsync(disposing: true, async);
+                _stream = null;
+            }
+            // Skip unconsumed bytes in the buffer.
+            else if ((Length - (_readBuffer.ReadPosition - _startPosition)) > 0)
+            {
+                using var tokenRegistration = IsBuffered
+                    ? default
+                    : _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken);
+                await _readBuffer.Skip(Length, async);
+            }
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/TupleData.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TupleData.cs
@@ -100,12 +100,10 @@ namespace Npgsql.Replication.PgOutput.Messages
         /// </summary>
         TextValue = (byte)'t',
 
-#if PG14
         /// <summary>
         /// Identifies the data as binary value.
         /// </summary>
         /// <remarks>Added in PG14</remarks>
         BinaryValue = (byte)'b'
-#endif
     }
 }

--- a/src/Npgsql/Replication/PgOutput/Messages/TypeInfo.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/TypeInfo.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    class TypeInfo
+    {
+        /// <summary>
+        /// ID of the data type.
+        /// </summary>
+        public uint TypeId { get; private set; }
+
+        /// <summary>
+        /// Namespace (empty string for pg_catalog).
+        /// </summary>
+        public string Namespace { get; private set; } = null!;
+
+        /// <summary>
+        /// Name of the data type.
+        /// </summary>
+        public string Name { get; private set; } = null!;
+
+        /// <summary>
+        /// Name of the data type.
+        /// </summary>
+        public string FullName { get; private set; } = null!;
+
+        public TypeInfo Populate(uint typeId, string ns, string name)
+        {
+            TypeId = typeId;
+            Namespace = ns;
+            // Hack: This is an unsafe way to detect array types
+            // - What if the actual type starts with an underscore?
+            // - What do we see here if the type name needs quotes?
+            Name = name.StartsWith("_", StringComparison.Ordinal) ? $"{name.Substring(1)}[]" : name;
+            FullName = Namespace.Length == 0 ? Name : $"{Namespace}.{Name}";
+            return this;
+        }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/UnchangedToasted.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/UnchangedToasted.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Npgsql.Replication.PgOutput.Messages
+{
+    /// <summary>
+    /// Represents an unchanged toasted value in a replication message. This class cannot be inherited.
+    /// </summary>
+    public sealed class UnchangedToasted
+    {
+        /// <summary>
+        /// Represents the sole instance of the <see cref="UnchangedToasted"/> class.
+        /// </summary>
+        public static readonly UnchangedToasted Value = new();
+
+        UnchangedToasted() { }
+    }
+}

--- a/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/UpdateMessage.cs
@@ -1,6 +1,5 @@
 ﻿using NpgsqlTypes;
 using System;
-using System.Collections.Generic;
 
 namespace Npgsql.Replication.PgOutput.Messages
 {

--- a/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/ConnectorTypeMapper.cs
@@ -172,7 +172,7 @@ namespace Npgsql.TypeMapping
         internal NpgsqlTypeHandler ResolveByDataTypeName(string typeName)
             => ResolveByDataTypeName(typeName, throwOnError: true)!;
 
-        NpgsqlTypeHandler? ResolveByDataTypeName(string typeName, bool throwOnError)
+        internal NpgsqlTypeHandler? ResolveByDataTypeName(string typeName, bool throwOnError)
         {
             if (_handlersByDataTypeName.TryGetValue(typeName, out var handler))
                 return handler;

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTestBase.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTestBase.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Npgsql.Replication;
+using Npgsql.Replication.PgOutput;
+using Npgsql.Replication.PgOutput.Messages;
+using NUnit.Framework;
+
+namespace Npgsql.Tests.Replication
+{
+    public abstract class PgOutputReplicationTestBase : SafeReplicationTestBase<LogicalReplicationConnection>
+    {
+        protected ulong ProtocolVersion { get; }
+        protected ReplicationDataMode DataMode { get; }
+        protected TransactionStreamingMode TransactionMode { get; }
+        protected bool IsBinaryMode => DataMode == ReplicationDataMode.BinaryReplicationData;
+        protected bool IsStreaming => TransactionMode == TransactionStreamingMode.StreamingTransaction;
+
+        bool? Binary => DataMode == ReplicationDataMode.BinaryReplicationData
+            ? true
+            : DataMode == ReplicationDataMode.TextReplicationData
+                ? false
+                : null;
+        bool? Streaming => TransactionMode == TransactionStreamingMode.StreamingTransaction
+            ? true
+            : TransactionMode == TransactionStreamingMode.NonStreamingTransaction
+                ? false
+                : null;
+
+        protected PgOutputReplicationTestBase(ProtocolVersionMode protocolVersion, ReplicationDataMode dataMode, TransactionStreamingMode transactionMode)
+        {
+            ProtocolVersion = (ulong)protocolVersion;
+            DataMode = dataMode;
+            TransactionMode = transactionMode;
+        }
+
+        protected async Task<uint?> AssertTransactionStart(IAsyncEnumerator<PgOutputReplicationMessage> messages)
+        {
+            Assert.True(await messages.MoveNextAsync());
+            if (IsStreaming)
+            {
+                Assert.That(messages.Current, Is.TypeOf<StreamStartMessage>());
+                var streamStartMessage = (messages.Current as StreamStartMessage)!;
+                return streamStartMessage.TransactionXid;
+            }
+            Assert.That(messages.Current, Is.TypeOf<BeginMessage>());
+            var beginMessage = (messages.Current as BeginMessage)!;
+            return beginMessage.TransactionXid;
+        }
+
+        protected async Task AssertTransactionCommit(IAsyncEnumerator<PgOutputReplicationMessage> messages)
+        {
+            Assert.True(await messages.MoveNextAsync());
+            if (IsStreaming)
+            {
+                Assert.That(messages.Current, Is.TypeOf<StreamStopMessage>());
+                Assert.True(await messages.MoveNextAsync());
+                Assert.That(messages.Current, Is.TypeOf<StreamCommitMessage>());
+            }
+            else
+                Assert.That(messages.Current, Is.TypeOf<CommitMessage>());
+        }
+
+        protected async ValueTask<TExpected> NextMessage<TExpected>(IAsyncEnumerator<PgOutputReplicationMessage> enumerator, bool expectRelationMessage = false)
+            where TExpected : PgOutputReplicationMessage
+        {
+            Assert.True(await enumerator.MoveNextAsync());
+            if (IsStreaming && enumerator.Current is StreamStopMessage)
+            {
+                Assert.True(await enumerator.MoveNextAsync());
+                Assert.That(enumerator.Current, Is.TypeOf<StreamStartMessage>());
+                Assert.True(await enumerator.MoveNextAsync());
+                if (expectRelationMessage)
+                {
+                    Assert.That(enumerator.Current, Is.TypeOf<RelationMessage>());
+                    Assert.True(await enumerator.MoveNextAsync());
+                }
+            }
+
+            Assert.That(enumerator.Current, Is.TypeOf<TExpected>());
+            return (TExpected)enumerator.Current!;
+        }
+
+        /// <summary>
+        /// Unfortunately, empty transactions may get randomly created by PG because of auto-vacuuming; these cause test failures as we
+        /// assert for specific expected message types. This filters them out.
+        /// </summary>
+        protected async IAsyncEnumerable<PgOutputReplicationMessage> SkipEmptyTransactions(IAsyncEnumerable<PgOutputReplicationMessage> messages)
+        {
+            var enumerator = messages.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
+            {
+                if (enumerator.Current is BeginMessage)
+                {
+                    var current = enumerator.Current.Clone();
+                    if (!await enumerator.MoveNextAsync())
+                    {
+                        yield return current;
+                        yield break;
+                    }
+
+                    var next = enumerator.Current;
+                    if (next is CommitMessage)
+                        continue;
+
+                    yield return current;
+                    yield return next;
+                    continue;
+                }
+
+                yield return enumerator.Current;
+            }
+        }
+
+        protected PgOutputReplicationOptions GetOptions(string publicationName, bool? messages = null)
+            => new(publicationName, ProtocolVersion, Binary, Streaming, messages);
+
+        protected Task SafePgOutputReplicationTest(Func<string, string, string, Task> testAction, [CallerMemberName] string memberName = "")
+            => SafeReplicationTest(testAction, GetObjectName(memberName));
+
+        protected string GetObjectName(string memberName)
+        {
+            var sb = new StringBuilder(memberName)
+                .Append("_v").Append(ProtocolVersion);
+            if (Binary.HasValue)
+                sb.Append("_b_").Append(BoolToChar(Binary.Value));
+            if (Streaming.HasValue)
+                sb.Append("_s_").Append(BoolToChar(Streaming.Value));
+            return sb.ToString();
+        }
+
+        protected static char BoolToChar(bool value)
+            => value ? 't' : 'f';
+
+
+        protected override string Postfix => "pgoutput_l";
+
+        [OneTimeSetUp]
+        public async Task SetUp()
+        {
+            await using var c = await OpenConnectionAsync();
+            TestUtil.MinimumPgVersion(c, "10.0", "The Logical Replication Protocol (via pgoutput plugin) was introduced in PostgreSQL 10");
+            if (ProtocolVersion > 1)
+                TestUtil.MinimumPgVersion(c, "14.0", "Logical Streaming Replication Protocol version 2 was introduced in PostgreSQL 14");
+            if (IsBinaryMode)
+                TestUtil.MinimumPgVersion(c, "14.0", "Sending replication values in binary representation was introduced in PostgreSQL 14");
+            if (IsStreaming)
+                TestUtil.MinimumPgVersion(c, "14.0", "Streaming of in-progress transactions was introduced in PostgreSQL 14");
+        }
+    }
+
+    public enum ProtocolVersionMode : ulong
+    {
+        ProtocolV1 = 1UL,
+        ProtocolV2 = 2UL,
+    }
+    public enum TransactionStreamingMode
+    {
+        DefaultTransaction,
+        NonStreamingTransaction,
+        StreamingTransaction,
+    }
+    public enum ReplicationDataMode
+    {
+        DefaultReplicationData,
+        TextReplicationData,
+        BinaryReplicationData,
+    }
+}

--- a/test/Npgsql.Tests/Replication/ReplicationDataRecordTests.cs
+++ b/test/Npgsql.Tests/Replication/ReplicationDataRecordTests.cs
@@ -1,0 +1,579 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql.Replication;
+using Npgsql.Replication.PgOutput.Messages;
+using NpgsqlTypes;
+using NUnit.Framework;
+
+namespace Npgsql.Tests.Replication
+{
+    [TestFixture(ReplicationDataMode.DefaultReplicationData, Buffering.Unbuffered, AsyncMode.Async)]
+    [TestFixture(ReplicationDataMode.BinaryReplicationData, Buffering.Unbuffered, AsyncMode.Async)]
+    [TestFixture(ReplicationDataMode.DefaultReplicationData, Buffering.Unbuffered, AsyncMode.Sync)]
+    [TestFixture(ReplicationDataMode.BinaryReplicationData, Buffering.Unbuffered, AsyncMode.Sync)]
+    [TestFixture(ReplicationDataMode.DefaultReplicationData, Buffering.Buffered, AsyncMode.Async)]
+    [TestFixture(ReplicationDataMode.BinaryReplicationData, Buffering.Buffered, AsyncMode.Async)]
+    [TestFixture(ReplicationDataMode.DefaultReplicationData, Buffering.Buffered, AsyncMode.Sync)]
+    [TestFixture(ReplicationDataMode.BinaryReplicationData, Buffering.Buffered, AsyncMode.Sync)]
+    public class ReplicationDataRecordTests : PgOutputReplicationTestBase
+    {
+        #region GetFieldValueTestCases
+
+        public delegate Task SqlCommandDelegate(NpgsqlConnection connection);
+
+        static IEnumerable GetFieldValueTestCases()
+        {
+            foreach (var t in TestCases())
+            {
+                var testCase = new TestCaseData(t.TypeName, t.BinaryValue, t.StringValue, t.InputString, t.TypeDelegates).SetName(t.TestCaseName);
+                testCase = t.ExplicitReason is null ? testCase : testCase.Explicit(t.ExplicitReason);
+                testCase = t.IgnoreReason is null ? testCase : testCase.Ignore(t.IgnoreReason);
+                yield return testCase;
+            }
+
+            static IEnumerable<GetFieldValueTestCase> TestCases()
+            {
+                #region Numeric Types
+
+                yield return new("smallint", (short)42);
+                yield return new("smallint[]", new short[]{1,2});
+                yield return new("integer", 42);
+                yield return new("integer[]", new []{1,2});
+                yield return new("bigint", 42L);
+                yield return new("bigint[]", new []{1L,2L});
+                yield return new("numeric", 42.42M);
+                yield return new("numeric[]", new []{1.1M,2.2M});
+                yield return new("real", 42.42f);
+                yield return new("real[]", new []{1.1f,2.2f});
+                yield return new("double precision", 42.42D);
+                yield return new("double precision[]", new []{1.1D,2.2D});
+
+                #endregion Numeric Types
+
+                #region Monetary Types
+
+                yield return new("money", 42.42M, "$42.42");
+                yield return new("money[]", new []{1.1M,2.2M}, "{$1.10,$2.20}");
+
+                #endregion Monetary Types
+
+                #region Character Types
+
+                yield return new("character varying(10)", "Test");
+                yield return new("character varying(10)[]", new []{"Test 1","Test 2"}, "{\"Test 1\",\"Test 2\"}");
+                yield return new("character(4)", "Test");
+                yield return new("character(6)[]", new []{"Test 1","Test 2"}, "{\"Test 1\",\"Test 2\"}");
+                yield return new("text", "Test");
+                yield return new("text[]", new []{"Test 1","Test 2"}, "{\"Test 1\",\"Test 2\"}");
+                yield return new("\"char\"", 'T');
+                yield return new("\"char\"[]", new []{'A','B'});
+                yield return new("name", "Test");
+                yield return new("name[]", new []{"Test 1","Test 2"}, "{\"Test 1\",\"Test 2\"}");
+
+                #endregion Character Types
+
+                #region Binary Data Types
+
+                static byte[] B(string text) => Encoding.UTF8.GetBytes(text);
+                yield return new("bytea", B("Test"), "Test");
+                yield return new("bytea[]", new []{B("Test 1"), B("Test 2")}, "{\"Test 1\",\"Test 2\"}");
+
+                #endregion Binary Data Types
+
+                #region Date/Time Types
+
+                var ts = new DateTime(2021, 06, 25, 19, 16, 48, DateTimeKind.Unspecified);
+                yield return new("timestamp", ts);
+                yield return new("timestamp[]", new []{ts, ts}, "{\"2021-06-25 19:16:48\",\"2021-06-25 19:16:48\"}");
+                var tstz = new DateTime(2021, 06, 25, 21, 16, 48, DateTimeKind.Local);
+                yield return new("timestamp with time zone", tstz);
+                yield return new("timestamp with time zone[]", new []{tstz, tstz}, "{\"2021-06-25 21:16:48+02\",\"2021-06-25 21:16:48+02\"}");
+                var date = new DateTime(2021, 06, 25);
+                yield return new("date", date);
+                yield return new("date[]", new []{date, date});
+                var time = new TimeSpan(19, 16, 48);
+                yield return new("time", time);
+                yield return new("time[]", new []{time, time});
+                // Mind you, the date has to be 0001-01-02 for the test to pass since that's the date we adjust
+                // the returned DateTimeOffset to.
+                var timetz = new DateTimeOffset(1, 1, 2, 19, 16, 48, TimeSpan.FromHours(2));
+                yield return new("time with time zone", timetz);
+                yield return new("time with time zone[]", new []{timetz, timetz});
+                var interval = new TimeSpan(456, 17, 6, 34);
+                yield return new("interval", interval);
+                yield return new("interval[]", new []{interval, interval}, "{\"456 days 17:06:34\",\"456 days 17:06:34\"}");
+
+                #endregion Date/Time Types
+
+                #region Boolean Type
+
+                yield return new("bool", true, "t");
+                yield return new("bool[]", new []{true, false}, "{t,f}");
+
+                #endregion Boolean Type
+
+                #region Enumerated Types
+
+                (SqlCommandDelegate createType, SqlCommandDelegate dropType) enumTypeDelegates = (
+                    static async c =>
+                    {
+                        var t = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator;
+                        await c.ExecuteNonQueryAsync(@$"DROP TYPE IF EXISTS {t.TranslateTypeName(nameof(RDRTGFVEnum))} CASCADE;
+                                                        CREATE TYPE {t.TranslateTypeName(nameof(RDRTGFVEnum))}
+                                                        AS ENUM (
+                                                            '{t.TranslateMemberName(nameof(RDRTGFVEnum.Happy))}',
+                                                            '{t.TranslateMemberName(nameof(RDRTGFVEnum.Ok))}',
+                                                            '{t.TranslateMemberName(nameof(RDRTGFVEnum.Sad))}')");
+                        c.ReloadTypes();
+                        NpgsqlConnection.GlobalTypeMapper.MapEnum<RDRTGFVEnum>();
+                    },
+                    static async c =>
+                    {
+                        var t = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator;
+                        NpgsqlConnection.GlobalTypeMapper.UnmapEnum<RDRTGFVEnum>();
+                        await c.ExecuteNonQueryAsync(@$"DROP TYPE IF EXISTS {t.TranslateTypeName(nameof(RDRTGFVEnum))} CASCADE");
+                    }
+                );
+
+                var enumTypeName = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator.TranslateTypeName(nameof(RDRTGFVEnum));
+                yield return new(enumTypeName, RDRTGFVEnum.Sad, typeDelegates: enumTypeDelegates);
+                yield return new($"{enumTypeName}[]", new []
+                {
+                    RDRTGFVEnum.Ok, RDRTGFVEnum.Happy
+                }, typeDelegates: enumTypeDelegates);
+
+                #endregion Enumerated Types
+
+                #region Geometric Types
+
+                var point = new NpgsqlPoint(4.2D, 42D);
+                yield return new("point", point);
+                yield return new("point[]", new []{point, point}, "{\"(4.2,42)\",\"(4.2,42)\"}");
+                var line = new NpgsqlLine(0.42D, 4.2D, 42D);
+                yield return new("line", line);
+                yield return new("line[]", new []{line, line}, "{\"{0.42,4.2,42}\",\"{0.42,4.2,42}\"}");
+                var lseg = new NpgsqlLSeg(0.42D, 4.2D, 42D, 420D);
+                yield return new("lseg", lseg);
+                yield return new("lseg[]", new []{lseg, lseg}, "{\"[(0.42,4.2),(42,420)]\",\"[(0.42,4.2),(42,420)]\"}");
+                var box = new NpgsqlBox(new(420D, 42D), new(4.2D, 0.42D));
+                yield return new("box", box);
+                yield return new("box[]", new []{box, box}, "{(420,42),(4.2,0.42);(420,42),(4.2,0.42)}");
+                var path = new NpgsqlPath(new NpgsqlPoint(420D, 42D), new NpgsqlPoint(4.2D, 0.42D));
+                yield return new("path", path);
+                yield return new("path[]", new []{path, path}, "{\"((420,42),(4.2,0.42))\",\"((420,42),(4.2,0.42))\"}");
+                var polygon = new NpgsqlPolygon(new NpgsqlPoint(420D, 42D), new NpgsqlPoint(4.2D, 0.42D));
+                yield return new("polygon", polygon);
+                yield return new("polygon[]", new []{polygon, polygon}, "{\"((420,42),(4.2,0.42))\",\"((420,42),(4.2,0.42))\"}");
+                var circle = new NpgsqlCircle(0.42D, 4.2D, 42D);
+                yield return new("circle", circle);
+                yield return new("circle[]", new []{circle, circle}, "{\"<(0.42,4.2),42>\",\"<(0.42,4.2),42>\"}");
+
+                #endregion Geometric Types
+
+                #region Network Address Types
+
+                var inet = IPAddress.Parse("127.0.0.1");
+                yield return new("inet", inet);
+                yield return new("inet[]", new []{inet, inet});
+                var cidr = (IPAddress.Parse("2001:4f8:3:ba:2e0:81ff:fe22:d1f1"), 128);
+                yield return new("cidr", cidr, testCaseName: $"{nameof(GetFieldValue)}<({nameof(IPAddress)},{nameof(Int32)})>({{0}})");
+                yield return new("cidr[]", new []{cidr, cidr}, testCaseName: $"{nameof(GetFieldValue)}<({nameof(IPAddress)},{nameof(Int32)})[]>({{0}})");
+                var macaddr = PhysicalAddress.Parse("08-00-2B-01-02-03");
+                yield return new("macaddr", macaddr);
+                yield return new("macaddr[]", new []{macaddr, macaddr});
+                var macaddr8 = PhysicalAddress.Parse("08-00-2B-01-02-03-04-05");
+                yield return new("macaddr8", macaddr8);
+                yield return new("macaddr8[]", new []{macaddr8, macaddr8});
+
+                #endregion Network Address Types
+
+                #region Bit String Types
+
+                yield return new("bit", true, "1");
+                yield return new("bit[]", new []{true, false}, "{1,0}");
+                var bit2 = new BitArray(2) { [0] = true };
+                yield return new("bit(2)", bit2);
+                yield return new("bit(2)[]", new []{bit2, bit2});
+                var varbit4 = new BitArray(2) { [0] = true };
+                yield return new("bit varying(4)", varbit4);
+                yield return new("bit varying(4)[]", new []{varbit4, varbit4});
+
+                #endregion Bit String Types
+
+                #region Text Search Types
+
+                var tsvector = NpgsqlTsVector.Parse("fat cat");
+                yield return new("tsvector", tsvector);
+                yield return new("tsvector[]", new []{tsvector, tsvector}, "{\"'cat' 'fat'\",\"'cat' 'fat'\"}");
+                var tsquery = NpgsqlTsQuery.Parse("fat & (rat | cat)");
+                yield return new("tsquery", tsquery, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlTsQuery)}>({{0}})");
+                yield return new("tsquery[]", new []{tsquery, tsquery}, "{\"'fat' & ( 'rat' | 'cat' )\",\"'fat' & ( 'rat' | 'cat' )\"}");
+
+                #endregion Text Search Types
+
+                #region UUID Type
+
+                var uuid = Guid.NewGuid();
+                yield return new("uuid", uuid);
+                yield return new("uuid[]", new []{uuid, uuid});
+
+                #endregion UUID Type
+
+                #region XML Type
+
+                var xml = "<foo>bar</foo>";
+                yield return new("xml", xml);
+                yield return new("xml[]", new []{xml, xml});
+
+                #endregion XML Type
+
+                #region JSON Types
+
+                var json = "{\"foo\": [true, \"bar\"], \"tags\": {\"a\": 1, \"b\": null}}";
+                yield return new("json", json);
+                yield return new("json[]", new []{json, json},
+                    "{\"{\\\"foo\\\": [true, \\\"bar\\\"], \\\"tags\\\": {\\\"a\\\": 1, \\\"b\\\": null}}\",\"{\\\"foo\\\": [true, \\\"bar\\\"], \\\"tags\\\": {\\\"a\\\": 1, \\\"b\\\": null}}\"}");
+                var jsonb = "{\"foo\": [true, \"bar\"], \"tags\": {\"a\": 1, \"b\": null}}";
+                yield return new("jsonb", jsonb);
+                yield return new("jsonb[]", new []{jsonb, jsonb},
+                    "{\"{\\\"foo\\\": [true, \\\"bar\\\"], \\\"tags\\\": {\\\"a\\\": 1, \\\"b\\\": null}}\",\"{\\\"foo\\\": [true, \\\"bar\\\"], \\\"tags\\\": {\\\"a\\\": 1, \\\"b\\\": null}}\"}");
+                var jsonpath = "$.\"id\"?(@ == 42)";
+                yield return new("jsonpath", jsonpath);
+                yield return new("jsonpath[]", new []{jsonpath, jsonpath}, "{\"$.\\\"id\\\"?(@ == 42)\",\"$.\\\"id\\\"?(@ == 42)\"}");
+
+                #endregion JSON Types
+
+                #region Composite Types
+
+                var composite = new RDRTGFVComposite(42, "Answer to the Ultimate Question of Life, the Universe, and Everything");
+                (SqlCommandDelegate createType, SqlCommandDelegate dropType) compositeTypeDelegates = (
+                    static async c =>
+                    {
+                        var compositeTypeName =
+                            NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator.TranslateTypeName(nameof(RDRTGFVComposite));
+                        await c.ExecuteNonQueryAsync(@$"DROP TYPE IF EXISTS {compositeTypeName} CASCADE;
+                                                        CREATE TYPE {compositeTypeName} AS (id int, value text)");
+                        c.ReloadTypes();
+                        NpgsqlConnection.GlobalTypeMapper.MapComposite<RDRTGFVComposite>();
+                    },
+                    static async c =>
+                    {
+                        var compositeTypeName =
+                            NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator.TranslateTypeName(nameof(RDRTGFVComposite));
+                        NpgsqlConnection.GlobalTypeMapper.UnmapComposite<RDRTGFVComposite>();
+                        await c.ExecuteNonQueryAsync(@$"DROP TYPE IF EXISTS {compositeTypeName} CASCADE");
+                    }
+                );
+                var compositeTypeName = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator.TranslateTypeName(nameof(RDRTGFVComposite));
+                yield return new(compositeTypeName, composite, typeDelegates: compositeTypeDelegates);
+                yield return new($"{compositeTypeName}[]", new[] { composite, composite },
+                    "{\"(42,\\\"Answer to the Ultimate Question of Life, the Universe, and Everything\\\")\",\"(42,\\\"Answer to the Ultimate Question of Life, the Universe, and Everything\\\")\"}",
+                    typeDelegates: compositeTypeDelegates);
+
+                #endregion Composite Types
+
+                #region Range Types
+
+                var int4Range = new NpgsqlRange<int>(-99, true, 99, false);
+                yield return new("int4range", int4Range, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<int>)}<{nameof(Int32)}>>({{0}})");
+                //yield return new("int4range[]", new []{int4range, int4range}, "{\"[-99,99)\",\"[-99,99)\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<int>)}<{nameof(Int32)}>[]>({{0}})");
+
+                var int8Range = new NpgsqlRange<long>(-99L, true, 99L, false);
+                yield return new("int8range", int8Range, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<long>)}<{nameof(Int64)}>>({{0}})");
+                //yield return new("int8range[]", new []{int8range, int8range}, "{\"[-99,99)\",\"[-99,99)\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<long>)}<{nameof(Int64)}>[]>({{0}})");
+
+                var numRange = new NpgsqlRange<decimal>(-99M, true, 99M, false);
+                yield return new("numrange", numRange, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<decimal>)}<{nameof(Decimal)}>>({{0}})");
+                //yield return new("numrange[]", new []{numrange, numrange}, "{\"[-99,99)\",\"[-99,99)\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<decimal>)}<{nameof(Decimal)}>[]>({{0}})");
+
+                var tsRange = new NpgsqlRange<DateTime>(new DateTime(2021, 08, 08, 17, 15, 56, DateTimeKind.Unspecified), true, new DateTime(2021, 08, 08, 17, 16, 15, DateTimeKind.Unspecified), false);
+                yield return new("tsrange", tsRange, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>>({{0}})");
+                //yield return new("tsrange[]", new []{tsrange, tsrange}, "{\"[\\\"2021-08-08 17:15:56\\\",\\\"2021-08-08 17:16:15\\\")\",\"[\\\"2021-08-08 17:15:56\\\",\\\"2021-08-08 17:16:15\\\")\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>[]>({{0}})");
+
+                var tstzRange = new NpgsqlRange<DateTime>(new DateTime(2021, 08, 08, 17, 15, 56, DateTimeKind.Local), true, new DateTime(2021, 08, 08, 17, 16, 15, DateTimeKind.Local), false);
+                yield return new("tstzrange", tstzRange, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>>({{0}})");
+                //yield return new("tstzrange[]", new []{tstzrange, tstzrange}, "{\"[\\\"2021-08-08 17:15:56+02\\\",\\\"2021-08-08 17:16:15+02\\\")\",\"[\\\"2021-08-08 17:15:56+02\\\",\\\"2021-08-08 17:16:15+02\\\")\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>[]>({{0}})");
+
+                var dateRange = new NpgsqlRange<DateTime>(new DateTime(2021, 08, 07), true, new DateTime(2021, 08, 08), false);
+                yield return new("daterange", dateRange, testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>>({{0}})");
+                //yield return new("daterange[]", new []{daterange, daterange}, "{\"[2021-08-07,2021-08-08)\",\"[2021-08-07,2021-08-08)\"}", testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<DateTime>)}<{nameof(DateTime)}>[]>({{0}})");
+
+                #endregion Range Types
+
+                #region Domain Types
+
+                (SqlCommandDelegate createType, SqlCommandDelegate dropType) posintDelegates = (
+                    static async c =>
+                    {
+                        await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS nullableposint_domain CASCADE;
+                                                        CREATE DOMAIN nullableposint_domain AS integer CHECK (VALUE >= 0)");
+                        c.ReloadTypes();
+                    },
+                    static async c =>
+                    {
+                        await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS nullableposint_domain CASCADE");
+                    }
+                );
+                // Domain over base type
+                yield return new("nullableposint_domain", 42, typeDelegates: posintDelegates);
+
+                // Array of domain over base type
+                yield return new("nullableposint_domain[]", new []{1,2}, typeDelegates: posintDelegates);
+
+                // Domain over array of base type
+                yield return new("intarray_domain", new[] { 1, 2 }, typeDelegates: (
+                    static async c =>
+                    {
+                        await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS intarray_domain CASCADE;
+                                                        CREATE DOMAIN intarray_domain AS integer[]");
+                        c.ReloadTypes();
+                    },
+                    static async c =>
+                    {
+                        await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS intarray_domain CASCADE");
+                    }
+                ));
+
+                // Domain over range of base type
+                yield return new("intrange_domain", int4Range,
+                    testCaseName: $"{nameof(GetFieldValue)}<{nameof(NpgsqlRange<int>)}<{nameof(Int32)}>>({{0}})",
+                    typeDelegates: (
+                        static async c =>
+                        {
+                            await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS intrange_domain CASCADE;
+                                                        CREATE DOMAIN intrange_domain AS int4range");
+                            c.ReloadTypes();
+                        },
+                        static async c =>
+                        {
+                            await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS intrange_domain CASCADE");
+                        }
+                    ));
+
+                // Domain over domain of base type is currently not supported by Npgsql
+                // yield return new("posint_domain", 42,
+                //     typeDelegates: (
+                //         static async c =>
+                //         {
+                //             await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS nullableposint_domain CASCADE;
+                //                                         CREATE DOMAIN nullableposint_domain AS integer CHECK (VALUE >= 0);
+                //                                         CREATE DOMAIN posint_domain AS nullableposint_domain NOT NULL");
+                //             c.ReloadTypes();
+                //         },
+                //         static async c =>
+                //         {
+                //             await c.ExecuteNonQueryAsync(@"DROP TYPE IF EXISTS nullableposint_domain CASCADE");
+                //         }
+                //     ));
+
+                // ToDo: Domains over enums and composite types
+
+                #endregion Domain Types
+
+                #region Object Identifier Types
+
+                yield return new("oid", 42U);
+                yield return new("oid[]", new []{1U,2U});
+
+                // Currently only the only Object Identifier Type that's mapped to uint is OID
+                // We might want to support others (https://www.postgresql.org/docs/9.4/datatype-oid.html)
+                // too but we currently don't.
+                // yield return new("regclass", 1247U, "pg_type");
+                // yield return new("regclass[]", new []{1247U,1259U},"{pg_type,pg_class}");
+
+                #endregion Object Identifier Types
+
+                #region pg_lsn Type
+
+                // ToDo
+
+                #endregion pg_lsn Type
+            }
+        }
+
+        class GetFieldValueTestCase
+        {
+            readonly string? _stringValue;
+            readonly string? _inputString;
+            public string TypeName { get; }
+            public object BinaryValue { get; }
+            public (SqlCommandDelegate createType, SqlCommandDelegate dropType)? TypeDelegates { get; }
+            public string? ExplicitReason { get; }
+            public string? IgnoreReason { get; }
+            public string TestCaseName { get; } = "{m}{a}";
+
+            public string StringValue => _stringValue
+                                         ?? (BinaryValue is Array a
+                                             ? $"{{{string.Join(',', a.Cast<object>().Select(Format))}}}"
+                                             : Format(BinaryValue));
+            public string InputString => _inputString
+                                         ?? $"$${StringValue}$$::{TypeName}";
+
+            static string Format(object o)
+                => o switch
+                {
+                    DateTime { Hour: 0, Minute: 0, Second: 0, Millisecond: 0 } date => date.ToString("yyyy-MM-dd"),
+                    DateTime { Hour: >0, Kind: DateTimeKind.Unspecified } ts => ts.ToString("yyyy-MM-dd HH:mm:ss"),
+                    DateTime { Hour: >0, Kind: DateTimeKind.Local } tstz => tstz.ToString("yyyy-MM-dd HH:mm:sszz"),
+                    DateTimeOffset timetz => timetz.ToString("HH:mm:sszz"),
+                    TimeSpan { Days: 0 } time => time.ToString("hh\\:mm\\:ss"),
+                    TimeSpan interval => interval.ToString("%d' days 'hh\\:mm\\:ss"),
+                    ValueTuple<IPAddress, int> cidr => string.Format(CultureInfo.InvariantCulture, "{0}/{1}", cidr.Item1, cidr.Item2),
+                    PhysicalAddress macaddr => macaddr.GetAddressBytes()
+                        switch
+                        {
+                            {Length: 6} m6 => string.Join(':', m6.Select(e => e.ToString("x2"))),
+                            {Length: 8} m8 => string.Join(':', m8.Select(e => e.ToString("x2"))),
+                            _ => throw new Exception()
+                        },
+                    BitArray bit => string.Concat(bit.Cast<bool>().Select(e => e ? '1' : '0')),
+                    RDRTGFVEnum enum_type => NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator.TranslateMemberName(enum_type.ToString("g")),
+                    RDRTGFVComposite composite => $"({composite.Id},\"{composite.Value}\")",
+                    NpgsqlRange<DateTime> { LowerBound: { Hour: 0, Minute: 0, Second: 0, Millisecond: 0 }, UpperBound: { Hour: 0, Minute: 0, Second: 0, Millisecond: 0 } } dtr
+                        => $"{(dtr.LowerBoundIsInclusive ? "[" : "(")}{Format(dtr.LowerBound)},{Format(dtr.UpperBound)}{(dtr.UpperBoundIsInclusive ? "]" : ")")}",
+                    NpgsqlRange<DateTime> dtr => $"{(dtr.LowerBoundIsInclusive ? "[" : "(")}\"{Format(dtr.LowerBound)}\",\"{Format(dtr.UpperBound)}\"{(dtr.UpperBoundIsInclusive ? "]" : ")")}",
+                    _ => string.Format(CultureInfo.InvariantCulture, "{0}", o),
+                };
+
+            public GetFieldValueTestCase(string typeName, object binaryValue, string? stringValue = null, string? inputString = null, (SqlCommandDelegate createType, SqlCommandDelegate dropType)? typeDelegates = null, string? testCaseName = "{m}({0})", string? explicitReason = null, string? ignoreReason = null)
+            {
+                _stringValue = stringValue;
+                _inputString = inputString;
+                TypeName = typeName;
+                BinaryValue = binaryValue;
+                TypeDelegates = typeDelegates;
+                ExplicitReason = explicitReason;
+                IgnoreReason = ignoreReason;
+                if (testCaseName is not null)
+                    TestCaseName = testCaseName;
+            }
+        }
+
+        enum RDRTGFVEnum { Sad, Ok, Happy }
+
+        record RDRTGFVComposite(int Id, string Value);
+
+        #endregion
+
+        [TestCaseSource(nameof(GetFieldValueTestCases)), NonParallelizable]
+        public Task GetFieldValue<T>(string typeName, T binaryValue, string stringValue, string inputString, (SqlCommandDelegate createType, SqlCommandDelegate dropType)? typeDelegates)
+            => SafePgOutputReplicationTest(
+                async (slotName, tableName, publicationName) =>
+                {
+                    var adjustedConnectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionString)
+                    {
+                        Options = "-c lc_monetary=C -c bytea_output=escape"
+                    };
+
+                    var triggersTypeMessage = false;
+                    await using var c = await OpenConnectionAsync(adjustedConnectionStringBuilder);
+                    if (typeDelegates?.createType is not null)
+                    {
+                        triggersTypeMessage = true;
+                        await typeDelegates.Value.createType(c);
+                    }
+
+                    await c.ExecuteNonQueryAsync(@$"CREATE TABLE {tableName} (value1 {typeName}, value2 {typeName});
+                                                    CREATE PUBLICATION {publicationName} FOR TABLE {tableName};");
+                    var rc = await OpenReplicationConnectionAsync(adjustedConnectionStringBuilder);
+                    var slot = await rc.CreatePgOutputReplicationSlot(slotName);
+                    await c.ExecuteNonQueryAsync(@$"INSERT INTO {tableName} VALUES ({inputString}, {inputString})");
+
+                    using var streamingCts = new CancellationTokenSource();
+                    var messages = SkipEmptyTransactions(rc.StartReplication(slot, GetOptions(publicationName), streamingCts.Token))
+                        .GetAsyncEnumerator(streamingCts.Token);
+
+                    // Begin Transaction, Type Relation
+                    await AssertTransactionStart(messages);
+                    if (triggersTypeMessage)
+                    {
+                        await NextMessage<TypeMessage>(messages);
+                        await NextMessage<TypeMessage>(messages);
+                    }
+                    await NextMessage<RelationMessage>(messages);
+
+                    // Insert value
+                    var insertMsg = await NextMessageBuffered<InsertMessage>(messages);
+                    await AssertFieldValue(insertMsg, 1, binaryValue, stringValue);
+                    if (Buffered)
+                        await AssertFieldValue(insertMsg, 0, binaryValue, stringValue);
+                    else
+                        Assert.That(async () =>
+                        {
+                            var _ = Async
+                                ? await insertMsg.NewRow.GetFieldValueAsync<T>(0)
+                                : insertMsg.NewRow.GetFieldValue<T>(0);
+                        }, Throws.InvalidOperationException);
+
+                    // Commit Transaction
+                    await AssertTransactionCommit(messages);
+                    streamingCts.Cancel();
+                    await AssertReplicationCancellation(messages);
+                    await rc.DropReplicationSlot(slotName, cancellationToken: CancellationToken.None);
+
+                    if (typeDelegates?.dropType is not null)
+                        await typeDelegates.Value.dropType(c);
+
+                    [SuppressMessage("ReSharper", "HeapView.PossibleBoxingAllocation")]
+                    [SuppressMessage("ReSharper", "MethodSupportsCancellation")]
+                    async Task AssertFieldValue(InsertMessage message, int ordinal, T expectedValue, string expectedStringValue)
+                    {
+                        object? value = Async
+                            ? IsBinaryMode
+                                ? await message.NewRow.GetFieldValueAsync<T>(ordinal)
+                                : await message.NewRow.GetFieldValueAsync<string>(ordinal)
+                            : IsBinaryMode
+                                ? message.NewRow.GetFieldValue<T>(ordinal)
+                                : message.NewRow.GetFieldValue<string>(ordinal);
+
+                        Assert.That(value, IsBinaryMode ? Is.EqualTo(expectedValue) : Is.EqualTo(expectedStringValue));
+                    }
+                });
+
+        async Task<T> NextMessageBuffered<T>(IAsyncEnumerator<PgOutputReplicationMessage> messages)
+            where T : PgOutputReplicationMessage
+        {
+            var message = await NextMessage<T>(messages);
+            if (message is InsertMessage insertMessage)
+                return Buffered
+                    ? Async
+                        ? (T)(PgOutputReplicationMessage)await insertMessage.CloneAsync()
+                        // ReSharper disable once MethodHasAsyncOverload
+                        : (T)(PgOutputReplicationMessage)insertMessage.Clone()
+                    : (T)(PgOutputReplicationMessage)insertMessage;
+
+            return Buffered ? (T)message.Clone() : message;
+        }
+
+        public ReplicationDataRecordTests(ReplicationDataMode dataMode, Buffering buffering, AsyncMode asyncMode)
+            : base(ProtocolVersionMode.ProtocolV1, dataMode, TransactionStreamingMode.DefaultTransaction)
+        {
+            Buffered = buffering == Buffering.Buffered;
+            Async = asyncMode == AsyncMode.Async;
+        }
+
+        bool Buffered { get; }
+        bool Async { get; }
+
+        public enum Buffering
+        {
+            Unbuffered,
+            Buffered
+        }
+
+        public enum AsyncMode
+        {
+            Sync,
+            Async
+        }
+    }
+}


### PR DESCRIPTION
Preliminary PR in order to let you have an initial look at a possible Npgsql implementation of the upcoming (PG14) binary replication feature.
This is by no means production ready or even feature complete yet.
The main reason I'm doing a PR now is to get some feedback about some warts the current implementation has, before moving on to finish it.
I still would like to ship this with Npgsql 6 but this might fail as I've a lot of other things going on right now.

Warts:
- Major
  - [ ] buffering in [ReplicationDataRecord.cs](https://github.com/Brar/npgsql/blob/89ab7ea0a42a38e604a9c80c02a6a8535c96c1e3/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecord.cs#L240)
- Intermediate
  - [ ] detecting array types in [TypeInfo.cs](https://github.com/Brar/npgsql/blob/89ab7ea0a42a38e604a9c80c02a6a8535c96c1e3/src/Npgsql/Replication/PgOutput/Messages/TypeInfo.cs#L29)
- Minor
  - [ ] Resetting AttemptPostgresCancellation in [ReplicationDataRecord.cs](https://github.com/Brar/npgsql/blob/89ab7ea0a42a38e604a9c80c02a6a8535c96c1e3/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecord.cs#L280)

ToDos:
- Use [`ReplicationDataRecord`](https://github.com/Brar/npgsql/blob/89ab7ea0a42a38e604a9c80c02a6a8535c96c1e3/src/Npgsql/Replication/PgOutput/Messages/ReplicationDataRecord.cs) instead of `ReadOnlyMemory<TupleData>` in 
  - [ ] FullDeleteMessage
  - [ ] FullUpdateMessage
  - [ ] IndexUpdateMessage
  - [ ] KeyDeleteMessage
  - [ ] UpdateMessage
- Better test coverage (at least test it once with type handlers from plugins to ensure that this works conceptually).