### PR TITLE
Clean up timestamp logic in replication

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -687,7 +686,7 @@ namespace Npgsql.Replication
                 var lastReceivedLsn = Interlocked.Read(ref _lastReceivedLsn);
                 var lastFlushedLsn = Interlocked.Read(ref _lastFlushedLsn);
                 var lastAppliedLsn = Interlocked.Read(ref _lastAppliedLsn);
-                var timestamp = DateTime.Now;
+                var timestamp = DateTime.UtcNow;
                 buf.WriteInt64(lastReceivedLsn);
                 buf.WriteInt64(lastFlushedLsn);
                 buf.WriteInt64(lastAppliedLsn);


### PR DESCRIPTION
Note that there isn't really a bug here: Ticks returns the same value for UTC and local DateTime. This is only to make the code cleaner etc.

Closes #3952
