### PR TITLE
Change the default value for CheckCertificateRevocation to false

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -547,7 +547,6 @@ namespace Npgsql
         [Category("Security")]
         [Description("Whether to check the certificate revocation list during authentication.")]
         [DisplayName("Check Certificate Revocation")]
-        [DefaultValue(true)]
         [NpgsqlConnectionStringProperty]
         public bool CheckCertificateRevocation
         {

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -3,6 +3,7 @@ using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using static Npgsql.Tests.TestUtil;
 
 namespace Npgsql.Tests
 {
@@ -41,13 +42,13 @@ namespace Npgsql.Tests
         [Test, Description("Makes sure a certificate whose root CA isn't known isn't accepted")]
         public void Reject_self_signed_certificate([Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode)
         {
-            var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
+            var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 SslMode = sslMode,
                 CheckCertificateRevocation = false,
-                Pooling = false
-            }.ToString();
+            };
 
+            using var _ = CreateTempPool(csb, out var connString);
             using var conn = new NpgsqlConnection(connString);
 
             var ex = Assert.Throws<NpgsqlException>(conn.Open)!;

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -39,20 +39,16 @@ namespace Npgsql.Tests
         }
 
         [Test, Description("Makes sure a certificate whose root CA isn't known isn't accepted")]
-        public void Reject_self_signed_certificate(
-            [Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode,
-            [Values] bool checkCertificateRevocation)
+        public void Reject_self_signed_certificate([Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode)
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 SslMode = sslMode,
-                CheckCertificateRevocation = checkCertificateRevocation
+                CheckCertificateRevocation = false,
+                Pooling = false
             }.ToString();
 
             using var conn = new NpgsqlConnection(connString);
-            // The following is necessary since a pooled connector may exist from a previous
-            // SSL test
-            NpgsqlConnection.ClearPool(conn);
 
             var ex = Assert.Throws<NpgsqlException>(conn.Open)!;
             Assert.That(ex.InnerException, Is.TypeOf<AuthenticationException>());


### PR DESCRIPTION
Fixes #4091.

As a bonus, also fix a situation with VerifyFull + root cert, where we didn't check for remote certificate name mismatch.