### PR TITLE
Fix tests failing on newer pg versions

### DIFF
--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -1020,6 +1020,7 @@ namespace Npgsql.Tests
             // See also ReaderTests.Statements()
             using (var conn = OpenConnection())
             {
+                TestUtil.MaximumPgVersionExclusive(conn, "12.0", "WITH OIDS is not supported anymore as of PostgreSQL 12");
                 conn.ExecuteNonQuery("CREATE TEMP TABLE data (name TEXT) WITH OIDS");
                 using (var cmd = new NpgsqlCommand(
                     "INSERT INTO data (name) VALUES (@p1);" +

--- a/test/Npgsql.Tests/ReaderOldSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderOldSchemaTests.cs
@@ -42,6 +42,7 @@ namespace Npgsql.Tests
         {
             using (var conn = OpenConnection())
             {
+                TestUtil.MaximumPgVersionExclusive(conn, "12.0", "WITH OIDS is not supported anymore as of PostgreSQL 12");
                 conn.ExecuteNonQuery("DROP TABLE IF EXISTS DATA2 CASCADE");
                 conn.ExecuteNonQuery(@"CREATE TEMP TABLE DATA2 (
                                 field_pk1                      INT2 NOT NULL,

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -182,6 +182,7 @@ namespace Npgsql.Tests
             // See also CommandTests.Statements()
             using (var conn = OpenConnection())
             {
+                TestUtil.MaximumPgVersionExclusive(conn, "12.0", "WITH OIDS is not supported anymore as of PostgreSQL 12");
                 conn.ExecuteNonQuery("CREATE TEMP TABLE data (name TEXT) WITH OIDS");
                 using (var cmd = new NpgsqlCommand(
                     "INSERT INTO data (name) VALUES ('a');" +

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -66,6 +66,18 @@ namespace Npgsql.Tests
             }
         }
 
+        public static void MaximumPgVersionExclusive(NpgsqlConnection conn, string maxVersion, string? ignoreText = null)
+        {
+            var max = new Version(maxVersion);
+            if (conn.PostgreSqlVersion >= max)
+            {
+                var msg = $"Postgresql backend version {conn.PostgreSqlVersion} is greater than or equal to the required (exclusive) maximum of {maxVersion}";
+                if (ignoreText != null)
+                    msg += ": " + ignoreText;
+                Assert.Ignore(msg);
+            }
+        }
+
         public static string GetUniqueIdentifier(string prefix)
             => prefix + Interlocked.Increment(ref _counter);
 


### PR DESCRIPTION
Since this branch hasn't been updated/tested for a while some tests are failing for PostgreSQL versions greater than 11.
This fixes it.