### PR TITLE
Sync fast path for WriteWithLength

### DIFF
--- a/test/Npgsql.Benchmarks/TypeHandlers/Bool.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/Bool.cs
@@ -1,0 +1,10 @@
+﻿using BenchmarkDotNet.Attributes;
+using Npgsql.Internal.TypeHandlers;
+
+namespace Npgsql.Benchmarks.TypeHandlers;
+
+[Config(typeof(Config))]
+public class Bool : TypeHandlerBenchmarks<bool>
+{
+    public Bool() : base(new BoolHandler(GetPostgresType("boolean"))) { }
+}

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -78,12 +78,12 @@ public abstract class TypeHandlerBenchmarks<T>
             _value = value;
             _elementSize = _handler.ValidateAndGetLength(value, ref cache, null);
 
-            cache.Rewind();
+            cache?.Rewind();
 
             _handler.WriteWithLength(_value, _writeBuffer, cache, null, false);
-            Buffer.BlockCopy(_writeBuffer.Buffer, 0, _readBuffer.Buffer, 0, _elementSize);
+            Buffer.BlockCopy(_writeBuffer.Buffer, 0, _readBuffer.Buffer, 0, sizeof(int) + _elementSize);
 
-            _readBuffer.FilledBytes = _elementSize;
+            _readBuffer.FilledBytes = sizeof(int) + _elementSize;
             _writeBuffer.WritePosition = 0;
         }
     }


### PR DESCRIPTION
Adds a sync path for WriteWithLength when the remaining buffer is large enough.
`Many_parameters_with_mixed_FormatCode` at least hits the async code for simple types.

Creating this as draft as I wasn't sure if this meets the patterns in your code base as it does lead to some duplication.
`Many_parameters_with_mixed_FormatCode` at least hits the async code for simple types.

The 10,000 text perf test doesn't fit in the provided buffer before or after.

**Uuid**
Before
| Method |                Value |     Mean |    Error |   StdDev |         Op/s | Allocated |
|------- |--------------------- |---------:|---------:|---------:|-------------:|----------:|
|   Read | 00000(...)00000 [36] | 16.58 ns | 0.247 ns | 0.231 ns | 60,321,591.9 |         - |
|  Write | 00000(...)00000 [36] | 26.51 ns | 0.349 ns | 0.309 ns | 37,724,693.1 |         - |

After
| Method |                Value |     Mean |    Error |   StdDev |         Op/s | Allocated |
|------- |--------------------- |---------:|---------:|---------:|-------------:|----------:|
|   Read | 00000(...)00000 [36] | 16.71 ns | 0.204 ns | 0.181 ns | 59,846,401.4 |         - |
|  Write | 00000(...)00000 [36] | 14.17 ns | 0.130 ns | 0.109 ns | 70,583,093.1 |         - |

**Bool**
Before
| Method | Value |      Mean |     Error |    StdDev |          Op/s | Allocated |
|------- |------ |----------:|----------:|----------:|--------------:|----------:|
|   Read | False |  7.134 ns | 0.0688 ns | 0.0574 ns | 140,176,979.2 |         - |
|  Write | False | 20.428 ns | 0.2388 ns | 0.1994 ns |  48,952,638.4 |         - |

After
| Method | Value |     Mean |     Error |    StdDev |          Op/s | Allocated |
|------- |------ |---------:|----------:|----------:|--------------:|----------:|
|   Read | False | 6.923 ns | 0.1661 ns | 0.2159 ns | 144,456,269.5 |         - |
|  Write | False | 8.851 ns | 0.1882 ns | 0.1760 ns | 112,983,949.4 |         - |

**Int64**
Before
| Method | Value |      Mean |     Error |    StdDev |          Op/s | Allocated |
|------- |------ |----------:|----------:|----------:|--------------:|----------:|
|   Read |     0 |  6.339 ns | 0.1584 ns | 0.1885 ns | 157,751,215.0 |         - |
|  Write |     0 | 24.983 ns | 0.2721 ns | 0.2272 ns |  40,027,422.3 |         - |

After
| Method | Value |     Mean |     Error |    StdDev |          Op/s | Allocated |
|------- |------ |---------:|----------:|----------:|--------------:|----------:|
|   Read |     0 | 5.999 ns | 0.1503 ns | 0.1406 ns | 166,685,721.9 |         - |
|  Write |     0 | 8.961 ns | 0.1352 ns | 0.1129 ns | 111,593,860.1 |         - |

**Text**
Before
| Method |                Value |      Mean |    Error |   StdDev |         Op/s |  Gen 0 | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
|   Read |                    x |  36.66 ns | 0.494 ns | 0.438 ns | 27,274,644.6 | 0.0076 |      24 B |
|  Write |                    x |  75.31 ns | 0.960 ns | 0.802 ns | 13,277,795.5 | 0.0305 |      96 B |
|   Read |           xxxxxxxxxx |  39.32 ns | 0.741 ns | 0.657 ns | 25,430,131.9 | 0.0153 |      48 B |
|  Write |           xxxxxxxxxx |  79.99 ns | 1.524 ns | 1.872 ns | 12,501,372.0 | 0.0305 |      96 B |
|   Read |  xxxx(...)xxxx [100] |  57.35 ns | 1.173 ns | 1.152 ns | 17,435,392.9 | 0.0714 |     224 B |
|  Write |  xxxx(...)xxxx [100] |  91.18 ns | 0.974 ns | 0.814 ns | 10,967,187.8 | 0.0305 |      96 B |
|   Read | xxxx(...)xxxx [1000] | 231.62 ns | 4.178 ns | 3.704 ns |  4,317,390.4 | 0.6452 |   2,024 B |
|  Write | xxxx(...)xxxx [1000] | 164.86 ns | 2.868 ns | 2.395 ns |  6,065,608.1 | 0.0305 |      96 B |
|   Read |  xxx(...)xxx [10000] |        NA |       NA |       NA |           NA |      - |         - |
|  Write |  xxx(...)xxx [10000] |        NA |       NA |       NA |           NA |      - |         - |

After
| Method |                Value |      Mean |    Error |   StdDev |         Op/s |  Gen 0 | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
|   Read |                    x |  34.19 ns | 0.292 ns | 0.228 ns | 29,248,576.5 | 0.0076 |      24 B |
|  Write |                    x |  56.53 ns | 0.424 ns | 0.354 ns | 17,690,165.6 | 0.0306 |      96 B |
|   Read |           xxxxxxxxxx |  37.44 ns | 0.705 ns | 0.589 ns | 26,708,271.9 | 0.0153 |      48 B |
|  Write |           xxxxxxxxxx |  58.21 ns | 1.083 ns | 1.329 ns | 17,178,042.2 | 0.0306 |      96 B |
|   Read |  xxxx(...)xxxx [100] |  55.62 ns | 1.199 ns | 0.936 ns | 17,977,603.0 | 0.0714 |     224 B |
|  Write |  xxxx(...)xxxx [100] |  67.22 ns | 0.929 ns | 0.824 ns | 14,876,010.8 | 0.0305 |      96 B |
|   Read | xxxx(...)xxxx [1000] | 231.38 ns | 4.713 ns | 7.337 ns |  4,321,818.8 | 0.6452 |   2,024 B |
|  Write | xxxx(...)xxxx [1000] | 137.72 ns | 2.021 ns | 1.578 ns |  7,260,846.3 | 0.0305 |      96 B |
|   Read |  xxx(...)xxx [10000] |        NA |       NA |       NA |           NA |      - |         - |
|  Write |  xxx(...)xxx [10000] |        NA |       NA |       NA |           NA |      - |         - |