### PR TITLE
Fix ConnectorPool exception message

### DIFF
--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -99,7 +99,7 @@ class ConnectorPool : ConnectorSource
         var connectionIdleLifetime = TimeSpan.FromSeconds(settings.ConnectionIdleLifetime);
         var pruningSamplingInterval = TimeSpan.FromSeconds(settings.ConnectionPruningInterval);
         if (connectionIdleLifetime < pruningSamplingInterval)
-            throw new ArgumentException($"Connection can't have ConnectionIdleLifetime {connectionIdleLifetime} under ConnectionPruningInterval {pruningSamplingInterval}");
+            throw new ArgumentException($"Connection can't have {nameof(settings.ConnectionIdleLifetime)} {connectionIdleLifetime} under {nameof(settings.ConnectionPruningInterval)} {pruningSamplingInterval}");
 
         _pruningTimer = new Timer(PruningTimerCallback, this, Timeout.Infinite, Timeout.Infinite);
         _pruningSampleSize = DivideRoundingUp(settings.ConnectionIdleLifetime, settings.ConnectionPruningInterval);

--- a/src/Npgsql/ConnectorPool.cs
+++ b/src/Npgsql/ConnectorPool.cs
@@ -99,7 +99,7 @@ class ConnectorPool : ConnectorSource
         var connectionIdleLifetime = TimeSpan.FromSeconds(settings.ConnectionIdleLifetime);
         var pruningSamplingInterval = TimeSpan.FromSeconds(settings.ConnectionPruningInterval);
         if (connectionIdleLifetime < pruningSamplingInterval)
-            throw new ArgumentException($"Connection can't have ConnectionIdleLifetime {connectionIdleLifetime} under ConnectionPruningInterval {_pruningSamplingInterval}");
+            throw new ArgumentException($"Connection can't have ConnectionIdleLifetime {connectionIdleLifetime} under ConnectionPruningInterval {pruningSamplingInterval}");
 
         _pruningTimer = new Timer(PruningTimerCallback, this, Timeout.Infinite, Timeout.Infinite);
         _pruningSampleSize = DivideRoundingUp(settings.ConnectionIdleLifetime, settings.ConnectionPruningInterval);


### PR DESCRIPTION
Fixed a bit confusing exception message (i.e. 'System.ArgumentException: Connection can't have ConnectionIdleLifetime 00:00:05 under ConnectionPruningInterval 00:00:00')