### PR TITLE
Set PostgresException.BatchCommand for legacy batching

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -70,7 +70,7 @@ public sealed class NpgsqlCommand : DbCommand, ICloneable, IComponent
     /// <summary>
     /// Whether this command is cached by <see cref="NpgsqlConnection" /> and returned by <see cref="NpgsqlConnection.CreateCommand" />.
     /// </summary>
-    bool _isCached;
+    internal bool IsCached { get; set; }
 
 #if DEBUG
     internal static bool EnableSqlRewriting;
@@ -162,7 +162,7 @@ public sealed class NpgsqlCommand : DbCommand, ICloneable, IComponent
         => _connector = connector;
 
     internal static NpgsqlCommand CreateCachedCommand(NpgsqlConnection connection)
-        => new(null, connection) { _isCached = true };
+        => new(null, connection) { IsCached = true };
 
     #endregion Constructors
 
@@ -1533,7 +1533,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
     {
         Transaction = null;
 
-        if (_isCached && _connection is not null && _connection.CachedCommand is null)
+        if (IsCached && _connection is not null && _connection.CachedCommand is null)
         {
             // TODO: Optimize NpgsqlParameterCollection to recycle NpgsqlParameter instances as well
             // TODO: Statements isn't cleared/recycled, leaving this for now, since it'll be replaced by the new batching API
@@ -1546,7 +1546,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             return;
         }
 
-        _isCached = false;
+        IsCached = false;
         State = CommandState.Disposed;
     }
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -504,12 +504,18 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         {
             State = ReaderState.Consumed;
 
-            // Reference the triggering statement from the exception (for batching)
-            if (e is PostgresException postgresException &&
-                Command.IsWrappedByBatch &&
-                StatementIndex >= 0 && StatementIndex < _statements.Count)
+            // Reference the triggering statement from the exception
+            if (e is PostgresException postgresException && StatementIndex >= 0 && StatementIndex < _statements.Count)
             {
                 postgresException.BatchCommand = _statements[StatementIndex];
+
+                // Prevent the command or batch from by recycled (by the connection) when it's disposed. This is important since
+                // the exception is very likely to escape the using statement of the command, and by that time some other user may
+                // already be using the recycled instance.
+                if (!Command.IsWrappedByBatch)
+                {
+                    Command.IsCached = false;
+                }
             }
 
             // An error means all subsequent statements were skipped by PostgreSQL.


### PR DESCRIPTION
Closes #4222

Note we don't yet recycle NpgsqlBatch (#4224), but I added the test coverage here.