### PR TITLE
Simplify implementation of ReplicationConnection.CreateReplicationSlot()

### DIFF
--- a/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
+++ b/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
@@ -92,7 +92,7 @@ public static class LogicalReplicationConnectionExtensions
             if (twoPhase)
                 builder.Append(" TWO_PHASE");
 
-            return connection.CreateReplicationSlot(builder.ToString(), isTemporary, cancellationToken);
+            return connection.CreateReplicationSlot(builder.ToString(), cancellationToken);
         }
     }
 

--- a/src/Npgsql/Replication/PhysicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/PhysicalReplicationConnection.cs
@@ -63,7 +63,7 @@ public sealed class PhysicalReplicationConnection : ReplicationConnection
             if (reserveWal)
                 builder.Append(" RESERVE_WAL");
 
-            var slotOptions = await CreateReplicationSlot(builder.ToString(), isTemporary, cancellationToken);
+            var slotOptions = await CreateReplicationSlot(builder.ToString(), cancellationToken);
 
             return new PhysicalReplicationSlot(slotOptions.SlotName);
         }


### PR DESCRIPTION
Also add an improved exception if the TWO_PHASE option is used on old
servers.