### PR TITLE
Benchmark insights and perf improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>7.0.0-preview.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+<!--    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest</AnalysisLevel>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1201,6 +1201,7 @@ namespace Npgsql.Internal
                 if (consumedButInFlight)
                 {
                     Interlocked.Decrement(ref CommandsInFlightCount);
+                    command!.ExecutionCompletion.RunContinuationsAsynchronously = true;
                     command!.ExecutionCompletion.SetException(_breakReason!);
                 }
                 
@@ -1212,6 +1213,7 @@ namespace Npgsql.Internal
 
                         // TODO: the exception we have here is sometimes just the result of the write loop breaking
                         // the connector, so it doesn't represent the actual root cause.
+                        pendingCommand.ExecutionCompletion.RunContinuationsAsynchronously = true;
                         pendingCommand.ExecutionCompletion.SetException(_breakReason!);
                     }
                 }

--- a/src/Npgsql/MultiplexingConnectorPool.cs
+++ b/src/Npgsql/MultiplexingConnectorPool.cs
@@ -65,7 +65,8 @@ namespace Npgsql
                 new BoundedChannelOptions(MultiplexingCommandChannelBound)
                 {
                     FullMode = BoundedChannelFullMode.Wait,
-                    SingleReader = false
+                    SingleReader = false,
+                    AllowSynchronousContinuations = true
                 });
             _multiplexCommandReader = multiplexCommandChannel.Reader;
             MultiplexCommandWriter = multiplexCommandChannel.Writer;

--- a/src/Npgsql/MultiplexingConnectorPool.cs
+++ b/src/Npgsql/MultiplexingConnectorPool.cs
@@ -173,7 +173,7 @@ namespace Npgsql
                         var minInFlight = int.MaxValue;
                         foreach (var c in Connectors)
                         {
-                            if (c?.MultiplexAsyncWritingLock == 0 && c.CommandsInFlightCount < minInFlight)
+                            if (c?.MultiplexAsyncWritingLock == 0 && c.CommandsInFlightCount > 0 && c.CommandsInFlightCount < minInFlight)
                             {
                                 minInFlight = c.CommandsInFlightCount;
                                 connector = c;

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -7,7 +7,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json, which is
          necessary for older TFMs. -->
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1267,7 +1267,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
         // TODO: Maybe pool these?
         internal ManualResetValueTaskSource<NpgsqlConnector> ExecutionCompletion { get; }
-            = new() { RunContinuationsAsynchronously = true, GlobalAsync = false };
+            = new() { RunContinuationsAsynchronously = false, GlobalAsync = false };
 
         internal async ValueTask<NpgsqlDataReader> ExecuteReader(CommandBehavior behavior, bool async, CancellationToken cancellationToken)
         {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -207,8 +207,7 @@ namespace Npgsql
         {
             // This is an optimized execution path that avoids calling any async methods for the (usual)
             // case where the next row (or CommandComplete) is already in memory.
-
-            if (_behavior.HasFlag(CommandBehavior.SingleRow))
+            if (_behavior.HasFlag(CommandBehavior.SingleRow) && (State == ReaderState.InResult || StatementIndex > 0))
                 return null;
 
             switch (State)

--- a/src/Npgsql/ThrowHelper.cs
+++ b/src/Npgsql/ThrowHelper.cs
@@ -37,5 +37,8 @@ namespace Npgsql
         [DoesNotReturn]
         internal static void ThrowInvalidOperationException_BinaryImportParametersMismatch(int columnCount, int valueCount) =>
             throw new InvalidOperationException($"The binary import operation was started with {columnCount} column(s), but {valueCount} value(s) were provided.");
+
+        public static void ThrowInvalidOperationException() => 
+            throw new InvalidOperationException();
     }
 }

--- a/src/Npgsql/Util/ManualResetValueTaskSource.cs
+++ b/src/Npgsql/Util/ManualResetValueTaskSource.cs
@@ -178,14 +178,14 @@ namespace Npgsql.Util
                             case null:
                                 ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: !GlobalAsync);
 
-                                //         if (_executionContext != null)
-                                //         {
-                                //             ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: false);
-                                //         }
-                                //         else
-                                //         {
-                                //             ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: false);
-                                //         }
+                                // if (_executionContext != null)
+                                // {
+                                //     ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: !GlobalAsync);
+                                // }
+                                // else
+                                // {
+                                //     ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: !GlobalAsync);
+                                // }
                                 break;
                             //
                             case SynchronizationContext sc:

--- a/src/Npgsql/Util/ManualResetValueTaskSource.cs
+++ b/src/Npgsql/Util/ManualResetValueTaskSource.cs
@@ -1,19 +1,432 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
+using Npgsql.Internal;
 
 namespace Npgsql.Util
 {
-    sealed class ManualResetValueTaskSource<T> : IValueTaskSource<T>, IValueTaskSource
+    sealed class ManualResetValueTaskSource<TResult> : IValueTaskSource<TResult>, IValueTaskSource
     {
-        ManualResetValueTaskSourceCore<T> _core; // mutable struct; do not make this readonly
+        
+        
+        [StructLayout(LayoutKind.Auto)]
+        public struct ManualResetValueTaskSourceCore
+        {
+            /// <summary>
+            /// The callback to invoke when the operation completes if <see cref="OnCompleted"/> was called before the operation completed,
+            /// or <see cref="ManualResetValueTaskSourceCoreShared.s_sentinel"/> if the operation completed before a callback was supplied,
+            /// or null if a callback hasn't yet been provided and the operation hasn't yet completed.
+            /// </summary>
+            Action<object?>? _continuation;
+            /// <summary>State to pass to <see cref="_continuation"/>.</summary>
+            object? _continuationState;
+            /// <summary><see cref="ExecutionContext"/> to flow to the callback, or null if no flowing is required.</summary>
+            ExecutionContext? _executionContext;
+            /// <summary>
+            /// A "captured" <see cref="SynchronizationContext"/> or <see cref="TaskScheduler"/> with which to invoke the callback,
+            /// or null if no special context is required.
+            /// </summary>
+            object? _capturedContext;
+            /// <summary>Whether the current operation has completed.</summary>
+            bool _completed;
+            /// <summary>The result with which the operation succeeded, or the default value if it hasn't yet completed or failed.</summary>
+            TResult? _result;
+            /// <summary>The exception with which the operation failed, or null if it hasn't yet completed or completed successfully.</summary>
+            ExceptionDispatchInfo? _error;
+            /// <summary>The current version of this value, used to help prevent misuse.</summary>
+            short _version;
 
+            /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
+            /// <remarks>Continuations may run asynchronously if this is false, but they'll never run synchronously if this is true.</remarks>
+            public bool RunContinuationsAsynchronously { get; set; }
+
+            public bool GlobalAsync { get; set; }
+            
+            /// <summary>Resets to prepare for the next operation.</summary>
+            public void Reset()
+            {
+                // Reset/update state for the next use/await of this instance.
+                _version++;
+                _completed = false;
+                _result = default;
+                _error = null;
+                _executionContext = null;
+                _capturedContext = null;
+                _continuation = null;
+                _continuationState = null;
+            }
+
+            /// <summary>Completes with a successful result.</summary>
+            /// <param name="result">The result.</param>
+            public void SetResult(TResult result)
+            {
+                _result = result;
+                SignalCompletion();
+            }
+
+            /// <summary>Completes with an error.</summary>
+            /// <param name="error">The exception.</param>
+            public void SetException(Exception error)
+            {
+                _error = ExceptionDispatchInfo.Capture(error);
+                SignalCompletion();
+            }
+
+            /// <summary>Gets the operation version.</summary>
+            public short Version => _version;
+
+            /// <summary>Gets the status of the operation.</summary>
+            /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                // ValidateToken(token);
+                return 
+                    _continuation == null || !_completed ? ValueTaskSourceStatus.Pending :
+                    _error == null ? ValueTaskSourceStatus.Succeeded :
+                    _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
+                    ValueTaskSourceStatus.Faulted;
+            }
+
+            /// <summary>Gets the result of the operation.</summary>
+            /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+            // [StackTraceHidden]
+            public TResult GetResult(short token)
+            {
+                if (!_completed || _error is not null)
+                {
+                    ThrowForFailedGetResult(token);
+                }
+
+                return _result!;
+            }
+
+            // [StackTraceHidden]
+            void ThrowForFailedGetResult(short token)
+            {
+                if (token != _version || !_completed)
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
+                }
+
+                _error?.Throw();
+                Debug.Fail($"{nameof(ThrowForFailedGetResult)} should never get here");
+            }
+
+            /// <summary>Schedules the continuation action for this operation.</summary>
+            /// <param name="continuation">The continuation to invoke when the operation has completed.</param>
+            /// <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+            /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+            /// <param name="flags">The flags describing the behavior of the continuation.</param>
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                // if (continuation == null)
+                // {
+                //     throw new ArgumentNullException(nameof(continuation));
+                // }
+                // ValidateToken(token);
+                //
+                // if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) != 0)
+                // {
+                //     _executionContext = ExecutionContext.Capture();
+                // }
+                //
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) != 0)
+                {
+                    var sc = SynchronizationContext.Current;
+                    if (sc != null && sc.GetType() != typeof(SynchronizationContext))
+                    {
+                        _capturedContext = sc;
+                    }
+                    else
+                    {
+                        var ts = TaskScheduler.Current;
+                        if (ts != TaskScheduler.Default)
+                        {
+                            _capturedContext = ts;
+                        }
+                    }
+                }
+
+                // We need to set the continuation state before we swap in the delegate, so that
+                // if there's a race between this and SetResult/Exception and SetResult/Exception
+                // sees the _continuation as non-null, it'll be able to invoke it with the state
+                // stored here.  However, this also means that if this is used incorrectly (e.g.
+                // awaited twice concurrently), _continuationState might get erroneously overwritten.
+                // To minimize the chances of that, we check preemptively whether _continuation
+                // is already set to something other than the completion sentinel.
+
+                object? oldContinuation = _continuation;
+                if (oldContinuation == null)
+                {
+                    _continuationState = state;
+                    oldContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
+                }
+
+                if (oldContinuation != null)
+                {
+                    // Operation already completed, so we need to queue the supplied callback.
+                    if (!ReferenceEquals(oldContinuation, ManualResetValueTaskSourceCoreShared.s_sentinel))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException();
+                    }
+
+                    if (RunContinuationsAsynchronously)
+                    {
+                        switch (_capturedContext)
+                        {
+                            case null:
+                                ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: !GlobalAsync);
+
+                                //         if (_executionContext != null)
+                                //         {
+                                //             ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: false);
+                                //         }
+                                //         else
+                                //         {
+                                //             ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: false);
+                                //         }
+                                break;
+                            //
+                            case SynchronizationContext sc:
+                                sc.Post(static s =>
+                                {
+                                    var tuple = (Tuple<Action<object?>, object?>) s!;
+                                    tuple.Item1(tuple.Item2);
+                                }, new Tuple<Action<object?>, object?>(continuation, state));
+                                break;
+                            //
+                            //     case TaskScheduler ts:
+                            //         Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                            //         break;
+                            // }
+
+                        }
+                    }
+                    else
+                        // TODO this needs a stack guard
+                        continuation(state);
+
+                    //
+                    // switch (_capturedContext)
+                    // {
+                    //     case null:
+                    //         if (_executionContext != null)
+                    //         {
+                    //             ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: false);
+                    //         }
+                    //         else
+                    //         {
+                    //             ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: false);
+                    //         }
+                    //         break;
+                    //
+                    //     case SynchronizationContext sc:
+                    //         sc.Post(static s =>
+                    //         {
+                    //             var tuple = (Tuple<Action<object?>, object?>)s!;
+                    //             tuple.Item1(tuple.Item2);
+                    //         }, new Tuple<Action<object?>, object?>(continuation, state));
+                    //         break;
+                    //
+                    //     case TaskScheduler ts:
+                    //         Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                    //         break;
+                    // }
+                }
+            }
+            
+            
+
+            /// <summary>Ensures that the specified token matches the current version.</summary>
+            /// <param name="token">The token supplied by <see cref="ValueTask"/>.</param>
+            void ValidateToken(short token)
+            {
+                if (token != _version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
+                }
+            }
+
+            /// <summary>Signals that the operation has completed.  Invoked after the result or error has been set.</summary>
+            void SignalCompletion()
+            {
+                if (_completed)
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
+                }
+                _completed = true;
+
+                if (_continuation is null && Interlocked.CompareExchange(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel, null) is null)
+                {
+                    return;
+                }
+
+                if (RunContinuationsAsynchronously)
+                {
+                    if (_capturedContext is null)
+                    {
+                        ThreadPool.UnsafeQueueUserWorkItem(_continuation, _continuationState, preferLocal: !GlobalAsync);
+                    }
+                    else
+                    {
+                        // Console.WriteLine("exec on sc");
+                        InvokeSchedulerContinuation();
+                    }
+                }
+                else
+                {
+                    _continuation(_continuationState);
+                }
+                
+                
+                // if (_executionContext is null)
+                // {
+                //     if (_capturedContext is null)
+                //     {
+
+                //     }
+                //     else
+                //     {
+                //         InvokeSchedulerContinuation();
+                //     }
+                // }
+                // else
+                // {
+                //     InvokeContinuationWithContext();
+                // }
+            }
+
+            void InvokeContinuationWithContext()
+            {
+                // This is in a helper as the error handling causes the generated asm
+                // for the surrounding code to become less efficent (stack spills etc)
+                // and it is an uncommon path.
+
+                Debug.Assert(_continuation != null, $"Null {nameof(_continuation)}");
+                Debug.Assert(_executionContext != null, $"Null {nameof(_executionContext)}");
+
+                // May be null if flow is suppressed, see next block.
+                var currentContext = ExecutionContext.Capture()!;
+                
+                if (ExecutionContext.IsFlowSuppressed())
+                {
+                    ExecutionContext.RestoreFlow();
+                    currentContext = ExecutionContext.Capture()!;
+                    ExecutionContext.SuppressFlow();
+                }
+
+                // Restore the captured ExecutionContext before executing anything.
+                ExecutionContext.Restore(_executionContext);
+
+                if (_capturedContext is null)
+                {
+                    if (RunContinuationsAsynchronously)
+                    {
+                        try
+                        {
+                            ThreadPool.QueueUserWorkItem(_continuation, _continuationState, preferLocal: !GlobalAsync);
+                        }
+                        finally
+                        {
+                            // Restore the current ExecutionContext.
+                            ExecutionContext.Restore(currentContext);
+                        }
+                    }
+                    else
+                    {
+                        // Running inline may throw; capture the edi if it does as we changed the ExecutionContext,
+                        // so need to restore it back before propagating the throw.
+                        ExceptionDispatchInfo? edi = null;
+                        var syncContext = SynchronizationContext.Current;
+                        try
+                        {
+                            _continuation(_continuationState);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Note: we have a "catch" rather than a "finally" because we want
+                            // to stop the first pass of EH here.  That way we can restore the previous
+                            // context before any of our callers' EH filters run.
+                            edi = ExceptionDispatchInfo.Capture(ex);
+                        }
+                        finally
+                        {
+                            // Set sync context back to what it was prior to coming in
+                            SynchronizationContext.SetSynchronizationContext(syncContext);
+                            // Restore the current ExecutionContext.
+                            ExecutionContext.Restore(currentContext);
+                        }
+
+                        // Now rethrow the exception; if there is one.
+                        edi?.Throw();
+                    }
+
+                    return;
+                }
+
+                try
+                {
+                    InvokeSchedulerContinuation();
+                }
+                finally
+                {
+                    // Restore the current ExecutionContext.
+                    ExecutionContext.Restore(currentContext);
+                }
+            }
+
+            /// <summary>
+            /// Invokes the continuation with the appropriate scheduler.
+            /// This assumes that if <see cref="_continuation"/> is not null we're already
+            /// running within that <see cref="ExecutionContext"/>.
+            /// </summary>
+            void InvokeSchedulerContinuation()
+            {
+                Debug.Assert(_capturedContext != null, $"Null {nameof(_capturedContext)}");
+                Debug.Assert(_continuation != null, $"Null {nameof(_continuation)}");
+
+                switch (_capturedContext)
+                {
+                    case SynchronizationContext sc:
+                        sc.Post(static s =>
+                        {
+                            var state = (Tuple<Action<object?>, object?>)s!;
+                            state.Item1(state.Item2);
+                        }, new Tuple<Action<object?>, object?>(_continuation, _continuationState));
+                        break;
+
+                    case TaskScheduler ts:
+                        Task.Factory.StartNew(_continuation, _continuationState, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                        break;
+                }
+            }
+        }
+
+        internal static class ManualResetValueTaskSourceCoreShared // separated out of generic to avoid unnecessary duplication
+        {
+            internal static readonly Action<object?> s_sentinel = CompletionSentinel;
+            static void CompletionSentinel(object? _) // named method to aid debugging
+            {
+                Debug.Fail("The sentinel delegate should never be invoked.");
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+        }
+    
+        ManualResetValueTaskSourceCore _core;
+        
+        public bool GlobalAsync { get => _core.GlobalAsync; set => _core.GlobalAsync = value; }
+        
         public bool RunContinuationsAsynchronously { get => _core.RunContinuationsAsynchronously; set => _core.RunContinuationsAsynchronously = value; }
         public short Version => _core.Version;
         public void Reset() => _core.Reset();
-        public void SetResult(T result) => _core.SetResult(result);
+        public void SetResult(TResult result) => _core.SetResult(result);
         public void SetException(Exception error) => _core.SetException(error);
 
-        public T GetResult(short token) => _core.GetResult(token);
+        public TResult GetResult(short token) => _core.GetResult(token);
         void IValueTaskSource.GetResult(short token) => _core.GetResult(token);
         public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
         public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)

--- a/src/Npgsql/Util/ManualResetValueTaskSource.cs
+++ b/src/Npgsql/Util/ManualResetValueTaskSource.cs
@@ -5,14 +5,11 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
-using Npgsql.Internal;
 
 namespace Npgsql.Util
 {
     sealed class ManualResetValueTaskSource<TResult> : IValueTaskSource<TResult>, IValueTaskSource
     {
-        
-        
         [StructLayout(LayoutKind.Auto)]
         public struct ManualResetValueTaskSourceCore
         {
@@ -406,16 +403,6 @@ namespace Npgsql.Util
             }
         }
 
-        internal static class ManualResetValueTaskSourceCoreShared // separated out of generic to avoid unnecessary duplication
-        {
-            internal static readonly Action<object?> s_sentinel = CompletionSentinel;
-            static void CompletionSentinel(object? _) // named method to aid debugging
-            {
-                Debug.Fail("The sentinel delegate should never be invoked.");
-                ThrowHelper.ThrowInvalidOperationException();
-            }
-        }
-    
         ManualResetValueTaskSourceCore _core;
         
         public bool GlobalAsync { get => _core.GlobalAsync; set => _core.GlobalAsync = value; }
@@ -432,4 +419,15 @@ namespace Npgsql.Util
         public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
             => _core.OnCompleted(continuation, state, token, flags);
     }
+    
+    static class ManualResetValueTaskSourceCoreShared // separated out of generic to avoid unnecessary duplication
+    {
+        internal static readonly Action<object?> s_sentinel = CompletionSentinel;
+        static void CompletionSentinel(object? _) // named method to aid debugging
+        {
+            Debug.Fail("The sentinel delegate should never be invoked.");
+            ThrowHelper.ThrowInvalidOperationException();
+        }
+    }
+
 }


### PR DESCRIPTION
Draft PR to discuss some of the changes motivated by benchmarking. 

Specifically the first commit really helped perf a lot. There are two sides to that as I see it. 

Firstly being the updates of CommandInFlight to be per command completed. Additionally to being more accurate, we're updating more often than per 'loop batch' (which can cause some issues around unbalanced query loads) we have lower chances to end up idle in the pool while there could have been more work added. 

Given a connector with a load like this - in the old situation - you could have: 
- In flight == 10, highest of all connectors, no longer picked.
- We're at 8 commands completed.
- Query 9 is somewhat slow or has a large resultset.
- Multiplexing is still skipping this connector even though its socket could have easily written a lot more.
- At some point we're done and back at 0 in flight and the connection would be completely idle on both ends, wasted time. 

Say after this multiplexing is still scheduling in overcapacity mode and it picks this connector because it's a desirable connector again. Now depending on timing we could be racing between pool return and command scheduling. If so then that's another iteration of delay to (likely) get exactly that connector, but now as idle from the pool. All this behavior is improved by the more granular updates of the in flight count (especially with the second commit included, improving 0 to 1 behavior is most useful in scenarios when loads fluctuate).

Secondly, on the read side I've moved the request for more data (ReadBuffer.Ensure) inline to the thread doing the previous reader.Dispose, though making sure to await it only after a yield. This had a huge difference locally (something like an additional 7% RPS or so). To me that really shows we're not reading fast enough... (and we may actually be stalling PG too much!). I can see how this may be a bit more debatable so I'm happy to hear any thoughts!

Any other improvements I'll add to this PR or the benchmark PR over here https://github.com/aspnet/Benchmarks/pull/1710

Fyi, it's an npgsql branch so push away!