### PR TITLE
Fix auto-preparation with SchemaOnly

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1020,9 +1020,8 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
                 if (batchCommand.PreparedStatement?.State == PreparedState.Prepared)
                     continue;   // Prepared, we already have the RowDescription
-                Debug.Assert(batchCommand.PreparedStatement == null);
 
-                await connector.WriteParse(batchCommand.FinalCommandText!, string.Empty, batchCommand.PositionalParameters, async, cancellationToken);
+                await connector.WriteParse(batchCommand.FinalCommandText!, batchCommand.StatementName, batchCommand.PositionalParameters, async, cancellationToken);
                 await connector.WriteDescribe(StatementOrPortal.Statement, batchCommand.StatementName, async, cancellationToken);
                 wroteSomething = true;
             }

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -622,7 +622,27 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 }
                 else
                 {
+                    var pStatement = statement.PreparedStatement;
+                    if (pStatement != null)
+                    {
+                        Debug.Assert(!pStatement.IsPrepared);
+                        if (pStatement.StatementBeingReplaced != null)
+                        {
+                            Expect<CloseCompletedMessage>(await Connector.ReadMessage(async), Connector);
+                            pStatement.StatementBeingReplaced.CompleteUnprepare();
+                            pStatement.StatementBeingReplaced = null;
+                        }
+                    }
+
                     Expect<ParseCompleteMessage>(await Connector.ReadMessage(async), Connector);
+
+                    if (statement.IsPreparing)
+                    {
+                        pStatement!.State = PreparedState.Prepared;
+                        Connector.PreparedStatementManager.NumPrepared++;
+                        statement.IsPreparing = false;
+                    }
+
                     Expect<ParameterDescriptionMessage>(await Connector.ReadMessage(async), Connector);
                     var msg = await Connector.ReadMessage(async);
                     switch (msg.Code)
@@ -658,12 +678,31 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         {
             State = ReaderState.Consumed;
 
-            // Reference the triggering statement from the exception (for batching)
-            if (e is PostgresException postgresException &&
-                Command.IsWrappedByBatch &&
-                StatementIndex >= 0 && StatementIndex < _statements.Count)
+            // Reference the triggering statement from the exception
+            if (e is PostgresException postgresException && StatementIndex >= 0 && StatementIndex < _statements.Count)
             {
                 postgresException.BatchCommand = _statements[StatementIndex];
+
+                // Prevent the command or batch from by recycled (by the connection) when it's disposed. This is important since
+                // the exception is very likely to escape the using statement of the command, and by that time some other user may
+                // already be using the recycled instance.
+                if (!Command.IsWrappedByBatch)
+                {
+                    Command.IsCached = false;
+                }
+            }
+
+            // An error means all subsequent statements were skipped by PostgreSQL.
+            // If any of them were being prepared, we need to update our bookkeeping to put
+            // them back in unprepared state.
+            for (; StatementIndex < _statements.Count; StatementIndex++)
+            {
+                var statement = _statements[StatementIndex];
+                if (statement.IsPreparing)
+                {
+                    statement.IsPreparing = false;
+                    statement.PreparedStatement!.AbortPrepare();
+                }
             }
 
             throw;


### PR DESCRIPTION
Fixes #4404

I debated whether to simply not auto-prepare for SchemaOnly, but finally decided it's an "execution" just like any other (and I'd rather not introduce more checks in the critical path because of SchemaOnly). But if you think we should go the other way I'm open to that too...

In any case, at some point we should look at maybe refactoring NpgsqlDataReader.{NextResult,NextResultSchemaOnly} since they contain lots of duplication.