### PR TITLE
Move parameter collection to case-insenstive matching

### DIFF
--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -35,8 +35,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected  object? _value;
     private protected  string _sourceColumn;
 
-    internal string TrimmedName { get; private protected set; } = string.Empty;
-
+    internal string TrimmedName { get; private protected set; } = PositionalName;
+    internal const string PositionalName = ""; 
+        
     /// <summary>
     /// Can be used to communicate a value from the validation phase to the writing phase.
     /// To be used by type handlers only.
@@ -246,18 +247,21 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         get => _name;
         set
         {
-            var oldName = _name;
-            var oldTrimmedName = TrimmedName;
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (value == null)
-                _name = TrimmedName = string.Empty;
-            else if (value.Length > 0 && (value[0] == ':' || value[0] == '@'))
-                TrimmedName = (_name = value).Substring(1);
-            else
-                _name = TrimmedName = value;
-
-            Collection?.ChangeParameterName(this, oldName, oldTrimmedName);
+            if (Collection is not null)
+                Collection.ChangeParameterName(this, value);
+            else 
+                ChangeParameterName(value);
         }
+    }
+
+    internal void ChangeParameterName(string? value)
+    {
+        if (value == null)
+            _name = TrimmedName = PositionalName;
+        else if (value.Length > 0 && (value[0] == ':' || value[0] == '@'))
+            TrimmedName = (_name = value).Substring(1);
+        else
+            _name = TrimmedName = value;
     }
 
     internal bool IsPositional => ParameterName.Length == 0;

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -53,7 +53,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
         if (TwoPassCompatMode && !_caseSensitiveLookup!.ContainsKey(name))
             _caseSensitiveLookup[name] = index;
-        
+
         if (!_caseInsensitiveLookup.ContainsKey(name))
             _caseInsensitiveLookup[name] = index;
     }
@@ -73,7 +73,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
             }
             _caseSensitiveLookup[name] = index;
         }
-            
+
         if (!_caseInsensitiveLookup.TryGetValue(name, out var indexCi) || index < indexCi)
         {
             foreach (var kv in _caseInsensitiveLookup)
@@ -106,7 +106,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
                 if (index < kv.Value)
                     _caseInsensitiveLookup[kv.Key] = kv.Value - 1;
             }
-            
+
             // Fix-up the case-insensitive lookup to point to the next match, if any.
             for (var i = 0; i < InternalList.Count; i++)
             {
@@ -117,7 +117,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
                     break;
                 }
             }
-        }        
+        }
 
     }
 
@@ -137,7 +137,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
         var oldName = parameter.ParameterName;
         var oldTrimmedName = parameter.TrimmedName;
         parameter.ChangeParameterName(value);
-            
+
         if (_caseInsensitiveLookup is null || _caseInsensitiveLookup.Count == 0)
             return;
 
@@ -183,7 +183,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
             if (!string.Equals(parameterName, value.TrimmedName, StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentException("Parameter name must be a case-insensitive match with the property 'ParameterName' on the given NpgsqlParameter", nameof(parameterName));
-                
+
             var oldValue = InternalList[index];
             LookupChangeName(value, oldValue.ParameterName, oldValue.TrimmedName, index);
 
@@ -205,7 +205,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
                 throw new ArgumentNullException(nameof(value));
             if (value.Collection is not null)
                 throw new InvalidOperationException("The parameter already belongs to a collection");
-                
+
             var oldValue = InternalList[index];
 
             if (ReferenceEquals(oldValue, value))
@@ -230,7 +230,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
             throw new ArgumentNullException(nameof(value));
         if (value.Collection is not null)
             throw new InvalidOperationException("The parameter already belongs to a collection");
-            
+
         InternalList.Add(value);
         value.Collection = this;
         if (!value.IsPositional)
@@ -368,7 +368,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
             if (TwoPassCompatMode && _caseSensitiveLookup!.TryGetValue(parameterName, out var indexCs))
                 return indexCs;
-                
+
             if (_caseInsensitiveLookup!.TryGetValue(parameterName, out var indexCi))
                 return indexCi;
 
@@ -400,7 +400,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
         {
             if (TwoPassCompatMode)
                 _caseSensitiveLookup = new Dictionary<string, int>(InternalList.Count, StringComparer.Ordinal);
-                
+
             _caseInsensitiveLookup = new Dictionary<string, int>(InternalList.Count, StringComparer.OrdinalIgnoreCase);
 
             for (var i = 0; i < InternalList.Count; i++)
@@ -598,7 +598,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
             throw new ArgumentNullException(nameof(item));
         if (item.Collection != null)
             throw new Exception("The parameter already belongs to a collection");
-            
+
         InternalList.Insert(index, item);
         item.Collection = this;
         if (!item.IsPositional)

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -662,7 +662,13 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
             newParam.Collection = this;
             other.InternalList.Add(newParam);
         }
-        other._caseInsensitiveLookup = _caseInsensitiveLookup;
+
+        if (LookupEnabled)
+        {
+            other._caseInsensitiveLookup = new Dictionary<string, int>(_caseInsensitiveLookup!, StringComparer.OrdinalIgnoreCase);
+            if (TwoPassCompatMode)
+                other._caseSensitiveLookup = new Dictionary<string, int>(_caseSensitiveLookup!, StringComparer.Ordinal);    
+        }
     }
 
     internal void ValidateAndBind(ConnectorTypeMapper typeMapper)

--- a/test/Npgsql.Tests/NpgsqlParameterCollectionTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterCollectionTests.cs
@@ -174,11 +174,8 @@ public class NpgsqlParameterCollectionTests
     }
 
     [Test]
-    public void One_pass_finds_case_insensitive_lookups([Values(LookupThreshold, LookupThreshold - 2)] int count)
+    public void Finds_case_insensitive_lookups([Values(LookupThreshold, LookupThreshold - 2)] int count)
     {
-        if (_compatMode == CompatMode.TwoPass)
-            return;
-
         using var command = new NpgsqlCommand();
         var parameters = command.Parameters;
         for (var i = 0; i < count; i++)
@@ -188,11 +185,8 @@ public class NpgsqlParameterCollectionTests
     }
 
     [Test]
-    public void One_pass_finds_case_sensitive_lookups([Values(LookupThreshold, LookupThreshold - 2)] int count)
+    public void Finds_case_sensitive_lookups([Values(LookupThreshold, LookupThreshold - 2)] int count)
     {
-        if (_compatMode == CompatMode.TwoPass)
-            return;
-
         using var command = new NpgsqlCommand();
         var parameters = command.Parameters;
         for (var i = 0; i < count; i++)

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -62,6 +62,16 @@ public class NpgsqlParameterTest : TestBase
     }
 
     [Test]
+    public void Positional_parameter_is_positional()
+    {
+        var p = new NpgsqlParameter(NpgsqlParameter.PositionalName, 1);
+        Assert.That(p.IsPositional, Is.True);
+
+        var p2 = new NpgsqlParameter(null, 1);
+        Assert.That(p2.IsPositional, Is.True);
+    }
+
+    [Test]
     public void Infer_data_type_name_from_NpgsqlDbType()
     {
         var p = new NpgsqlParameter("par_field1", NpgsqlDbType.Varchar, 50);


### PR DESCRIPTION
As discussed.

Effectively two pass vs one pass matching now comes down to failing or succeeding the  `IndexOf_falls_back_to_first_insensitive_match` test.