### PR TITLE
Stop swallowing exceptions in reader Dispose

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1002,7 +1002,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         catch (Exception ex)
         {
             // In the case of a PostgresException (or multiple ones, if we have error barriers), the reader's state has already been set
-            // to Disposed in Close above; otherwise, we need to set it here.
+            // to Disposed in Close above; in multiplexing, we also unbind the connector (with its reader), and at that point it can be used
+            // by other consumers. Therefore, we only set the state fo Disposed if the exception *wasn't* a PostgresException.
             if (!(ex is PostgresException ||
                   ex is NpgsqlException { InnerException: AggregateException aggregateException } &&
                   aggregateException.InnerExceptions.All(e => e is PostgresException)))
@@ -1040,7 +1041,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             catch (Exception ex)
             {
                 // In the case of a PostgresException (or multiple ones, if we have error barriers), the reader's state has already been set
-                // to Disposed in Close above; otherwise, we need to set it here.
+                // to Disposed in Close above; in multiplexing, we also unbind the connector (with its reader), and at that point it can be used
+                // by other consumers. Therefore, we only set the state fo Disposed if the exception *wasn't* a PostgresException.
                 if (!(ex is PostgresException ||
                       ex is NpgsqlException { InnerException: AggregateException aggregateException } &&
                       aggregateException.InnerExceptions.All(e => e is PostgresException)))

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1222,8 +1222,8 @@ LANGUAGE plpgsql VOLATILE";
         Assert.DoesNotThrowAsync(reader.ReadAsync);
     }
 
-    [Test]
-    public async Task Dispose_swallows_exceptions([Values(true, false)] bool async)
+    [Test] // #4377
+    public async Task Dispose_does_not_swallow_exceptions([Values(true, false)] bool async)
     {
         await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
         using var _ = CreateTempPool(postmasterMock.ConnectionString, out var connectionString);
@@ -1245,9 +1245,9 @@ LANGUAGE plpgsql VOLATILE";
         pgMock.Close();
 
         if (async)
-            Assert.DoesNotThrow(() => reader.Dispose());
+            Assert.Throws<NpgsqlException>(() => reader.Dispose());
         else
-            Assert.DoesNotThrowAsync(async () => await reader.DisposeAsync());
+            Assert.ThrowsAsync<NpgsqlException>(async () => await reader.DisposeAsync());
     }
 
     #region GetBytes / GetStream


### PR DESCRIPTION
And a fix to multiple exception handling with error barriers.

Closes #4377