### PR TITLE
Fix header size for GeoJSON collections

### DIFF
--- a/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
+++ b/src/Npgsql.GeoJSON/Internal/GeoJSONHandler.cs
@@ -449,7 +449,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(LineString value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.LineString;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {
@@ -476,7 +476,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(Polygon value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.Polygon;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {
@@ -510,7 +510,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(MultiPoint value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.MultiPoint;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {
@@ -537,7 +537,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(MultiLineString value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.MultiLineString;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {
@@ -564,7 +564,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(MultiPolygon value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.MultiPolygon;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {
@@ -590,7 +590,7 @@ sealed partial class GeoJsonHandler : NpgsqlTypeHandler<GeoJSONObject>,
     public async Task Write(GeometryCollection value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
     {
         var type = EwkbGeometryType.GeometryCollection;
-        var size = SizeOfHeader;
+        var size = SizeOfHeaderWithLength;
         var srid = GetSrid(value.CRS);
         if (srid != 0)
         {

--- a/test/Npgsql.PluginTests/GeoJSONTests.cs
+++ b/test/Npgsql.PluginTests/GeoJSONTests.cs
@@ -8,6 +8,7 @@ using GeoJSON.Net.CoordinateReferenceSystem;
 using GeoJSON.Net.Geometry;
 using Newtonsoft.Json;
 using Npgsql.Tests;
+using NpgsqlTypes;
 using NUnit.Framework;
 using static Npgsql.Tests.TestUtil;
 
@@ -283,6 +284,66 @@ public class GeoJSONTests : TestBase
             Assert.That(reader[0], Is.EqualTo(point));
             Assert.That(reader[1], Is.EqualTo(point));
         }
+    }
+
+    [Test, TestCaseSource(nameof(Tests))]
+    public async Task Import_geometry(TestData data)
+    {
+        await using var conn = await OpenConnectionAsync(options: GeoJSONOptions.BoundingBox);
+        var table = await CreateTempTable(conn, "field geometry");
+
+        await using (var writer = await conn.BeginBinaryImportAsync($"COPY {table} (field) FROM STDIN BINARY"))
+        {
+            await writer.StartRowAsync();
+            await writer.WriteAsync(data.Geometry, NpgsqlDbType.Geometry);
+
+            var rowsWritten = await writer.CompleteAsync();
+            Assert.That(rowsWritten, Is.EqualTo(1));
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT field FROM {table}";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.IsTrue(await reader.ReadAsync());
+        var actual = reader.GetValue(0);
+        Assert.That(actual, Is.EqualTo(data.Geometry));
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4693")]
+    public async Task Import_big_geometry()
+    {
+        await using var conn = await OpenConnectionAsync();
+        var table = await CreateTempTable(conn, "id text, field geometry");
+
+        var geometry = new MultiLineString(new[] {
+            new LineString(
+                Enumerable.Range(1, 507)
+                    .Select(i => new Position(longitude: i, latitude: i))
+                    .Append(new Position(longitude: 1d, latitude: 1d))),
+            new LineString(new[] {
+                new Position(longitude: 1d, latitude: 1d),
+                new Position(longitude: 1d, latitude: 2d),
+                new Position(longitude: 1d, latitude: 3d),
+                new Position(longitude: 1d, latitude: 1d),
+            })
+        });
+
+        await using (var writer = await conn.BeginBinaryImportAsync($"COPY {table} (id, field) FROM STDIN BINARY"))
+        {
+            await writer.StartRowAsync();
+            await writer.WriteAsync("a", NpgsqlDbType.Text);
+            await writer.WriteAsync(geometry, NpgsqlDbType.Geometry);
+
+            var rowsWritten = await writer.CompleteAsync();
+            Assert.That(rowsWritten, Is.EqualTo(1));
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT field FROM {table}";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.IsTrue(await reader.ReadAsync());
+        var actual = reader.GetValue(0);
+        Assert.That(actual, Is.EqualTo(geometry));
     }
 
     ValueTask<NpgsqlConnection> OpenConnectionAsync(GeoJSONOptions options = GeoJSONOptions.None)

--- a/test/Npgsql.PluginTests/GeoJSONTests.cs
+++ b/test/Npgsql.PluginTests/GeoJSONTests.cs
@@ -309,7 +309,7 @@ public class GeoJSONTests : TestBase
         Assert.That(actual, Is.EqualTo(data.Geometry));
     }
 
-    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4693")]
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4827")]
     public async Task Import_big_geometry()
     {
         await using var conn = await OpenConnectionAsync();


### PR DESCRIPTION
Fixes #4827

It does not impact the serialization of GeoJSON objects but the trigger to force the `Flush` operation when the buffer does not contain enough place.