### PR TITLE
Break connection if Wait gets timeout with SSL and netstandard2.0

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1252,7 +1252,7 @@ public sealed partial class NpgsqlConnector : IDisposable
             readingNotifications ||
             ReadBuffer.ReadBytesLeft < 5)
         {
-            return ReadMessageLong(this, async, dataRowLoadingMode, readingNotifications: readingNotifications);
+            return ReadMessageLong(this, async, dataRowLoadingMode, readingNotifications);
         }
 
         var messageCode = (BackendMessageCode)ReadBuffer.ReadByte();

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -133,6 +133,7 @@ public class ConnectionTests : MultiplexingTestBase
     }
 
     [Test]
+    [Platform(Exclude = "MacOsX", Reason = "Flaky on MacOS")]
     public async Task Break_while_open()
     {
         if (IsMultiplexing)


### PR DESCRIPTION
Because in .NET Framework, SslStream is dead after any IOException.

Fixes #4342