### PR TITLE
Fix timestamp in trace logging message

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -700,7 +700,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
                           $"{nameof(LastReceivedLsn)} of {new NpgsqlLogSequenceNumber(unchecked((ulong)lastReceivedLsn))}, " +
                           $"{nameof(LastFlushedLsn)} of {new NpgsqlLogSequenceNumber(unchecked((ulong)lastFlushedLsn))}, " +
                           $"{nameof(LastAppliedLsn)} of {new NpgsqlLogSequenceNumber(unchecked((ulong)lastAppliedLsn))} " +
-                          $"at {timestamp}, .", Connector.Id);
+                          $"at {timestamp.ToLocalTime()}, .", Connector.Id);
             }
         }
         finally

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -143,7 +143,7 @@ public class PgOutputReplicationTests : SafeReplicationTestBase<LogicalReplicati
                 insertMsg = await NextMessage<InsertMessage>(messages);
                 Assert.That(insertMsg.TransactionXid, IsStreaming ? Is.EqualTo(transactionXid) : Is.Null);
                 Assert.That(insertMsg.Relation, Is.SameAs(relationMsg));
-                await foreach(var tuple in insertMsg.NewRow) // Don't consume the value to trigger eventual bugs
+                await foreach (var tuple in insertMsg.NewRow) // Don't consume the value to trigger eventual bugs
                     Assert.That(tuple.Kind, IsBinary ? Is.EqualTo(TupleDataKind.BinaryValue) : Is.EqualTo(TupleDataKind.TextValue));
 
                 // Remaining inserts


### PR DESCRIPTION
Since we trace log the local timestamp when we receive a primary
keepalive streaming replication message we should also do so when
we send a keepalive. Otherwise the timestamps that appear next to
eachother in the trace log will be offset in non GMT time zones.

Also fix a minor whitespace.