### PR TITLE
Add type loading for logical replication connections

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -113,9 +113,6 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
         => $@"
 SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid
 FROM (
-    -- Arrays have typtype=b - this subquery identifies them by their typreceive and converts their typtype to a
-    -- We first do this for the type (innerest-most subquery), and then for its element type
-    -- This also returns the array element, range subtype and domain base type as elemtypoid
     SELECT
         typ.oid, typ.typnamespace, typ.typname, typ.typtype, typ.typrelid, typ.typnotnull, typ.relkind,
         elemtyp.oid AS elemtypoid, elemtyp.typname AS elemtypname, elemcls.relkind AS elemrelkind,
@@ -140,27 +137,31 @@ FROM (
 ) AS t
 JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
 WHERE
-    typtype IN ('b', 'r', 'm', 'e', 'd') OR -- Base, range, multirange, enum, domain
-    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR -- User-defined free-standing composites (not table composites) by default
-    (typtype = 'p' AND typname IN ('record', 'void')) OR -- Some special supported pseudo-types
-    (typtype = 'a' AND (  -- Array of...
-        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR -- Array of base, range, multirange, enum, domain
-        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR -- Arrays of special supported pseudo-types
-        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")}) -- Array of user-defined free-standing composites (not table composites) by default
+    typtype IN ('b', 'r', 'm', 'e', 'd') OR
+    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR
+    (typtype = 'p' AND typname IN ('record', 'void')) OR
+    (typtype = 'a' AND (
+        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR
+        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR
+        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")})
     ))
 ORDER BY CASE
-       WHEN typtype IN ('b', 'e', 'p') THEN 0           -- First base types, enums, pseudo-types
-       WHEN typtype = 'r' THEN 1                        -- Ranges after
-       WHEN typtype = 'm' THEN 2                        -- Multiranges after
-       WHEN typtype = 'c' THEN 3                        -- Composites after
-       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4 -- Domains over non-arrays after
-       WHEN typtype = 'a' THEN 5                        -- Arrays after
-       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6  -- Domains over arrays last
-END;";
+       WHEN typtype IN ('b', 'e', 'p') THEN 0
+       WHEN typtype = 'r' THEN 1
+       WHEN typtype = 'm' THEN 2
+       WHEN typtype = 'c' THEN 3
+       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4
+       WHEN typtype = 'a' THEN 5
+       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6
+END;"
+#if NET6_0_OR_GREATER
+    .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
 
     static string GenerateLoadCompositeTypesQuery(bool loadTableComposites)
         => $@"
--- Load field definitions for (free-standing) composite types
 SELECT typ.oid, att.attname, att.atttypid
 FROM pg_type AS typ
 JOIN pg_namespace AS ns ON (ns.oid = typ.typnamespace)
@@ -168,17 +169,26 @@ JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
 JOIN pg_attribute AS att ON (att.attrelid = typ.typrelid)
 WHERE
   (typ.typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "cls.relkind='c'")}) AND
-  attnum > 0 AND     -- Don't load system attributes
+  attnum > 0 AND
   NOT attisdropped
-ORDER BY typ.oid, att.attnum;";
+ORDER BY typ.oid, att.attnum;"
+#if NET6_0_OR_GREATER
+    .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
 
     static string GenerateLoadEnumFieldsQuery(bool withEnumSortOrder)
         => $@"
--- Load enum fields
 SELECT pg_type.oid, enumlabel
 FROM pg_enum
 JOIN pg_type ON pg_type.oid=enumtypid
-ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
+ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
+#if NET6_0_OR_GREATER
+    .ReplaceLineEndings("\n");
+#else
+    .Replace("\r\n", "\n").Replace('\r', '\n');
+#endif
 
     /// <summary>
     /// Loads type information from the backend specified by <paramref name="conn"/>.
@@ -197,16 +207,19 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
         if (timeout.IsSet)
             commandTimeout = (int)timeout.CheckAndGetTimeLeft().TotalSeconds;
 
-        var batchQuery = new StringBuilder()
-            .AppendLine("SELECT version();")
-            .AppendLine(GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites))
-            .AppendLine(GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites));
-
-        if (SupportsEnumTypes)
-            batchQuery.AppendLine(GenerateLoadEnumFieldsQuery(HasEnumSortOrder));
+        var versionQuery = "SELECT version();";
+        var loadTypesQuery = GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites);
+        var loadCompositeTypesQuery = GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites);
+        var loadEnumFieldsQuery = SupportsEnumTypes
+            ? GenerateLoadEnumFieldsQuery(HasEnumSortOrder)
+            : string.Empty;
 
         timeout.CheckAndApply(conn);
-        await conn.WriteQuery(batchQuery.ToString(), async);
+        await conn.WriteQuery(versionQuery, async);
+        await conn.WriteQuery(loadTypesQuery, async);
+        await conn.WriteQuery(loadCompositeTypesQuery, async);
+        if (SupportsEnumTypes)
+            await conn.WriteQuery(loadEnumFieldsQuery, async);
         await conn.Flush(async);
         var byOID = new Dictionary<uint, PostgresType>();
         var buf = conn.ReadBuffer;
@@ -220,6 +233,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
         buf.Skip(2); // Column count
         LongVersion = ReadNonNullableString(buf);
         Expect<CommandCompleteMessage>(await conn.ReadMessage(async), conn);
+        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         // Then load the types
         Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
@@ -328,6 +342,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
             }
         }
         Expect<CommandCompleteMessage>(msg, conn);
+        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         // Then load the composite type fields
         Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
@@ -386,6 +401,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
             currentComposite!.MutableFields.Add(new PostgresCompositeType.Field(attname, fieldType));
         }
         Expect<CommandCompleteMessage>(msg, conn);
+        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         if (SupportsEnumTypes)
         {
@@ -435,9 +451,9 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                 currentEnum!.MutableLabels.Add(enumlabel);
             }
             Expect<CommandCompleteMessage>(msg, conn);
+            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
         }
 
-        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
         return byOID.Values.ToList();
 
         static string ReadNonNullableString(NpgsqlReadBuffer buffer)

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -113,6 +113,9 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
         => $@"
 SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid
 FROM (
+    -- Arrays have typtype=b - this subquery identifies them by their typreceive and converts their typtype to a
+    -- We first do this for the type (innerest-most subquery), and then for its element type
+    -- This also returns the array element, range subtype and domain base type as elemtypoid
     SELECT
         typ.oid, typ.typnamespace, typ.typname, typ.typtype, typ.typrelid, typ.typnotnull, typ.relkind,
         elemtyp.oid AS elemtypoid, elemtyp.typname AS elemtypname, elemcls.relkind AS elemrelkind,
@@ -137,31 +140,27 @@ FROM (
 ) AS t
 JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
 WHERE
-    typtype IN ('b', 'r', 'm', 'e', 'd') OR
-    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR
-    (typtype = 'p' AND typname IN ('record', 'void')) OR
-    (typtype = 'a' AND (
-        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR
-        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR
-        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")})
+    typtype IN ('b', 'r', 'm', 'e', 'd') OR -- Base, range, multirange, enum, domain
+    (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR -- User-defined free-standing composites (not table composites) by default
+    (typtype = 'p' AND typname IN ('record', 'void')) OR -- Some special supported pseudo-types
+    (typtype = 'a' AND (  -- Array of...
+        elemtyptype IN ('b', 'r', 'm', 'e', 'd') OR -- Array of base, range, multirange, enum, domain
+        (elemtyptype = 'p' AND elemtypname IN ('record', 'void')) OR -- Arrays of special supported pseudo-types
+        (elemtyptype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "elemrelkind='c'")}) -- Array of user-defined free-standing composites (not table composites) by default
     ))
 ORDER BY CASE
-       WHEN typtype IN ('b', 'e', 'p') THEN 0
-       WHEN typtype = 'r' THEN 1
-       WHEN typtype = 'm' THEN 2
-       WHEN typtype = 'c' THEN 3
-       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4
-       WHEN typtype = 'a' THEN 5
-       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6
-END;"
-#if NET6_0_OR_GREATER
-    .ReplaceLineEndings("\n");
-#else
-    .Replace("\r\n", "\n").Replace('\r', '\n');
-#endif
+       WHEN typtype IN ('b', 'e', 'p') THEN 0           -- First base types, enums, pseudo-types
+       WHEN typtype = 'r' THEN 1                        -- Ranges after
+       WHEN typtype = 'm' THEN 2                        -- Multiranges after
+       WHEN typtype = 'c' THEN 3                        -- Composites after
+       WHEN typtype = 'd' AND elemtyptype <> 'a' THEN 4 -- Domains over non-arrays after
+       WHEN typtype = 'a' THEN 5                        -- Arrays after
+       WHEN typtype = 'd' AND elemtyptype = 'a' THEN 6  -- Domains over arrays last
+END;";
 
     static string GenerateLoadCompositeTypesQuery(bool loadTableComposites)
         => $@"
+-- Load field definitions for (free-standing) composite types
 SELECT typ.oid, att.attname, att.atttypid
 FROM pg_type AS typ
 JOIN pg_namespace AS ns ON (ns.oid = typ.typnamespace)
@@ -169,26 +168,17 @@ JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
 JOIN pg_attribute AS att ON (att.attrelid = typ.typrelid)
 WHERE
   (typ.typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "cls.relkind='c'")}) AND
-  attnum > 0 AND
+  attnum > 0 AND     -- Don't load system attributes
   NOT attisdropped
-ORDER BY typ.oid, att.attnum;"
-#if NET6_0_OR_GREATER
-    .ReplaceLineEndings("\n");
-#else
-    .Replace("\r\n", "\n").Replace('\r', '\n');
-#endif
+ORDER BY typ.oid, att.attnum;";
 
     static string GenerateLoadEnumFieldsQuery(bool withEnumSortOrder)
         => $@"
+-- Load enum fields
 SELECT pg_type.oid, enumlabel
 FROM pg_enum
 JOIN pg_type ON pg_type.oid=enumtypid
-ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
-#if NET6_0_OR_GREATER
-    .ReplaceLineEndings("\n");
-#else
-    .Replace("\r\n", "\n").Replace('\r', '\n');
-#endif
+ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
 
     /// <summary>
     /// Loads type information from the backend specified by <paramref name="conn"/>.
@@ -215,11 +205,102 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
             : string.Empty;
 
         timeout.CheckAndApply(conn);
-        await conn.WriteQuery(versionQuery, async);
-        await conn.WriteQuery(loadTypesQuery, async);
-        await conn.WriteQuery(loadCompositeTypesQuery, async);
-        if (SupportsEnumTypes)
-            await conn.WriteQuery(loadEnumFieldsQuery, async);
+        // The Lexer (https://github.com/postgres/postgres/blob/master/src/backend/replication/repl_scanner.l)
+        // and Parser (https://github.com/postgres/postgres/blob/master/src/backend/replication/repl_gram.y)
+        // for replication connections are pretty picky and somewhat flawed.
+        // Currently (2022-01-22) they do not support
+        // - SQL batches containing multiple commands
+        // - The <CR> ('\r') in Windows or Mac newlines
+        // - Comments
+        // For this reason we need clean up our type loading queries for replication connections and execute
+        // them individually instead of batched.
+        // Theoretically we cold even use the extended protocol + batching for regular (non-replication)
+        // connections but that would branch our code even more for very little gain.
+        var isReplicationConnection = conn.Settings.ReplicationMode != ReplicationMode.Off;
+        if (isReplicationConnection)
+        {
+            await conn.WriteQuery(versionQuery, async);
+            await conn.WriteQuery(SanitizeForReplicationConnection(loadTypesQuery), async);
+            await conn.WriteQuery(SanitizeForReplicationConnection(loadCompositeTypesQuery), async);
+            if (SupportsEnumTypes)
+                await conn.WriteQuery(SanitizeForReplicationConnection(loadEnumFieldsQuery), async);
+
+            static string SanitizeForReplicationConnection(string str)
+            {
+                var sb = new StringBuilder(str.Length);
+                using var c = str.GetEnumerator();
+                while (c.MoveNext())
+                {
+                    switch (c.Current)
+                    {
+                    case '\r':
+                        sb.Append('\n');
+                        // Check for a \n after the \r
+                        // and swallow it if it exists
+                        if (c.MoveNext())
+                        {
+                            if (c.Current == '-')
+                                goto case '-';
+                            if (c.Current != '\n')
+                                sb.Append(c.Current);
+                        }
+                        break;
+                    case '-':
+                        // Check if there is a second dash
+                        if (c.MoveNext())
+                        {
+                            if (c.Current == '\r')
+                            {
+                                sb.Append('-');
+                                goto case '\r';
+                            }
+                            if (c.Current != '-')
+                            {
+                                sb.Append('-');
+                                sb.Append(c.Current);
+                                break;
+                            }
+
+                            // Comment mode
+                            // Swallow everything until we find a newline
+                            while (c.MoveNext())
+                            {
+                                if (c.Current == '\r')
+                                    goto case '\r';
+                                if (c.Current == '\n')
+                                {
+                                    sb.Append('\n');
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        sb.Append(c.Current);
+                        break;
+                    }
+                }
+
+                return sb.ToString();
+            }
+        }
+        else
+        {
+            var batchQuery = new StringBuilder(
+                    versionQuery.Length +
+                    loadTypesQuery.Length +
+                    loadCompositeTypesQuery.Length +
+                    (SupportsEnumTypes
+                        ? loadEnumFieldsQuery.Length
+                        : 0))
+                .AppendLine(versionQuery)
+                .AppendLine(loadTypesQuery)
+                .AppendLine(loadCompositeTypesQuery);
+
+            if (SupportsEnumTypes)
+                batchQuery.AppendLine(loadEnumFieldsQuery);
+            await conn.WriteQuery(batchQuery.ToString(), async);
+        }
         await conn.Flush(async);
         var byOID = new Dictionary<uint, PostgresType>();
         var buf = conn.ReadBuffer;
@@ -233,7 +314,8 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
         buf.Skip(2); // Column count
         LongVersion = ReadNonNullableString(buf);
         Expect<CommandCompleteMessage>(await conn.ReadMessage(async), conn);
-        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
+        if (isReplicationConnection)
+            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         // Then load the types
         Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
@@ -342,7 +424,8 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
             }
         }
         Expect<CommandCompleteMessage>(msg, conn);
-        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
+        if (isReplicationConnection)
+            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         // Then load the composite type fields
         Expect<RowDescriptionMessage>(await conn.ReadMessage(async), conn);
@@ -401,7 +484,8 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
             currentComposite!.MutableFields.Add(new PostgresCompositeType.Field(attname, fieldType));
         }
         Expect<CommandCompleteMessage>(msg, conn);
-        Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
+        if (isReplicationConnection)
+            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
 
         if (SupportsEnumTypes)
         {
@@ -451,9 +535,12 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};"
                 currentEnum!.MutableLabels.Add(enumlabel);
             }
             Expect<CommandCompleteMessage>(msg, conn);
-            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
+            if (isReplicationConnection)
+                Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
         }
 
+        if (!isReplicationConnection)
+            Expect<ReadyForQueryMessage>(await conn.ReadMessage(async), conn);
         return byOID.Values.ToList();
 
         static string ReadNonNullableString(NpgsqlReadBuffer buffer)

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -21,9 +21,12 @@ public class CommonReplicationTests<TConnection> : SafeReplicationTestBase<TConn
 {
     #region Open
 
-    [Test]
+    [Test, Parallelizable(ParallelScope.None)]
     public async Task Open()
     {
+        // Force type reloading from the replication connection if it is a logical replication connection
+        if (typeof(TConnection) == typeof(LogicalReplicationConnection))
+            Internal.NpgsqlDatabaseInfo.Cache.Clear();
         await using var rc = await OpenReplicationConnectionAsync();
     }
 


### PR DESCRIPTION
This adds support for binary replication of mapped composite and enum
types that already exist in the database when the replication connection
is opened.

Closes #4286