### PR TITLE
Add AddNpgsql to set up OpenTelemetry tracing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageVersion Include="OpenTelemetry.API" Version="1.1.0" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.SourceGenerators", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.NodaTime.Tests", "test\Npgsql.NodaTime.Tests\Npgsql.NodaTime.Tests.csproj", "{C00D2EB1-5719-4372-9E1C-5ED05DC23A00}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.OpenTelemetry", "src\Npgsql.OpenTelemetry\Npgsql.OpenTelemetry.csproj", "{DA29F063-1828-47D8-B051-800AF7C9A0BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,14 @@ Global
 		{C00D2EB1-5719-4372-9E1C-5ED05DC23A00}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C00D2EB1-5719-4372-9E1C-5ED05DC23A00}.Release|x86.ActiveCfg = Release|Any CPU
 		{C00D2EB1-5719-4372-9E1C-5ED05DC23A00}.Release|x86.Build.0 = Release|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +159,7 @@ Global
 		{A77E5FAF-D775-4AB4-8846-8965C2104E60} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 		{63026A19-60B8-4906-81CB-216F30E8094B} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{C00D2EB1-5719-4372-9E1C-5ED05DC23A00} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
+		{DA29F063-1828-47D8-B051-800AF7C9A0BE} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/src/Npgsql.OpenTelemetry/Npgsql.OpenTelemetry.csproj
+++ b/src/Npgsql.OpenTelemetry/Npgsql.OpenTelemetry.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Npgsql\Npgsql.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry.API" />
+    </ItemGroup>
+</Project>

--- a/src/Npgsql.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Npgsql.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using OpenTelemetry.Trace;
+
+// ReSharper disable once CheckNamespace
+namespace Npgsql
+{
+    /// <summary>
+    /// Extension method for setting up Npgsql OpenTelemetry tracing.
+    /// </summary>
+    public static class TracerProviderBuilderExtensions
+    {
+        /// <summary>
+        /// Subscribes to the Npgsql activity source to enable OpenTelemetry tracing.
+        /// </summary>
+        public static TracerProviderBuilder AddNpgsql(
+            this TracerProviderBuilder builder,
+            Action<NpgsqlTracingOptions>? options = null)
+            => builder.AddSource("Npgsql");
+    }
+}

--- a/src/Npgsql/NpgsqlTracingOptions.cs
+++ b/src/Npgsql/NpgsqlTracingOptions.cs
@@ -1,0 +1,10 @@
+namespace Npgsql
+{
+    /// <summary>
+    /// Options to configure Npgsql's support for OpenTelemetry tracing.
+    /// Currently no options are available.
+    /// </summary>
+    public class NpgsqlTracingOptions
+    {
+    }
+}

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -72,6 +72,8 @@ Npgsql.NpgsqlException.BatchCommand.set -> void
 *REMOVED*Npgsql.NpgsqlLengthCache
 *REMOVED*Npgsql.NpgsqlLengthCache.Get() -> int
 *REMOVED*Npgsql.NpgsqlLengthCache.Set(int len) -> int
+Npgsql.NpgsqlTracingOptions
+Npgsql.NpgsqlTracingOptions.NpgsqlTracingOptions() -> void
 Npgsql.PostgresTypes.PostgresMultirangeType
 Npgsql.PostgresTypes.PostgresMultirangeType.PostgresMultirangeType(string! ns, string! name, uint oid, Npgsql.PostgresTypes.PostgresRangeType! rangePostgresType) -> void
 Npgsql.PostgresTypes.PostgresMultirangeType.Subrange.get -> Npgsql.PostgresTypes.PostgresRangeType!


### PR DESCRIPTION
Part of #4037

What do you think about this @vonzshik? It's a bit heavy to heavy a nuget package just for AddNpgsql, but it's a bit nicer than telling users to do `AddSource("Npgsql")`. It also allows us to add config options in via a nice, fluent API...