### PR TITLE
Skip replication tests on Mac

### DIFF
--- a/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs
@@ -16,6 +16,7 @@ namespace Npgsql.Tests.Replication
     /// for the individual logical replication tests, they are in fact not, because
     /// the methods they test are extension points for plugin developers.
     /// </remarks>
+    [Platform(Exclude = "MacOsX", Reason = "Replication tests are flaky in CI on Mac")]
     public class CommonLogicalReplicationTests : SafeReplicationTestBase<LogicalReplicationConnection>
     {
         // We use the test_decoding logical decoding plugin for the common

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -15,6 +15,7 @@ namespace Npgsql.Tests.Replication
 {
     [TestFixture(typeof(LogicalReplicationConnection))]
     [TestFixture(typeof(PhysicalReplicationConnection))]
+    [Platform(Exclude = "MacOsX", Reason = "Replication tests are flaky in CI on Mac")]
     public class CommonReplicationTests<TConnection> : SafeReplicationTestBase<TConnection>
         where TConnection : ReplicationConnection, new()
     {

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -24,6 +24,7 @@ namespace Npgsql.Tests.Replication
     // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.TextReplicationDataMode, TransactionMode.NonStreamingTransactionMode)]
     // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.BinaryReplicationDataMode, TransactionMode.DefaultTransactionMode)]
     // [TestFixture(ProtocolVersion.V2, ReplicationDataMode.BinaryReplicationDataMode, TransactionMode.StreamingTransactionMode)]
+    [Platform(Exclude = "MacOsX", Reason = "Replication tests are flaky in CI on Mac")]
     public class PgOutputReplicationTests : SafeReplicationTestBase<LogicalReplicationConnection>
     {
         readonly ulong _protocolVersion;
@@ -304,7 +305,7 @@ namespace Npgsql.Tests.Replication
                 });
 
         [Test(Description = "Tests whether DELETE commands get replicated as Logical Replication Protocol Messages for tables using the default replica identity")]
-        public  Task Delete_for_default_replica_identity()
+        public Task Delete_for_default_replica_identity()
             => SafeReplicationTest(
                 async (slotName, tableName, publicationName) =>
                 {

--- a/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/TestDecodingReplicationTests.cs
@@ -13,6 +13,7 @@ namespace Npgsql.Tests.Replication
     /// implementation of logical replication was still somewhat incomplete.
     /// Please don't change them without confirming that they still work on those old versions.
     /// </summary>
+    [Platform(Exclude = "MacOsX", Reason = "Replication tests are flaky in CI on Mac")]
     public class TestDecodingReplicationTests : SafeReplicationTestBase<LogicalReplicationConnection>
     {
         [Test]


### PR DESCRIPTION
Because of flakiness, part of #4087

/cc @Brar
