### PR TITLE
Fix the handling of tstzrange when one or both ends are open

### DIFF
--- a/src/Npgsql.NodaTime/Internal/TimestampTzRangeHandler.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampTzRangeHandler.cs
@@ -49,11 +49,11 @@ public partial class TimestampTzRangeHandler : RangeHandler<Instant>,
 
     public int ValidateAndGetLength(Interval value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         => ValidateAndGetLengthRange(
-            new NpgsqlRange<Instant>(value.Start, true, !value.HasStart, value.End, false, !value.HasEnd), ref lengthCache, parameter);
+            new NpgsqlRange<Instant>(value.HasStart ? value.Start : Instant.MinValue, true, !value.HasStart, value.HasEnd ? value.End : Instant.MaxValue, false, !value.HasEnd), ref lengthCache, parameter);
 
     public Task Write(Interval value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache,
         NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
-        => WriteRange(new NpgsqlRange<Instant>(value.Start, true, !value.HasStart, value.End, false, !value.HasEnd),
+        => WriteRange(new NpgsqlRange<Instant>(value.HasStart ? value.Start : Instant.MinValue, true, !value.HasStart, value.HasEnd ? value.End : Instant.MaxValue, false, !value.HasEnd),
             buf, lengthCache, parameter, async, cancellationToken);
 
     #region Boilerplate

--- a/test/Npgsql.NodaTime.Tests/NodaTimeTests.cs
+++ b/test/Npgsql.NodaTime.Tests/NodaTimeTests.cs
@@ -215,6 +215,31 @@ public class NodaTimeTests : TestBase
             "tstzrange",
             NpgsqlDbType.TimestampTzRange);
 
+    [Test]
+    public Task Tstzrange_with_no_end_as_Interval()
+        => AssertType(
+            new Interval(
+                new LocalDateTime(1998, 4, 12, 13, 26, 38).InUtc().ToInstant(), null),
+            @"[""1998-04-12 15:26:38+02"",)",
+            "tstzrange",
+            NpgsqlDbType.TimestampTzRange);
+
+    [Test]
+    public Task Tstzrange_with_no_start_as_Interval()
+        => AssertType(
+            new Interval( null,
+                new LocalDateTime(1998, 4, 12, 13, 26, 38).InUtc().ToInstant()),
+            @"(,""1998-04-12 15:26:38+02"")",
+            "tstzrange",
+            NpgsqlDbType.TimestampTzRange);
+
+    [Test]
+    public Task Tstzrange_with_no_start_or_end_as_Interval()
+        => AssertType(
+            new Interval(null, null),
+            @"(,)",
+            "tstzrange",
+            NpgsqlDbType.TimestampTzRange);
 
     [Test]
     public Task Tstzrange_as_NpgsqlRange_of_Instant()
@@ -350,8 +375,17 @@ public class NodaTimeTests : TestBase
                 new Interval(
                     new LocalDateTime(1998, 4, 13, 13, 26, 38).InUtc().ToInstant(),
                     new LocalDateTime(1998, 4, 13, 15, 26, 38).InUtc().ToInstant()),
+                new Interval(
+                    new LocalDateTime(1998, 4, 13, 13, 26, 38).InUtc().ToInstant(),
+                    null),
+                new Interval(
+                    null,
+                    new LocalDateTime(1998, 4, 13, 13, 26, 38).InUtc().ToInstant()),
+                new Interval(
+                    null,
+                    null)
             },
-            @"{""[\""1998-04-12 15:26:38+02\"",\""1998-04-12 17:26:38+02\"")"",""[\""1998-04-13 15:26:38+02\"",\""1998-04-13 17:26:38+02\"")""}",
+            @"{""[\""1998-04-12 15:26:38+02\"",\""1998-04-12 17:26:38+02\"")"",""[\""1998-04-13 15:26:38+02\"",\""1998-04-13 17:26:38+02\"")"",""[\""1998-04-13 15:26:38+02\"",)"",""(,\""1998-04-13 15:26:38+02\"")"",""(,)""}",
             "tstzrange[]",
             NpgsqlDbType.TimestampTzRange | NpgsqlDbType.Array,
             isDefaultForWriting: false);


### PR DESCRIPTION
Trying to read `Start` or `End` of an `Interval` object throws `Interval extends to start/end of time` exceptions when that end is open. To prevent that, I added checks to make sure we don't try to access them if the values don't exist to begin with.