### PR TITLE
Report positional parameters in DataSourceInformation

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -73,7 +73,7 @@ namespace Npgsql
 #if DEBUG
         internal static bool EnableSqlRewriting;
 #else
-        static readonly bool EnableSqlRewriting;
+        internal static readonly bool EnableSqlRewriting;
 #endif
 
         static readonly List<NpgsqlParameter> EmptyParameters = new();

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -22,7 +22,7 @@ namespace Npgsql
 #if DEBUG
         internal static bool CaseInsensitiveCompatMode;
 #else
-        static readonly bool CaseInsensitiveCompatMode;
+        internal static readonly bool CaseInsensitiveCompatMode;
 #endif
 
         static NpgsqlParameterCollection()

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -484,12 +484,8 @@ FROM pg_constraint c
             row["IdentifierPattern"] = @"(^\[\p{Lo}\p{Lu}\p{Ll}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Nd}@$#_]*$)|(^\[[^\]\0]|\]\]+\]$)|(^\""[^\""\0]|\""\""+\""$)";
             row["IdentifierCase"] = IdentifierCase.Insensitive;
             row["OrderByColumnsInSelect"] = false;
-            row["ParameterMarkerFormat"] = @"{0}";  // TODO: Not sure
-            row["ParameterMarkerPattern"] = @"@[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)";
-            row["ParameterNameMaxLength"] = 63; // For function out parameters
             row["QuotedIdentifierPattern"] = @"""(([^\""]|\""\"")*)""";
             row["QuotedIdentifierCase"] = IdentifierCase.Sensitive;
-            row["ParameterNamePattern"] = @"^[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)";
             row["StatementSeparatorPattern"] = ";";
             row["StringLiteralPattern"] = @"'(([^']|'')*)'";
             row["SupportedJoinOperators"] =
@@ -497,6 +493,20 @@ FROM pg_constraint c
                 SupportedJoinOperators.Inner |
                 SupportedJoinOperators.LeftOuter |
                 SupportedJoinOperators.RightOuter;
+
+            row["ParameterNameMaxLength"] = 63; // For function out parameters
+            row["ParameterMarkerFormat"] = @"{0}";  // TODO: Not sure
+
+            if (NpgsqlCommand.EnableSqlRewriting)
+            {
+                row["ParameterMarkerPattern"] = @"@[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)";
+                row["ParameterNamePattern"] = @"^[\p{Lo}\p{Lu}\p{Ll}\p{Lm}_@#][\p{Lo}\p{Lu}\p{Ll}\p{Lm}\p{Nd}\uff3f_@#\$]*(?=\s+|$)";
+            }
+            else
+            {
+                row["ParameterMarkerPattern"] = @"$\d+";
+                row["ParameterNamePattern"] = @"\d+";
+            }
 
             return table;
         }


### PR DESCRIPTION
Only when opting out of named parameters.

Probably useless, but for completeness...
