### PR TITLE
Use Rfc2898DeriveBytes in SCRAM-SHA-256 Hi function to reduce allocations

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -221,6 +221,9 @@ partial class NpgsqlConnector
 
         static byte[] Hi(string str, byte[] salt, int count)
         {
+#if NET6_0_OR_GREATER
+            return Rfc2898DeriveBytes.Pbkdf2(str, salt, count, HashAlgorithmName.SHA256, 256 / 8);
+#else
             using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(str));
             var salt1 = new byte[salt.Length + 4];
             byte[] hi, u1;
@@ -238,6 +241,7 @@ partial class NpgsqlConnector
             }
 
             return hi;
+#endif
         }
 
         static byte[] Xor(byte[] buffer1, byte[] buffer2)


### PR DESCRIPTION
On a default local install the `Hi` function on login creates 4,096 `byte[32]`'s. The new one-shot `Rfc2898DeriveBytes.Pbkdf2` reduces that.

| Method |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
|------- |---------:|----------:|----------:|---------:|----------:|
| HiOld  | 3.482 ms | 0.0678 ms | 0.0882 ms | 144.5313 | 459,130 B |
| HiNew  | 2.692 ms | 0.0362 ms | 0.0302 ms |        - |      90 B |