### PR TITLE
Clean up and expose physical connection initializers

### DIFF
--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -32,6 +32,9 @@ public abstract class NpgsqlDataSource : DbDataSource
     readonly Func<NpgsqlConnectionStringBuilder, CancellationToken, ValueTask<string>>? _periodicPasswordProvider;
     readonly TimeSpan _periodicPasswordSuccessRefreshInterval, _periodicPasswordFailureRefreshInterval;
 
+    internal Action<NpgsqlConnection>? ConnectionInitializer { get; }
+    internal Func<NpgsqlConnection, Task>? ConnectionInitializerAsync { get; }
+
     readonly Timer? _passwordProviderTimer;
     readonly CancellationTokenSource? _timerPasswordProviderCancellationTokenSource;
     readonly Task _passwordRefreshTask = null!;
@@ -59,7 +62,12 @@ public abstract class NpgsqlDataSource : DbDataSource
 
         Configuration = dataSourceConfig;
 
-        (LoggingConfiguration, _periodicPasswordProvider, _periodicPasswordSuccessRefreshInterval, _periodicPasswordFailureRefreshInterval)
+        (LoggingConfiguration,
+                _periodicPasswordProvider,
+                _periodicPasswordSuccessRefreshInterval,
+                _periodicPasswordFailureRefreshInterval,
+                ConnectionInitializer,
+                ConnectionInitializerAsync)
             = dataSourceConfig;
         _connectionLogger = LoggingConfiguration.ConnectionLogger;
 

--- a/src/Npgsql/NpgsqlDataSourceConfiguration.cs
+++ b/src/Npgsql/NpgsqlDataSourceConfiguration.cs
@@ -8,4 +8,6 @@ sealed record NpgsqlDataSourceConfiguration(
     NpgsqlLoggingConfiguration LoggingConfiguration,
     Func<NpgsqlConnectionStringBuilder, CancellationToken, ValueTask<string>>? PeriodicPasswordProvider,
     TimeSpan PeriodicPasswordSuccessRefreshInterval,
-    TimeSpan PeriodicPasswordFailureRefreshInterval);
+    TimeSpan PeriodicPasswordFailureRefreshInterval,
+    Action<NpgsqlConnection>? ConnectionInitializer,
+    Func<NpgsqlConnection, Task>? ConnectionInitializerAsync);

--- a/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
+++ b/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
@@ -134,5 +134,11 @@ namespace Npgsql.Properties {
                 return ResourceManager.GetString("CannotReadInfinityValue", resourceCulture);
             }
         }
+        
+        internal static string SyncAndAsyncConnectionInitializersRequired {
+            get {
+                return ResourceManager.GetString("SyncAndAsyncConnectionInitializersRequired", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Npgsql/Properties/NpgsqlStrings.resx
+++ b/src/Npgsql/Properties/NpgsqlStrings.resx
@@ -63,4 +63,7 @@
     <data name="CannotReadInfinityValue" xml:space="preserve">
         <value>Cannot read infinity value since Npgsql.DisableDateTimeInfinityConversions is enabled.</value>
     </data>
+    <data name="SyncAndAsyncConnectionInitializersRequired" xml:space="preserve">
+        <value>Both sync and async connection initializers must be provided.</value>
+    </data>
 </root>

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Npgsql.NpgsqlBatch.EnableErrorBarriers.get -> bool
 Npgsql.NpgsqlBatch.EnableErrorBarriers.set -> void
 Npgsql.NpgsqlBatchCommand.AppendErrorBarrier.get -> bool?
 Npgsql.NpgsqlBatchCommand.AppendErrorBarrier.set -> void
+Npgsql.NpgsqlDataSourceBuilder.UsePhysicalConnectionInitializer(System.Action<Npgsql.NpgsqlConnection!>? connectionInitializer, System.Func<Npgsql.NpgsqlConnection!, System.Threading.Tasks.Task!>? connectionInitializerAsync) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlLoggingConfiguration
 Npgsql.Schema.NpgsqlDbColumn.IsIdentity.get -> bool?
 Npgsql.Schema.NpgsqlDbColumn.IsIdentity.set -> void
@@ -23,6 +24,10 @@ static Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(Microsoft.Extensions.
 *REMOVED*const NpgsqlTypes.NpgsqlTimeSpan.TicksPerMinute = 600000000 -> long
 *REMOVED*const NpgsqlTypes.NpgsqlTimeSpan.TicksPerMonth = 25920000000000 -> long
 *REMOVED*const NpgsqlTypes.NpgsqlTimeSpan.TicksPerSecond = 10000000 -> long
+*REMOVED*Npgsql.NpgsqlConnection.PhysicalOpenAsyncCallback.get -> Npgsql.PhysicalOpenAsyncCallback?
+*REMOVED*Npgsql.NpgsqlConnection.PhysicalOpenAsyncCallback.set -> void
+*REMOVED*Npgsql.NpgsqlConnection.PhysicalOpenCallback.get -> Npgsql.PhysicalOpenCallback?
+*REMOVED*Npgsql.NpgsqlConnection.PhysicalOpenCallback.set -> void
 *REMOVED*Npgsql.NpgsqlConnectionStringPropertyAttribute
 *REMOVED*Npgsql.NpgsqlConnectionStringPropertyAttribute.NpgsqlConnectionStringPropertyAttribute() -> void
 *REMOVED*Npgsql.NpgsqlConnectionStringPropertyAttribute.NpgsqlConnectionStringPropertyAttribute(params string![]! synonyms) -> void
@@ -46,6 +51,8 @@ static Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(Microsoft.Extensions.
 *REMOVED*Npgsql.NpgsqlDataReader.GetDate(int ordinal) -> NpgsqlTypes.NpgsqlDate
 *REMOVED*Npgsql.NpgsqlDataReader.GetInterval(int ordinal) -> NpgsqlTypes.NpgsqlTimeSpan
 *REMOVED*Npgsql.NpgsqlDataReader.GetTimeStamp(int ordinal) -> NpgsqlTypes.NpgsqlDateTime
+*REMOVED*Npgsql.PhysicalOpenAsyncCallback
+*REMOVED*Npgsql.PhysicalOpenCallback
 *REMOVED*NpgsqlTypes.NpgsqlDate
 *REMOVED*NpgsqlTypes.NpgsqlDate.Add(in NpgsqlTypes.NpgsqlTimeSpan interval) -> NpgsqlTypes.NpgsqlDate
 *REMOVED*NpgsqlTypes.NpgsqlDate.AddDays(int days) -> NpgsqlTypes.NpgsqlDate

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1466,117 +1466,152 @@ CREATE TABLE record ()");
                 : original));
     }
 
-    [Test]
-    public async Task Physical_open_callback_sync()
-    {
-        await using var defaultConn = await OpenConnectionAsync();
-        await using var _ = await CreateTempTable(defaultConn, "ID INTEGER", out var table);
+    #region Physical connection initialization
 
-        using var __ = CreateTempPool(ConnectionString, out var connectionString);
-        using var conn = new NpgsqlConnection(connectionString);
-        conn.PhysicalOpenCallback = connector =>
+    [Test]
+    public async Task PhysicalConnectionInitializer_sync()
+    {
+        await using var adminConn = await OpenConnectionAsync();
+        await using var _ = await CreateTempTable(adminConn, "ID INTEGER", out var table);
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            conn => conn.ExecuteNonQuery($"INSERT INTO {table} VALUES (1)"),
+            _ => throw new NotSupportedException());
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using (var conn = dataSource.OpenConnection())
         {
-            using var cmd = connector.CreateCommand($"INSERT INTO \"{table}\" VALUES(1)");
-            cmd.ExecuteNonQuery();
-        };
-        conn.PhysicalOpenAsyncCallback = _ => throw new NotImplementedException();
+            Assert.That(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""), Is.EqualTo(1));
+        }
 
-        Assert.DoesNotThrow(conn.Open);
-
-        var rowsCount = (long)(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""))!;
-        Assert.AreEqual(1, rowsCount);
-    }
-
-    [Test]
-    public async Task Physical_open_async_callback()
-    {
-        await using var defaultConn = await OpenConnectionAsync();
-        await using var _ = await CreateTempTable(defaultConn, "ID INTEGER", out var table);
-
-        using var __ = CreateTempPool(ConnectionString, out var connectionString);
-        await using var conn = new NpgsqlConnection(connectionString);
-        conn.PhysicalOpenAsyncCallback = async connector =>
+        // Opening a second time should get us an idle connection, which should not cause the initializer to get executed
+        await using (var conn = dataSource.OpenConnection())
         {
-            using var cmd = connector.CreateCommand($"INSERT INTO \"{table}\" VALUES(1)");
-            await cmd.ExecuteNonQueryAsync();
-        };
-        conn.PhysicalOpenCallback = _ => throw new NotImplementedException();
-
-        Assert.DoesNotThrowAsync(conn.OpenAsync);
-
-        var rowsCount = (long)(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""))!;
-        Assert.AreEqual(1, rowsCount);
-    }
-
-    [Test]
-    public async Task Physical_open_callback_throws()
-    {
-        using var _ = CreateTempPool(ConnectionString, out var connectionString);
-        await using var conn = new NpgsqlConnection(connectionString);
-        conn.PhysicalOpenCallback = _ => throw new NotImplementedException();
-
-        Assert.Throws<NotImplementedException>(conn.Open);
-    }
-
-    [Test]
-    public async Task Physical_open_async_callback_throws()
-    {
-        PhysicalOpenAsyncCallback callback = _ => throw new NotImplementedException();
-
-        using var _ = CreateTempPool(ConnectionString, out var connectionString);
-        await using var conn = new NpgsqlConnection(connectionString);
-        conn.PhysicalOpenAsyncCallback = callback;
-
-        Assert.ThrowsAsync<NotImplementedException>(conn.OpenAsync);
-
-        if (IsMultiplexing)
-        {
-            // With multiplexing a physical connection might open on NpgsqlConnection.OpenAsync (if there was no completed bootstrap beforehand)
-            // or on NpgsqlCommand.ExecuteReaderAsync.
-            // We've already tested the first case above, testing the second one below.
-            conn.PhysicalOpenAsyncCallback = null;
-            // Allow the bootstrap to complete
-            Assert.DoesNotThrowAsync(conn.OpenAsync);
-
-            NpgsqlConnection.ClearPool(conn);
-
-            conn.PhysicalOpenAsyncCallback = callback;
-            Assert.ThrowsAsync<NotImplementedException>(() => conn.ExecuteNonQueryAsync("SELECT 1"));
+            Assert.That(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""), Is.EqualTo(1));
         }
     }
 
     [Test]
-    public async Task Physical_open_callback_idle_connection()
+    public async Task PhysicalConnectionInitializer_async()
     {
-        if (IsMultiplexing)
-            return;
+        await using var adminConn = await OpenConnectionAsync();
+        await using var _ = await CreateTempTable(adminConn, "ID INTEGER", out var table);
 
-        using var _ = CreateTempPool(ConnectionString, out var connectionString);
-        await using var conn = new NpgsqlConnection(connectionString);
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            _ => throw new NotSupportedException(),
+            async conn => await conn.ExecuteNonQueryAsync($"INSERT INTO {table} VALUES (1)"));
+        await using var dataSource = dataSourceBuilder.Build();
 
-        Assert.DoesNotThrow(conn.Open);
-        conn.Close();
+        await using (var conn = await dataSource.OpenConnectionAsync())
+        {
+            Assert.That(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""), Is.EqualTo(1));
+        }
 
-        conn.PhysicalOpenCallback = _ => throw new NotImplementedException();
-
-        Assert.DoesNotThrow(conn.Open);
-        Assert.DoesNotThrow(() => conn.ExecuteNonQuery("SELECT 1"));
+        // Opening a second time should get us an idle connection, which should not cause the initializer to get executed
+        await using (var conn = await dataSource.OpenConnectionAsync())
+        {
+            Assert.That(await conn.ExecuteScalarAsync($"SELECT COUNT(*) FROM \"{table}\""), Is.EqualTo(1));
+        }
     }
 
     [Test]
-    public async Task Physical_open_async_callback_idle_connection()
+    public async Task PhysicalConnectionInitializer_sync_with_break()
     {
-        using var _ = CreateTempPool(ConnectionString, out var connectionString);
-        await using var conn = new NpgsqlConnection(connectionString);
+        if (IsMultiplexing) // Sync I/O
+            return;
 
-        Assert.DoesNotThrowAsync(conn.OpenAsync);
-        await conn.CloseAsync();
+        await using var adminConn = await OpenConnectionAsync();
 
-        conn.PhysicalOpenAsyncCallback = _ => throw new NotImplementedException();
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            conn =>
+            {
+                // Use another connection to kill the connector currently in the pool
+                using (var conn2 = OpenConnection())
+                    conn2.ExecuteNonQuery($"SELECT pg_terminate_backend({conn.ProcessID})");
 
-        Assert.DoesNotThrowAsync(conn.OpenAsync);
-        Assert.DoesNotThrowAsync(() => conn.ExecuteNonQueryAsync("SELECT 1"));
+                conn.ExecuteScalar("SELECT 1");
+            },
+            _ => throw new NotSupportedException());
+        await using var dataSource = dataSourceBuilder.Build();
+
+        Assert.That(() => dataSource.OpenConnection(), Throws.Exception.InstanceOf<NpgsqlException>());
+        Assert.That(dataSource.Statistics, Is.EqualTo((0, 0, 0)));
     }
+
+    [Test]
+    public async Task PhysicalConnectionInitializer_async_with_break()
+    {
+        await using var adminConn = await OpenConnectionAsync();
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            _ => throw new NotSupportedException(),
+            async conn =>
+            {
+                // Use another connection to kill the connector currently in the pool
+                await using (var conn2 = await OpenConnectionAsync())
+                    await conn2.ExecuteNonQueryAsync($"SELECT pg_terminate_backend({conn.ProcessID})");
+
+                await conn.ExecuteScalarAsync("SELECT 1");
+            });
+        await using var dataSource = dataSourceBuilder.Build();
+
+        Assert.That(async () => await dataSource.OpenConnectionAsync(), Throws.Exception.InstanceOf<NpgsqlException>());
+        Assert.That(dataSource.Statistics, Is.EqualTo((0, 0, 0)));
+    }
+
+    [Test]
+    public async Task PhysicalConnectionInitializer_async_throws_on_second_open()
+    {
+        // With multiplexing a physical connection might open on NpgsqlConnection.OpenAsync (if there was no completed bootstrap beforehand)
+        // or on NpgsqlCommand.ExecuteReaderAsync.
+        // We've already tested the first case in PhysicalConnectionInitializer_async_throws above, testing the second one below.
+        await using var adminConn = await OpenConnectionAsync();
+
+        var count = 0;
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            _ => throw new NotSupportedException(),
+            _ =>
+            {
+                if (++count == 1)
+                    return Task.CompletedTask;
+                throw new Exception("INTENTIONAL FAILURE");
+            });
+        await using var dataSource = dataSourceBuilder.Build();
+
+        Assert.DoesNotThrowAsync(async () => await dataSource.OpenConnectionAsync());
+
+        var exception = Assert.ThrowsAsync<Exception>(async () => await dataSource.OpenConnectionAsync())!;
+        Assert.That(exception.Message, Is.EqualTo("INTENTIONAL FAILURE"));
+    }
+
+    [Test]
+    public async Task PhysicalConnectionInitializer_disposes_connection()
+    {
+        NpgsqlConnection? initializerConnection = null;
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.UsePhysicalConnectionInitializer(
+            _ => throw new NotSupportedException(),
+            conn =>
+            {
+                initializerConnection = conn;
+                return Task.CompletedTask;
+            });
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        Assert.That(initializerConnection, Is.Not.Null);
+        Assert.That(conn, Is.Not.SameAs(initializerConnection));
+        Assert.That(() => initializerConnection!.Open(), Throws.Exception.TypeOf<ObjectDisposedException>());
+    }
+
+    #endregion Physical connection initialization
 
     [Test]
     [NonParallelizable]

--- a/test/Npgsql.Tests/DataSourceTests.cs
+++ b/test/Npgsql.Tests/DataSourceTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Data;
 using System.Threading.Tasks;
-using System.Xml.Schema;
 using NUnit.Framework;
 
 // ReSharper disable MethodHasAsyncOverload

--- a/test/Npgsql.Tests/Support/TestBase.cs
+++ b/test/Npgsql.Tests/Support/TestBase.cs
@@ -301,6 +301,9 @@ public abstract class TestBase
 
     protected static readonly NpgsqlDataSource DataSource = NpgsqlDataSource.Create(TestUtil.ConnectionString);
 
+    protected virtual NpgsqlDataSourceBuilder CreateDataSourceBuilder()
+        => new(TestUtil.ConnectionString);
+
     protected virtual NpgsqlDataSource CreateLoggingDataSource(
         out ListLoggerProvider listLoggerProvider,
         string? connectionString = null,


### PR DESCRIPTION
@NinoFloris this one's for you.

Note that during the physical initialization phase, there's no multiplexing - the connection is bound to the connector (this is kinda obvious since the whole point is to do initialization on a physical connection).

The relationalship between connection and connector is ever annoying... Oh well.

Closes #3817
Closes #3745

