### PR TITLE
Implement OpenTelemetry tracing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -237,6 +237,8 @@ namespace Npgsql.Internal
         /// </summary>
         readonly ConnectorSource _connectorSource;
 
+        internal string UserFacingConnectionString => _connectorSource.UserFacingConnectionString;
+
         /// <summary>
         /// Contains the UTC timestamp when this connector was opened, used to implement
         /// <see cref="NpgsqlConnectionStringBuilder.ConnectionLifetime"/>.
@@ -262,6 +264,8 @@ namespace Npgsql.Internal
         static readonly NpgsqlLogger Log = NpgsqlLogManager.CreateLogger(nameof(NpgsqlConnector));
 
         internal readonly Stopwatch QueryLogStopWatch = new();
+
+        internal EndPoint? ConnectedEndPoint { get; private set; }
 
         #endregion
 
@@ -915,6 +919,7 @@ namespace Npgsql.Internal
                     socket.Blocking = true;
                     SetSocketOptions(socket);
                     _socket = socket;
+                    ConnectedEndPoint = endpoint;
                     return;
                 }
                 catch (Exception e)
@@ -965,6 +970,7 @@ namespace Npgsql.Internal
                     await OpenSocketConnectionAsync(socket, endpoint, perIpTimeout, cancellationToken);
                     SetSocketOptions(socket);
                     _socket = socket;
+                    ConnectedEndPoint = endpoint;
                     return;
                 }
                 catch (Exception e)
@@ -1112,6 +1118,7 @@ namespace Npgsql.Internal
 
                         // We have a resultset for the command - hand back control to the command (which will
                         // return it to the user)
+                        command.TraceReceivedFirstResponse();
                         ReaderCompleted.Reset();
                         command.ExecutionCompletion.SetResult(this);
 

--- a/src/Npgsql/MultiplexingConnectorPool.cs
+++ b/src/Npgsql/MultiplexingConnectorPool.cs
@@ -226,6 +226,7 @@ namespace Npgsql
                 {
                     stats.Reset();
                     connector.FlagAsNotWritableForMultiplexing();
+                    command.TraceCommandStart(connector);
 
                     // Read queued commands and write them to the connector's buffer, for as long as we're
                     // under our write threshold and timer delay.

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+  </ItemGroup>
+
 </Project>

--- a/src/Npgsql/NpgsqlActivitySource.cs
+++ b/src/Npgsql/NpgsqlActivitySource.cs
@@ -1,0 +1,89 @@
+﻿using Npgsql.Internal;
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+
+namespace Npgsql
+{
+    static class NpgsqlActivitySource
+    {
+        static readonly ActivitySource Source;
+
+        static NpgsqlActivitySource()
+        {
+            var assembly = typeof(NpgsqlActivitySource).Assembly;
+            var version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "0.0.0";
+            Source = new("Npgsql", version);
+        }
+
+        internal static bool IsEnabled => Source.HasListeners();
+
+        internal static Activity? CommandStart(NpgsqlConnector connector, string sql)
+        {
+            var settings = connector.Settings;
+            var activity = Source.StartActivity(settings.Database!, ActivityKind.Client);
+            if (activity is not { IsAllDataRequested: true })
+                return activity;
+
+            activity.SetTag("db.system", "postgresql");
+            activity.SetTag("db.connection_string", connector.UserFacingConnectionString);
+            activity.SetTag("db.user", settings.Username);
+            activity.SetTag("db.name", settings.Database);
+            activity.SetTag("db.statement", sql);
+            activity.SetTag("db.connection_id", connector.Id);
+
+            var endPoint = connector.ConnectedEndPoint;
+            Debug.Assert(endPoint is not null);
+            switch (endPoint)
+            {
+            case IPEndPoint ipEndPoint:
+                activity.SetTag("net.transport", "ip_tcp");
+                activity.SetTag("net.peer.ip", ipEndPoint.Address.ToString());
+                if (ipEndPoint.Port != 5432)
+                    activity.SetTag("net.peer.port", ipEndPoint.Port);
+                activity.SetTag("net.peer.name", settings.Host);
+                break;
+
+            case UnixDomainSocketEndPoint:
+                activity.SetTag("net.transport", "unix");
+                activity.SetTag("net.peer.name", settings.Host);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException("Invalid endpoint type: " + endPoint.GetType());
+            }
+
+            return activity;
+        }
+
+        internal static void ReceivedFirstResponse(Activity activity)
+        {
+            var activityEvent = new ActivityEvent("received-first-response");
+            activity.AddEvent(activityEvent);
+        }
+
+        internal static void CommandStop(Activity activity)
+        {
+            activity.SetTag("otel.status_code", "OK");
+            activity.Dispose();
+        }
+
+        internal static void SetException(Activity activity, Exception ex, bool escaped = true)
+        {
+            var tags = new ActivityTagsCollection
+            {
+                { "exception.type", ex.GetType().FullName },
+                { "exception.message", ex.Message },
+                { "exception.stacktrace", ex.ToString() },
+                { "exception.escaped", escaped }
+            };
+            var activityEvent = new ActivityEvent("exception", tags: tags);
+            activity.AddEvent(activityEvent);
+            activity.SetTag("otel.status_code", "ERROR");
+            activity.SetTag("otel.status_description", ex is PostgresException pgEx ? pgEx.SqlState : ex.Message);
+            activity.Dispose();
+        }
+    }
+}

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -870,6 +870,10 @@ namespace Npgsql
                 if (e is not PostgresException)
                     State = ReaderState.Disposed;
             }
+            finally
+            {
+                Command.TraceCommandStop();
+            }
         }
 
         /// <summary>
@@ -896,6 +900,10 @@ namespace Npgsql
                     Log.Error("Exception caught while disposing a reader", e, Connector.Id);
                     if (e is not PostgresException)
                         State = ReaderState.Disposed;
+                }
+                finally
+                {
+                    Command.TraceCommandStop();
                 }
             }
         }
@@ -1010,8 +1018,8 @@ namespace Npgsql
                 Log.Debug($"Query duration time: {Connector.QueryLogStopWatch.ElapsedMilliseconds}ms", Connector.Id);
                 Connector.QueryLogStopWatch.Reset();
             }
-            Connector.EndUserAction();
             NpgsqlEventSource.Log.CommandStop();
+            Connector.EndUserAction();
 
             // The reader shouldn't be unbound, if we're disposing - so the state is set prematurely
             if (isDisposing)


### PR DESCRIPTION
Continues work by @vonzshik in #3967

* The span/activity is ended when NpgsqlReader is disposed. An event is traced in the span for the first response, as discussed in [this comment](https://github.com/npgsql/npgsql/pull/3967#discussion_r705255298).
* Kept the "standard" OpenTelemetry span name for now ([see this useful discussion](https://github.com/npgsql/npgsql/pull/3967/files#r711801257)). I do think the specs should be different, we'll try to work on the specs in the coming months.
* We currently trace only exceptions which are thrown during ExecuteReader; if an exception is thrown later (e.g. bad SQL in later batched command), this isn't currently detected. Some refactoring will be needed for this.

Some more ideas for future improvements are in #4038.

Compared before and after perf on TechEmpower Fortunes platform raw, all is well - looks like this is implemented efficiently in the runtime 😌 

Scenario                   | Commit                                   | RPS
-------------------------- | ---------------------------------------- | -------
Before change              | dba60fb5a87bc6d661bbdcd2a31be687edfc10e9 | 471,824
After change               | d39c9c04026f3338be3a744d8dd86e6e8f6b9965 | 474,877

<details>
<summary>Detailed run results</summary>

### Before change

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles C:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 38      |
| Cores usage (%)     | 1,067   |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,801   |
| Start Time (ms)     | 347     |
| Published Size (KB) | 915,610 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 94                         |
| Cores usage (%)       | 2,643                      |
| Working Set (MB)      | 465                        |
| Private Memory (MB)   | 2,039                      |
| Build Time (ms)       | 2,957                      |
| Start Time (ms)       | 1,615                      |
| Published Size (KB)   | 93,744                     |
| .NET Core SDK Version | 6.0.100-rtm.21513.25       |
| ASP.NET Core Version  | 6.0.0-rtm.21512.11+ffe6a20 |
| .NET Runtime Version  | 6.0.0-rtm.21513.8+77fe2e0  |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 870        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 74         |
| Requests/sec           | 471,824    |
| Requests               | 56,665,641 |
| Mean latency (ms)      | 1.13       |
| Max latency (ms)       | 19.85      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 612.40     |
| Latency 50th (ms)      | 1.02       |
| Latency 75th (ms)      | 1.23       |
| Latency 90th (ms)      | 1.54       |
| Latency 99th (ms)      | 4.04       |
```

### After change

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.options.outputFiles C:\projects\npgsql\src\Npgsql\bin\Release\net6.0\Npgsql.dll --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 38      |
| Cores usage (%)     | 1,067   |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,725   |
| Start Time (ms)     | 350     |
| Published Size (KB) | 915,610 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 94                         |
| Cores usage (%)       | 2,641                      |
| Working Set (MB)      | 458                        |
| Private Memory (MB)   | 2,033                      |
| Build Time (ms)       | 2,656                      |
| Start Time (ms)       | 1,437                      |
| Published Size (KB)   | 93,744                     |
| .NET Core SDK Version | 6.0.100-rtm.21513.25       |
| ASP.NET Core Version  | 6.0.0-rtm.21512.11+ffe6a20 |
| .NET Runtime Version  | 6.0.0-rtm.21513.8+77fe2e0  |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 870        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 75         |
| Requests/sec           | 474,877    |
| Requests               | 57,025,414 |
| Mean latency (ms)      | 1.14       |
| Max latency (ms)       | 20.84      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 616.37     |
| Latency 50th (ms)      | 1.02       |
| Latency 75th (ms)      | 1.23       |
| Latency 90th (ms)      | 1.53       |
| Latency 99th (ms)      | 4.45       |
```

</details>

Additional tasks:

* [x] #4040

/cc @bgrainger @NinoFloris 