### PR TITLE
Support chaining the mapper configuration

### DIFF
--- a/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
@@ -13,7 +13,7 @@ public static class NpgsqlNodaTimeExtensions
     /// Sets up NodaTime mappings for the PostgreSQL date/time types.
     /// </summary>
     /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
-    public static INpgsqlTypeMapper UseNodaTime(this INpgsqlTypeMapper mapper)
+    public static T UseNodaTime<T>(this T mapper) where T : INpgsqlTypeMapper
     {
         mapper.AddTypeResolverFactory(new NodaTimeTypeHandlerResolverFactory());
         return mapper;


### PR DESCRIPTION
I would like to go:
```
new NpgsqlDataSourceBuilder(connectionString)
            .UseNodaTime()               // <-- currently returns INpgsqlTypeMapper
            .UseLoggerFactory(logging)   // <-- which doesn't work for subsequent chained calls
            .Build();
```
`UseNodaTime()` returns the interface `INpgsqlTypeMapper` and not the `NpgsqlDataSourceBuilder`, which breaks the fluent API here.
This PR uses a generic type constraint to fix this.