### PR TITLE
Tweaks to certificate validation

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -818,9 +818,6 @@ public sealed partial class NpgsqlConnector : IDisposable
 
                     RemoteCertificateValidationCallback? certificateValidationCallback;
 
-                    if (Settings.TrustServerCertificate && sslMode is SslMode.Allow or SslMode.VerifyCA or SslMode.VerifyFull)
-                        throw new ArgumentException(NpgsqlStrings.CannotUseTrustServerCertificate);
-
                     if (UserCertificateValidationCallback is not null)
                     {
                         if (sslMode is SslMode.VerifyCA or SslMode.VerifyFull)

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -522,9 +522,15 @@ public sealed partial class NpgsqlConnector : IDisposable
             throw;
         }
 
-        static async Task OpenCore(NpgsqlConnector conn, SslMode sslMode, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
+        static async Task OpenCore(
+            NpgsqlConnector conn,
+            SslMode sslMode,
+            NpgsqlTimeout timeout,
+            bool async,
+            CancellationToken cancellationToken,
+            bool isFirstAttempt = true)
         {
-            await conn.RawOpen(sslMode, timeout, async, cancellationToken);
+            await conn.RawOpen(sslMode, timeout, async, cancellationToken, isFirstAttempt);
 
             var username = conn.GetUsername();
             if (conn.Settings.Database == null)
@@ -550,7 +556,14 @@ public sealed partial class NpgsqlConnector : IDisposable
 
                 // If Prefer was specified and we failed (with SSL), retry without SSL.
                 // If Allow was specified and we failed (without SSL), retry with SSL
-                await OpenCore(conn, sslMode == SslMode.Prefer ? SslMode.Disable : SslMode.Require, timeout, async, cancellationToken);
+                await OpenCore(
+                    conn,
+                    sslMode == SslMode.Prefer ? SslMode.Disable : SslMode.Require,
+                    timeout,
+                    async,
+                    cancellationToken,
+                    isFirstAttempt: false);
+
                 return;
             }
 
@@ -719,7 +732,7 @@ public sealed partial class NpgsqlConnector : IDisposable
         throw new NpgsqlException("No username could be found, please specify one explicitly");
     }
 
-    async Task RawOpen(SslMode sslMode, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
+    async Task RawOpen(SslMode sslMode, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken, bool isFirstAttempt = true)
     {
         var cert = default(X509Certificate2?);
         try
@@ -750,7 +763,7 @@ public sealed partial class NpgsqlConnector : IDisposable
 
             IsSecure = false;
 
-            if (sslMode == SslMode.Prefer || sslMode == SslMode.Require || sslMode == SslMode.VerifyCA || sslMode == SslMode.VerifyFull)
+            if (sslMode is SslMode.Prefer or SslMode.Require or SslMode.VerifyCA or SslMode.VerifyFull)
             {
                 WriteSslRequest();
                 await Flush(async, cancellationToken);
@@ -804,24 +817,32 @@ public sealed partial class NpgsqlConnector : IDisposable
                     var checkCertificateRevocation = Settings.CheckCertificateRevocation;
 
                     RemoteCertificateValidationCallback? certificateValidationCallback;
-                    if (sslMode == SslMode.Prefer || sslMode == SslMode.Require)
+
+                    if (Settings.TrustServerCertificate && sslMode is SslMode.Allow or SslMode.VerifyCA or SslMode.VerifyFull)
+                        throw new ArgumentException(NpgsqlStrings.CannotUseTrustServerCertificate);
+
+                    if (UserCertificateValidationCallback is not null)
                     {
+                        if (sslMode is SslMode.VerifyCA or SslMode.VerifyFull)
+                            throw new ArgumentException(string.Format(NpgsqlStrings.CannotUseSslVerifyWithUserCallback, sslMode));
+
+                        if (Settings.RootCertificate is not null)
+                            throw new ArgumentException(string.Format(NpgsqlStrings.CannotUseSslRootCertificateWithUserCallback));
+
+                        certificateValidationCallback = UserCertificateValidationCallback;
+                    }
+                    else if (sslMode is SslMode.Prefer or SslMode.Require)
+                    {
+                        if (isFirstAttempt && sslMode is SslMode.Require && !Settings.TrustServerCertificate)
+                            throw new ArgumentException(NpgsqlStrings.CannotUseSslModeRequireWithoutTrustServerCertificate);
+
                         certificateValidationCallback = SslTrustServerValidation;
                         checkCertificateRevocation = false;
                     }
-                    else if ((Settings.RootCertificate ?? PostgresEnvironment.SslCertRoot ?? PostgresEnvironment.SslCertRootDefault) is { } certRootPath)
+                    else if ((Settings.RootCertificate ?? PostgresEnvironment.SslCertRoot ?? PostgresEnvironment.SslCertRootDefault) is
+                             { } certRootPath)
                     {
                         certificateValidationCallback = SslRootValidation(certRootPath, sslMode == SslMode.VerifyFull);
-                    }
-                    else if (UserCertificateValidationCallback is not null)
-                    {
-                        if (sslMode is SslMode.VerifyCA or SslMode.VerifyFull)
-                        {
-                            throw new NotSupportedException(
-                                string.Format(NpgsqlStrings.CannotUseSslVerifyWithUserCallback, sslMode));
-                        }
-
-                        certificateValidationCallback = UserCertificateValidationCallback;
                     }
                     else if (sslMode == SslMode.VerifyCA)
                     {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1052,9 +1052,13 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     public ProvideClientCertificatesCallback? ProvideClientCertificatesCallback { get; set; }
 
     /// <summary>
+    /// <para>
     /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
-    /// Ignored if <see cref="NpgsqlConnectionStringBuilder.SslMode"/> is set to <see cref="SslMode.Allow"/>,
-    /// <see cref="SslMode.Prefer"/> or <see cref="SslMode.Require"/>.
+    /// </para>
+    /// <para>
+    /// Cannot be used in conjunction with <see cref="SslMode.Disable" />, <see cref="SslMode.VerifyCA" /> and
+    /// <see cref="SslMode.VerifyFull" />.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// See <see href="https://msdn.microsoft.com/en-us/library/system.net.security.remotecertificatevalidationcallback(v=vs.110).aspx"/>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1569,6 +1569,8 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
             throw new ArgumentException("Host can't be null");
         if (Multiplexing && !Pooling)
             throw new ArgumentException("Pooling must be on to use multiplexing");
+        if (TrustServerCertificate && SslMode is SslMode.Allow or SslMode.VerifyCA or SslMode.VerifyFull)
+            throw new ArgumentException(NpgsqlStrings.CannotUseTrustServerCertificate);
     }
 
     internal string ToStringWithoutPassword()
@@ -1711,6 +1713,10 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     #endregion
 
     internal static readonly string[] EmptyStringArray = new string[0];
+}
+
+class Settings
+{
 }
 
 #region Attributes

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1715,10 +1715,6 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     internal static readonly string[] EmptyStringArray = new string[0];
 }
 
-class Settings
-{
-}
-
 #region Attributes
 
 /// <summary>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Npgsql.Internal;
 using Npgsql.Netstandard20;
+using Npgsql.Properties;
 using Npgsql.Replication;
 
 namespace Npgsql;
@@ -1568,13 +1569,6 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
             throw new ArgumentException("Host can't be null");
         if (Multiplexing && !Pooling)
             throw new ArgumentException("Pooling must be on to use multiplexing");
-        if (SslMode == SslMode.Require && !TrustServerCertificate)
-            throw new NpgsqlException(
-                "To validate server certificates, please use VerifyFull or VerifyCA instead of Require. " +
-                "To disable validation, explicitly set 'Trust Server Certificate' to true. " +
-                "See https://www.npgsql.org/doc/release-notes/6.0.html for more details.");
-        if (TrustServerCertificate && (SslMode == SslMode.Allow || SslMode == SslMode.VerifyCA || SslMode == SslMode.VerifyFull))
-            throw new NpgsqlException($"TrustServerCertificate=true is not supported with SslMode={SslMode}");
     }
 
     internal string ToStringWithoutPassword()

--- a/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
+++ b/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
@@ -50,5 +50,23 @@ namespace Npgsql.Properties {
                 return ResourceManager.GetString("CannotUseSslVerifyWithUserCallback", resourceCulture);
             }
         }
+        
+        internal static string CannotUseSslRootCertificateWithUserCallback {
+            get {
+                return ResourceManager.GetString("CannotUseSslRootCertificateWithUserCallback", resourceCulture);
+            }
+        }
+        
+        internal static string CannotUseSslModeRequireWithoutTrustServerCertificate {
+            get {
+                return ResourceManager.GetString("CannotUseSslModeRequireWithoutTrustServerCertificate", resourceCulture);
+            }
+        }
+        
+        internal static string CannotUseTrustServerCertificate {
+            get {
+                return ResourceManager.GetString("CannotUseTrustServerCertificate", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Npgsql/Properties/NpgsqlStrings.resx
+++ b/src/Npgsql/Properties/NpgsqlStrings.resx
@@ -21,4 +21,13 @@
     <data name="CannotUseSslVerifyWithUserCallback" xml:space="preserve">
         <value>SslMode.{0} cannot be used in conjunction with UserCertificateValidationCallback; when registering a validation callback, perform whatever validation you require in that callback.</value>
     </data>
+    <data name="CannotUseSslRootCertificateWithUserCallback" xml:space="preserve">
+        <value>RootCertificate cannot be used in conjunction with UserCertificateValidationCallback; when registering a validation callback, perform whatever validation you require in that callback.</value>
+    </data>
+    <data name="CannotUseSslModeRequireWithoutTrustServerCertificate" xml:space="preserve">
+        <value>To validate server certificates, please use VerifyFull or VerifyCA instead of Require. To disable validation, explicitly set 'Trust Server Certificate' to true. See https://www.npgsql.org/doc/release-notes/6.0.html for more details.</value>
+    </data>
+    <data name="CannotUseTrustServerCertificate" xml:space="preserve">
+        <value>TrustServerCertificate=true is not supported with SslMode={0}</value>
+    </data>
 </root>


### PR DESCRIPTION
* Allow user callback with Require without TSC
* Throw if there's a user callback and RootCertificate
* Use the user callback with Prefer

Closes #4309