### PR TITLE
Various cleanup and a bit of microoptimizations

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -211,12 +211,6 @@ public sealed partial class NpgsqlConnector : IDisposable
     internal int UserTimeout { private get; set; }
 
     /// <summary>
-    /// A lock that's taken while a user action is in progress, e.g. a command being executed.
-    /// Only used when keepalive is enabled, otherwise null.
-    /// </summary>
-    SemaphoreSlim? _userLock;
-
-    /// <summary>
     /// A lock that's taken while a cancellation is being delivered; new queries are blocked until the
     /// cancellation is delivered. This reduces the chance that a cancellation meant for a previous
     /// command will accidentally cancel a later one, see #615.
@@ -237,7 +231,7 @@ public sealed partial class NpgsqlConnector : IDisposable
     /// <summary>
     /// The connector source (e.g. pool) from where this connector came, and to which it will be returned.
     /// Note that in multi-host scenarios, this references the host-specific <see cref="PoolingDataSource"/> rather than the
-    /// <see cref="NpgsqlMultiHostDataSource"/>,
+    /// <see cref="NpgsqlMultiHostDataSource"/>.
     /// </summary>
     readonly NpgsqlDataSource _dataSource;
 
@@ -360,7 +354,6 @@ public sealed partial class NpgsqlConnector : IDisposable
         _isKeepAliveEnabled = Settings.KeepAlive > 0;
         if (_isKeepAliveEnabled)
         {
-            _userLock = new SemaphoreSlim(1, 1);
             _keepAliveTimer = new Timer(PerformKeepAlive, null, Timeout.Infinite, Timeout.Infinite);
         }
 
@@ -1245,16 +1238,13 @@ public sealed partial class NpgsqlConnector : IDisposable
 
     #region Backend message processing
 
-    internal IBackendMessage ReadMessage(DataRowLoadingMode dataRowLoadingMode = DataRowLoadingMode.NonSequential)
-        => ReadMessage(async: false, dataRowLoadingMode).GetAwaiter().GetResult();
-
     internal ValueTask<IBackendMessage> ReadMessage(bool async, DataRowLoadingMode dataRowLoadingMode = DataRowLoadingMode.NonSequential)
         => ReadMessage(async, dataRowLoadingMode, readingNotifications: false)!;
 
     internal ValueTask<IBackendMessage?> ReadMessageWithNotifications(bool async)
         => ReadMessage(async, DataRowLoadingMode.NonSequential, readingNotifications: true);
 
-    internal ValueTask<IBackendMessage?> ReadMessage(
+    ValueTask<IBackendMessage?> ReadMessage(
         bool async,
         DataRowLoadingMode dataRowLoadingMode,
         bool readingNotifications)
@@ -2021,8 +2011,6 @@ public sealed partial class NpgsqlConnector : IDisposable
 
         if (_isKeepAliveEnabled)
         {
-            _userLock!.Dispose();
-            _userLock = null;
             _keepAliveTimer!.Change(Timeout.Infinite, Timeout.Infinite);
             _keepAliveTimer.Dispose();
         }
@@ -2275,30 +2263,14 @@ public sealed partial class NpgsqlConnector : IDisposable
                 throw IsBroken
                     ? new NpgsqlException("The connection was previously broken because of the following exception", _breakReason)
                     : new NpgsqlException("The connection is closed");
-            }  
-
-            if (!_userLock!.Wait(0))
-            {
-                var currentCommand = _currentCommand;
-                throw currentCommand == null
-                    ? new NpgsqlOperationInProgressException(State)
-                    : new NpgsqlOperationInProgressException(currentCommand);
             }
 
-            try
-            {
-                // Disable keepalive, it will be restarted at the end of the user action
-                _keepAliveTimer!.Change(Timeout.Infinite, Timeout.Infinite);
+            // Disable keepalive, it will be restarted at the end of the user action
+            _keepAliveTimer!.Change(Timeout.Infinite, Timeout.Infinite);
 
-                // We now have both locks and are sure nothing else is running.
-                // Check that the connector is ready.
-                return DoStartUserAction(newState, command);
-            }
-            catch
-            {
-                _userLock.Release();
-                throw;
-            }
+            // We now have both locks and are sure nothing else is running.
+            // Check that the connector is ready.
+            return DoStartUserAction(newState, command);
         }
 
         UserAction DoStartUserAction(ConnectorState newState, NpgsqlCommand? command)
@@ -2361,7 +2333,6 @@ public sealed partial class NpgsqlConnector : IDisposable
 
                 LogMessages.EndUserAction(ConnectionLogger, Id);
                 _currentCommand = null;
-                _userLock!.Release();
                 State = ConnectorState.Ready;
             }
         }
@@ -2411,7 +2382,7 @@ public sealed partial class NpgsqlConnector : IDisposable
             var timeout = InternalCommandTimeout;
             WriteBuffer.Timeout = TimeSpan.FromSeconds(timeout);
             UserTimeout = timeout;
-            WriteSync(async: false);
+            WriteSync(async: false).GetAwaiter().GetResult();
             Flush();
             SkipUntil(BackendMessageCode.ReadyForQuery);
             LogMessages.CompletedKeepalive(ConnectionLogger, Id);

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -595,9 +595,8 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
         var index = Buffer.AsSpan(ReadPosition, FilledBytes - ReadPosition).IndexOf((byte)0);
         if (index >= 0)
         {
-            var byteLen = index + ReadPosition;
-            var result = new ValueTask<string>(encoding.GetString(Buffer, ReadPosition, byteLen));
-            ReadPosition += byteLen + 1;
+            var result = new ValueTask<string>(encoding.GetString(Buffer, ReadPosition, index));
+            ReadPosition += index + 1;
             return result;
         }
 

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -279,8 +279,6 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
         }
     }
 
-    internal void ReadMore() => ReadMore(false).GetAwaiter().GetResult();
-
     internal Task ReadMore(bool async) => Ensure(ReadBytesLeft + 1, async);
 
     internal NpgsqlReadBuffer AllocateOversize(int count)
@@ -297,7 +295,6 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
     /// <summary>
     /// Does not perform any I/O - assuming that the bytes to be skipped are in the memory buffer.
     /// </summary>
-    /// <param name="len"></param>
     internal void Skip(long len)
     {
         Debug.Assert(ReadBytesLeft >= len);
@@ -595,15 +592,13 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
     /// </summary>
     ValueTask<string> ReadNullTerminatedString(Encoding encoding, bool async, CancellationToken cancellationToken = default)
     {
-        for (var i = ReadPosition; i < FilledBytes; i++)
+        var index = Buffer.AsSpan(ReadPosition, FilledBytes - ReadPosition).IndexOf((byte)0);
+        if (index >= 0)
         {
-            if (Buffer[i] == 0)
-            {
-                var byteLen = i - ReadPosition;
-                var result = new ValueTask<string>(encoding.GetString(Buffer, ReadPosition, byteLen));
-                ReadPosition += byteLen + 1;
-                return result;
-            }
+            var byteLen = index + ReadPosition;
+            var result = new ValueTask<string>(encoding.GetString(Buffer, ReadPosition, byteLen));
+            ReadPosition += byteLen + 1;
+            return result;
         }
 
         return ReadLong(encoding, async);

--- a/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ArrayHandler.cs
@@ -127,7 +127,7 @@ public abstract class ArrayHandler : NpgsqlTypeHandler
         var dimLengths = new int[dimensions];
         await buf.Ensure(dimensions * 8, async);
 
-        for (var i = 0; i < dimensions; i++)
+        for (var i = 0; i < dimLengths.Length; i++)
         {
             dimLengths[i] = buf.ReadInt32();
             buf.ReadInt32(); // Lower bound

--- a/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/NetworkHandlers/InetHandler.cs
@@ -50,7 +50,7 @@ public partial class InetHandler : NpgsqlSimpleTypeHandlerWithPsv<IPAddress, (IP
         Debug.Assert(isCidrHandler == isCidr);
         var numBytes = buf.ReadByte();
         var bytes = new byte[numBytes];
-        for (var i = 0; i < numBytes; i++)
+        for (var i = 0; i < bytes.Length; i++)
             bytes[i] = buf.ReadByte();
 
         return (new IPAddress(bytes), mask);

--- a/src/Npgsql/Internal/TypeHandling/ITextReaderHandler.cs
+++ b/src/Npgsql/Internal/TypeHandling/ITextReaderHandler.cs
@@ -11,5 +11,3 @@ interface ITextReaderHandler
 {
     TextReader GetTextReader(Stream stream, NpgsqlReadBuffer buffer);
 }
-
-#pragma warning disable CA1032

--- a/src/Npgsql/MultiplexingDataSource.cs
+++ b/src/Npgsql/MultiplexingDataSource.cs
@@ -85,8 +85,8 @@ sealed class MultiplexingDataSource : PoolingDataSource
     internal async Task BootstrapMultiplexing(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken = default)
     {
         var hasSemaphore = async
-            ? await _bootstrapSemaphore!.WaitAsync(timeout.CheckAndGetTimeLeft(), cancellationToken)
-            : _bootstrapSemaphore!.Wait(timeout.CheckAndGetTimeLeft(), cancellationToken);
+            ? await _bootstrapSemaphore.WaitAsync(timeout.CheckAndGetTimeLeft(), cancellationToken)
+            : _bootstrapSemaphore.Wait(timeout.CheckAndGetTimeLeft(), cancellationToken);
 
         // We've timed out - calling Check, to throw the correct exception
         if (!hasSemaphore)
@@ -264,10 +264,8 @@ sealed class MultiplexingDataSource : PoolingDataSource
             if (_autoPrepare)
             {
                 // TODO: Need to log based on numPrepared like in non-multiplexing mode...
-                var numPrepared = 0;
                 for (var i = 0; i < command.InternalBatchCommands.Count; i++)
-                    if (command.InternalBatchCommands[i].TryAutoPrepare(connector))
-                        numPrepared++;
+                    command.InternalBatchCommands[i].TryAutoPrepare(connector);
             }
 
             var written = connector.CommandsInFlightWriter!.TryWrite(command);

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1284,7 +1284,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         {
             Debug.Assert(conn is null);
             if (behavior.HasFlag(CommandBehavior.CloseConnection))
-                throw new ArgumentException($"{nameof(CommandBehavior.CloseConnection)} is not supported with ${nameof(NpgsqlConnector)}", nameof(behavior));
+                throw new ArgumentException($"{nameof(CommandBehavior.CloseConnection)} is not supported with {nameof(NpgsqlConnector)}", nameof(behavior));
             connector = _connector;
         }
         else
@@ -1457,7 +1457,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 // Previous behavior was to wait on reading, which throw the exception from ExecuteReader (and not from
                 // the first read). But waiting on writing would allow us to do sync writing and async reading.
                 ExecutionCompletion.Reset();
-                await pool.MultiplexCommandWriter!.WriteAsync(this, cancellationToken);
+                await pool.MultiplexCommandWriter.WriteAsync(this, cancellationToken);
                 connector = await new ValueTask<NpgsqlConnector>(ExecutionCompletion, ExecutionCompletion.Version);
                 // TODO: Overload of StartBindingScope?
                 conn.Connector = connector;
@@ -1475,7 +1475,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
         catch (Exception e)
         {
             var reader = connector?.CurrentReader;
-            if (!(e is NpgsqlOperationInProgressException) && reader != null)
+            if (e is not NpgsqlOperationInProgressException && reader is not null)
                 await reader.Cleanup(async);
 
             TraceSetException(e);

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1079,13 +1079,11 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         if (_connection?.ConnectorBindingScope == ConnectorBindingScope.Reader)
         {
-            // We may unbind the current reader, which also sets the connector to null
-            var connector = Connector;
             UnbindIfNecessary();
 
             // TODO: Refactor... Use proper scope
             _connection.Connector = null;
-            connector.Connection = null;
+            Connector.Connection = null;
             _connection.ConnectorBindingScope = ConnectorBindingScope.None;
 
             // If the reader is being closed as part of the connection closing, we don't apply
@@ -1093,7 +1091,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             if (_behavior.HasFlag(CommandBehavior.CloseConnection) && !connectionClosing)
                 _connection.Close();
 
-            connector.ReaderCompleted.SetResult(null);
+            Connector.ReaderCompleted.SetResult(null);
         }
         else if (_behavior.HasFlag(CommandBehavior.CloseConnection) && !connectionClosing)
         {

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -234,7 +234,7 @@ public abstract class NpgsqlDataSource : DbDataSource
         lock (_pendingEnlistedConnectors)
         {
             if (!_pendingEnlistedConnectors.TryGetValue(transaction, out var list))
-                list = _pendingEnlistedConnectors[transaction] = new List<NpgsqlConnector>();
+                list = _pendingEnlistedConnectors[transaction] = new List<NpgsqlConnector>(1);
             list.Add(connector);
         }
     }

--- a/src/Npgsql/NpgsqlEventSource.cs
+++ b/src/Npgsql/NpgsqlEventSource.cs
@@ -187,7 +187,7 @@ sealed class NpgsqlEventSource : EventSource
 
             _multiplexingAverageWriteTimePerBatchCounter = new PollingCounter("multiplexing-average-write-time-per-batch", this, GetMultiplexingAverageWriteTimePerBatch)
             {
-                DisplayName = "Average write time per multiplexing batch (us)",
+                DisplayName = "Average write time per multiplexing batch",
                 DisplayUnits = "us"
             };
             lock (_dataSourcesLock)

--- a/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlDbType.cs
@@ -513,19 +513,19 @@ public enum NpgsqlDbType
     /// <summary>
     /// The PostgreSQL ltree type, each value is a label path "a.label.tree.value", forming a tree in a set.
     /// </summary>
-    /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+    /// <remarks>See https://www.postgresql.org/docs/current/static/ltree.html</remarks>
     LTree = 60, // Extension type
 
     /// <summary>
     /// The PostgreSQL lquery type for PostgreSQL extension ltree
     /// </summary>
-    /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+    /// <remarks>See https://www.postgresql.org/docs/current/static/ltree.html</remarks>
     LQuery = 61, // Extension type
 
     /// <summary>
     /// The PostgreSQL ltxtquery type for PostgreSQL extension ltree
     /// </summary>
-    /// <remarks>See http://www.postgresql.org/docs/current/static/ltree.html</remarks>
+    /// <remarks>See https://www.postgresql.org/docs/current/static/ltree.html</remarks>
     LTxtQuery = 62, // Extension type
 
     #endregion

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -192,10 +192,6 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
     /// <exception cref="ArgumentOutOfRangeException">Unknown typtype for type '{internalName}' in pg_type: {typeChar}.</exception>
     internal async Task<List<PostgresType>> LoadBackendTypes(NpgsqlConnector conn, NpgsqlTimeout timeout, bool async)
     {
-        var commandTimeout = 0;  // Default to infinity
-        if (timeout.IsSet)
-            commandTimeout = (int)timeout.CheckAndGetTimeLeft().TotalSeconds;
-
         var versionQuery = "SELECT version();";
         var loadTypesQuery = GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites);
         var loadCompositeTypesQuery = GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites);


### PR DESCRIPTION
A bit of a cleanup and optimized some of the things. Notable mentions:

1. Removed `SemaphoreSlim? _userLock` from `NpgsqlConnector` (it's not like it's used in any way)
2. Optimized `NpgsqlReadBuffer.ReadNullTerminatedString` (`IndexOf` might use SIMD to search faster)