### PR TITLE
Add an ability to cache the result of SqlParser

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -881,7 +881,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 else
                 {
                     var queryText = batchCommand.CommandText;
-                    if (!ParsedQueryCache.TryGet(queryText, out var parsedQuery) || !parsedQuery.GenerateCommand(batchCommand))
+                    if (!ParsedQueryCache.TryGet(queryText, out var parsedQuery) || !parsedQuery.GenerateCommand(batchCommand, batchCommand.Parameters))
                     {
                         // The parser is cached on NpgsqlConnector - unless we're in multiplexing mode.
                         parser ??= new SqlQueryParser();

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -871,7 +871,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     for (var i = 0; i < InternalBatchCommands.Count; i++)
                         ValidateParameterCount(InternalBatchCommands[i]);
 
-                    if (InternalBatchCommands.Count == 1)
+                    if (parsedQuery is null && InternalBatchCommands.Count == 1)
                     {
                         var internalBatchCommand = InternalBatchCommands[0];
                         Debug.Assert(internalBatchCommand.FinalCommandText is not null);
@@ -891,8 +891,12 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     if (batchCommand.Parameters.HasOutputParameters)
                         throw new NotSupportedException("Batches cannot cannot have out parameters");
                     ValidateParameterCount(batchCommand);
-                    Debug.Assert(batchCommand.FinalCommandText is not null);
-                    ParsedQueryCache.TryAdd(queryText, batchCommand.FinalCommandText, batchCommand.PositionalParameters);
+
+                    if (parsedQuery is null)
+                    {
+                        Debug.Assert(batchCommand.FinalCommandText is not null);
+                        ParsedQueryCache.TryAdd(queryText, batchCommand.FinalCommandText, batchCommand.PositionalParameters);
+                    }
                 }
 
                 break;

--- a/src/Npgsql/ParsedQuery.cs
+++ b/src/Npgsql/ParsedQuery.cs
@@ -39,19 +39,19 @@ class ParsedQuery
             internalBatchCommands.Add(internalBatchCommand);
         }
 
-        return GenerateCommand(internalBatchCommand);
+        return GenerateCommand(internalBatchCommand, command.Parameters);
     }
 
-    internal bool GenerateCommand(NpgsqlBatchCommand command)
+    internal bool GenerateCommand(NpgsqlBatchCommand command, NpgsqlParameterCollection commandParameters)
     {
         command.FinalCommandText = Query;
         for (var i = 0; i < Parameters.Count; i++)
         {
             var parameterFound = false;
             var positionalParameter = Parameters[i];
-            for (var j = 0; j < command.Parameters.Count; j++)
+            for (var j = 0; j < commandParameters.Count; j++)
             {
-                var namedParameter = command.Parameters[j];
+                var namedParameter = commandParameters[j];
                 if (namedParameter.ParameterName == positionalParameter.Name)
                 {
                     command.PositionalParameters.Add(namedParameter);

--- a/src/Npgsql/ParsedQuery.cs
+++ b/src/Npgsql/ParsedQuery.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Npgsql;
+
+class ParsedQuery
+{
+    public ParsedQuery(string queryText, List<NpgsqlParameter> queryParameters)
+    {
+        Query = queryText;
+
+        var parameters = new List<ParsedQueryParameter>(queryParameters.Count);
+        for (var i = 0; i < queryParameters.Count; i++)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(queryParameters[i].ParameterName));
+            parameters.Add(new ParsedQueryParameter(queryParameters[i].ParameterName));
+        }
+        Parameters = parameters.AsReadOnly();
+    }   
+    
+    internal string Query { get; }
+    
+    internal IReadOnlyList<ParsedQueryParameter> Parameters { get; }
+
+    internal bool GenerateCommand(NpgsqlCommand command)
+    {
+        var internalBatchCommands = command.InternalBatchCommands;
+        NpgsqlBatchCommand internalBatchCommand;
+        if (internalBatchCommands.Count > 0)
+        {
+            internalBatchCommand = internalBatchCommands[0];
+            internalBatchCommand.Reset();
+            if (internalBatchCommands.Count > 1)
+                internalBatchCommands.RemoveRange(1, internalBatchCommands.Count - 1);
+        }
+        else
+        {
+            internalBatchCommand = new NpgsqlBatchCommand();
+            internalBatchCommands.Add(internalBatchCommand);
+        }
+
+        return GenerateCommand(internalBatchCommand);
+    }
+
+    internal bool GenerateCommand(NpgsqlBatchCommand command)
+    {
+        command.FinalCommandText = Query;
+        for (var i = 0; i < Parameters.Count; i++)
+        {
+            var parameterFound = false;
+            var positionalParameter = Parameters[i];
+            for (var j = 0; j < command.Parameters.Count; j++)
+            {
+                var namedParameter = command.Parameters[j];
+                if (namedParameter.ParameterName == positionalParameter.Name)
+                {
+                    command.PositionalParameters.Add(namedParameter);
+                    parameterFound = true;
+                    break;
+                }
+            }
+
+            if (!parameterFound)
+                return false;
+        }
+
+        return true;
+    }
+}
+
+class ParsedQueryParameter
+{
+    public ParsedQueryParameter(string name) => Name = name;
+    
+    internal string Name { get; }
+}

--- a/src/Npgsql/ParsedQueryCache.cs
+++ b/src/Npgsql/ParsedQueryCache.cs
@@ -8,9 +8,9 @@ static class ParsedQueryCache
 {
     static readonly ConcurrentDictionary<string, ParsedQuery> Cache = new();
 
-    internal static bool TryGet(string query, [NotNullWhen(true)] out ParsedQuery? parsedQuery) 
+    internal static bool TryGet(string query, [NotNullWhen(true)] out ParsedQuery? parsedQuery)
         => Cache.TryGetValue(query, out parsedQuery);
 
-    internal static void TryAdd(string query, string parsedQuery, List<NpgsqlParameter> parameters) 
+    internal static void TryAdd(string query, string parsedQuery, List<NpgsqlParameter> parameters)
         => Cache.TryAdd(query, new ParsedQuery(parsedQuery, parameters));
 }

--- a/src/Npgsql/ParsedQueryCache.cs
+++ b/src/Npgsql/ParsedQueryCache.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Npgsql;
+
+static class ParsedQueryCache
+{
+    static readonly ConcurrentDictionary<string, ParsedQuery> Cache = new();
+
+    internal static bool TryGet(string query, [NotNullWhen(true)] out ParsedQuery? parsedQuery) 
+        => Cache.TryGetValue(query, out parsedQuery);
+
+    internal static void TryAdd(string query, string parsedQuery, List<NpgsqlParameter> parameters) 
+        => Cache.TryAdd(query, new ParsedQuery(parsedQuery, parameters));
+}


### PR DESCRIPTION
Closes #4609

I think, the main thing missing here is an ability to set the limit to the amount of queries we can cache (though I'm not sure yet how to implement it properly). And some tests.

cc @NinoFloris 