### PR TITLE
Fix deadlock between break and cancellation

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1668,7 +1668,14 @@ public sealed partial class NpgsqlConnector : IDisposable
         if (connection is null || connection.ConnectorBindingScope == ConnectorBindingScope.Reader)
             return;
 
-        lock (CancelLock)
+        // There's a subtle race condition where cancellation may be happening just as Break is called. Break takes the connector lock, and
+        // then ends the user action; this disposes the cancellation token registration, which waits until the cancellation callback
+        // completes. But the callback needs to take the connector lock below, which led to a deadlock (#4654).
+        // As a result, Break takes CancelLock, and we abort the cancellation attempt immediately if we can't get it here.
+        if (!Monitor.TryEnter(CancelLock))
+            return;
+
+        try
         {
             _userCancellationRequested = true;
 
@@ -1701,6 +1708,10 @@ public sealed partial class NpgsqlConnector : IDisposable
                 ReadBuffer.Timeout = _cancelImmediatelyTimeout;
                 ReadBuffer.Cts.Cancel();
             }
+        }
+        finally
+        {
+            Monitor.Exit(CancelLock);
         }
     }
 
@@ -1938,6 +1949,8 @@ public sealed partial class NpgsqlConnector : IDisposable
     {
         Debug.Assert(!IsClosed);
 
+        // See PerformUserCancellation on why we take CancelLock
+        lock (CancelLock)
         lock (this)
         {
             if (State != ConnectorState.Broken)

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -367,6 +367,7 @@ public class CommandTests : MultiplexingTestBase
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/3466")]
+    [Ignore("https://github.com/npgsql/npgsql/issues/4668")]
     public async Task Bug3466([Values(false, true)] bool isBroken)
     {
         if (IsMultiplexing)
@@ -374,7 +375,7 @@ public class CommandTests : MultiplexingTestBase
 
         var csb = new NpgsqlConnectionStringBuilder(ConnectionString)
         {
-            Pooling = false,
+            Pooling = false
         };
         await using var postmasterMock = PgPostmasterMock.Start(csb.ToString(), completeCancellationImmediately: false);
         using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);


### PR DESCRIPTION
Fixes #4654

<details>
<summary>Repro console program</summary>

Thanks to #kaiohenrique for the original version in https://github.com/npgsql/npgsql/issues/4654#issuecomment-1247177081

```c#
using var conn = new NpgsqlConnection("Host=localhost;Username=test;Password=test");

var timeout = 1;

while (true)
{
    Console.WriteLine("Doing request");
    conn.Open();
    try
    {
        using var source = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
        using var command = new NpgsqlCommand("SELECT 1 FROM pg_sleep(20);", conn)
        {
            CommandTimeout = timeout
        };
        Console.WriteLine($"Before: {DateTime.Now}");
        await command.ExecuteNonQueryAsync(source.Token);
        Console.WriteLine($"After: {DateTime.Now}");
    }
    catch (Exception e)
    {
        Console.WriteLine(e.Message);
    }
    finally
    {
        conn.Close();
        Console.WriteLine("Done");
    }
}
```
</details>