### PR TITLE
Use ref locals for indexed creations

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -57,7 +57,10 @@ sealed class RowDescriptionMessage : IBackendMessage, IReadOnlyList<FieldDescrip
 
         for (var i = 0; i < numFields; ++i)
         {
-            var field = _fields[i] ??= new();
+            ref var field = ref _fields[i];
+
+            if (field is null)
+                field = new();
 
             field.Populate(
                 typeMapper,

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -219,9 +219,9 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             throw new InvalidOperationException("Not reading a row");
 
         var type = typeof(T);
-        var handler = _typeHandlerCache[_column];
+        ref var handler = ref _typeHandlerCache[_column];
         if (handler == null)
-            handler = _typeHandlerCache[_column] = _typeMapper.ResolveByClrType(type);
+            handler = _typeMapper.ResolveByClrType(type);
 
         return DoRead<T>(handler, async, cancellationToken);
     }
@@ -269,9 +269,9 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         if (_column == -1 || _column == NumColumns)
             throw new InvalidOperationException("Not reading a row");
 
-        var handler = _typeHandlerCache[_column];
+        ref var handler = ref _typeHandlerCache[_column];
         if (handler == null)
-            handler = _typeHandlerCache[_column] = _typeMapper.ResolveByNpgsqlDbType(type);
+            handler = _typeMapper.ResolveByNpgsqlDbType(type);
 
         return DoRead<T>(handler, async, cancellationToken);
     }

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -183,11 +183,11 @@ public sealed class NpgsqlBinaryImporter : ICancelable
     {
         CheckColumnIndex();
 
-        var p = _params[_column];
+        ref var p = ref _params[_column];
         if (p == null)
         {
             // First row, create the parameter objects
-            _params[_column] = p = typeof(T) == typeof(object)
+            p = typeof(T) == typeof(object)
                 ? new NpgsqlParameter()
                 : new NpgsqlParameter<T>();
         }
@@ -235,11 +235,11 @@ public sealed class NpgsqlBinaryImporter : ICancelable
     {
         CheckColumnIndex();
 
-        var p = _params[_column];
+        ref var p = ref _params[_column];
         if (p == null)
         {
             // First row, create the parameter objects
-            _params[_column] = p = typeof(T) == typeof(object)
+            p = typeof(T) == typeof(object)
                 ? new NpgsqlParameter()
                 : new NpgsqlParameter<T>();
             p.NpgsqlDbType = npgsqlDbType;
@@ -287,11 +287,11 @@ public sealed class NpgsqlBinaryImporter : ICancelable
     {
         CheckColumnIndex();
 
-        var p = _params[_column];
+        ref var p = ref _params[_column];
         if (p == null)
         {
             // First row, create the parameter objects
-            _params[_column] = p = typeof(T) == typeof(object)
+            p = typeof(T) == typeof(object)
                 ? new NpgsqlParameter()
                 : new NpgsqlParameter<T>();
             p.DataTypeName = dataTypeName;


### PR DESCRIPTION
A little bit shorter compiled result

```
    public object test1()
    {
        var obj = objs[2] ??= new();
        
        return obj;
    }
    
    public object test2()
    {
        ref var obj = ref objs[2];
            
        if (obj == null)
            obj = new();
        
        return obj;
    }
```

```
C.test1()
    L0000: push rdi
    L0001: push rsi
    L0002: sub rsp, 0x28
    L0006: mov rsi, [rcx+8]
    L000a: cmp dword ptr [rsi+8], 2
    L000e: jbe short L0045
    L0010: mov rax, [rsi+0x20]
    L0014: test rax, rax
    L0017: jne short L003e
    L0019: mov rcx, 0x7fff4de25678
    L0023: call 0x00007fffad9fb080
    L0028: mov rdi, rax
    L002b: mov rcx, rsi
    L002e: mov r8, rdi
    L0031: mov edx, 2
    L0036: call 0x00007fff4de38190
    L003b: mov rax, rdi
    L003e: add rsp, 0x28
    L0042: pop rsi
    L0043: pop rdi
    L0044: ret
    L0045: call 0x00007fffadb1ec40
    L004a: int3

C.test2()
    L0000: push rsi
    L0001: sub rsp, 0x20
    L0005: mov rcx, [rcx+8]
    L0009: mov edx, 2
    L000e: mov r8, 0x7fff4de25678
    L0018: call 0x00007fff4de38200
    L001d: mov rsi, rax
    L0020: cmp qword ptr [rsi], 0
    L0024: jne short L0040
    L0026: mov rcx, 0x7fff4de25678
    L0030: call 0x00007fffad9fb080
    L0035: mov rcx, rsi
    L0038: mov rdx, rax
    L003b: call 0x00007fffad9fab80
    L0040: mov rax, [rsi]
    L0043: add rsp, 0x20
    L0047: pop rsi
    L0048: ret
```