### PR TITLE
Support for non-generic Enum mapping

### DIFF
--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -292,12 +292,15 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
         => _internalBuilder.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+    [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
+    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+        => _internalBuilder.MapEnum(clrType, pgName, nameTranslator);
 
     /// <inheritdoc />
-    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+        => _internalBuilder.UnmapEnum(clrType, pgName, nameTranslator);
 
     /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types, requiring require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -292,6 +292,14 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
         => _internalBuilder.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
+    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types, requiring require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
     public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -275,12 +275,18 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         => _userTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        Type enumType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+    [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
+    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    {
+        _userTypeMapper.MapEnum(clrType, pgName, nameTranslator);
+        return this;
+    }
 
     /// <inheritdoc />
-    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
-        Type enumType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+        => _userTypeMapper.UnmapEnum(clrType, pgName, nameTranslator);
 
     /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types, requiring require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -275,6 +275,14 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         => _userTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
+    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type enumType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type enumType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types, requiring require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
     public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -11,8 +11,10 @@ Npgsql.NpgsqlConnectionStringBuilder.ChannelBinding.set -> void
 Npgsql.NpgsqlBinaryImporter.WriteRow(params object?[]! values) -> void
 Npgsql.NpgsqlBinaryImporter.WriteRowAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), params object?[]! values) -> System.Threading.Tasks.Task!
 Npgsql.NpgsqlDataSourceBuilder.AddTypeInfoResolver(Npgsql.Internal.IPgTypeInfoResolver! resolver) -> void
+Npgsql.NpgsqlDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlDataSourceBuilder.Name.get -> string?
 Npgsql.NpgsqlDataSourceBuilder.Name.set -> void
+Npgsql.NpgsqlDataSourceBuilder.UnmapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.NpgsqlDataSourceBuilder.UseRootCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2? rootCertificate) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.UseRootCertificateCallback(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2!>? rootCertificateCallback) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder
@@ -35,12 +37,14 @@ Npgsql.NpgsqlSlimDataSourceBuilder.EnableRecords() -> Npgsql.NpgsqlSlimDataSourc
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableTransportSecurity() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlSlimDataSourceBuilder.Name.get -> string?
 Npgsql.NpgsqlSlimDataSourceBuilder.Name.set -> void
 Npgsql.NpgsqlSlimDataSourceBuilder.NpgsqlSlimDataSourceBuilder(string? connectionString = null) -> void
 Npgsql.NpgsqlSlimDataSourceBuilder.UnmapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.NpgsqlSlimDataSourceBuilder.UnmapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
+Npgsql.NpgsqlSlimDataSourceBuilder.UnmapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.NpgsqlSlimDataSourceBuilder.UnmapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.NpgsqlSlimDataSourceBuilder.UseClientCertificate(System.Security.Cryptography.X509Certificates.X509Certificate? clientCertificate) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.UseClientCertificates(System.Security.Cryptography.X509Certificates.X509CertificateCollection? clientCertificates) -> Npgsql.NpgsqlSlimDataSourceBuilder!
@@ -58,6 +62,8 @@ Npgsql.Replication.PhysicalReplicationConnection.StartReplication(NpgsqlTypes.Np
 Npgsql.Replication.PhysicalReplicationSlot.PhysicalReplicationSlot(string! slotName, NpgsqlTypes.NpgsqlLogSequenceNumber? restartLsn = null, uint? restartTimeline = null) -> void
 Npgsql.Replication.PhysicalReplicationSlot.RestartTimeline.get -> uint?
 Npgsql.TypeMapping.INpgsqlTypeMapper.AddTypeInfoResolver(Npgsql.Internal.IPgTypeInfoResolver! resolver) -> void
+Npgsql.TypeMapping.INpgsqlTypeMapper.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+Npgsql.TypeMapping.INpgsqlTypeMapper.UnmapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.TypeMapping.UserTypeMapping
 Npgsql.TypeMapping.UserTypeMapping.ClrType.get -> System.Type!
 Npgsql.TypeMapping.UserTypeMapping.PgTypeName.get -> string!

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -216,6 +216,14 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
+    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) => throw new NotImplementedException();
+
+    /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types, requiring require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
     public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => MapComposite(typeof(T), pgName, nameTranslator);

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -65,6 +65,49 @@ public interface INpgsqlTypeMapper
         where TEnum : struct, Enum;
 
     /// <summary>
+    /// Maps a CLR enum to a PostgreSQL enum type.
+    /// </summary>
+    /// <remarks>
+    /// CLR enum labels are mapped by name to PostgreSQL enum labels.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your enum fields to manually specify a PostgreSQL enum label.
+    /// If there is a discrepancy between the .NET and database labels while an enum is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="clrType">The .NET enum type to be mapped</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
+    INpgsqlTypeMapper MapEnum(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type clrType,
+        string? pgName = null,
+        INpgsqlNameTranslator? nameTranslator = null);
+
+    /// <summary>
+    /// Removes an existing enum mapping.
+    /// </summary>
+    /// <param name="clrType">The .NET enum type to be mapped</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    bool UnmapEnum(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type clrType,
+        string? pgName = null,
+        INpgsqlNameTranslator? nameTranslator = null);
+
+    /// <summary>
     /// Maps a CLR type to a PostgreSQL composite type.
     /// </summary>
     /// <remarks>

--- a/test/Npgsql.Tests/GlobalTypeMapperTests.cs
+++ b/test/Npgsql.Tests/GlobalTypeMapperTests.cs
@@ -34,7 +34,7 @@ public class GlobalTypeMapperTests : TestBase
         // Global mapping changes have no effect on already-built data sources
         await AssertType(dataSource1, Mood.Happy, "happy", type, npgsqlDbType: null);
 
-        // But they do affect on new data sources
+        // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
         await AssertType(dataSource2, "happy", "happy", type, npgsqlDbType: null, isDefault: false);
     }
@@ -63,7 +63,7 @@ public class GlobalTypeMapperTests : TestBase
             // Global mapping changes have no effect on already-built data sources
             await AssertType(dataSource1, Mood.Happy, "happy", type, npgsqlDbType: null);
 
-            // But they do affect on new data sources
+            // But they do affect new data sources
             await using var dataSource2 = CreateDataSource();
             Assert.ThrowsAsync<ArgumentException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, npgsqlDbType: null));
         }
@@ -94,7 +94,7 @@ public class GlobalTypeMapperTests : TestBase
         // Global mapping changes have no effect on already-built data sources
         await AssertType(dataSource1, Mood.Happy, "happy", type, npgsqlDbType: null);
 
-        // But they do affect on new data sources
+        // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
         await AssertType(dataSource2, "happy", "happy", type, npgsqlDbType: null, isDefault: false);
     }

--- a/test/Npgsql.Tests/GlobalTypeMapperTests.cs
+++ b/test/Npgsql.Tests/GlobalTypeMapperTests.cs
@@ -65,7 +65,7 @@ public class GlobalTypeMapperTests : TestBase
 
             // But they do affect new data sources
             await using var dataSource2 = CreateDataSource();
-            Assert.ThrowsAsync<ArgumentException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, npgsqlDbType: null));
+            Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, npgsqlDbType: null));
         }
         finally
         {

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -30,6 +30,27 @@ public class EnumTests : MultiplexingTestBase
     }
 
     [Test]
+    public async Task Data_source_mapping_non_generic()
+    {
+        await using var adminConnection = await OpenConnectionAsync();
+        var type = await GetTempTypeName(adminConnection);
+        await adminConnection.ExecuteNonQueryAsync($"CREATE TYPE {type} AS ENUM ('sad', 'ok', 'happy')");
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.MapEnum(typeof(Mood), type);
+        await using var dataSource = dataSourceBuilder.Build();
+        await AssertType(dataSource, Mood.Happy, "happy", type, npgsqlDbType: null);
+
+        // Mapping changes have no effect on already-built data sources
+        dataSourceBuilder.UnmapEnum(typeof(Mood), type);
+        await AssertType(dataSource, Mood.Happy, "happy", type, npgsqlDbType: null);
+
+        // But they do affect new data sources
+        await using var dataSource2 = dataSourceBuilder.Build();
+        Assert.ThrowsAsync<ArgumentException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, npgsqlDbType: null));
+    }
+
+    [Test]
     public async Task Dual_enums()
     {
         await using var adminConnection = await OpenConnectionAsync();


### PR DESCRIPTION
Hi @roji, @vonzshik,

Changes resolve https://github.com/npgsql/npgsql/issues/3383 by adding non-generic Map/UnmapEnum methods to INpgsqlTypeMapper.

This PR replaces the old one - https://github.com/npgsql/npgsql/pull/4629. 
Since ConnectorTypeMapper was removed, it was easier to create a new one.
I took all comments from the previous pull request into account.

Best regards and Happy New Year :)
Bogdan
