### PR TITLE
Manage date/time infinity conversions via an AppContext switch

### DIFF
--- a/src/Npgsql.NodaTime/Internal/LegacyTimestampHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/LegacyTimestampHandler.cs
@@ -12,20 +12,16 @@ namespace Npgsql.NodaTime.Internal
     sealed partial class LegacyTimestampHandler : NpgsqlSimpleTypeHandler<Instant>,
         INpgsqlSimpleTypeHandler<LocalDateTime>, INpgsqlSimpleTypeHandler<DateTime>, INpgsqlSimpleTypeHandler<long>
     {
-        readonly bool _convertInfinityDateTime;
         readonly BclTimestampHandler _bclHandler;
 
-        internal LegacyTimestampHandler(PostgresType postgresType, bool convertInfinityDateTime)
+        internal LegacyTimestampHandler(PostgresType postgresType)
             : base(postgresType)
-        {
-            _convertInfinityDateTime = convertInfinityDateTime;
-            _bclHandler = new BclTimestampHandler(postgresType, convertInfinityDateTime);
-        }
+            => _bclHandler = new BclTimestampHandler(postgresType);
 
         #region Read
 
         public override Instant Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => TimestampTzHandler.ReadInstant(buf, _convertInfinityDateTime);
+            => TimestampTzHandler.ReadInstant(buf);
 
         LocalDateTime INpgsqlSimpleTypeHandler<LocalDateTime>.Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription)
             => TimestampHandler.ReadLocalDateTime(buf);
@@ -47,7 +43,7 @@ namespace Npgsql.NodaTime.Internal
             => 8;
 
         public override void Write(Instant value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => TimestampTzHandler.WriteInstant(value, buf, _convertInfinityDateTime);
+            => TimestampTzHandler.WriteInstant(value, buf);
 
         void INpgsqlSimpleTypeHandler<LocalDateTime>.Write(LocalDateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
             => TimestampHandler.WriteLocalDateTime(value, buf);

--- a/src/Npgsql.NodaTime/Internal/LegacyTimestampTzHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/LegacyTimestampTzHandler.cs
@@ -16,11 +16,11 @@ namespace Npgsql.NodaTime.Internal
         readonly IDateTimeZoneProvider _dateTimeZoneProvider;
         readonly TimestampTzHandler _wrappedHandler;
 
-        public LegacyTimestampTzHandler(PostgresType postgresType, bool convertInfinityDateTime)
+        public LegacyTimestampTzHandler(PostgresType postgresType)
             : base(postgresType)
         {
             _dateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
-            _wrappedHandler = new TimestampTzHandler(postgresType, convertInfinityDateTime);
+            _wrappedHandler = new TimestampTzHandler(postgresType);
         }
 
         #region Read

--- a/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
+++ b/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
@@ -29,12 +29,12 @@ namespace Npgsql.NodaTime.Internal
             _databaseInfo = connector.DatabaseInfo;
 
             _timestampHandler = LegacyTimestampBehavior
-                ? new LegacyTimestampHandler(PgType("timestamp without time zone"), connector.Settings.ConvertInfinityDateTime)
-                : new TimestampHandler(PgType("timestamp without time zone"), connector.Settings.ConvertInfinityDateTime);
+                ? new LegacyTimestampHandler(PgType("timestamp without time zone"))
+                : new TimestampHandler(PgType("timestamp without time zone"));
             _timestampTzHandler = LegacyTimestampBehavior
-                ? new LegacyTimestampTzHandler(PgType("timestamp with time zone"), connector.Settings.ConvertInfinityDateTime)
-                : new TimestampTzHandler(PgType("timestamp with time zone"), connector.Settings.ConvertInfinityDateTime);
-            _dateHandler = new DateHandler(PgType("date"), connector.Settings.ConvertInfinityDateTime);
+                ? new LegacyTimestampTzHandler(PgType("timestamp with time zone"))
+                : new TimestampTzHandler(PgType("timestamp with time zone"));
+            _dateHandler = new DateHandler(PgType("date"));
             _timeHandler = new TimeHandler(PgType("time without time zone"));
             _timeTzHandler = new TimeTzHandler(PgType("time with time zone"));
             _intervalHandler = new IntervalHandler(PgType("interval"));

--- a/src/Npgsql.NodaTime/Internal/NodaTimeUtils.cs
+++ b/src/Npgsql.NodaTime/Internal/NodaTimeUtils.cs
@@ -7,12 +7,17 @@ namespace Npgsql.NodaTime.Internal
     {
 #if DEBUG
         internal static bool LegacyTimestampBehavior;
+        internal static bool DisableDateTimeInfinityConversions;
 #else
         internal static readonly bool LegacyTimestampBehavior;
+        internal static readonly bool DisableDateTimeInfinityConversions;
 #endif
 
         static NodaTimeUtils()
-            => LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out var enabled) && enabled;
+        {
+            LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out var enabled) && enabled;
+            DisableDateTimeInfinityConversions = AppContext.TryGetSwitch("Npgsql.DisableDateTimeInfinityConversions", out enabled) && enabled;
+        }
 
         static readonly Instant Instant2000 = Instant.FromUtc(2000, 1, 1, 0, 0, 0);
         static readonly Duration Plus292Years = Duration.FromDays(292 * 365);

--- a/src/Npgsql.NodaTime/Internal/TimestampHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampHandler.cs
@@ -14,9 +14,9 @@ namespace Npgsql.NodaTime.Internal
     {
         readonly BclTimestampHandler _bclHandler;
 
-        internal TimestampHandler(PostgresType postgresType, bool convertInfinityDateTime)
+        internal TimestampHandler(PostgresType postgresType)
             : base(postgresType)
-            => _bclHandler = new BclTimestampHandler(postgresType, convertInfinityDateTime);
+            => _bclHandler = new BclTimestampHandler(postgresType);
 
         #region Read
 

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -376,7 +376,6 @@ namespace Npgsql.Internal
         string KerberosServiceName => Settings.KerberosServiceName;
         int ConnectionTimeout => Settings.Timeout;
         bool IntegratedSecurity => Settings.IntegratedSecurity;
-        internal bool ConvertInfinityDateTime => Settings.ConvertInfinityDateTime;
 
         /// <summary>
         /// The actual command timeout value that gets set on internal commands.

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampHandler.cs
@@ -23,23 +23,15 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     public partial class TimestampHandler : NpgsqlSimpleTypeHandlerWithPsv<DateTime, NpgsqlDateTime>, INpgsqlSimpleTypeHandler<long>
     {
         /// <summary>
-        /// Whether to convert positive and negative infinity values to DateTime.{Max,Min}Value when
-        /// a DateTime is requested
-        /// </summary>
-        protected readonly bool ConvertInfinityDateTime;
-
-        /// <summary>
         /// Constructs a <see cref="TimestampHandler"/>.
         /// </summary>
-        public TimestampHandler(PostgresType postgresType, bool convertInfinityDateTime)
-            : base(postgresType)
-            => ConvertInfinityDateTime = convertInfinityDateTime;
+        public TimestampHandler(PostgresType postgresType) : base(postgresType) {}
 
         #region Read
 
         /// <inheritdoc />
         public override DateTime Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
-            => ReadDateTime(buf, ConvertInfinityDateTime, DateTimeKind.Unspecified);
+            => ReadDateTime(buf, DateTimeKind.Unspecified);
 
         /// <inheritdoc />
         protected override NpgsqlDateTime ReadPsv(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)
@@ -77,11 +69,11 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
 
         /// <inheritdoc />
         public override void Write(DateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => WriteTimestamp(value, buf, ConvertInfinityDateTime);
+            => WriteTimestamp(value, buf);
 
         /// <inheritdoc />
         public override void Write(NpgsqlDateTime value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)
-            => WriteTimestamp(value, buf, ConvertInfinityDateTime);
+            => WriteTimestamp(value, buf);
 
         /// <inheritdoc />
         public void Write(long value, NpgsqlWriteBuffer buf, NpgsqlParameter? parameter)

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1414,28 +1414,23 @@ namespace Npgsql
         }
         ServerCompatibilityMode _serverCompatibilityMode;
 
+        #endregion
+
+        #region Properties - Obsolete
+
         /// <summary>
-        /// Makes MaxValue and MinValue timestamps and dates readable as infinity and negative infinity.
+        /// Obsolete, see https://www.npgsql.org/doc/release-notes/6.0.html
         /// </summary>
         [Category("Compatibility")]
         [Description("Makes MaxValue and MinValue timestamps and dates readable as infinity and negative infinity.")]
         [DisplayName("Convert Infinity DateTime")]
-        [DefaultValue(true)]
         [NpgsqlConnectionStringProperty]
+        [Obsolete("The ConvertInfinityDateTime parameter is no longer supported.")]
         public bool ConvertInfinityDateTime
         {
-            get => _convertInfinityDateTime;
-            set
-            {
-                _convertInfinityDateTime = value;
-                SetValue(nameof(ConvertInfinityDateTime), value);
-            }
+            get => false;
+            set => throw new NotSupportedException("The Convert Infinity DateTime parameter is no longer supported; Npgsql 6.0 and above convert min/max values to Infinity by default. See https://www.npgsql.org/doc/types/datetime.html for more details.");
         }
-        bool _convertInfinityDateTime;
-
-        #endregion
-
-        #region Properties - Obsolete
 
         /// <summary>
         /// Obsolete, see https://www.npgsql.org/doc/release-notes/3.1.html

--- a/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolver.cs
@@ -261,9 +261,9 @@ namespace Npgsql.TypeMapping
             _doubleHandler = new DoubleHandler(PgType("double precision"));
             _numericHandler = new NumericHandler(PgType("numeric"));
             _textHandler ??= new TextHandler(PgType("text"), _connector.TextEncoding);
-            _timestampHandler ??= new TimestampHandler(PgType("timestamp without time zone"), _connector.Settings.ConvertInfinityDateTime);
-            _timestampTzHandler ??= new TimestampTzHandler(PgType("timestamp with time zone"), _connector.Settings.ConvertInfinityDateTime);
-            _dateHandler ??= new DateHandler(PgType("date"), _connector.Settings.ConvertInfinityDateTime);
+            _timestampHandler ??= new TimestampHandler(PgType("timestamp without time zone"));
+            _timestampTzHandler ??= new TimestampTzHandler(PgType("timestamp with time zone"));
+            _dateHandler ??= new DateHandler(PgType("date"));
             _boolHandler ??= new BoolHandler(PgType("boolean"));
             _uuidHandler ??= new UuidHandler(PgType("uuid"));
             _jsonbHandler ??= new JsonHandler(PgType("jsonb"), _connector.TextEncoding, isJsonb: true);

--- a/src/Npgsql/Util/PGUtil.cs
+++ b/src/Npgsql/Util/PGUtil.cs
@@ -13,12 +13,17 @@ namespace Npgsql.Util
     {
 #if DEBUG
         internal static bool LegacyTimestampBehavior;
+        internal static bool DisableDateTimeInfinityConversions;
 #else
         internal static readonly bool LegacyTimestampBehavior;
+        internal static readonly bool DisableDateTimeInfinityConversions;
 #endif
 
         static Statics()
-            => LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out var enabled) && enabled;
+        {
+            LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out var enabled) && enabled;
+            DisableDateTimeInfinityConversions = AppContext.TryGetSwitch("Npgsql.DisableDateTimeInfinityConversions", out enabled) && enabled;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T Expect<T>(IBackendMessage msg, NpgsqlConnector connector)

--- a/test/Npgsql.NodaTime.Tests/LegacyNodaTimeTests.cs
+++ b/test/Npgsql.NodaTime.Tests/LegacyNodaTimeTests.cs
@@ -103,8 +103,7 @@ namespace Npgsql.NodaTime.Tests
         [Test]
         public async Task Timestamp_read_infinity()
         {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString) { ConvertInfinityDateTime = true }.ConnectionString;
-            await using var conn = await OpenConnectionAsync(connectionString);
+            await using var conn = await OpenConnectionAsync();
             await using var cmd =
                 new NpgsqlCommand("SELECT 'infinity'::timestamp without time zone, '-infinity'::timestamp without time zone", conn);
             await using var reader = await cmd.ExecuteReaderAsync();
@@ -119,8 +118,7 @@ namespace Npgsql.NodaTime.Tests
         [Test]
         public async Task Timestamp_write_infinity()
         {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString) { ConvertInfinityDateTime = true }.ConnectionString;
-            await using var conn = await OpenConnectionAsync(connectionString);
+            await using var conn = await OpenConnectionAsync();
             await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text, $3::text, $4::text", conn)
             {
                 Parameters =
@@ -229,8 +227,7 @@ namespace Npgsql.NodaTime.Tests
         [Test]
         public async Task Timestamptz_read_infinity()
         {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString) { ConvertInfinityDateTime = true }.ConnectionString;
-            await using var conn = await OpenConnectionAsync(connectionString);
+            await using var conn = await OpenConnectionAsync();
             await using var cmd =
                 new NpgsqlCommand("SELECT 'infinity'::timestamp with time zone, '-infinity'::timestamp with time zone", conn);
             await using var reader = await cmd.ExecuteReaderAsync();
@@ -245,8 +242,7 @@ namespace Npgsql.NodaTime.Tests
         [Test]
         public async Task Timestamptz_write_infinity()
         {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString) { ConvertInfinityDateTime = true }.ConnectionString;
-            await using var conn = await OpenConnectionAsync(connectionString);
+            await using var conn = await OpenConnectionAsync();
             await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text, $3::text, $4::text", conn)
             {
                 Parameters =

--- a/test/Npgsql.NodaTime.Tests/NodaTimeInfinityTests.cs
+++ b/test/Npgsql.NodaTime.Tests/NodaTimeInfinityTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Threading.Tasks;
+using NodaTime;
+using Npgsql.Tests;
+using Npgsql.Util;
+using NpgsqlTypes;
+using NUnit.Framework;
+using static Npgsql.NodaTime.Internal.NodaTimeUtils;
+
+namespace Npgsql.NodaTime.Tests
+{
+    [TestFixture(true)]
+#if DEBUG
+    [TestFixture(false)]
+#endif
+    [NonParallelizable]
+    public class NodaTimeInfinityTests : TestBase
+    {
+        [Test]
+        public async Task Timestamptz_read_values()
+        {
+            if (DisableDateTimeInfinityConversions)
+                return;
+
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd =
+                new NpgsqlCommand("SELECT 'infinity'::timestamp with time zone, '-infinity'::timestamp with time zone", conn);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            Assert.That(reader.GetFieldValue<Instant>(0), Is.EqualTo(Instant.MaxValue));
+            Assert.That(reader.GetFieldValue<DateTime>(0), Is.EqualTo(DateTime.MaxValue));
+            Assert.That(reader.GetFieldValue<Instant>(1), Is.EqualTo(Instant.MinValue));
+            Assert.That(reader.GetFieldValue<DateTime>(1), Is.EqualTo(DateTime.MinValue));
+        }
+
+        [Test]
+        public async Task Timestamptz_write_values()
+        {
+            if (DisableDateTimeInfinityConversions)
+                return;
+
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text, $3::text, $4::text", conn)
+            {
+                Parameters =
+                {
+                    new() { Value = Instant.MaxValue },
+                    new() { Value = DateTime.MaxValue },
+                    new() { Value = Instant.MinValue },
+                    new() { Value = DateTime.MinValue }
+                }
+            };
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            Assert.That(reader[0], Is.EqualTo("infinity"));
+            Assert.That(reader[1], Is.EqualTo("infinity"));
+            Assert.That(reader[2], Is.EqualTo("-infinity"));
+            Assert.That(reader[3], Is.EqualTo("-infinity"));
+        }
+
+        [Test]
+        public async Task Timestamptz_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT ($1 AT TIME ZONE 'UTC')::text", conn)
+            {
+                Parameters = { new() { Value = Instant.MinValue, NpgsqlDbType = NpgsqlDbType.TimestampTz } }
+            };
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                // NodaTime Instant.MinValue is outside the PG timestamp range.
+                Assert.That(async () => await cmd.ExecuteScalarAsync(),
+                    Throws.Exception.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo("22008"));
+            }
+            else
+            {
+                Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo("-infinity"));
+            }
+
+            await using var cmd2 = new NpgsqlCommand("SELECT ($1 AT TIME ZONE 'UTC')::text", conn)
+            {
+                Parameters = { new() { Value = Instant.MaxValue, NpgsqlDbType = NpgsqlDbType.TimestampTz } }
+            };
+
+            Assert.That(await cmd2.ExecuteScalarAsync(), Is.EqualTo(DisableDateTimeInfinityConversions ? "9999-12-31 23:59:59.999999" : "infinity"));
+        }
+
+        [Test]
+        public async Task Timestamptz_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new NpgsqlCommand(
+                "SELECT '-infinity'::timestamp with time zone, 'infinity'::timestamp with time zone", conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader[0], Is.EqualTo(Instant.MinValue));
+                Assert.That(reader[1], Is.EqualTo(Instant.MaxValue));
+            }
+        }
+
+        [Test]
+        public async Task Date_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT $1::text", conn)
+            {
+                Parameters = { new() { Value = LocalDate.MinIsoValue, NpgsqlDbType = NpgsqlDbType.Date } }
+            };
+
+            // LocalDate.MinIsoValue is outside of the PostgreSQL date range
+            if (DisableDateTimeInfinityConversions)
+                Assert.That(async () => await cmd.ExecuteScalarAsync(),
+                    Throws.Exception.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo("22008"));
+            else
+                Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo("-infinity"));
+
+            cmd.Parameters[0].Value = LocalDate.MaxIsoValue;
+
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(DisableDateTimeInfinityConversions ? "9999-12-31" : "infinity"));
+        }
+
+        [Test]
+        public async Task Date_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT '-infinity'::date, 'infinity'::date", conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader[0], Is.EqualTo(LocalDate.MinIsoValue));
+                Assert.That(reader[1], Is.EqualTo(LocalDate.MaxIsoValue));
+            }
+        }
+
+        [Test, Description("Makes sure that when ConvertInfinityDateTime is true, infinity values are properly converted")]
+        public async Task DateConvertInfinity()
+        {
+            if (DisableDateTimeInfinityConversions)
+                return;
+
+            await using var conn = await OpenConnectionAsync();
+            conn.ExecuteNonQuery("CREATE TEMP TABLE data (d1 DATE, d2 DATE, d3 DATE, d4 DATE)");
+
+            using (var cmd = new NpgsqlCommand("INSERT INTO data VALUES (@p1, @p2, @p3, @p4)", conn))
+            {
+                cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Date, LocalDate.MaxIsoValue);
+                cmd.Parameters.AddWithValue("p2", NpgsqlDbType.Date, LocalDate.MinIsoValue);
+                cmd.Parameters.AddWithValue("p3", NpgsqlDbType.Date, DateTime.MaxValue);
+                cmd.Parameters.AddWithValue("p4", NpgsqlDbType.Date, DateTime.MinValue);
+                cmd.ExecuteNonQuery();
+            }
+
+            using (var cmd = new NpgsqlCommand("SELECT d1::TEXT, d2::TEXT, d3::TEXT, d4::TEXT FROM data", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+                Assert.That(reader.GetValue(0), Is.EqualTo("infinity"));
+                Assert.That(reader.GetValue(1), Is.EqualTo("-infinity"));
+                Assert.That(reader.GetValue(2), Is.EqualTo("infinity"));
+                Assert.That(reader.GetValue(3), Is.EqualTo("-infinity"));
+            }
+
+            using (var cmd = new NpgsqlCommand("SELECT * FROM data", conn))
+            using (var reader = cmd.ExecuteReader())
+            {
+                reader.Read();
+                Assert.That(reader.GetFieldValue<LocalDate>(0), Is.EqualTo(LocalDate.MaxIsoValue));
+                Assert.That(reader.GetFieldValue<LocalDate>(1), Is.EqualTo(LocalDate.MinIsoValue));
+                Assert.That(reader.GetFieldValue<DateTime>(2), Is.EqualTo(DateTime.MaxValue));
+                Assert.That(reader.GetFieldValue<DateTime>(3), Is.EqualTo(DateTime.MinValue));
+            }
+        }
+
+        protected override async ValueTask<NpgsqlConnection> OpenConnectionAsync(string? connectionString = null)
+        {
+            var conn = await base.OpenConnectionAsync(connectionString);
+            conn.TypeMapper.UseNodaTime();
+            await conn.ExecuteNonQueryAsync("SET TimeZone='Europe/Berlin'");
+            return conn;
+        }
+
+        protected override NpgsqlConnection OpenConnection(string? connectionString = null)
+            => throw new NotSupportedException();
+
+        public NodaTimeInfinityTests(bool disableDateTimeInfinityConversions)
+        {
+#if DEBUG
+            DisableDateTimeInfinityConversions = disableDateTimeInfinityConversions;
+            Statics.DisableDateTimeInfinityConversions = disableDateTimeInfinityConversions;
+#else
+            if (disableDateTimeInfinityConversions)
+            {
+                Assert.Ignore(
+                    "NodaTimeInfinityTests rely on the Npgsql.DisableDateTimeInfinityConversions AppContext switch and can only be run in DEBUG builds");
+            }
+#endif
+        }
+
+        public void Dispose()
+        {
+#if DEBUG
+            DisableDateTimeInfinityConversions = false;
+            Statics.DisableDateTimeInfinityConversions = false;
+#endif
+        }
+    }
+}

--- a/test/Npgsql.Tests/Types/DateTimeInfinityTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeInfinityTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Threading.Tasks;
+using NpgsqlTypes;
+using NUnit.Framework;
+using static Npgsql.Util.Statics;
+
+namespace Npgsql.Tests.Types
+{
+    [TestFixture(true)]
+#if DEBUG
+    [TestFixture(false)]
+#endif
+    [NonParallelizable]
+    public class DateTimeInfinityTests : TestBase, IDisposable
+    {
+        [Test]
+        public async Task TimestampTz_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT ($1 AT TIME ZONE 'UTC')::text", conn)
+            {
+                Parameters =
+                {
+                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.TimestampTz },
+                }
+            };
+
+            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(DisableDateTimeInfinityConversions ? "0001-01-01 00:00:00" : "-infinity"));
+
+            cmd.Parameters[0].Value = DateTime.MaxValue;
+
+            if (DisableDateTimeInfinityConversions)
+                Assert.That(async () => await cmd.ExecuteScalarAsync(), Throws.Exception.TypeOf<InvalidCastException>());
+            else
+                Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo("infinity"));
+        }
+
+        [Test]
+        public async Task TimestampTz_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand(
+                "SELECT '-infinity'::timestamp with time zone, 'infinity'::timestamp with time zone",
+                conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
+                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
+            }
+        }
+
+        [Test]
+        public async Task Timestamp_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
+            {
+                Parameters =
+                {
+                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.Timestamp },
+                    new() { Value = DateTime.MaxValue, NpgsqlDbType = NpgsqlDbType.Timestamp },
+                }
+            };
+            await using (var reader = await cmd.ExecuteReaderAsync())
+            {
+                await reader.ReadAsync();
+
+                Assert.That(reader[0], Is.EqualTo(DisableDateTimeInfinityConversions ? "0001-01-01 00:00:00" : "-infinity"));
+                Assert.That(reader[1], Is.EqualTo(DisableDateTimeInfinityConversions ? "9999-12-31 23:59:59.999999" : "infinity"));
+            }
+        }
+
+        [Test]
+        public async Task Timestamp_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand(
+                "SELECT '-infinity'::timestamp without time zone, 'infinity'::timestamp without time zone",
+                conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
+                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
+            }
+        }
+
+        [Test, NonParallelizable]
+        public async Task Date_DateTime_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
+            {
+                Parameters =
+                {
+                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.Date },
+                    new() { Value = DateTime.MaxValue, NpgsqlDbType = NpgsqlDbType.Date }
+                }
+            };
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            Assert.That(reader[0], Is.EqualTo(DisableDateTimeInfinityConversions ? "0001-01-01" : "-infinity"));
+            Assert.That(reader[1], Is.EqualTo(DisableDateTimeInfinityConversions ? "9999-12-31" : "infinity"));
+        }
+
+        [Test]
+        public async Task Date_DateTime_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT '-infinity'::date, 'infinity'::date", conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
+                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
+            }
+        }
+
+#if NET6_0_OR_GREATER
+        [Test]
+        public async Task Date_DateOnly_write()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
+            {
+                Parameters =
+                {
+                    new() { Value = DateOnly.MinValue, NpgsqlDbType = NpgsqlDbType.Date },
+                    new() { Value = DateOnly.MaxValue, NpgsqlDbType = NpgsqlDbType.Date }
+                }
+            };
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            Assert.That(reader[0], Is.EqualTo(DisableDateTimeInfinityConversions ? "0001-01-01" : "-infinity"));
+            Assert.That(reader[1], Is.EqualTo(DisableDateTimeInfinityConversions ? "9999-12-31" : "infinity"));
+        }
+
+        [Test]
+        public async Task Date_DateOnly_read()
+        {
+            await using var conn = await OpenConnectionAsync();
+
+            await using var cmd = new NpgsqlCommand("SELECT '-infinity'::date, 'infinity'::date", conn);
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+
+            if (DisableDateTimeInfinityConversions)
+            {
+                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
+                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
+            }
+            else
+            {
+                Assert.That(reader.GetFieldValue<DateOnly>(0), Is.EqualTo(DateOnly.MinValue));
+                Assert.That(reader.GetFieldValue<DateOnly>(1), Is.EqualTo(DateOnly.MaxValue));
+            }
+        }
+#endif
+
+        public DateTimeInfinityTests(bool disableDateTimeInfinityConversions)
+        {
+#if DEBUG
+            DisableDateTimeInfinityConversions = disableDateTimeInfinityConversions;
+#else
+            if (disableDateTimeInfinityConversions)
+            {
+                Assert.Ignore(
+                    "DateTimeInfinityTests rely on the Npgsql.DisableDateTimeInfinityConversions AppContext switch and can only be run in DEBUG builds");
+            }
+#endif
+        }
+
+        public void Dispose()
+        {
+#if DEBUG
+            DisableDateTimeInfinityConversions = false;
+#endif
+        }
+    }
+}

--- a/test/Npgsql.Tests/Types/DateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeTests.cs
@@ -52,57 +52,6 @@ namespace Npgsql.Tests.Types
             }
         }
 
-        [Test]
-        public async Task Date_DateTime_ConvertInfinityDateTime_write([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
-            {
-                Parameters =
-                {
-                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.Date },
-                    new() { Value = DateTime.MaxValue, NpgsqlDbType = NpgsqlDbType.Date }
-                }
-            };
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            Assert.That(reader[0], Is.EqualTo(convertInfinityDateTime ? "-infinity" : "0001-01-01"));
-            Assert.That(reader[1], Is.EqualTo(convertInfinityDateTime ? "infinity" : "9999-12-31"));
-        }
-
-        [Test]
-        public async Task Date_DateTime_ConvertInfinityDateTime_read([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT '-infinity'::date, 'infinity'::date", conn);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            if (convertInfinityDateTime)
-            {
-                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
-                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
-            }
-            else
-            {
-                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
-                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
-            }
-        }
-
 #if NET6_0_OR_GREATER
         [Test]
         public async Task Date_DateOnly()
@@ -125,57 +74,6 @@ namespace Npgsql.Tests.Types
             Assert.That(reader.GetDateTime(0), Is.EqualTo(dateTime));
             Assert.That(reader[0], Is.EqualTo(dateTime));
             Assert.That(reader.GetValue(0), Is.EqualTo(dateTime));
-        }
-
-        [Test]
-        public async Task Date_DateOnly_ConvertInfinityDateTime_write([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
-            {
-                Parameters =
-                {
-                    new() { Value = DateOnly.MinValue, NpgsqlDbType = NpgsqlDbType.Date },
-                    new() { Value = DateOnly.MaxValue, NpgsqlDbType = NpgsqlDbType.Date }
-                }
-            };
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            Assert.That(reader[0], Is.EqualTo(convertInfinityDateTime ? "-infinity" : "0001-01-01"));
-            Assert.That(reader[1], Is.EqualTo(convertInfinityDateTime ? "infinity" : "9999-12-31"));
-        }
-
-        [Test]
-        public async Task Date_DateOnly_ConvertInfinityDateTime_read([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT '-infinity'::date, 'infinity'::date", conn);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            if (convertInfinityDateTime)
-            {
-                Assert.That(reader.GetFieldValue<DateOnly>(0), Is.EqualTo(DateOnly.MinValue));
-                Assert.That(reader.GetFieldValue<DateOnly>(1), Is.EqualTo(DateOnly.MaxValue));
-            }
-            else
-            {
-                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
-                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
-            }
         }
 
         [Test]
@@ -409,60 +307,6 @@ namespace Npgsql.Tests.Types
         }
 
         [Test]
-        public async Task Timestamp_ConvertInfinityDateTime_write([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT $1::text, $2::text", conn)
-            {
-                Parameters =
-                {
-                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.Timestamp },
-                    new() { Value = DateTime.MaxValue, NpgsqlDbType = NpgsqlDbType.Timestamp },
-                }
-            };
-            await using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                await reader.ReadAsync();
-
-                Assert.That(reader[0], Is.EqualTo(convertInfinityDateTime ? "-infinity" : "0001-01-01 00:00:00"));
-                Assert.That(reader[1], Is.EqualTo(convertInfinityDateTime ? "infinity" : "9999-12-31 23:59:59.999999"));
-            }
-        }
-
-        [Test]
-        public async Task Timestamp_ConvertInfinityDateTime_read([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand(
-                "SELECT '-infinity'::timestamp without time zone, 'infinity'::timestamp without time zone",
-                conn);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            if (convertInfinityDateTime)
-            {
-                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
-                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
-            }
-            else
-            {
-                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
-                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
-            }
-        }
-
-        [Test]
         public async Task Timestamp_array_resolution()
         {
             await using var conn = await OpenConnectionAsync();
@@ -680,61 +524,6 @@ namespace Npgsql.Tests.Types
             };
 
             Assert.That(() => cmd.ExecuteReaderAsync(), Throws.Exception.TypeOf<InvalidCastException>());
-        }
-
-        [Test]
-        public async Task TimestampTz_ConvertInfinityDateTime_write([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand("SELECT ($1 AT TIME ZONE 'UTC')::text", conn)
-            {
-                Parameters =
-                {
-                    new() { Value = DateTime.MinValue, NpgsqlDbType = NpgsqlDbType.TimestampTz },
-                }
-            };
-
-            Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(convertInfinityDateTime ? "-infinity" : "0001-01-01 00:00:00"));
-
-            cmd.Parameters[0].Value = DateTime.MaxValue;
-
-            if (convertInfinityDateTime)
-                Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo("infinity"));
-            else
-                Assert.That(async () => await cmd.ExecuteScalarAsync(), Throws.Exception.TypeOf<InvalidCastException>());
-        }
-
-        [Test]
-        public async Task TimestampTz_ConvertInfinityDateTime_read([Values] bool convertInfinityDateTime)
-        {
-            var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-            {
-                ConvertInfinityDateTime = convertInfinityDateTime
-            }.ToString();
-            await using var conn = await OpenConnectionAsync(connectionString);
-
-            await using var cmd = new NpgsqlCommand(
-                "SELECT '-infinity'::timestamp with time zone, 'infinity'::timestamp with time zone",
-                conn);
-
-            await using var reader = await cmd.ExecuteReaderAsync();
-            await reader.ReadAsync();
-
-            if (convertInfinityDateTime)
-            {
-                Assert.That(reader[0], Is.EqualTo(DateTime.MinValue));
-                Assert.That(reader[1], Is.EqualTo(DateTime.MaxValue));
-            }
-            else
-            {
-                Assert.That(() => reader[0], Throws.Exception.TypeOf<InvalidCastException>());
-                Assert.That(() => reader[1], Throws.Exception.TypeOf<InvalidCastException>());
-            }
         }
 
         [Test]


### PR DESCRIPTION
And obsolete the previous connection string parameter

/cc @NinoFloris 
