### PR TITLE
Optimize inlining (part 2)

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -960,7 +960,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             break;
 
         default:
-            ThrowHelper.ThrowInvalidOperationException($"Internal Npgsql bug: unexpected value {{0}} of enum {nameof(CommandType)}. Please file a bug.", CommandType);
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(CommandType), $"Internal Npgsql bug: unexpected value {{0}} of enum {nameof(CommandType)}. Please file a bug.", commandType);
             break;
         }
 

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -891,7 +891,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 break;
 
             default:
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {Parameters.PlaceholderType}");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {{0}}", Parameters.PlaceholderType);
                 break;
             }
 
@@ -960,7 +960,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             break;
 
         default:
-            ThrowHelper.ThrowInvalidOperationException($"Internal Npgsql bug: unexpected value {CommandType} of enum {nameof(CommandType)}. Please file a bug.");
+            ThrowHelper.ThrowInvalidOperationException($"Internal Npgsql bug: unexpected value {{0}} of enum {nameof(CommandType)}. Please file a bug.", CommandType);
             break;
         }
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -512,7 +512,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
                 ThrowHelper.ThrowInvalidOperationException("Internal Npgsql bug: connection is in state Open but connector is in state Closed");
                 return ConnectionState.Broken;
             default:
-                ThrowHelper.ThrowInvalidOperationException($"Internal Npgsql bug: unexpected value {Connector.State} of enum {nameof(ConnectorState)}. Please file a bug.");
+                ThrowHelper.ThrowInvalidOperationException($"Internal Npgsql bug: unexpected value {{0}} of enum {nameof(ConnectorState)}. Please file a bug.", Connector.State);
                 return ConnectionState.Broken;
             }
         }
@@ -634,7 +634,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     async ValueTask<NpgsqlTransaction> BeginTransaction(IsolationLevel level, bool async, CancellationToken cancellationToken)
     {
         if (level == IsolationLevel.Chaos)
-            ThrowHelper.ThrowNotSupportedException($"Unsupported IsolationLevel: {IsolationLevel.Chaos}");
+            ThrowHelper.ThrowNotSupportedException($"Unsupported IsolationLevel: {nameof(IsolationLevel.Chaos)}");
 
         CheckReady();
         if (Connector is { InTransaction: true })

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -705,8 +705,8 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
             case PlaceholderType.Mixed:
                 break;
             default:
-                throw new ArgumentOutOfRangeException(
-                    nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {PlaceholderType}");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(PlaceholderType), $"Unknown {nameof(PlaceholderType)} value: {{0}}", PlaceholderType);
+                break;
             }
 
             switch (p.Direction)
@@ -716,13 +716,13 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
             case ParameterDirection.InputOutput:
                 if (PlaceholderType == PlaceholderType.Positional && commandType != CommandType.StoredProcedure)
-                    throw new NotSupportedException("Output parameters are not supported in positional mode (unless used with CommandType.StoredProcedure)");
+                    ThrowHelper.ThrowNotSupportedException("Output parameters are not supported in positional mode (unless used with CommandType.StoredProcedure)");
                 HasOutputParameters = true;
                 break;
 
             case ParameterDirection.Output:
                 if (PlaceholderType == PlaceholderType.Positional && commandType != CommandType.StoredProcedure)
-                    throw new NotSupportedException("Output parameters are not supported in positional mode (unless used with CommandType.StoredProcedure)");
+                    ThrowHelper.ThrowNotSupportedException("Output parameters are not supported in positional mode (unless used with CommandType.StoredProcedure)");
                 HasOutputParameters = true;
                 continue;
 
@@ -731,8 +731,9 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
                 continue;
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(ParameterDirection),
-                    $"Unhandled {nameof(ParameterDirection)} value: {p.Direction}");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(ParameterDirection),
+                    $"Unhandled {nameof(ParameterDirection)} value: {{0}}", p.Direction);
+                break;
             }
 
             p.Bind(typeMapper);

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -207,7 +207,7 @@ sealed class SqlQueryParser
                     }
 
                     if (!parameter.IsInputDirection)
-                        throw new Exception($"Parameter '{paramName}' referenced in SQL but is an out-only parameter");
+                        ThrowHelper.ThrowInvalidOperationException("Parameter '{{0}}' referenced in SQL but is an out-only parameter", paramName);
 
                     batchCommand.PositionalParameters.Add(parameter);
                     index = _paramIndexMap[paramName] = batchCommand.PositionalParameters.Count;
@@ -466,9 +466,8 @@ sealed class SqlQueryParser
 
             if (command is null)
             {
-                throw new NotSupportedException(
-                    $"Specifying multiple SQL statements in a single {nameof(NpgsqlBatchCommand)} isn't supported, " +
-                    "please remove all semicolons.");
+                ThrowHelper.ThrowNotSupportedException($"Specifying multiple SQL statements in a single {nameof(NpgsqlBatchCommand)} isn't supported, " +
+                                                       "please remove all semicolons.");
             }
 
             statementIndex++;

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -207,7 +207,7 @@ sealed class SqlQueryParser
                     }
 
                     if (!parameter.IsInputDirection)
-                        ThrowHelper.ThrowInvalidOperationException("Parameter '{{0}}' referenced in SQL but is an out-only parameter", paramName);
+                        ThrowHelper.ThrowInvalidOperationException("Parameter '{0}' referenced in SQL but is an out-only parameter", paramName);
 
                     batchCommand.PositionalParameters.Add(parameter);
                     index = _paramIndexMap[paramName] = batchCommand.PositionalParameters.Count;

--- a/src/Npgsql/ThrowHelper.cs
+++ b/src/Npgsql/ThrowHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Npgsql.Internal;
 
 namespace Npgsql;
 
@@ -14,6 +15,10 @@ static class ThrowHelper
     [DoesNotReturn]
     internal static void ThrowArgumentOutOfRangeException(string paramName, string message)
         => throw new ArgumentOutOfRangeException(paramName, message);
+
+    [DoesNotReturn]
+    internal static void ThrowArgumentOutOfRangeException(string paramName, string message, object argument)
+        => throw new ArgumentOutOfRangeException(paramName, string.Format(message, argument));
 
     [DoesNotReturn]
     internal static void ThrowInvalidOperationException()
@@ -40,6 +45,10 @@ static class ThrowHelper
         => throw new ObjectDisposedException(objectName, innerException);
 
     [DoesNotReturn]
+    internal static void ThrowInvalidCastException(string message, object argument)
+        => throw new InvalidCastException(string.Format(message, argument));
+
+    [DoesNotReturn]
     internal static void ThrowInvalidCastException_NoValue(FieldDescription field) =>
         throw new InvalidCastException($"Column '{field.Name}' is null.");
 
@@ -58,6 +67,18 @@ static class ThrowHelper
     [DoesNotReturn]
     internal static void ThrowNpgsqlException(string message)
         => throw new NpgsqlException(message);
+
+    [DoesNotReturn]
+    internal static void ThrowNpgsqlException(string message, Exception? innerException)
+        => throw new NpgsqlException(message, innerException);
+
+    [DoesNotReturn]
+    internal static void ThrowNpgsqlOperationInProgressException(NpgsqlCommand command)
+        => throw new NpgsqlOperationInProgressException(command);
+    
+    [DoesNotReturn]
+    internal static void ThrowNpgsqlOperationInProgressException(ConnectorState state)
+        => throw new NpgsqlOperationInProgressException(state);
 
     [DoesNotReturn]
     internal static void ThrowArgumentException(string message)


### PR DESCRIPTION
Contributes to #2237.

The second (and the final for now) part. The main differences are:
1. `StartUserAction` now is going to be inlined and replaced with `DoStartUserAction`.
2. `TypeMapper`'s `ResolveBy...` now can be inlined.
3. To compensate for `ResolveBy...`, `NpgsqlParameter.ResolveHandler` (which is usually inlined in `ProcessParameters`) is split in two.