### PR TITLE
Always observe exception while closing Reader/Disposing COPY operation

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -2035,9 +2035,7 @@ public sealed partial class NpgsqlConnector : IDisposable
             CurrentReader.Command.State = CommandState.Idle;
             try
             {
-                // Will never complete asynchronously (stream is already closed)
-                var readerCloseTask = CurrentReader.CloseAsync();
-                Debug.Assert(readerCloseTask.IsCompleted);
+                CurrentReader.Close();
             }
             catch
             {
@@ -2050,9 +2048,7 @@ public sealed partial class NpgsqlConnector : IDisposable
         {
             try
             {
-                // Will never complete asynchronously (stream is already closed)
-                var copyOperationDisposeTask = CurrentCopyOperation.DisposeAsync();
-                Debug.Assert(copyOperationDisposeTask.IsCompleted);
+                CurrentCopyOperation.Dispose();
             }
             catch
             {

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -2035,6 +2035,8 @@ public sealed partial class NpgsqlConnector : IDisposable
             CurrentReader.Command.State = CommandState.Idle;
             try
             {
+                // Note that this never actually blocks on I/O, since the stream is also closed
+                // (which is why we don't need to call CloseAsync)
                 CurrentReader.Close();
             }
             catch
@@ -2048,6 +2050,8 @@ public sealed partial class NpgsqlConnector : IDisposable
         {
             try
             {
+                // Note that this never actually blocks on I/O, since the stream is also closed
+                // (which is why we don't need to call DisposeAsync)
                 CurrentCopyOperation.Dispose();
             }
             catch


### PR DESCRIPTION
Fixes #4347

Highly doubt that's something anyone can reproduce (we can in CI due to broken COPY with multiplexing).