### PR TITLE
DRAFT: Add role support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,8 @@ jobs:
           
           sudo -u postgres psql -c "CREATE USER npgsql_tests_ssl SUPERUSER PASSWORD 'npgsql_tests_ssl'"
           sudo -u postgres psql -c "CREATE USER npgsql_tests_nossl SUPERUSER PASSWORD 'npgsql_tests_nossl'"
+          sudo -u postgres psql -c "CREATE ROLE npgsql_tests_role1"
+          sudo -u postgres psql -c "CREATE ROLE npgsql_tests_role2"
 
           # To disable PostGIS for prereleases (because it usually isn't available until late), surround with the following:
           if [ -z "${{ matrix.pg_prerelease }}" ]; then
@@ -194,6 +196,9 @@ jobs:
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_ssl SUPERUSER LOGIN PASSWORD 'npgsql_tests_ssl'"
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_nossl SUPERUSER LOGIN PASSWORD 'npgsql_tests_nossl'"
 
+          pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_role1"
+          pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_role2"
+
           # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
           if [ ${{ matrix.pg_major }} -ge 14 ]; then
             sed -i "s|password_encryption = md5|password_encryption = scram-sha-256|" pgsql/PGDATA/postgresql.conf
@@ -250,6 +255,9 @@ jobs:
             
             psql -c "CREATE USER npgsql_tests_ssl SUPERUSER PASSWORD 'npgsql_tests_ssl'" postgres
             psql -c "CREATE USER npgsql_tests_nossl SUPERUSER PASSWORD 'npgsql_tests_nossl'" postgres
+
+            psql -c "CREATE ROLE npgsql_tests_role1" postgres
+            psql -c "CREATE ROLE npgsql_tests_role2" postgres
 
             sudo sed -i '' 's/#password_encryption = md5/password_encryption = scram-sha-256/' $PGDATA/postgresql.conf
             sudo sed -i '' 's/#wal_level =/wal_level = logical #/' $PGDATA/postgresql.conf

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -427,6 +427,24 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     }
     string? _timezone;
 
+    /// <summary>
+    /// The role to assume upon connection.
+    /// </summary>
+    [Category("Connection")]
+    [Description("The role to assume upon connection.")]
+    [DisplayName("Role")]
+    [NpgsqlConnectionStringProperty("Role")]
+    public string? Role
+    {
+        get => _role;
+        set
+        {
+            _role = value;
+            SetValue(nameof(Role), value);
+        }
+    }
+    string? _role;
+
     #endregion
 
     #region Properties - Security

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -541,6 +541,8 @@ Npgsql.NpgsqlConnectionStringBuilder.PreloadReader.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.ReadBufferSize.get -> int
 Npgsql.NpgsqlConnectionStringBuilder.ReadBufferSize.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.Remove(System.Collections.Generic.KeyValuePair<string!, object?> item) -> bool
+Npgsql.NpgsqlConnectionStringBuilder.Role.get -> string?
+Npgsql.NpgsqlConnectionStringBuilder.Role.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.RootCertificate.get -> string?
 Npgsql.NpgsqlConnectionStringBuilder.RootCertificate.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.SearchPath.get -> string?

--- a/test/Npgsql.Tests/RoleTests.cs
+++ b/test/Npgsql.Tests/RoleTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Npgsql.Tests;
+
+public class RoleTests : MultiplexingTestBase
+{
+    private const string TestRole = "npgsql_role";
+
+    [Test]
+    [TestCase(true, TestName = "Role")]
+    [TestCase(false, TestName = "NoRole")]
+    public async Task Role(bool useRole)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            Role = useRole ? TestRole : null,
+            MaxPoolSize = 1,
+        };
+
+        var doTest = async () =>
+        {
+            using var conn = await OpenConnectionAsync(builder);
+            var currentUser = await conn.ExecuteScalarAsync("SELECT current_user");
+            var currentUserAsString = currentUser as string;
+
+            Assert.That(currentUserAsString, Is.Not.Null);
+            if (useRole)
+                Assert.That(currentUser, Is.EqualTo(TestRole));
+            else
+                Assert.That(currentUser, Is.EqualTo(builder.Username));
+
+            await conn.CloseAsync();
+        };
+
+        await doTest();
+        await doTest();
+    }
+
+    [OneTimeSetUp]
+    public async Task Setup()
+    {
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionString);
+        using var conn = await OpenConnectionAsync(builder);
+        var result = await conn.ExecuteNonQueryAsync($"CREATE ROLE {TestRole}");
+        await conn.CloseAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDown()
+    {
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionString);
+        using var conn = await OpenConnectionAsync(builder);
+        var result = await conn.ExecuteNonQueryAsync($"DROP ROLE {TestRole}");
+        await conn.CloseAsync();
+    }
+
+    public RoleTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) { }
+}


### PR DESCRIPTION
I've started adding role support. The idea is that you can put `Role=a_role` in the connection string and then `SET ROLE a_role` will be executed at the start of each logical connection.

My implementation is pretty broken at the moment. My tests work one at a time, but not if they are all run together, and they break some of the existing tests as well.

I am interested in some feedback on:
1. Maintainer interest in merging this functionality if I get it implemented correctly.
2. Any tips on where I'm going wrong with the current implementation.

Some background info on my motivation in case it's useful:

 My end goal is to use this through EF Core, which is why I can't insert the `SET ROLE` commands on the application level.

I tried implementing this using [EF Core Interceptors](https://docs.microsoft.com/en-us/ef/core/logging-events-diagnostics/interceptors). I could inject the `SET ROLE` statement, but I couldn't figure out a way to filter out the result of that statement in the [IDbCommandInterceptor.ReaderExecuted](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.diagnostics.idbcommandinterceptor.readerexecuted?view=efcore-6.0#microsoft-entityframeworkcore-diagnostics-idbcommandinterceptor-readerexecuted) method. efcore.pg relies on the return from that method being an `NpgsqlDataReader`, which doesn't have a public constructor, and then in updates looks at the `Statements` property to find the per-statement number of rows affected, which causes then causes `DbUpdateConcurrencyException ` to be thrown because the first statement is my injected `SET ROLE`, not the first statement controlled by EF Core/efcore.pg.
