### PR TITLE
Allow specifying ReadOnlySequence<byte> for JSON documents to avoid temporairly memory allocations

### DIFF
--- a/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
@@ -86,13 +86,9 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             {
                 return (int)sequence.Length;
             }
-            else if (parameter.ConvertedValue is byte[] byteParam)
-            {
-                return byteParam.Length;
-            }
             else
             {
-                throw new Exception($"Unknown type {value.GetType().FullName}");
+                return ((byte[])parameter.ConvertedValue).Length;
             }
         }
         var serializedBytes = SerializeJsonDocument((JsonDocument)value);
@@ -138,13 +134,9 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
                         buf.DirectWrite(segment.Span);
                     }
                 }
-                else if (parameter.ConvertedValue is byte[] bytes)
-                {
-                    await buf.WriteBytesRaw(bytes, async, cancellationToken);
-                }
                 else
                 {
-                    throw new Exception($"Unknown type {parameter.ConvertedValue.GetType().FullName}");
+                    await buf.WriteBytesRaw((byte[])parameter.ConvertedValue, async, cancellationToken);
                 }
             }
             else


### PR DESCRIPTION
This is the change in https://github.com/npgsql/npgsql/pull/4248 taken one step further which allows me to specify the JSONDocument as ReadOnlySequence<byte> instead of a byte[]. I can then insert many documents without any pressure on the GC:
```csharp
foreach (var document in documents)
{
    using var stream = (RecyclableMemoryStream)RecyclableMemoryStreamManager.GetStream();

    if (utf8JsonWriter == null)
        utf8JsonWriter = new Utf8JsonWriter((MemoryStream)stream);
    else
        utf8JsonWriter.Reset((MemoryStream)stream);

    jsonDocument.WriteTo(utf8JsonWriter);
    utf8JsonWriter.Flush();

    var memory = stream.GetReadOnlySequence();

    using var cmd = new NpgsqlCommand("INSERT INTO mydocuments (id, document) VALUES (@document)", conn);
    cmd.Parameters.Add(new NpgsqlParameter("document", NpgsqlDbType.Jsonb)
    {
        Value = jsonDocument,
        ConvertedValue = memory
    });

    cmd.ExecuteNonQuery();
}
``` 

I am also discussing this implementation here: https://github.com/npgsql/npgsql/issues/1727#issuecomment-1001774788