### PR TITLE
Allow flushing of NpgsqlReadBuffer.Stream

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -112,10 +112,14 @@ namespace Npgsql.Internal
             }
 
             public override void Flush()
-                => throw new NotSupportedException();
+                => CheckDisposed();
 
             public override Task FlushAsync(CancellationToken cancellationToken)
-                => throw new NotSupportedException();
+            {
+                CheckDisposed();
+                return cancellationToken.IsCancellationRequested
+                    ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
+            }
 
             public override int Read(byte[] buffer, int offset, int count)
             {

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1428,5 +1428,20 @@ $$;");
             Assert.That(data, Is.EquivalentTo((byte[])(await firstQuery)!));
             Assert.That(otherData, Is.EquivalentTo((byte[])(await secondQuery)!));
         }
+
+        [Test]
+        [IssueLink("https://github.com/npgsql/npgsql/issues/4123")]
+        public async Task Bug4123()
+        {
+            using var conn = OpenConnection();
+            using var cmd = new NpgsqlCommand("SELECT 1", conn);
+            using var rdr = await cmd.ExecuteReaderAsync();
+
+            await rdr.ReadAsync();
+            using var stream = await rdr.GetStreamAsync(0);
+
+            Assert.DoesNotThrowAsync(stream.FlushAsync);
+            Assert.DoesNotThrow(stream.Flush);
+        }
     }
 }


### PR DESCRIPTION
Changes the NpgsqlReadBuffer.Stream Flush to be nop to line up with the Stream.Flush{Async} documentation.

Fixes #4123