### PR TITLE
Remove package reference for System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +35,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This removes the package reference for
System.Runtime.CompilerServices.Unsafe from TFM net7.0 and above.
When testing, Npgsql actually built perfectly even when removing the
package reference for all TFMs but this doesn't feel safe for now and
also is not what is suggested by the documentation at:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/unsafe-package
