### PR TITLE
Improve multiplexing fairness

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1123,6 +1123,13 @@ public sealed partial class NpgsqlConnector : IDisposable
     internal ManualResetValueTaskSource<object?> ReaderCompleted { get; } =
         new() { RunContinuationsAsynchronously = true };
 
+
+    // When multiplexing we may run in over-capacity mode for a long time.
+    // We need a way of introducing fairness during this time for pool waiters that require exclusive connection use.
+    // This flag allows us to remove it from the eligible connectors for multiplexing.
+    // Eventually causing it to become idle and available for exclusive use for a waiter.
+    internal volatile int ReservedForExclusiveUse;
+
     async Task MultiplexingReadLoop()
     {
         Debug.Assert(Settings.Multiplexing);

--- a/src/Npgsql/MultiplexingDataSource.cs
+++ b/src/Npgsql/MultiplexingDataSource.cs
@@ -170,10 +170,11 @@ sealed class MultiplexingDataSource : PoolingDataSource
                     // There were no idle connectors and we're at max capacity, so we can't open a new one.
                     // Enter over-capacity mode - find an unlocked connector with the least currently in-flight
                     // commands and sent on it, even though there are already pending commands.
+                    // We skip connectors that are either waiting for IO or those that are reserved by pool waiters for the purpose of exclusive use.
                     var minInFlight = int.MaxValue;
                     foreach (var c in Connectors)
                     {
-                        if (c?.MultiplexAsyncWritingLock == 0 && c.CommandsInFlightCount < minInFlight)
+                        if (c?.MultiplexAsyncWritingLock == 0 && c.CommandsInFlightCount < minInFlight && c.ReservedForExclusiveUse == 0)
                         {
                             minInFlight = c.CommandsInFlightCount;
                             connector = c;


### PR DESCRIPTION
Should help with fairness under high load when multiplexing is enabled. Either when there are a lot of exclusive use connections or when multiplexing is keeping many busy in over-capacity mode.

Closes #4180

Not super happy about the layering of the reservation concept in the poolingdatasource but the other options are copying the pool implementation into multiplexing or introducing hooks into poolingdatasource to thread this into the right places from the derived type. Neither seem to be much better than this smell.

Finally, after reasoning through the some of the relevant scenarios for a while I found that while we do have fairness for the idle channel (blocked waiter being prioritized over TryRead consumers) we don't have this property on opening new connectors. 
There is potential for a blocked waiter to be woken up with a null while we also have the multiplexing loop running. At this point both are racing to open a new connector while the blocked waiter should have been prioritized.

It's a bit of an edge case given we don't really close busy connectors all that much. Only users with a connection liftetime might hit this 'more easily'. Mostly important to realize for future features that may want to depend on this being fair.