### PR TITLE
Support for Stream in Json/Text type

### DIFF
--- a/src/Npgsql.Json.NET/Internal/JsonHandler.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -23,7 +24,8 @@ class JsonHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T) == typeof(char[]) ||
             typeof(T) == typeof(ArraySegment<char>) ||
             typeof(T) == typeof(char) ||
-            typeof(T) == typeof(byte[]))
+            typeof(T) == typeof(byte[]) ||
+            typeof(T) == typeof(Stream))
         {
             return await base.ReadCustom<T>(buf, len, async, fieldDescription);
         }
@@ -39,7 +41,8 @@ class JsonHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T2) == typeof(char[]) ||
             typeof(T2) == typeof(ArraySegment<char>) ||
             typeof(T2) == typeof(char) ||
-            typeof(T2) == typeof(byte[]))
+            typeof(T2) == typeof(byte[]) ||
+            typeof(T2) == typeof(Stream))
         {
             return base.ValidateAndGetLengthCustom(value, ref lengthCache, parameter);
         }
@@ -56,7 +59,8 @@ class JsonHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T2) == typeof(char[]) ||
             typeof(T2) == typeof(ArraySegment<char>) ||
             typeof(T2) == typeof(char) ||
-            typeof(T2) == typeof(byte[]))
+            typeof(T2) == typeof(byte[]) ||
+            typeof(T2) == typeof(Stream))
         {
             return base.WriteWithLengthCustom(value, buf, lengthCache, parameter, async, cancellationToken);
         }
@@ -74,7 +78,8 @@ class JsonHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             value is char[] ||
             value is ArraySegment<char> ||
             value is char ||
-            value is byte[])
+            value is byte[] ||
+            value is Stream)
         {
             return base.ValidateObjectAndGetLength(value, ref lengthCache, parameter);
         }
@@ -90,7 +95,8 @@ class JsonHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             value is char[] ||
             value is ArraySegment<char> ||
             value is char ||
-            value is byte[])
+            value is byte[] ||
+            value is Stream)
         {
             return base.WriteObjectWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
         }

--- a/src/Npgsql.Json.NET/Internal/JsonbHandler.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonbHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -23,7 +24,8 @@ class JsonbHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T) == typeof(char[])             ||
             typeof(T) == typeof(ArraySegment<char>) ||
             typeof(T) == typeof(char)               ||
-            typeof(T) == typeof(byte[]))
+            typeof(T) == typeof(byte[])             ||
+            typeof(T) == typeof(Stream))
         {
             return await base.ReadCustom<T>(buf, len, async, fieldDescription);
         }
@@ -39,7 +41,8 @@ class JsonbHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T2) == typeof(char[]) ||
             typeof(T2) == typeof(ArraySegment<char>) ||
             typeof(T2) == typeof(char) ||
-            typeof(T2) == typeof(byte[]))
+            typeof(T2) == typeof(byte[]) ||
+            typeof(T2) == typeof(Stream))
         {
             return base.ValidateAndGetLengthCustom(value, ref lengthCache, parameter);
         }
@@ -56,7 +59,8 @@ class JsonbHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             typeof(T2) == typeof(char[]) ||
             typeof(T2) == typeof(ArraySegment<char>) ||
             typeof(T2) == typeof(char) ||
-            typeof(T2) == typeof(byte[]))
+            typeof(T2) == typeof(byte[]) ||
+            typeof(T2) == typeof(Stream))
         {
             return base.WriteWithLengthCustom(value, buf, lengthCache, parameter, async, cancellationToken);
         }
@@ -74,7 +78,8 @@ class JsonbHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             value is char[] ||
             value is ArraySegment<char> ||
             value is char ||
-            value is byte[])
+            value is byte[] ||
+            value is Stream)
         {
             return base.ValidateObjectAndGetLength(value, ref lengthCache, parameter);
         }
@@ -90,7 +95,8 @@ class JsonbHandler : Npgsql.Internal.TypeHandlers.JsonHandler
             value is char[] ||
             value is ArraySegment<char> ||
             value is char ||
-            value is byte[])
+            value is byte[] ||
+            value is Stream)
         {
             return base.WriteObjectWithLength(value, buf, lengthCache, parameter, async, cancellationToken);
         }

--- a/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/JsonHandler.cs
@@ -54,7 +54,8 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             typeof(TAny) == typeof(char[])             ||
             typeof(TAny) == typeof(ArraySegment<char>) ||
             typeof(TAny) == typeof(char)               ||
-            typeof(TAny) == typeof(byte[]))
+            typeof(TAny) == typeof(byte[])             ||
+            typeof(TAny) == typeof(Stream))
         {
             return _textHandler.ValidateAndGetLength(value, ref lengthCache, parameter) + _headerLen;
         }
@@ -102,6 +103,8 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             await _textHandler.Write((char)(object)value!, buf, lengthCache, parameter, async, cancellationToken);
         else if (typeof(TAny) == typeof(byte[]))
             await _textHandler.Write((byte[])(object)value!, buf, lengthCache, parameter, async, cancellationToken);
+        else if (typeof(TAny) == typeof(Stream))
+            await _textHandler.Write((Stream)(object)value!, buf, lengthCache, parameter, async, cancellationToken);
         else if (typeof(TAny) == typeof(JsonDocument))
         {
             var data = parameter?.ConvertedValue != null
@@ -146,6 +149,7 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             ArraySegment<char> s      => ValidateAndGetLength(s, ref lengthCache, parameter),
             char s                    => ValidateAndGetLength(s, ref lengthCache, parameter),
             byte[] s                  => ValidateAndGetLength(s, ref lengthCache, parameter),
+            Stream s                  => ValidateAndGetLength(s, ref lengthCache, parameter),
             JsonDocument jsonDocument => ValidateAndGetLength(jsonDocument, ref lengthCache, parameter),
             _                         => ValidateAndGetLength(value, ref lengthCache, parameter)
         };
@@ -166,6 +170,7 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             ArraySegment<char> s      => WriteWithLengthCustom(s, buf, lengthCache, parameter, async, cancellationToken),
             char s                    => WriteWithLengthCustom(s, buf, lengthCache, parameter, async, cancellationToken),
             byte[] s                  => WriteWithLengthCustom(s, buf, lengthCache, parameter, async, cancellationToken),
+            Stream s                  => WriteWithLengthCustom(s, buf, lengthCache, parameter, async, cancellationToken),
             JsonDocument jsonDocument => WriteWithLengthCustom(jsonDocument, buf, lengthCache, parameter, async, cancellationToken),
             _                         => WriteWithLengthCustom(value, buf, lengthCache, parameter, async, cancellationToken),
         });
@@ -187,7 +192,8 @@ public class JsonHandler : NpgsqlTypeHandler<string>, ITextReaderHandler
             typeof(T) == typeof(char[])             ||
             typeof(T) == typeof(ArraySegment<char>) ||
             typeof(T) == typeof(char)               ||
-            typeof(T) == typeof(byte[]))
+            typeof(T) == typeof(byte[])             ||
+            typeof(T) == typeof(Stream))
         {
             return await _textHandler.Read<T>(buf, byteLen, async, fieldDescription);
         }


### PR DESCRIPTION
Basing on [PR 4517](https://github.com/npgsql/npgsql/pull/4517) for [#4466](https://github.com/npgsql/npgsql/issues/4466) which added the ability to pass a Stream as a parameter to bytea column, I added support for passing Stream for Json/Text type columns.

I think it makes sense to pass Steam as a parameter to every type that already accepts byte[], especially if it is a binary type like jsonb.

It relates to [#4052](https://github.com/npgsql/npgsql/issues/4052).