### PR TITLE
Allow setting serialized ConvertedValue for JSON objects

### DIFF
--- a/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
@@ -65,7 +65,10 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             if (lengthCache.IsPopulated)
                 return lengthCache.Get();
 
-            var data = SerializeJsonDocument((JsonDocument)(object)value!);
+            var data = parameter?.ConvertedValue != null
+                ? (byte[])parameter.ConvertedValue
+                : SerializeJsonDocument((JsonDocument)(object)value!);
+
             if (parameter != null)
                 parameter.ConvertedValue = data;
             return lengthCache.Set(data.Length + _headerLen);


### PR DESCRIPTION
Today when adding a json parameter in queries, the serialized json document in bytes gets copied multiple times. One time in `JsonHandler.SerializeJsonDocument` when writing the byte array, which is then copied once the function returns. If this function gets called frequently with large documents, blocks will become allocated on LOH which is far from ideal in high performance critical application. 

This change allows me to use strategies such as buffer pooling when building the JSON object, for example:
```csharp
var document = JsonSerializer.SerializeToDocument(obj);
var documentBytes = SerializeToBytes(document);

... 

new NpgsqlParameter("document", NpgsqlDbType.Jsonb)
{
    Value = document,
    ConvertedValue = documentBytes
}
```

The function `SerializeToBytes` can then use for example a [RecyclableMemoryStream](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream) to re-use the memory being used for sending the documents.

Related to the discussion here: https://github.com/npgsql/npgsql/issues/1727