### PR TITLE
Make CloneWith work with data source password

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -335,8 +335,7 @@ partial class NpgsqlConnector
             }
         }
 
-        if (password is null)
-            password = PostgresEnvironment.Password;
+        password ??= PostgresEnvironment.Password;
 
         if (password != null)
             return password;

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -482,8 +482,6 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// </summary>
     public string? UserName => Settings.Username;
 
-    internal string? Password => Settings.Password;
-
     // The following two lines are here for backwards compatibility with the EF6 provider
     // ReSharper disable UnusedMember.Global
     internal string? EntityTemplateDatabase => Settings.EntityTemplateDatabase;
@@ -1972,10 +1970,10 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         CheckDisposed();
         var csb = new NpgsqlConnectionStringBuilder(connectionString);
-        if (csb.Password == null && Password != null)
-            csb.Password = Password;
+        csb.Password ??= _dataSource?.GetPassword(async: false).GetAwaiter().GetResult();
         if (csb.PersistSecurityInfo && !Settings.PersistSecurityInfo)
             csb.PersistSecurityInfo = false;
+
         return new NpgsqlConnection(csb.ToString()) {
             ProvideClientCertificatesCallback = ProvideClientCertificatesCallback,
             UserCertificateValidationCallback = UserCertificateValidationCallback,


### PR DESCRIPTION
CloneWith is currently broken when using data source (this affects e.g. EF).

Note: will also make sure CloneWith works with the auth callbacks in #4694