### PR TITLE
Generate source to populate a NpgsqlDatabaseInfo

### DIFF
--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -1,0 +1,22 @@
+name: Update catalogs.json from PostgreSQL .dat files
+
+on:
+  push:
+    branches:
+      - main
+      - 'hotfix/**'
+      - DAT_FILE_UPDATER
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update_catalogs:
+    name: Update catalogs.json from PostgreSQL .dat files if necessary and create a pull request in that case
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update
+        run: |
+          sudo apt-get -y install libwww-perl libjson-perl libnet-github-perl > /dev/null
+          perl ./src/Npgsql/pg_catalog/dat2json.pl ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-catalogs.yml
+++ b/.github/workflows/update-catalogs.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'hotfix/**'
-      - DAT_FILE_UPDATER
   schedule:
     - cron: "0 0 * * *"
 

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -45,6 +45,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Github", "Github", "{BA7B6F
 		.github\dependabot.yml = .github\dependabot.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\rich-code-nav.yml = .github\workflows\rich-code-nav.yml
+		.github\workflows\update-catalogs.yml = .github\workflows\update-catalogs.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.DependencyInjection", "src\Npgsql.DependencyInjection\Npgsql.DependencyInjection.csproj", "{B58E12EB-E43D-4D77-894E-5157D2269836}"

--- a/src/Npgsql.SourceGenerators/DatabaseInfoSourceGenerator.cs
+++ b/src/Npgsql.SourceGenerators/DatabaseInfoSourceGenerator.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Scriban;
+using Scriban.Runtime;
+
+namespace Npgsql.SourceGenerators;
+
+[Generator]
+sealed class DatabaseInfoSourceGenerator : ISourceGenerator
+{
+    public void Initialize(GeneratorInitializationContext context) { }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        CatalogInfo? catalogs = null;
+        var hasCatalogJson = false;
+        foreach (var file in context.AdditionalFiles)
+        {
+            if (Path.GetFileName(file.Path) != "catalogs.json")
+                continue;
+
+            hasCatalogJson = true;
+            catalogs = JsonSerializer.Deserialize<CatalogInfo>(
+                file.GetText()?.ToString() ??
+                throw new Exception($"An error occurred when reading the additional build file '{file.Path}'"));
+        }
+
+        // There is no catalogs.json file in the additional files for this project.
+        // This probably means that the project just isn't interested in this source generator
+        if (!hasCatalogJson)
+            return;
+
+        if (catalogs == null)
+            throw new("This source generator needs a reference to a valid catalogs.json file in AdditionalFiles to perform it's work");
+
+        var compilation = context.Compilation;
+        var postgresMinimalDatabaseInfoSymbol = compilation.GetTypeByMetadataName("Npgsql.PostgresMinimalDatabaseInfo");
+        if (postgresMinimalDatabaseInfoSymbol is null)
+            throw new("Could not find PostgresMinimalDatabaseInfo");
+
+        var template = Template.Parse(EmbeddedResource.GetContent("PostgresMinimalDatabaseInfo.snbtxt"), "PostgresMinimalDatabaseInfo.snbtxt");
+
+        var rangeTypes = new List<object>();
+        var multiRangeTypes = new List<object>();
+        foreach (var range in catalogs.pg_range)
+        {
+            var rangeSubTypeName = range.rngsubtype;
+            var rangeTypeName = range.rngtypid;
+            var rangeMultiTypeName = range.rngmultitypid;
+            var rangeTypeOid = catalogs.pg_type.Where(t => t.typname == rangeTypeName).Select(t => t.oid).First();
+            var rangeMultiTypeOid = catalogs.pg_type.Where(t => t.typname == rangeMultiTypeName).Select(t => t.oid).First();
+            rangeTypes.Add(new
+            {
+                Name = rangeTypeName,
+                Oid = rangeTypeOid,
+                ElementName = rangeSubTypeName,
+            });
+            multiRangeTypes.Add(new
+            {
+                Name = rangeMultiTypeName,
+                Oid = rangeMultiTypeOid,
+                ElementName = rangeTypeName,
+            });
+        }
+
+        // There currently is information about 4 composite types from pg_type.dat in catalogs.json:
+        // pg_type, pg_attribute, pg_proc, pg_class.
+        // We don't bother adding them for now since there is no pg_attribute.dat and we'd have to parse the
+        // C header file pg_attribute.h to acquire the field information we need to make them work
+        var obj = new ScriptObject();
+        obj.Import(new
+        {
+            UnreferencedBaseTypes = catalogs.pg_type.Where(d =>
+                d.typtype == null && d.array_type_oid == null &&
+                catalogs.pg_range.All(r => r.rngsubtype != d.typname)).Select(t => new
+            {
+                Name = t.typname,
+                Oid = t.oid
+            }).ToArray(),
+            ReferencedBaseTypes = catalogs.pg_type.Where(d =>
+                d.typtype == null &&
+                (d.array_type_oid != null || catalogs.pg_range.Any(r => r.rngsubtype == d.typname))).Select(t => new
+            {
+                Name = t.typname,
+                Oid = t.oid
+            }).ToArray(),
+            UnreferencedPseudoTypes = catalogs.pg_type.Where(d =>
+                d.typtype is "p" && !d.typname.StartsWith("_") &&
+                d.array_type_oid == null &&
+                catalogs.pg_range.All(r => r.rngsubtype != d.typname) &&
+                catalogs.pg_type.All(p => p.typtype is "p" && p.typname != "_" + d.typname)
+                ).Select(t => new
+            {
+                Name = t.typname,
+                Oid = t.oid
+            }).ToArray(),
+            ReferencedPseudoTypes = catalogs.pg_type.Where(d =>
+                d.typtype is "p" && !d.typname.StartsWith("_") && (
+                    d.array_type_oid != null ||
+                    catalogs.pg_range.Any(r => r.rngsubtype == d.typname) ||
+                    catalogs.pg_type.Any(p => p.typtype is "p" && p.typname == "_" + d.typname)
+                ))
+                .Select(t => new
+                {
+                    Name = t.typname,
+                    Oid = t.oid
+                }).ToArray(),
+            RangeTypes = rangeTypes,
+            MultirangeTypes = multiRangeTypes,
+            ArrayTypes = catalogs.pg_type
+                .Where(d => (d.array_type_oid!= null || d.typname.StartsWith("_"))
+                            && (d.typtype == null ||
+                                d.typtype != "c") // Exclude arrays of composite types. See comment above
+                )
+                .Select(t => t.typname.StartsWith("_")
+                    ? new
+                    {
+                        Name = t.typname,
+                        Oid = t.oid,
+                        ElementName = t.typname.Substring(1),
+                    }
+                    : new
+                    {
+                        Name = "_" + t.typname,
+                        Oid = t.array_type_oid!,
+                        ElementName = t.typname,
+                    }).ToArray(),
+        });
+        var tc = new TemplateContext(obj);
+        tc.AutoIndent = false;
+        var output = template.Render(tc);
+        context.AddSource(postgresMinimalDatabaseInfoSymbol.Name + ".Generated.cs", SourceText.From(output, Encoding.UTF8));
+    }
+
+    // ReSharper disable InconsistentNaming
+    // ReSharper disable IdentifierTypo
+    // ReSharper disable MemberHidesStaticFromOuterClass
+    class pg_type
+    {
+        public string oid { get; set; } = null!;
+        public string typname { get; set; } = null!;
+        public string? array_type_oid { get; set; }
+        public string? typtype { get; set; }
+    }
+
+    class pg_range
+    {
+        public string rngtypid { get; set; } = null!;
+        public string rngsubtype { get; set; } = null!;
+        public string rngmultitypid { get; set; } = null!;
+    }
+
+    class CatalogInfo
+    {
+        public int version { get; set; }
+        public List<pg_type> pg_type { get; set; } = null!;
+        public List<pg_range> pg_range { get; set; } = null!;
+    }
+}

--- a/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
+++ b/src/Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="System.Text.Json" />
 
         <!-- For this and the below, see https://github.com/dotnet/roslyn/discussions/47517#discussioncomment-64145 -->
         <PackageReference Include="Scriban.Signed" GeneratePathProperty="true" PrivateAssets="all" />
@@ -28,5 +29,6 @@
     <ItemGroup>
         <EmbeddedResource Include="TypeHandler.snbtxt" />
         <EmbeddedResource Include="NpgsqlConnectionStringBuilder.snbtxt" />
+        <EmbeddedResource Include="PostgresMinimalDatabaseInfo.snbtxt" />
     </ItemGroup>
 </Project>

--- a/src/Npgsql.SourceGenerators/PostgresMinimalDatabaseInfo.snbtxt
+++ b/src/Npgsql.SourceGenerators/PostgresMinimalDatabaseInfo.snbtxt
@@ -10,10 +10,14 @@ namespace Npgsql;
 
 partial class PostgresMinimalDatabaseInfo
 {
+    internal static readonly int CatalogVersion;
+
     static readonly PostgresType[] Types;
 
     static PostgresMinimalDatabaseInfo()
     {
+        CatalogVersion = {{ version }};
+
         ///////////////////////////
         // Referenced base types //
         ///////////////////////////

--- a/src/Npgsql.SourceGenerators/PostgresMinimalDatabaseInfo.snbtxt
+++ b/src/Npgsql.SourceGenerators/PostgresMinimalDatabaseInfo.snbtxt
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql.Internal;
+using Npgsql.PostgresTypes;
+using Npgsql.Util;
+
+namespace Npgsql;
+
+partial class PostgresMinimalDatabaseInfo
+{
+    static readonly PostgresType[] Types;
+
+    static PostgresMinimalDatabaseInfo()
+    {
+        ///////////////////////////
+        // Referenced base types //
+        ///////////////////////////
+        {{ for base_type in referenced_base_types }}var t_{{ base_type.name }} = new PostgresBaseType("pg_catalog", "{{ base_type.name }}", {{ base_type.oid }}u);
+        {{ end }}
+
+        /////////////////////////////
+        // Referenced pseudo types //
+        /////////////////////////////
+        {{ for pseudo_type in referenced_pseudo_types }}var t_{{ pseudo_type.name }} = new PostgresBaseType("pg_catalog", "{{ pseudo_type.name }}", {{ pseudo_type.oid }}u);
+        {{ end }}
+
+        /////////////////
+        // Range types //
+        /////////////////
+        {{ for range_type in range_types }}var t_{{ range_type.name }} = new PostgresRangeType("pg_catalog", "{{ range_type.name }}", {{ range_type.oid }}u, t_{{ range_type.element_name }});
+        {{ end }}
+
+        //////////////////////
+        // Multirange types //
+        //////////////////////
+        {{ for multirange_type in multirange_types }}var t_{{ multirange_type.name }} = new PostgresMultirangeType("pg_catalog", "{{ multirange_type.name }}", {{ multirange_type.oid }}u, t_{{ multirange_type.element_name }});
+        {{ end }}
+
+        Types = new PostgresType[]
+        {
+            // Base types
+            {{ for base_type in referenced_base_types }}t_{{ base_type.name }},{{ end }}
+            {{ for base_type in unreferenced_base_types }}new PostgresBaseType("pg_catalog", "{{ base_type.name }}", {{ base_type.oid }}u),
+            {{ end }}
+
+            // Pseudo types
+            {{ for pseudo_type in referenced_pseudo_types }}t_{{ pseudo_type.name }},{{ end }}
+            {{ for pseudo_type in unreferenced_pseudo_types }}new PostgresBaseType("pg_catalog", "{{ pseudo_type.name }}", {{ pseudo_type.oid }}u),
+            {{ end }}
+
+            // Range types
+            {{ for range_type in range_types }}t_{{ range_type.name }},{{ end }}
+
+            // Multirange types
+            {{ for multirange_type in multirange_types }}t_{{ multirange_type.name }},{{ end }}
+
+            // Array types
+            {{ for array_type in array_types }}new PostgresArrayType("pg_catalog", "{{ array_type.name }}", {{ array_type.oid }}u, t_{{ array_type.element_name }}),
+            {{ end }}
+        };
+    }
+}

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -21,6 +21,10 @@
     <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="pg_catalog/catalogs.json" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1773,7 +1773,7 @@ public enum ServerCompatibilityMode
     /// </summary>
     Redshift,
     /// <summary>
-    /// The server is doesn't support full type loading from the PostgreSQL catalogs, support the basic set
+    /// The server doesn't support type loading from the PostgreSQL catalogs, support the basic set
     /// of types via information hardcoded inside Npgsql.
     /// </summary>
     NoTypeLoading,

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -24,49 +24,42 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL 8-byte "bigint" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("int8", PostgresTypeOIDs.Int8)]
     Bigint = 1,
 
     /// <summary>
     /// Corresponds to the PostgreSQL 8-byte floating-point "double" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("float8", PostgresTypeOIDs.Float8)]
     Double = 8,
 
     /// <summary>
     /// Corresponds to the PostgreSQL 4-byte "integer" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("int4", PostgresTypeOIDs.Int4)]
     Integer = 9,
 
     /// <summary>
     /// Corresponds to the PostgreSQL arbitrary-precision "numeric" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("numeric", PostgresTypeOIDs.Numeric)]
     Numeric = 13,
 
     /// <summary>
     /// Corresponds to the PostgreSQL floating-point "real" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("float4", PostgresTypeOIDs.Float4)]
     Real = 17,
 
     /// <summary>
     /// Corresponds to the PostgreSQL 2-byte "smallint" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-numeric.html</remarks>
-    [BuiltInPostgresType("int2", PostgresTypeOIDs.Int2)]
     Smallint = 18,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "money" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-money.html</remarks>
-    [BuiltInPostgresType("money", PostgresTypeOIDs.Money)]
     Money = 12,
 
     #endregion
@@ -77,7 +70,6 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "boolean" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-boolean.html</remarks>
-    [BuiltInPostgresType("bool", PostgresTypeOIDs.Bool)]
     Boolean = 2,
 
     #endregion
@@ -88,49 +80,42 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL geometric "box" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("box", PostgresTypeOIDs.Box)]
     Box = 3,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "circle" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("circle", PostgresTypeOIDs.Circle)]
     Circle = 5,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "line" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("line", PostgresTypeOIDs.Line)]
     Line = 10,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "lseg" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("lseg", PostgresTypeOIDs.LSeg)]
     LSeg = 11,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "path" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("path", PostgresTypeOIDs.Path)]
     Path = 14,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "point" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("point", PostgresTypeOIDs.Point)]
     Point = 15,
 
     /// <summary>
     /// Corresponds to the PostgreSQL geometric "polygon" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-geometric.html</remarks>
-    [BuiltInPostgresType("polygon", PostgresTypeOIDs.Polygon)]
     Polygon = 16,
 
     #endregion
@@ -141,28 +126,24 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "char(n)" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-    [BuiltInPostgresType("bpchar", PostgresTypeOIDs.BPChar)]
     Char = 6,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "text" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-    [BuiltInPostgresType("text", PostgresTypeOIDs.Text)]
     Text = 19,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "varchar" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-    [BuiltInPostgresType("varchar", PostgresTypeOIDs.Varchar)]
     Varchar = 22,
 
     /// <summary>
     /// Corresponds to the PostgreSQL internal "name" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-character.html</remarks>
-    [BuiltInPostgresType("name", PostgresTypeOIDs.Name)]
     Name = 32,
 
     /// <summary>
@@ -179,7 +160,6 @@ public enum NpgsqlDbType
     ///
     /// See https://www.postgresql.org/docs/current/static/datatype-text.html
     /// </remarks>
-    [BuiltInPostgresType("char", PostgresTypeOIDs.Char)]
     InternalChar = 38,
 
     #endregion
@@ -190,7 +170,6 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "bytea" type, holding a raw byte string.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-binary.html</remarks>
-    [BuiltInPostgresType("bytea", PostgresTypeOIDs.Bytea)]
     Bytea = 4,
 
     #endregion
@@ -201,21 +180,18 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "date" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("date", PostgresTypeOIDs.Date)]
     Date = 7,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "time" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("time", PostgresTypeOIDs.Time)]
     Time = 20,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "timestamp" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("timestamp", PostgresTypeOIDs.Timestamp)]
     Timestamp = 21,
 
     /// <summary>
@@ -229,14 +205,12 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "timestamp with time zone" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("timestamptz", PostgresTypeOIDs.TimestampTz)]
     TimestampTz = 26,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "interval" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("interval", PostgresTypeOIDs.Interval)]
     Interval = 30,
 
     /// <summary>
@@ -250,7 +224,6 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "time with time zone" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
-    [BuiltInPostgresType("timetz", PostgresTypeOIDs.TimeTz)]
     TimeTz = 31,
 
     /// <summary>
@@ -258,7 +231,6 @@ public enum NpgsqlDbType
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-datetime.html</remarks>
     [Obsolete("The PostgreSQL abstime time is obsolete.")]
-    [BuiltInPostgresType("abstime", PostgresTypeOIDs.Abstime)]
     Abstime = 33,
 
     #endregion
@@ -269,28 +241,24 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "inet" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-    [BuiltInPostgresType("inet", PostgresTypeOIDs.Inet)]
     Inet = 24,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "cidr" type, a field storing an IPv4 or IPv6 network.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-    [BuiltInPostgresType("cidr", PostgresTypeOIDs.Cidr)]
     Cidr = 44,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "macaddr" type, a field storing a 6-byte physical address.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-    [BuiltInPostgresType("macaddr", PostgresTypeOIDs.Macaddr)]
     MacAddr = 34,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "macaddr8" type, a field storing a 6-byte or 8-byte physical address.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-net-types.html</remarks>
-    [BuiltInPostgresType("macaddr8", PostgresTypeOIDs.Macaddr8)]
     MacAddr8 = 54,
 
     #endregion
@@ -301,14 +269,12 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "bit" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-bit.html</remarks>
-    [BuiltInPostgresType("bit", PostgresTypeOIDs.Bit)]
     Bit = 25,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "varbit" type, a field storing a variable-length string of bits.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-boolean.html</remarks>
-    [BuiltInPostgresType("varbit", PostgresTypeOIDs.Varbit)]
     Varbit = 39,
 
     #endregion
@@ -319,21 +285,18 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "tsvector" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-    [BuiltInPostgresType("tsvector", PostgresTypeOIDs.TsVector)]
     TsVector = 45,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tsquery" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-    [BuiltInPostgresType("tsquery", PostgresTypeOIDs.TsQuery)]
     TsQuery = 46,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "regconfig" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-textsearch.html</remarks>
-    [BuiltInPostgresType("regconfig", PostgresTypeOIDs.Regconfig)]
     Regconfig = 56,
 
     #endregion
@@ -344,7 +307,6 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "uuid" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-uuid.html</remarks>
-    [BuiltInPostgresType("uuid", PostgresTypeOIDs.Uuid)]
     Uuid = 27,
 
     #endregion
@@ -355,7 +317,6 @@ public enum NpgsqlDbType
     /// Corresponds to the PostgreSQL "xml" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-xml.html</remarks>
-    [BuiltInPostgresType("xml", PostgresTypeOIDs.Xml)]
     Xml = 28,
 
     #endregion
@@ -367,7 +328,6 @@ public enum NpgsqlDbType
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-json.html</remarks>
     /// <seealso cref="Jsonb"/>
-    [BuiltInPostgresType("json", PostgresTypeOIDs.Json)]
     Json = 35,
 
     /// <summary>
@@ -378,7 +338,6 @@ public enum NpgsqlDbType
     /// Supported since PostgreSQL 9.4.
     /// See https://www.postgresql.org/docs/current/static/datatype-json.html
     /// </remarks>
-    [BuiltInPostgresType("jsonb", PostgresTypeOIDs.Jsonb)]
     Jsonb = 36,
 
     /// <summary>
@@ -389,7 +348,6 @@ public enum NpgsqlDbType
     /// Supported since PostgreSQL 12.
     /// See https://www.postgresql.org/docs/current/datatype-json.html#DATATYPE-JSONPATH
     /// </remarks>
-    [BuiltInPostgresType("jsonpath", PostgresTypeOIDs.JsonPath)]
     JsonPath = 57,
 
     #endregion
@@ -409,60 +367,51 @@ public enum NpgsqlDbType
     /// <summary>
     /// Corresponds to the PostgreSQL "refcursor" type.
     /// </summary>
-    [BuiltInPostgresType("refcursor", PostgresTypeOIDs.Refcursor)]
     Refcursor = 23,
 
     /// <summary>
     /// Corresponds to the PostgreSQL internal "oidvector" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-    [BuiltInPostgresType("oidvector", PostgresTypeOIDs.Oidvector)]
     Oidvector = 29,
 
     /// <summary>
     /// Corresponds to the PostgreSQL internal "int2vector" type.
     /// </summary>
-    [BuiltInPostgresType("int2vector", PostgresTypeOIDs.Int2vector)]
     Int2Vector = 52,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "oid" type.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-    [BuiltInPostgresType("oid", PostgresTypeOIDs.Oid)]
     Oid = 41,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "xid" type, an internal transaction identifier.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-    [BuiltInPostgresType("xid", PostgresTypeOIDs.Xid)]
     Xid = 42,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "xid8" type, an internal transaction identifier.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-    [BuiltInPostgresType("xid8", PostgresTypeOIDs.Xid8)]
     Xid8 = 64,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "cid" type, an internal command identifier.
     /// </summary>
     /// <remarks>See https://www.postgresql.org/docs/current/static/datatype-oid.html</remarks>
-    [BuiltInPostgresType("cid", PostgresTypeOIDs.Cid)]
     Cid = 43,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "regtype" type, a numeric (OID) ID of a type in the pg_type table.
     /// </summary>
-    [BuiltInPostgresType("regtype", PostgresTypeOIDs.Regtype)]
     Regtype = 49,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tid" type, a tuple id identifying the physical location of a row within its table.
     /// </summary>
-    [BuiltInPostgresType("tid", PostgresTypeOIDs.Tid)]
     Tid = 53,
 
     /// <summary>
@@ -473,7 +422,6 @@ public enum NpgsqlDbType
     /// See: https://www.postgresql.org/docs/current/datatype-pg-lsn.html and
     /// https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=7d03a83f4d0736ba869fa6f93973f7623a27038a
     /// </remarks>
-    [BuiltInPostgresType("pg_lsn", PostgresTypeOIDs.PgLsn)]
     PgLsn = 59,
 
     #endregion
@@ -489,7 +437,6 @@ public enum NpgsqlDbType
     /// This value shouldn't ordinarily be used, and makes sense only when sending a data type
     /// unsupported by Npgsql.
     /// </remarks>
-    [BuiltInPostgresType("unknown", PostgresTypeOIDs.Unknown)]
     Unknown = 40,
 
     #endregion
@@ -535,37 +482,31 @@ public enum NpgsqlDbType
     /// <summary>
     /// Corresponds to the PostgreSQL "int4range" type.
     /// </summary>
-    [BuiltInPostgresType("int4range", PostgresTypeOIDs.Int4Range)]
     IntegerRange = Range | Integer,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "int8range" type.
     /// </summary>
-    [BuiltInPostgresType("int8range", PostgresTypeOIDs.Int8Range)]
     BigIntRange = Range | Bigint,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "numrange" type.
     /// </summary>
-    [BuiltInPostgresType("numrange", PostgresTypeOIDs.NumRange)]
     NumericRange = Range | Numeric,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tsrange" type.
     /// </summary>
-    [BuiltInPostgresType("tsrange", PostgresTypeOIDs.TsRange)]
     TimestampRange = Range | Timestamp,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tstzrange" type.
     /// </summary>
-    [BuiltInPostgresType("tstzrange", PostgresTypeOIDs.TsTzRange)]
     TimestampTzRange = Range | TimestampTz,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "daterange" type.
     /// </summary>
-    [BuiltInPostgresType("daterange", PostgresTypeOIDs.DateRange)]
     DateRange = Range | Date,
 
     #endregion Range types
@@ -575,37 +516,31 @@ public enum NpgsqlDbType
     /// <summary>
     /// Corresponds to the PostgreSQL "int4multirange" type.
     /// </summary>
-    [BuiltInPostgresType("int4multirange", PostgresTypeOIDs.Int4Multirange)]
     IntegerMultirange = Multirange | Integer,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "int8multirange" type.
     /// </summary>
-    [BuiltInPostgresType("int8multirange", PostgresTypeOIDs.Int8Multirange)]
     BigIntMultirange = Multirange | Bigint,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "nummultirange" type.
     /// </summary>
-    [BuiltInPostgresType("nummultirange", PostgresTypeOIDs.NumMultirange)]
     NumericMultirange = Multirange | Numeric,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tsmultirange" type.
     /// </summary>
-    [BuiltInPostgresType("tsmultirange", PostgresTypeOIDs.TsMultirange)]
     TimestampMultirange = Multirange | Timestamp,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "tstzmultirange" type.
     /// </summary>
-    [BuiltInPostgresType("tstzmultirange", PostgresTypeOIDs.TsTzMultirange)]
     TimestampTzMultirange = Multirange | TimestampTz,
 
     /// <summary>
     /// Corresponds to the PostgreSQL "datemultirange" type.
     /// </summary>
-    [BuiltInPostgresType("datemultirange", PostgresTypeOIDs.DateMultirange)]
     DateMultirange = Multirange | Date,
 
     #endregion Multirange types

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -579,19 +579,3 @@ public enum NpgsqlDbType
 
     #endregion
 }
-
-/// <summary>
-/// Represents a built-in PostgreSQL type as it appears in pg_type, including its name and OID.
-/// Extension types with variable OIDs are not represented.
-/// </summary>
-class BuiltInPostgresType : Attribute
-{
-    internal string Name { get; }
-    internal uint OID { get; }
-
-    internal BuiltInPostgresType(string name, uint oid)
-    {
-        Name = name;
-        OID = oid;
-    }
-}

--- a/src/Npgsql/PostgresMinimalDatabaseInfo.cs
+++ b/src/Npgsql/PostgresMinimalDatabaseInfo.cs
@@ -1,11 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Npgsql.Internal;
 using Npgsql.PostgresTypes;
 using Npgsql.Util;
-using NpgsqlTypes;
 
 namespace Npgsql;
 
@@ -19,20 +16,11 @@ class PostgresMinimalDatabaseInfoFactory : INpgsqlDatabaseInfoFactory
         );
 }
 
-class PostgresMinimalDatabaseInfo : PostgresDatabaseInfo
+sealed partial class PostgresMinimalDatabaseInfo : PostgresDatabaseInfo
 {
-    static readonly PostgresBaseType[] Types = typeof(NpgsqlDbType).GetFields()
-        .Select(f => f.GetCustomAttribute<BuiltInPostgresType>())
-        .OfType<BuiltInPostgresType>()
-        .Select(a => new PostgresBaseType("pg_catalog", a.Name, a.OID))
-        .ToArray();
-
     protected override IEnumerable<PostgresType> GetTypes() => Types;
 
-    internal PostgresMinimalDatabaseInfo(NpgsqlConnector conn)
-        : base(conn)
-    {
-        HasIntegerDateTimes = !conn.PostgresParameters.TryGetValue("integer_datetimes", out var intDateTimes) ||
-                              intDateTimes == "on";
-    }
+    internal PostgresMinimalDatabaseInfo(NpgsqlConnector conn) : base(conn)
+        => HasIntegerDateTimes = !conn.PostgresParameters.TryGetValue("integer_datetimes", out var intDateTimes) ||
+                                 intDateTimes == "on";
 }

--- a/src/Npgsql/pg_catalog/catalogs.json
+++ b/src/Npgsql/pg_catalog/catalogs.json
@@ -1,0 +1,526 @@
+{
+   "pg_range" : [
+      {
+         "rngmultitypid" : "int4multirange",
+         "rngsubtype" : "int4",
+         "rngtypid" : "int4range"
+      },
+      {
+         "rngmultitypid" : "nummultirange",
+         "rngsubtype" : "numeric",
+         "rngtypid" : "numrange"
+      },
+      {
+         "rngmultitypid" : "tsmultirange",
+         "rngsubtype" : "timestamp",
+         "rngtypid" : "tsrange"
+      },
+      {
+         "rngmultitypid" : "tstzmultirange",
+         "rngsubtype" : "timestamptz",
+         "rngtypid" : "tstzrange"
+      },
+      {
+         "rngmultitypid" : "datemultirange",
+         "rngsubtype" : "date",
+         "rngtypid" : "daterange"
+      },
+      {
+         "rngmultitypid" : "int8multirange",
+         "rngsubtype" : "int8",
+         "rngtypid" : "int8range"
+      }
+   ],
+   "pg_type" : [
+      {
+         "oid" : "16",
+         "typname" : "bool"
+      },
+      {
+         "oid" : "17",
+         "typname" : "bytea"
+      },
+      {
+         "oid" : "18",
+         "typname" : "char"
+      },
+      {
+         "oid" : "19",
+         "typname" : "name"
+      },
+      {
+         "oid" : "20",
+         "typname" : "int8"
+      },
+      {
+         "oid" : "21",
+         "typname" : "int2"
+      },
+      {
+         "oid" : "22",
+         "typname" : "int2vector"
+      },
+      {
+         "oid" : "23",
+         "typname" : "int4"
+      },
+      {
+         "oid" : "24",
+         "typname" : "regproc"
+      },
+      {
+         "oid" : "25",
+         "typname" : "text"
+      },
+      {
+         "oid" : "26",
+         "typname" : "oid"
+      },
+      {
+         "oid" : "27",
+         "typname" : "tid"
+      },
+      {
+         "oid" : "28",
+         "typname" : "xid"
+      },
+      {
+         "oid" : "29",
+         "typname" : "cid"
+      },
+      {
+         "oid" : "30",
+         "typname" : "oidvector"
+      },
+      {
+         "oid" : "71",
+         "typname" : "pg_type",
+         "typtype" : "c"
+      },
+      {
+         "oid" : "75",
+         "typname" : "pg_attribute",
+         "typtype" : "c"
+      },
+      {
+         "oid" : "81",
+         "typname" : "pg_proc",
+         "typtype" : "c"
+      },
+      {
+         "oid" : "83",
+         "typname" : "pg_class",
+         "typtype" : "c"
+      },
+      {
+         "oid" : "114",
+         "typname" : "json"
+      },
+      {
+         "oid" : "142",
+         "typname" : "xml"
+      },
+      {
+         "oid" : "194",
+         "typname" : "pg_node_tree"
+      },
+      {
+         "oid" : "3361",
+         "typname" : "pg_ndistinct"
+      },
+      {
+         "oid" : "3402",
+         "typname" : "pg_dependencies"
+      },
+      {
+         "oid" : "5017",
+         "typname" : "pg_mcv_list"
+      },
+      {
+         "oid" : "32",
+         "typname" : "pg_ddl_command",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "5069",
+         "typname" : "xid8"
+      },
+      {
+         "oid" : "600",
+         "typname" : "point"
+      },
+      {
+         "oid" : "601",
+         "typname" : "lseg"
+      },
+      {
+         "oid" : "602",
+         "typname" : "path"
+      },
+      {
+         "oid" : "603",
+         "typname" : "box"
+      },
+      {
+         "oid" : "604",
+         "typname" : "polygon"
+      },
+      {
+         "oid" : "628",
+         "typname" : "line"
+      },
+      {
+         "oid" : "700",
+         "typname" : "float4"
+      },
+      {
+         "oid" : "701",
+         "typname" : "float8"
+      },
+      {
+         "oid" : "705",
+         "typname" : "unknown",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "718",
+         "typname" : "circle"
+      },
+      {
+         "oid" : "790",
+         "typname" : "money"
+      },
+      {
+         "oid" : "829",
+         "typname" : "macaddr"
+      },
+      {
+         "oid" : "869",
+         "typname" : "inet"
+      },
+      {
+         "oid" : "650",
+         "typname" : "cidr"
+      },
+      {
+         "oid" : "774",
+         "typname" : "macaddr8"
+      },
+      {
+         "oid" : "1033",
+         "typname" : "aclitem"
+      },
+      {
+         "oid" : "1042",
+         "typname" : "bpchar"
+      },
+      {
+         "oid" : "1043",
+         "typname" : "varchar"
+      },
+      {
+         "oid" : "1082",
+         "typname" : "date"
+      },
+      {
+         "oid" : "1083",
+         "typname" : "time"
+      },
+      {
+         "oid" : "1114",
+         "typname" : "timestamp"
+      },
+      {
+         "oid" : "1184",
+         "typname" : "timestamptz"
+      },
+      {
+         "oid" : "1186",
+         "typname" : "interval"
+      },
+      {
+         "oid" : "1266",
+         "typname" : "timetz"
+      },
+      {
+         "oid" : "1560",
+         "typname" : "bit"
+      },
+      {
+         "oid" : "1562",
+         "typname" : "varbit"
+      },
+      {
+         "oid" : "1700",
+         "typname" : "numeric"
+      },
+      {
+         "oid" : "1790",
+         "typname" : "refcursor"
+      },
+      {
+         "oid" : "2202",
+         "typname" : "regprocedure"
+      },
+      {
+         "oid" : "2203",
+         "typname" : "regoper"
+      },
+      {
+         "oid" : "2204",
+         "typname" : "regoperator"
+      },
+      {
+         "oid" : "2205",
+         "typname" : "regclass"
+      },
+      {
+         "oid" : "4191",
+         "typname" : "regcollation"
+      },
+      {
+         "oid" : "2206",
+         "typname" : "regtype"
+      },
+      {
+         "oid" : "4096",
+         "typname" : "regrole"
+      },
+      {
+         "oid" : "4089",
+         "typname" : "regnamespace"
+      },
+      {
+         "oid" : "2950",
+         "typname" : "uuid"
+      },
+      {
+         "oid" : "3220",
+         "typname" : "pg_lsn"
+      },
+      {
+         "oid" : "3614",
+         "typname" : "tsvector"
+      },
+      {
+         "oid" : "3642",
+         "typname" : "gtsvector"
+      },
+      {
+         "oid" : "3615",
+         "typname" : "tsquery"
+      },
+      {
+         "oid" : "3734",
+         "typname" : "regconfig"
+      },
+      {
+         "oid" : "3769",
+         "typname" : "regdictionary"
+      },
+      {
+         "oid" : "3802",
+         "typname" : "jsonb"
+      },
+      {
+         "oid" : "4072",
+         "typname" : "jsonpath"
+      },
+      {
+         "oid" : "2970",
+         "typname" : "txid_snapshot"
+      },
+      {
+         "oid" : "5038",
+         "typname" : "pg_snapshot"
+      },
+      {
+         "oid" : "3904",
+         "typname" : "int4range",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "3906",
+         "typname" : "numrange",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "3908",
+         "typname" : "tsrange",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "3910",
+         "typname" : "tstzrange",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "3912",
+         "typname" : "daterange",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "3926",
+         "typname" : "int8range",
+         "typtype" : "r"
+      },
+      {
+         "oid" : "4451",
+         "typname" : "int4multirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "4532",
+         "typname" : "nummultirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "4533",
+         "typname" : "tsmultirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "4534",
+         "typname" : "tstzmultirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "4535",
+         "typname" : "datemultirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "4536",
+         "typname" : "int8multirange",
+         "typtype" : "m"
+      },
+      {
+         "oid" : "2249",
+         "typname" : "record",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2287",
+         "typname" : "_record",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2275",
+         "typname" : "cstring",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2276",
+         "typname" : "any",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2277",
+         "typname" : "anyarray",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2278",
+         "typname" : "void",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2279",
+         "typname" : "trigger",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "3838",
+         "typname" : "event_trigger",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2280",
+         "typname" : "language_handler",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2281",
+         "typname" : "internal",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2283",
+         "typname" : "anyelement",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "2776",
+         "typname" : "anynonarray",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "3500",
+         "typname" : "anyenum",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "3115",
+         "typname" : "fdw_handler",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "325",
+         "typname" : "index_am_handler",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "3310",
+         "typname" : "tsm_handler",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "269",
+         "typname" : "table_am_handler",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "3831",
+         "typname" : "anyrange",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "5077",
+         "typname" : "anycompatible",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "5078",
+         "typname" : "anycompatiblearray",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "5079",
+         "typname" : "anycompatiblenonarray",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "5080",
+         "typname" : "anycompatiblerange",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "4537",
+         "typname" : "anymultirange",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "4538",
+         "typname" : "anycompatiblemultirange",
+         "typtype" : "p"
+      },
+      {
+         "oid" : "4600",
+         "typname" : "pg_brin_bloom_summary"
+      },
+      {
+         "oid" : "4601",
+         "typname" : "pg_brin_minmax_multi_summary"
+      }
+   ]
+}

--- a/src/Npgsql/pg_catalog/catalogs.json
+++ b/src/Npgsql/pg_catalog/catalogs.json
@@ -33,90 +33,111 @@
    ],
    "pg_type" : [
       {
+         "array_type_oid" : "1000",
          "oid" : "16",
          "typname" : "bool"
       },
       {
+         "array_type_oid" : "1001",
          "oid" : "17",
          "typname" : "bytea"
       },
       {
+         "array_type_oid" : "1002",
          "oid" : "18",
          "typname" : "char"
       },
       {
+         "array_type_oid" : "1003",
          "oid" : "19",
          "typname" : "name"
       },
       {
+         "array_type_oid" : "1016",
          "oid" : "20",
          "typname" : "int8"
       },
       {
+         "array_type_oid" : "1005",
          "oid" : "21",
          "typname" : "int2"
       },
       {
+         "array_type_oid" : "1006",
          "oid" : "22",
          "typname" : "int2vector"
       },
       {
+         "array_type_oid" : "1007",
          "oid" : "23",
          "typname" : "int4"
       },
       {
+         "array_type_oid" : "1008",
          "oid" : "24",
          "typname" : "regproc"
       },
       {
+         "array_type_oid" : "1009",
          "oid" : "25",
          "typname" : "text"
       },
       {
+         "array_type_oid" : "1028",
          "oid" : "26",
          "typname" : "oid"
       },
       {
+         "array_type_oid" : "1010",
          "oid" : "27",
          "typname" : "tid"
       },
       {
+         "array_type_oid" : "1011",
          "oid" : "28",
          "typname" : "xid"
       },
       {
+         "array_type_oid" : "1012",
          "oid" : "29",
          "typname" : "cid"
       },
       {
+         "array_type_oid" : "1013",
          "oid" : "30",
          "typname" : "oidvector"
       },
       {
+         "array_type_oid" : "210",
          "oid" : "71",
          "typname" : "pg_type",
          "typtype" : "c"
       },
       {
+         "array_type_oid" : "270",
          "oid" : "75",
          "typname" : "pg_attribute",
          "typtype" : "c"
       },
       {
+         "array_type_oid" : "272",
          "oid" : "81",
          "typname" : "pg_proc",
          "typtype" : "c"
       },
       {
+         "array_type_oid" : "273",
          "oid" : "83",
          "typname" : "pg_class",
          "typtype" : "c"
       },
       {
+         "array_type_oid" : "199",
          "oid" : "114",
          "typname" : "json"
       },
       {
+         "array_type_oid" : "143",
          "oid" : "142",
          "typname" : "xml"
       },
@@ -142,38 +163,47 @@
          "typtype" : "p"
       },
       {
+         "array_type_oid" : "271",
          "oid" : "5069",
          "typname" : "xid8"
       },
       {
+         "array_type_oid" : "1017",
          "oid" : "600",
          "typname" : "point"
       },
       {
+         "array_type_oid" : "1018",
          "oid" : "601",
          "typname" : "lseg"
       },
       {
+         "array_type_oid" : "1019",
          "oid" : "602",
          "typname" : "path"
       },
       {
+         "array_type_oid" : "1020",
          "oid" : "603",
          "typname" : "box"
       },
       {
+         "array_type_oid" : "1027",
          "oid" : "604",
          "typname" : "polygon"
       },
       {
+         "array_type_oid" : "629",
          "oid" : "628",
          "typname" : "line"
       },
       {
+         "array_type_oid" : "1021",
          "oid" : "700",
          "typname" : "float4"
       },
       {
+         "array_type_oid" : "1022",
          "oid" : "701",
          "typname" : "float8"
       },
@@ -183,213 +213,263 @@
          "typtype" : "p"
       },
       {
+         "array_type_oid" : "719",
          "oid" : "718",
          "typname" : "circle"
       },
       {
+         "array_type_oid" : "791",
          "oid" : "790",
          "typname" : "money"
       },
       {
+         "array_type_oid" : "1040",
          "oid" : "829",
          "typname" : "macaddr"
       },
       {
+         "array_type_oid" : "1041",
          "oid" : "869",
          "typname" : "inet"
       },
       {
+         "array_type_oid" : "651",
          "oid" : "650",
          "typname" : "cidr"
       },
       {
+         "array_type_oid" : "775",
          "oid" : "774",
          "typname" : "macaddr8"
       },
       {
+         "array_type_oid" : "1034",
          "oid" : "1033",
          "typname" : "aclitem"
       },
       {
+         "array_type_oid" : "1014",
          "oid" : "1042",
          "typname" : "bpchar"
       },
       {
+         "array_type_oid" : "1015",
          "oid" : "1043",
          "typname" : "varchar"
       },
       {
+         "array_type_oid" : "1182",
          "oid" : "1082",
          "typname" : "date"
       },
       {
+         "array_type_oid" : "1183",
          "oid" : "1083",
          "typname" : "time"
       },
       {
+         "array_type_oid" : "1115",
          "oid" : "1114",
          "typname" : "timestamp"
       },
       {
+         "array_type_oid" : "1185",
          "oid" : "1184",
          "typname" : "timestamptz"
       },
       {
+         "array_type_oid" : "1187",
          "oid" : "1186",
          "typname" : "interval"
       },
       {
+         "array_type_oid" : "1270",
          "oid" : "1266",
          "typname" : "timetz"
       },
       {
+         "array_type_oid" : "1561",
          "oid" : "1560",
          "typname" : "bit"
       },
       {
+         "array_type_oid" : "1563",
          "oid" : "1562",
          "typname" : "varbit"
       },
       {
+         "array_type_oid" : "1231",
          "oid" : "1700",
          "typname" : "numeric"
       },
       {
+         "array_type_oid" : "2201",
          "oid" : "1790",
          "typname" : "refcursor"
       },
       {
+         "array_type_oid" : "2207",
          "oid" : "2202",
          "typname" : "regprocedure"
       },
       {
+         "array_type_oid" : "2208",
          "oid" : "2203",
          "typname" : "regoper"
       },
       {
+         "array_type_oid" : "2209",
          "oid" : "2204",
          "typname" : "regoperator"
       },
       {
+         "array_type_oid" : "2210",
          "oid" : "2205",
          "typname" : "regclass"
       },
       {
+         "array_type_oid" : "4192",
          "oid" : "4191",
          "typname" : "regcollation"
       },
       {
+         "array_type_oid" : "2211",
          "oid" : "2206",
          "typname" : "regtype"
       },
       {
+         "array_type_oid" : "4097",
          "oid" : "4096",
          "typname" : "regrole"
       },
       {
+         "array_type_oid" : "4090",
          "oid" : "4089",
          "typname" : "regnamespace"
       },
       {
+         "array_type_oid" : "2951",
          "oid" : "2950",
          "typname" : "uuid"
       },
       {
+         "array_type_oid" : "3221",
          "oid" : "3220",
          "typname" : "pg_lsn"
       },
       {
+         "array_type_oid" : "3643",
          "oid" : "3614",
          "typname" : "tsvector"
       },
       {
+         "array_type_oid" : "3644",
          "oid" : "3642",
          "typname" : "gtsvector"
       },
       {
+         "array_type_oid" : "3645",
          "oid" : "3615",
          "typname" : "tsquery"
       },
       {
+         "array_type_oid" : "3735",
          "oid" : "3734",
          "typname" : "regconfig"
       },
       {
+         "array_type_oid" : "3770",
          "oid" : "3769",
          "typname" : "regdictionary"
       },
       {
+         "array_type_oid" : "3807",
          "oid" : "3802",
          "typname" : "jsonb"
       },
       {
+         "array_type_oid" : "4073",
          "oid" : "4072",
          "typname" : "jsonpath"
       },
       {
+         "array_type_oid" : "2949",
          "oid" : "2970",
          "typname" : "txid_snapshot"
       },
       {
+         "array_type_oid" : "5039",
          "oid" : "5038",
          "typname" : "pg_snapshot"
       },
       {
+         "array_type_oid" : "3905",
          "oid" : "3904",
          "typname" : "int4range",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "3907",
          "oid" : "3906",
          "typname" : "numrange",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "3909",
          "oid" : "3908",
          "typname" : "tsrange",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "3911",
          "oid" : "3910",
          "typname" : "tstzrange",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "3913",
          "oid" : "3912",
          "typname" : "daterange",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "3927",
          "oid" : "3926",
          "typname" : "int8range",
          "typtype" : "r"
       },
       {
+         "array_type_oid" : "6150",
          "oid" : "4451",
          "typname" : "int4multirange",
          "typtype" : "m"
       },
       {
+         "array_type_oid" : "6151",
          "oid" : "4532",
          "typname" : "nummultirange",
          "typtype" : "m"
       },
       {
+         "array_type_oid" : "6152",
          "oid" : "4533",
          "typname" : "tsmultirange",
          "typtype" : "m"
       },
       {
+         "array_type_oid" : "6153",
          "oid" : "4534",
          "typname" : "tstzmultirange",
          "typtype" : "m"
       },
       {
+         "array_type_oid" : "6155",
          "oid" : "4535",
          "typname" : "datemultirange",
          "typtype" : "m"
       },
       {
+         "array_type_oid" : "6157",
          "oid" : "4536",
          "typname" : "int8multirange",
          "typtype" : "m"
@@ -405,6 +485,7 @@
          "typtype" : "p"
       },
       {
+         "array_type_oid" : "1263",
          "oid" : "2275",
          "typname" : "cstring",
          "typtype" : "p"
@@ -522,5 +603,6 @@
          "oid" : "4601",
          "typname" : "pg_brin_minmax_multi_summary"
       }
-   ]
+   ],
+   "version" : 15
 }

--- a/src/Npgsql/pg_catalog/dat2json.pl
+++ b/src/Npgsql/pg_catalog/dat2json.pl
@@ -1,0 +1,275 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Basename;
+use MIME::Base64;
+
+# sudo apt-get install libwww-perl
+use LWP::UserAgent;
+
+# sudo apt-get install libjson-perl
+use JSON;
+
+# sudo apt-get install libnet-github-perl
+use Net::GitHub::V4;
+
+# Update this once in a while if there is a
+# newer PostgreSQL major release
+use constant LATEST_KNOWN_POSTGRES_MAJOR => 14;
+
+# The URL template in sprintf format where parameter index 1 is the file name and parameter index 2 is the branch
+#use constant URL_TEMPLATE => 'https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob_plain;f=src/include/catalog/%1$s;hb=refs/heads/%2$s';
+use constant URL_TEMPLATE => 'https://raw.githubusercontent.com/postgres/postgres/%2$s/src/include/catalog/%1$s';
+
+# The template for the stable PostgreSQL git branch to pull from in sprintf format
+use constant BRANCH_TEMPLATE => 'REL_%u_STABLE';
+
+# The the names of the catalog initialization files the in the PostgreSQL repository
+use constant PG_RANGE_CATALOG_FILE_NAME => 'pg_range.dat';
+use constant PG_TYPE_CATALOG_FILE_NAME => 'pg_type.dat';
+
+# Positive lists of the keys we are interested in so that we can trim down our generated json files to the bare minimum.
+# This avoids creating PRs for .dat file changes that don't really affect our behavior
+use constant PG_RANGE_KEYS => qw(rngtypid rngsubtype rngmultitypid);
+use constant PG_TYPE_KEYS => qw(oid typname typtype);
+
+die "Please pass the access token" unless defined $ARGV[0];
+run();
+
+sub run {
+    my $access_token = shift(@ARGV);
+    my ($pg_range, $pg_type, $latestBranch, $pg_range_url, $pg_type_url, $httpResponse);
+    my $ua = LWP::UserAgent->new;
+    $ua->agent("Npgsql catalog updater");
+
+    # Try to get the .dat files latest stable PostgreSQL release by trying urls while incrementing the major version
+    # starting at LATEST_KNOWN_POSTGRES_MAJOR
+    for (my $i = LATEST_KNOWN_POSTGRES_MAJOR;$i < 100;$i++) {
+        my $currentBranch = sprintf(BRANCH_TEMPLATE, $i);
+        $pg_range_url = sprintf(URL_TEMPLATE, PG_RANGE_CATALOG_FILE_NAME, $currentBranch);
+        my $req = HTTP::Request->new(GET => $pg_range_url);
+        $httpResponse = $ua->request($req);
+        last unless $httpResponse->is_success;
+        $pg_range = $httpResponse->decoded_content;
+
+        $pg_type_url = sprintf(URL_TEMPLATE, PG_TYPE_CATALOG_FILE_NAME, $currentBranch);
+        $req = HTTP::Request->new(GET => $pg_type_url);
+        $httpResponse = $ua->request($req);
+        last unless $httpResponse->is_success;
+        $pg_type = $httpResponse->decoded_content;
+        $latestBranch = $currentBranch;
+    }
+
+    die "Failed to get ${\PG_RANGE_CATALOG_FILE_NAME} from $pg_range_url: ${\$httpResponse->status_line}" unless defined $pg_range;
+    die "Failed to get ${\PG_TYPE_CATALOG_FILE_NAME} from $pg_type_url: ${\$httpResponse->status_line}" unless defined $pg_type;
+
+    $pg_type = filter_dat_entries($pg_type, PG_TYPE_KEYS);
+    $pg_range = filter_dat_entries($pg_range, PG_RANGE_KEYS);
+
+    my $json = JSON->new->allow_nonref;
+    $json->canonical();
+
+    my $newJson = $json->pretty->encode( { pg_range => $pg_range, pg_type => $pg_type } );
+    my $catalogs_json_path = sprintf("%s/catalogs.json", dirname(__FILE__));
+    open(my $fh, '+<:raw', $catalogs_json_path) or die "Failed to open '$catalogs_json_path': $!";
+    read $fh, my $oldJson, -s $fh;
+    if ($newJson ne $oldJson) {
+        print "Detected changes in $latestBranch.\n";
+        truncate $fh, 0;
+        seek $fh, 0, 0;
+        print $fh $newJson;
+        commit_and_pr($access_token, $latestBranch, encode_base64($newJson, ''));
+    }
+    else {
+        print "The file '$catalogs_json_path' is up to date.\n";
+    }
+    close($fh);
+}
+
+sub filter_dat_entries {
+    my $datArray = eval(shift);
+    my @wantedKeys = @_;
+
+    for my $i (0 .. $#$datArray) {
+        # We don't use hash slicing here since this adds missing keys with null values
+        foreach my $key (keys %{${$datArray}[$i]}) {
+            delete ${${$datArray}[$i]}{$key} unless (grep $_ eq $key, @wantedKeys);
+        }
+    }
+    return $datArray;
+}
+
+sub commit_and_pr {
+    my ($access_token, $postgresBranch, $encoded_json) = @_;
+
+    my $gh = Net::GitHub::V4->new( access_token => $access_token );
+    my $repositoryOwner = 'Brar';
+    my $repository = 'Npgsql';
+    my $currentBranch = 'main';
+    if (defined($ENV{GITHUB_REPOSITORY_OWNER})) {
+        $repositoryOwner = $ENV{GITHUB_REPOSITORY_OWNER};
+    }
+    if (defined($ENV{GITHUB_REPOSITORY})) {
+        $repository = $ENV{GITHUB_REPOSITORY};
+    }
+    if (defined($ENV{GITHUB_REF_NAME})) {
+        $currentBranch = $ENV{GITHUB_REF_NAME};
+    }
+
+    # First get the current repository's id and the HEAD which we need to create a branch
+    my $result = $gh->query(<<'QUERY_END', { 'owner' => $repositoryOwner, 'repository' => $repository, 'branch' => $currentBranch });
+query GetRepositoryInfoForBranching($owner: String!, $repository: String!, $branch: String!) {
+  repository(owner: $owner, name: $repository) {
+    id
+    ref(qualifiedName: $branch) {
+      target {
+        ... on Commit {
+          history(first: 1) {
+            nodes {
+              oid
+            }
+          }
+        }
+      }
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+
+    my $headOid = ${${${${${${${$$result{'data'}}{'repository'}}{'ref'}}{'target'}}{'history'}}{'nodes'}}[0]}{'oid'};
+    my $repositoryId = ${${$$result{'data'}}{'repository'}}{'id'};
+
+    # Then get all update_catalog/* branches to find the next available branch name
+    # This may cause race conditions if two GitHub actions jobs run at the same
+    # time but let's see whether this really happens in practice
+    $result = $gh->query(<<'QUERY_END', { 'owner' => $repositoryOwner, 'repository' => $repository });
+query GetUpdateCatalogBranches($owner: String!, $repository: String!) {
+  repository(owner: $owner, name: $repository) {
+    refs(
+      refPrefix: "refs/heads/"
+      first: 100
+      query: "update_catalog/"
+    ) {
+      nodes {
+        name
+      }
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+    
+    my @updateCatalogBranches = @{${${${$$result{'data'}}{'repository'}}{'refs'}}{'nodes'}};
+    my $nextBranchIndex = 1;
+    foreach(@updateCatalogBranches) {
+        my $branchIndex = 0 + ((split(/\//, $$_{'name'}))[1]);
+        if ($nextBranchIndex <= $branchIndex) {
+            $nextBranchIndex = 1 + $branchIndex;
+        }
+    }
+    my $updateCatalogBranch = sprintf('refs/heads/update_catalog/%04u', $nextBranchIndex);
+
+    # Then create a new branch to later create a pull request from it
+    $result = $gh->query(<<'QUERY_END', { 'repository_id' => $repositoryId, 'update_catalog_branch' => $updateCatalogBranch, 'head_oid' => $headOid });
+mutation CreateUpdateCatalogBranch($repository_id: ID!, $update_catalog_branch: String!, $head_oid: GitObjectID!) {
+  createRef(
+    input: {repositoryId: $repository_id, name: $update_catalog_branch, oid: $head_oid}
+  ) {
+    ref {
+      name
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+
+    my $updateCatalogBranchName = ${${${$$result{'data'}}{'createRef'}}{'ref'}}{'name'};
+    print "Created branch $updateCatalogBranchName from $currentBranch in $repositoryOwner/$repository\n";
+
+    # Then get the head of the newly created branch to append the commit to it
+    $result = $gh->query(<<'QUERY_END', { 'owner' => $repositoryOwner, 'repository' => $repository, 'branch' => $updateCatalogBranchName });
+query GetExpectedHeadOid($owner:String!, $repository:String!, $branch:String!) {
+  repository(owner: $owner, name: $repository) {
+    ref(qualifiedName: $branch) {
+      target {
+        ... on Commit {
+          history(first: 1) {
+            nodes {
+              oid
+            }
+          }
+        }
+      }
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+
+    my $expectedHeadOid = ${${${${${${${$$result{'data'}}{'repository'}}{'ref'}}{'target'}}{'history'}}{'nodes'}}[0]}{'oid'};
+    
+    # Then add a commit with the new catalogs.json file
+    my $commitAndPrTitle = "Update catalogs.json from PostgreSQL's $postgresBranch branch";
+    my $commitInput = {
+        'branch' => {
+            'repositoryNameWithOwner' => "$repositoryOwner/$repository",
+            'branchName' => $updateCatalogBranchName
+        },
+        'message' => {
+            'headline' => $commitAndPrTitle
+        },
+        'fileChanges' => {
+            'additions' => [
+                {
+                    'path'     => 'src/Npgsql/pg_catalog/catalogs.json',
+                    'contents' => $encoded_json
+                }
+            ]
+        },
+        'expectedHeadOid' => $expectedHeadOid };
+
+    $result = $gh->query(<<'QUERY_END', {'input' => $commitInput });
+mutation CommitJsonUpdate($input:CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      url
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+
+    my $commitUrl = ${${${$$result{'data'}}{'createCommitOnBranch'}}{'commit'}}{'url'};
+
+    print "Added commit $commitUrl\n";
+
+    # Finally create a pull request to the original branch
+    $result = $gh->query(<<'QUERY_END', { 'repository_id' => $repositoryId, 'head_branch' => $updateCatalogBranchName, 'base_branch' => $currentBranch, 'title' => $commitAndPrTitle });
+mutation CreatePullRequest($repository_id: ID!, $base_branch: String!, $head_branch: String!, $title: String!) {
+  createPullRequest(
+    input: {repositoryId: $repository_id, baseRefName: $base_branch, headRefName: $head_branch, title: $title}
+  ) {
+    pullRequest {
+      url
+    }
+  }
+}
+QUERY_END
+    handle_graphql_error($result);
+
+    my $prUrl = ${${${$$result{'data'}}{'createPullRequest'}}{'pullRequest'}}{'url'};
+
+    print "Created pull request $prUrl\n";
+}
+
+sub handle_graphql_error {
+    my $result = shift;
+
+    if (defined($$result{'message'})) {
+        die "API query failed: $$result{'message'}";
+    }
+    elsif (defined(${${$$result{'errors'}}[0]}{'message'})) {
+        die "API query failed: ${${$$result{'errors'}}[0]}{'message'}";
+    }
+}

--- a/src/Npgsql/pg_catalog/dat2json.pl
+++ b/src/Npgsql/pg_catalog/dat2json.pl
@@ -33,7 +33,6 @@ use constant PG_TYPE_CATALOG_FILE_NAME => 'pg_type.dat';
 use constant PG_RANGE_KEYS => qw(rngtypid rngsubtype rngmultitypid);
 use constant PG_TYPE_KEYS => qw(oid typname typtype array_type_oid);
 
-die "Please pass the access token" unless defined $ARGV[0];
 run();
 
 sub run {
@@ -79,7 +78,7 @@ sub run {
         truncate $fh, 0;
         seek $fh, 0, 0;
         print $fh $newJson;
-        commit_and_pr($access_token, $latestBranch, encode_base64($newJson, ''));
+        commit_and_pr($access_token, $latestBranch, encode_base64($newJson, '')) if defined($access_token);
     }
     else {
         print "The file '$catalogs_json_path' is up to date.\n";


### PR DESCRIPTION
This adds a souce generator that parses the pg_type.dat and pg_range.dat
(copies from their src/include/catalog/ folder) files, that PostgreSQL
itself uses to initialize a cluster, to generate a NpgsqlDatabaseInfo.

Closes #3890