### PR TITLE
Exposed SnapshotName property for ReplicationSlotOptions to enable querying for existing data

### DIFF
--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+
+Npgsql.Replication.ReplicationSlotOptions.SnapshotName.get -> string?

--- a/src/Npgsql/Replication/ReplicationSlotOptions.cs
+++ b/src/Npgsql/Replication/ReplicationSlotOptions.cs
@@ -55,5 +55,5 @@ public readonly struct ReplicationSlotOptions
     /// <summary>
     /// The identifier of the snapshot exported by the CREATE_REPLICATION_SLOT command.
     /// </summary>
-    internal string? SnapshotName { get; }
+    public string? SnapshotName { get; }
 }


### PR DESCRIPTION
Exposed the `SnapshotName` property for ReplicationSlotOptions to enable querying for existing data

It is required to get already existing rows when the replication slot is created. This feature is already tested in https://github.com/npgsql/npgsql/blob/main/test/Npgsql.Tests/Replication/CommonLogicalReplicationTests.cs#L160. Still, it works there, as the property is marked as internal. For regular usage, it's not possible to access this property and query the snapshotted data.

@Brar @roji, it's an appendix to our [Twitter discussion](https://twitter.com/BrarPiening/status/1593198781927165952?s=20&t=KB56tba67gitUnRHl1c3mQ).

See also more in https://github.com/oskardudycz/PostgresOutboxPatternWithCDC.NET/pull/2/files#diff-b5a35863af0f497217328c07327a9067d23c8b0b5c20ec43faa6b388230989f5R46.