### PR TITLE
Optimize OpenNewConnector for multiplexing

### DIFF
--- a/src/Npgsql/MultiplexingDataSource.cs
+++ b/src/Npgsql/MultiplexingDataSource.cs
@@ -109,7 +109,7 @@ sealed class MultiplexingDataSource : PoolingDataSource
                     }
 
                     connector = await OpenNewConnector(
-                        command.Connection!,
+                        command.InternalConnection!,
                         TimeSpan.FromSeconds(Settings.Timeout),
                         async: true,
                         CancellationToken.None);

--- a/src/Npgsql/MultiplexingDataSource.cs
+++ b/src/Npgsql/MultiplexingDataSource.cs
@@ -109,15 +109,15 @@ sealed class MultiplexingDataSource : PoolingDataSource
                     }
 
                     connector = await OpenNewConnector(
-                        command.InternalConnection!,
-                        new NpgsqlTimeout(TimeSpan.FromSeconds(Settings.Timeout)),
+                        command.Connection!,
+                        TimeSpan.FromSeconds(Settings.Timeout),
                         async: true,
                         CancellationToken.None);
 
                     if (connector != null)
                     {
                         // Managed to created a new connector
-                        connector.Connection = null;
+                        Debug.Assert(connector.Connection is null);
 
                         // See increment under over-capacity mode below
                         Interlocked.Increment(ref connector.CommandsInFlightCount);


### PR DESCRIPTION
By not creating `NpgsqlTimeout` unless necessary.