### PR TITLE
Fix concurrent query cancellation with timeout

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -233,7 +233,7 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
                             // TODO: As an optimization, we can still attempt to send a cancellation request, but after
                             // that immediately break the connection
                             if (connector.AttemptPostgresCancellation &&
-                                !connector.PostgresCancellationPerformed &&
+                                !connector.InternalCancellationRequested &&
                                 connector.PerformPostgresCancellation())
                             {
                                 // Note that if the cancellation timeout is negative, we flow down and break the
@@ -259,7 +259,7 @@ public sealed partial class NpgsqlReadBuffer : IDisposable
                         static Exception CreateException(NpgsqlConnector connector)
                             => !connector.UserCancellationRequested
                                 ? NpgsqlTimeoutException()
-                                : connector.PostgresCancellationPerformed
+                                : connector.InternalCancellationRequested
                                     ? new OperationCanceledException("Query was cancelled", TimeoutException(), connector.UserCancellationToken)
                                     : new OperationCanceledException("Query was cancelled", connector.UserCancellationToken);
                     }

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1418,7 +1418,7 @@ $$;");
         cmd.CommandText = "SELECT 1 FROM pg_sleep(20)";
         cmd.CommandTimeout = 5;
         Assert.ThrowsAsync(
-            Is.TypeOf<OperationCanceledException>().Or.TypeOf<TimeoutException>(),
+            Is.TypeOf<OperationCanceledException>().Or.TypeOf<NpgsqlException>().With.InnerException.TypeOf<TimeoutException>(),
             async () => await cmd.ExecuteNonQueryAsync(cts.Token));
     }
 }

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -375,6 +375,7 @@ public class CommandTests : MultiplexingTestBase
         var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
         {
             Pooling = false,
+            Timeout = 5 // Set the opening connection timeout to 5, so we're not stuck forever waiting for the cancellation request response
         };
         await using var postmasterMock = PgPostmasterMock.Start(csb.ToString(), completeCancellationImmediately: false);
         using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);


### PR DESCRIPTION
Fixes #4654

~For now let's just see whether the test fails in CI...~

Now, this fix isn't entirely complete. While it does fix the original problem, the deadlock still can happen if the user cancellation (via a `CancellationToken`) happens concurrently with connector break. What happens is:

1. The `CancellationToken` is cancelled at some point while executing the query, so we call `PerformUserCancellation` and take `CancelLock`:

https://github.com/npgsql/npgsql/blob/d12d74eebe039ae0bc0995c38f92f0f4bb52ed0f/src/Npgsql/Internal/NpgsqlConnector.cs#L1665-L1671

2. Concurrently, for any reason we attempt to break the connection, which takes the lock on the connector and also closes the current `NpgsqlReader`:

https://github.com/npgsql/npgsql/blob/d12d74eebe039ae0bc0995c38f92f0f4bb52ed0f/src/Npgsql/Internal/NpgsqlConnector.cs#L1937-L1941

https://github.com/npgsql/npgsql/blob/d12d74eebe039ae0bc0995c38f92f0f4bb52ed0f/src/Npgsql/Internal/NpgsqlConnector.cs#L2041

3. While closing the reader we attempt to end the current user action, which disposes the current registration over the cancellation token:

https://github.com/npgsql/npgsql/blob/d12d74eebe039ae0bc0995c38f92f0f4bb52ed0f/src/Npgsql/NpgsqlDataReader.cs#L1075

https://github.com/npgsql/npgsql/blob/d12d74eebe039ae0bc0995c38f92f0f4bb52ed0f/src/Npgsql/Internal/NpgsqlConnector.cs#L2326-L2330

4. Disposing the registration will not complete until the callback is also complete (step 1).
5. Now, the problem is, for the `PerformUserCancellation` to complete, it has to take a lock on the connector, but it's held by step 2, which is stuck waiting for `PerformUserCancellation`...

I think for now we should concentrate on fixing #4654 (it's relatively simple and should be easy to backport), and we can fix the deadlock in a separate pr.