### PR TITLE
Map specialized NodaTime range types by default

### DIFF
--- a/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
+++ b/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NodaTime;
 using Npgsql.Internal;
+using Npgsql.Internal.TypeHandlers;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
@@ -25,6 +26,11 @@ public class NodaTimeTypeHandlerResolver : TypeHandlerResolver
     DateMultirangeHandler? _dateMultirangeHandler;
     TimestampTzMultirangeHandler? _timestampTzMultirangeHandler;
 
+    NpgsqlTypeHandler? _timestampTzRangeArray;
+    NpgsqlTypeHandler? _dateRangeArray;
+
+    readonly ArrayNullabilityMode _arrayNullabilityMode;
+
     internal NodaTimeTypeHandlerResolver(NpgsqlConnector connector)
     {
         _databaseInfo = connector.DatabaseInfo;
@@ -42,6 +48,8 @@ public class NodaTimeTypeHandlerResolver : TypeHandlerResolver
 
         // Note that the range handlers are absent on some pseudo-PostgreSQL databases (e.g. CockroachDB), and multirange types
         // were only introduced in PG14. So we resolve these lazily.
+
+        _arrayNullabilityMode = connector.Settings.ArrayNullabilityMode;
     }
 
     public override NpgsqlTypeHandler? ResolveByDataTypeName(string typeName)
@@ -58,6 +66,9 @@ public class NodaTimeTypeHandlerResolver : TypeHandlerResolver
             "daterange" => DateRange(),
             "tstzmultirange" => TsTzMultirange(),
             "datemultirange" => DateMultirange(),
+
+            "tstzrange[]" => TsTzRangeArray(),
+            "daterange[]" => DateRangeArray(),
 
             _ => null
         };
@@ -206,4 +217,12 @@ public class NodaTimeTypeHandlerResolver : TypeHandlerResolver
 
     NpgsqlTypeHandler DateMultirange()
         => _dateMultirangeHandler ??= new DateMultirangeHandler((PostgresMultirangeType)PgType("datemultirange"), DateRange());
+
+    NpgsqlTypeHandler TsTzRangeArray()
+        => _timestampTzRangeArray ??=
+            new ArrayHandler<Interval>((PostgresArrayType)PgType("tstzrange[]"), TsTzRange(), _arrayNullabilityMode);
+
+    NpgsqlTypeHandler DateRangeArray()
+        => _dateRangeArray ??=
+            new ArrayHandler<DateInterval>((PostgresArrayType)PgType("daterange[]"), DateRange(), _arrayNullabilityMode);
 }

--- a/test/Npgsql.NodaTime.Tests/NodaTimeTests.cs
+++ b/test/Npgsql.NodaTime.Tests/NodaTimeTests.cs
@@ -336,6 +336,48 @@ public class NodaTimeTests : TestBase
             isDefaultForReading: false);
     }
 
+    [Test]
+    public async Task Tstzrange_array_as_array_of_Interval()
+    {
+        await using var conn = await OpenConnectionAsync();
+
+        await AssertType<Array>(
+            new[]
+            {
+                new Interval(
+                    new LocalDateTime(1998, 4, 12, 13, 26, 38).InUtc().ToInstant(),
+                    new LocalDateTime(1998, 4, 12, 15, 26, 38).InUtc().ToInstant()),
+                new Interval(
+                    new LocalDateTime(1998, 4, 13, 13, 26, 38).InUtc().ToInstant(),
+                    new LocalDateTime(1998, 4, 13, 15, 26, 38).InUtc().ToInstant()),
+            },
+            @"{""[\""1998-04-12 15:26:38+02\"",\""1998-04-12 17:26:38+02\"")"",""[\""1998-04-13 15:26:38+02\"",\""1998-04-13 17:26:38+02\"")""}",
+            "tstzrange[]",
+            NpgsqlDbType.TimestampTzRange | NpgsqlDbType.Array,
+            isDefaultForWriting: false);
+    }
+
+    [Test]
+    public async Task Tstzrange_array_as_array_of_NpgsqlRange_of_Instant()
+    {
+        await using var conn = await OpenConnectionAsync();
+
+        await AssertType(
+            new[]
+            {
+                new NpgsqlRange<Instant>(
+                    new LocalDateTime(1998, 4, 12, 13, 26, 38).InUtc().ToInstant(),
+                    new LocalDateTime(1998, 4, 12, 15, 26, 38).InUtc().ToInstant()),
+                new NpgsqlRange<Instant>(
+                    new LocalDateTime(1998, 4, 13, 13, 26, 38).InUtc().ToInstant(),
+                    new LocalDateTime(1998, 4, 13, 15, 26, 38).InUtc().ToInstant()),
+            },
+            @"{""[\""1998-04-12 15:26:38+02\"",\""1998-04-12 17:26:38+02\""]"",""[\""1998-04-13 15:26:38+02\"",\""1998-04-13 17:26:38+02\""]""}",
+            "tstzrange[]",
+            NpgsqlDbType.TimestampTzRange | NpgsqlDbType.Array,
+            isDefault: false);
+    }
+
     #endregion Timestamp with time zone
 
     #region Date
@@ -418,6 +460,40 @@ public class NodaTimeTests : TestBase
             NpgsqlDbType.DateRange,
             isDefaultForReading: false);
 #endif
+
+    [Test]
+    public async Task Daterange_array_as_array_of_DateInterval()
+    {
+        await using var conn = await OpenConnectionAsync();
+
+        await AssertType<Array>(
+            new[]
+            {
+                new DateInterval(new(2002, 3, 4), new(2002, 3, 5)),
+                new DateInterval(new(2002, 3, 8), new(2002, 3, 10))
+            },
+            @"{""[2002-03-04,2002-03-06)"",""[2002-03-08,2002-03-11)""}",
+            "daterange[]",
+            NpgsqlDbType.DateRange | NpgsqlDbType.Array,
+            isDefaultForWriting: false);
+    }
+
+    [Test]
+    public async Task Daterange_array_as_array_of_NpgsqlRange_of_LocalDate()
+    {
+        await using var conn = await OpenConnectionAsync();
+
+        await AssertType(
+            new[]
+            {
+                new NpgsqlRange<LocalDate>(new(2002, 3, 4), true, new(2002, 3, 6), false),
+                new NpgsqlRange<LocalDate>(new(2002, 3, 8), true, new(2002, 3, 11), false)
+            },
+            @"{""[2002-03-04,2002-03-06)"",""[2002-03-08,2002-03-11)""}",
+            "daterange[]",
+            NpgsqlDbType.DateRange | NpgsqlDbType.Array,
+            isDefault: false);
+    }
 
     #endregion Date
 


### PR DESCRIPTION
tstzrange[] -> Interval[] (instead of NpgsqlRange<Instant>[])
daterange[] -> DateInterval[] (instead of NpgsqlRange<LocalDate>[])

Fixes #4234
