### PR TITLE
Update the .NET TFMs for Npgsql 8

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3'
 
 services:
   npgsql-dev:
-    image: mcr.microsoft.com/dotnet/sdk:7.0
+    # Source for tags: https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
+    image: mcr.microsoft.com/dotnet/sdk:8.0.100-preview.1
     volumes:
       - ..:/workspace:cached
     tty: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  dotnet_sdk_version: '7.0.100'
+  dotnet_sdk_version: '8.0.100-preview.1.23115.2'
   postgis_version: 3
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   # Windows comes with PG pre-installed, and defines the PGPASSWORD environment variable. Remove it as it interferes
@@ -27,12 +27,12 @@ jobs:
         os: [ubuntu-22.04, windows-2022]
         pg_major: [15, 14, 13, 12, 11, 10]
         config: [Release]
-        test_tfm: [net7.0]
+        test_tfm: [net8.0]
         include:
           - os: ubuntu-22.04
             pg_major: 15
             config: Debug
-            test_tfm: net7.0
+            test_tfm: net8.0
           - os: ubuntu-22.04
             pg_major: 15
             config: Release
@@ -40,11 +40,11 @@ jobs:
           - os: macos-12
             pg_major: 14
             config: Release
-            test_tfm: net7.0
+            test_tfm: net8.0
 #          - os: ubuntu-22.04
 #            pg_major: 15
 #            config: Release
-#            test_tfm: net7.0
+#            test_tfm: net8.0
 #            pg_prerelease: 'PG Prerelease'
 
     outputs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,9 @@ on:
   schedule:
     - cron: '21 0 * * 4'
 
+env:
+  dotnet_sdk_version: '8.0.100-preview.1.23115.2'
+
 jobs:
   analyze:
     name: Analyze
@@ -56,10 +59,18 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v3.0.3
+      with:
+        dotnet-version: ${{ env.dotnet_sdk_version }}
+
+    - name: Build
+      run: dotnet build
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,7 +65,7 @@ jobs:
         dotnet-version: ${{ env.dotnet_sdk_version }}
 
     - name: Build
-      run: dotnet build
+      run: dotnet build -c Release
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/native-aot.yml
+++ b/.github/workflows/native-aot.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  dotnet_sdk_version: '7.0.102'
+  dotnet_sdk_version: '8.0.100-preview.1.23115.2'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
         shell: bash
 
       - name: Build
-        run: dotnet publish test/Npgsql.NativeAotTests/Npgsql.NativeAotTests.csproj -r linux-x64 -c Release -f net7.0
+        run: dotnet publish test/Npgsql.NativeAotTests/Npgsql.NativeAotTests.csproj -r linux-x64 -c Release -f net8.0
         shell: bash
 
       # Uncomment the following to SSH into the agent running the build (https://github.com/mxschmitt/action-tmate)
@@ -61,19 +61,19 @@ jobs:
           sudo -u postgres psql -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
 
       - name: Run
-        run: test/Npgsql.NativeAotTests/bin/Release/net7.0/linux-x64/native/Npgsql.NativeAotTests
+        run: test/Npgsql.NativeAotTests/bin/Release/net8.0/linux-x64/native/Npgsql.NativeAotTests
 
       - name: Write binary size to summary
         run: |
-          size="$(ls -l test/Npgsql.NativeAotTests/bin/Release/net7.0/linux-x64/native/Npgsql.NativeAotTests | cut -d ' ' -f 5)"
+          size="$(ls -l test/Npgsql.NativeAotTests/bin/Release/net8.0/linux-x64/native/Npgsql.NativeAotTests | cut -d ' ' -f 5)"
           echo "Binary size is $size bytes ($((size / (1024 * 1024))) mb)" >> $GITHUB_STEP_SUMMARY
 
       - name: Dump mstat
-        run: dotnet run --project test/MStatDumper/MStatDumper.csproj -c release -- "test/Npgsql.NativeAotTests/obj/Release/net7.0/linux-x64/native/Npgsql.NativeAotTests.mstat" md >> $GITHUB_STEP_SUMMARY
+        run: dotnet run --project test/MStatDumper/MStatDumper.csproj -c release -f net8.0 -- "test/Npgsql.NativeAotTests/obj/Release/net8.0/linux-x64/native/Npgsql.NativeAotTests.mstat" md >> $GITHUB_STEP_SUMMARY
 
       - name: Assert binary size
         run: |
-          size="$(ls -l test/Npgsql.NativeAotTests/bin/Release/net7.0/linux-x64/native/Npgsql.NativeAotTests | cut -d ' ' -f 5)"
+          size="$(ls -l test/Npgsql.NativeAotTests/bin/Release/net8.0/linux-x64/native/Npgsql.NativeAotTests | cut -d ' ' -f 5)"
           echo "Binary size is $size bytes ($((size / (1024 * 1024))) mb)"
 
           if (( size > 36700160 )); then

--- a/.github/workflows/rich-code-nav.yml
+++ b/.github/workflows/rich-code-nav.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  dotnet_sdk_version: '7.0.100'
+  dotnet_sdk_version: '8.0.100-preview.1.23115.2'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,15 +1,9 @@
 ﻿<Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
 
-    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
-    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageVersion Include="OpenTelemetry.API" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 
@@ -44,5 +38,21 @@
 
     <!-- NativeAOT -->
     <PackageVersion Include="Mono.Cecil" Version="0.11.4" />
+  </ItemGroup>
+
+  <!-- Compatibility -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
+    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net6.0' ">
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,16 +20,16 @@
 
     <!-- Tests -->
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.1.23110.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0-preview.1.23110.8" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.4.0-beta.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageVersion Include="AdoNet.Specification.Tests" Version="2.0.0-alpha8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.1.23110.8" />
 
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,16 +20,16 @@
 
     <!-- Tests -->
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.1.23110.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0-preview.1.23110.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.4.0-beta.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageVersion Include="AdoNet.Specification.Tests" Version="2.0.0-alpha8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.1.23110.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
 
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -55,8 +55,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.DependencyInjection.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.NativeAotTests", "test\Npgsql.NativeAotTests\Npgsql.NativeAotTests.csproj", "{20F2E9D6-A69E-4BAE-9236-574B0AA59139}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MStatDumper", "test\MStatDumper\MStatDumper.csproj", "{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,14 +183,6 @@ Global
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|x86.ActiveCfg = Release|Any CPU
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|x86.Build.0 = Release|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|x86.Build.0 = Debug|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|x86.ActiveCfg = Release|Any CPU
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -214,7 +204,6 @@ Global
 		{B58E12EB-E43D-4D77-894E-5157D2269836} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{EB2530FC-69F7-4DCB-A8B3-3671A157ED32} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
-		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.DependencyInjection.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.NativeAotTests", "test\Npgsql.NativeAotTests\Npgsql.NativeAotTests.csproj", "{20F2E9D6-A69E-4BAE-9236-574B0AA59139}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MStatDumper", "test\MStatDumper\MStatDumper.csproj", "{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,14 @@ Global
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|x86.ActiveCfg = Release|Any CPU
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139}.Release|x86.Build.0 = Release|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -204,6 +214,7 @@ Global
 		{B58E12EB-E43D-4D77-894E-5157D2269836} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{EB2530FC-69F7-4DCB-A8B3-3671A157ED32} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 		{20F2E9D6-A69E-4BAE-9236-574B0AA59139} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
+		{24F7AE57-EDB2-4932-AD5E-F2CE3ED59A3F} = {ED612DB1-AB32-4603-95E7-891BACA71C39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C90AEECD-DB4C-4BE6-B506-16A449852FB8}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": "true"
   }

--- a/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
+++ b/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
@@ -3,8 +3,8 @@
     <PropertyGroup>
         <Authors>Shay Rojansky</Authors>
         <!-- DbDataSource was introduced to .NET in net7.0. Before that Npgsql has its own built-in copy. -->
-        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
         <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;di;dependency injection</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
+++ b/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Authors>Shay Rojansky</Authors>
         <!-- DbDataSource was introduced to .NET in net7.0. Before that Npgsql has its own built-in copy. -->
-        <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net7.0</TargetFrameworks>
         <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
         <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;di;dependency injection</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -4,7 +4,7 @@
     <Description>GeoJSON plugin for Npgsql, allowing mapping of PostGIS geometry types to GeoJSON types.</Description>
     <PackageTags>npgsql;postgresql;postgres;postgis;geojson;spatial;ado;ado.net;database;sql</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -4,7 +4,7 @@
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql;postgresql;json;postgres;ado;ado.net;database;sql</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -5,7 +5,7 @@
     <PackageTags>npgsql;postgresql;postgres;postgis;spatial;nettopologysuite;nts;ado;ado.net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -4,8 +4,8 @@
     <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
     <PackageTags>npgsql;postgresql;postgres;nodatime;date;time;ado;ado;net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.OpenTelemetry/Npgsql.OpenTelemetry.csproj
+++ b/src/Npgsql.OpenTelemetry/Npgsql.OpenTelemetry.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Authors>Shay Rojansky</Authors>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFramework>
+        <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
         <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;opentelemetry;tracing;diagnostics;instrumentation</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -825,7 +825,10 @@ public sealed partial class NpgsqlConnector
                                 cert = new X509Certificate2(cert.Export(X509ContentType.Pkcs12));
                             }
 #else
-                            throw new NotSupportedException("PEM certificates are only supported with .NET 5 and higher");
+                            // Technically PEM certificates are supported as of .NET 5 but we don't build for the net5.0
+                            // TFM anymore since .NET 5 is out of support
+                            // This is a breaking change for .NET 5 as of Npgsql 8!
+                            throw new NotSupportedException("PEM certificates are only supported with .NET 6 and higher");
 #endif
                         }
 
@@ -879,8 +882,8 @@ public sealed partial class NpgsqlConnector
                         var sslStream = new SslStream(_stream, leaveInnerStreamOpen: false, certificateValidationCallback);
 
                         var sslProtocols = SslProtocols.None;
-                        // On .NET Framework SslProtocols.None can be disabled, see #3718
 #if NETSTANDARD2_0
+                        // On .NET Framework SslProtocols.None can be disabled, see #3718
                         sslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
 #endif
 

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Util;
 using static System.Threading.Timeout;
+using static Npgsql.Util.Statics;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Util;
 using static System.Threading.Timeout;
-using static Npgsql.Util.Statics;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 

--- a/src/Npgsql/Internal/TypeHandlers/ByteaHandler.cs
+++ b/src/Npgsql/Internal/TypeHandlers/ByteaHandler.cs
@@ -18,10 +18,7 @@ namespace Npgsql.Internal.TypeHandlers;
 /// should be considered somewhat unstable, and may change in breaking ways, including in non-major releases.
 /// Use it at your own risk.
 /// </remarks>
-public partial class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>, INpgsqlTypeHandler<Stream>
-#if !NETSTANDARD2_0
-    , INpgsqlTypeHandler<ReadOnlyMemory<byte>>, INpgsqlTypeHandler<Memory<byte>>
-#endif
+public partial class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandler<ArraySegment<byte>>, INpgsqlTypeHandler<Stream>, INpgsqlTypeHandler<ReadOnlyMemory<byte>>, INpgsqlTypeHandler<Memory<byte>>
 {
     public ByteaHandler(PostgresType pgType) : base(pgType) {}
 
@@ -113,7 +110,6 @@ public partial class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandle
     Task Write(Stream value, NpgsqlWriteBuffer buf, int count, bool async, CancellationToken cancellationToken = default) 
         => buf.WriteStreamRaw(value, count, async, cancellationToken);
 
-#if !NETSTANDARD2_0
     /// <inheritdoc />
     public int ValidateAndGetLength(Memory<byte> value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
         => ValidateAndGetLength(value.Length, parameter);
@@ -149,5 +145,4 @@ public partial class ByteaHandler : NpgsqlTypeHandler<byte[]>, INpgsqlTypeHandle
 
     ValueTask<Memory<byte>> INpgsqlTypeHandler<Memory<byte>>.Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription)
         => throw new NotSupportedException("Only writing Memory<byte> to PostgreSQL bytea is supported, no reading.");
-#endif
 }

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -5,10 +5,8 @@
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
     <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json, which is
-         necessary for older TFMs. -->
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +17,7 @@
     <ProjectReference Include="../Npgsql.SourceGenerators/Npgsql.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
@@ -31,13 +29,10 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
     <PackageReference Include="System.Collections.Immutable" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 

--- a/src/Npgsql/TypeMapping/JsonTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/JsonTypeHandlerResolver.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Npgsql.Internal;
 using Npgsql.Internal.TypeHandlers;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
-
-#if NET6_0_OR_GREATER || NETSTANDARD2_0 || NETSTANDARD2_1
-using System.Text.Json.Nodes;
-#endif
 
 namespace Npgsql.TypeMapping;
 
@@ -48,9 +45,7 @@ sealed class JsonTypeHandlerResolver : TypeHandlerResolver
 
     internal static string? ClrTypeToDataTypeName(Type type, Dictionary<Type, string>? clrTypes)
         => type == typeof(JsonDocument)
-#if NET6_0_OR_GREATER || NETSTANDARD2_0 || NETSTANDARD2_1
            || type == typeof(JsonObject) || type == typeof(JsonArray)
-#endif
             ? "jsonb"
             : clrTypes is not null && clrTypes.TryGetValue(type, out var dataTypeName) ? dataTypeName : null;
 
@@ -61,9 +56,7 @@ sealed class JsonTypeHandlerResolver : TypeHandlerResolver
         => dataTypeName switch
         {
             "jsonb" => new(NpgsqlDbType.Jsonb,     "jsonb", typeof(JsonDocument)
-#if NET6_0_OR_GREATER || NETSTANDARD2_0 || NETSTANDARD2_1
                 , typeof(JsonObject), typeof(JsonArray)
-#endif
             ),
             "json" => new(NpgsqlDbType.Json,    "json"),
             _ => null
@@ -73,10 +66,8 @@ sealed class JsonTypeHandlerResolver : TypeHandlerResolver
     {
         if (typeof(T) == typeof(JsonDocument))
             return _jsonbHandler;
-#if NET6_0_OR_GREATER || NETSTANDARD2_0 || NETSTANDARD2_1
         if (typeof(T) == typeof(JsonObject) || typeof(T) == typeof(JsonArray))
             return _jsonbHandler;
-#endif
 
         return null;
     }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,12 +2,21 @@
   <Import Project="../Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">net8.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
 
     <!-- Suppress warnings for [RequiresPreviewFeatures] (<EnablePreviewFeatures> doesn't seem to work across <ProjectReference>) -->
     <NoWarn>$(NoWarn);CA2252</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    We use the netcoreapp3.1 TFM to tests compatibility with netstandard2.0 but may of the the packages issue warnings
+    because they have not been tested with netcoreapp3.1.
+    Since testing for compatibility is exactly what we want to do here, we disable the warnings.
+  -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MStatDumper/MStatDumper.csproj
+++ b/test/MStatDumper/MStatDumper.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <!-- We need to override TargetFrameworks here to avoid build failures  -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/Npgsql.DependencyInjection.Tests/Npgsql.DependencyInjection.Tests.csproj
+++ b/test/Npgsql.DependencyInjection.Tests/Npgsql.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Npgsql.NativeAotTests/Npgsql.NativeAotTests.csproj
+++ b/test/Npgsql.NativeAotTests/Npgsql.NativeAotTests.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <PublishAot>true</PublishAot>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <!-- We need to override TargetFrameworks here to avoid build failures  -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
     <StaticallyLinked>true</StaticallyLinked>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/test/Npgsql.Tests/Types/ByteaTests.cs
+++ b/test/Npgsql.Tests/Types/ByteaTests.cs
@@ -34,7 +34,6 @@ public class ByteaTests : MultiplexingTestBase
         await Bytea(array, sqlLiteral);
     }
 
-#if !NETSTANDARD2_0
     [Test]
     public Task Write_as_Memory()
         => AssertTypeWrite(
@@ -52,7 +51,6 @@ public class ByteaTests : MultiplexingTestBase
     [Test]
     public Task Read_as_ReadOnlyMemory_not_supported()
         => AssertTypeUnsupportedRead<ReadOnlyMemory<byte>, NotSupportedException>("\\x010203", "bytea");
-#endif
 
     [Test]
     public Task Write_as_ArraySegment()


### PR DESCRIPTION
- Remove netcoreapp3.1 and net5.0 (out of support)
- Add net8.0
- Upgrade DeveloperBuild to net8.0

You'll need .NET 8 installed locally to build Npgsql after this gets merged.
See: https://github.com/dotnet/installer#table for the latest builds
