### PR TITLE
Do infinity conversions for LocalDateTime

### DIFF
--- a/src/Npgsql.NodaTime/Internal/DateHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/DateHandler.cs
@@ -20,7 +20,7 @@ namespace Npgsql.NodaTime.Internal
     {
         readonly BclDateHandler _bclHandler;
 
-        const string InfinityExceptionMessage = "Can't convert infinite timestamp values to DateTime";
+        const string InfinityExceptionMessage = "Can't read infinity value since Npgsql.DisableDateTimeInfinityConversions is enabled";
 
         internal DateHandler(PostgresType postgresType)
             : base(postgresType)

--- a/src/Npgsql.NodaTime/Internal/TimestampTzHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampTzHandler.cs
@@ -15,7 +15,7 @@ namespace Npgsql.NodaTime.Internal
     {
         readonly BclTimestampTzHandler _bclHandler;
 
-        const string InfinityExceptionMessage = "Can't convert infinite timestamp values to DateTime";
+        const string InfinityExceptionMessage = "Can't read infinity value since Npgsql.DisableDateTimeInfinityConversions is enabled";
 
         public TimestampTzHandler(PostgresType postgresType)
             : base(postgresType)

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/DateTimeUtils.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/DateTimeUtils.cs
@@ -9,7 +9,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
     static class DateTimeUtils
     {
         const long PostgresTimestampOffsetTicks = 630822816000000000L;
-        const string InfinityExceptionMessage = "Can't convert infinite timestamp values to DateTime";
+        const string InfinityExceptionMessage = "Can't read infinity value since Npgsql.DisableDateTimeInfinityConversions is enabled";
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static DateTime DecodeTimestamp(long value, DateTimeKind kind)

--- a/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampTzHandler.cs
@@ -35,8 +35,7 @@ namespace Npgsql.Internal.TypeHandlers.DateTimeHandlers
 
         #region Read
 
-        private protected const string InfinityExceptionMessage = "Can't convert infinite timestamp values to DateTime";
-        private protected const string OutOfRangeExceptionMessage = "Out of the range of DateTime (year must be between 1 and 9999)";
+        const string InfinityExceptionMessage = "Can't read infinity value since Npgsql.DisableDateTimeInfinityConversions is enabled";
 
         /// <inheritdoc />
         public override DateTime Read(NpgsqlReadBuffer buf, int len, FieldDescription? fieldDescription = null)


### PR DESCRIPTION
Part of #4034

Currently NodaTime.LocalDateTime has no Min/MaxValue, so we didn't do infinity conversions. [But these are being added](https://github.com/nodatime/nodatime/pull/1660), so we may as well do the translations now to let people read/write infinity values, and change to use the official properties later (#4061).
