### PR TITLE
Remove possible references to ArrayHandler in AOT unless necessary

### DIFF
--- a/src/Npgsql/Shims/RuntimeFeature.cs
+++ b/src/Npgsql/Shims/RuntimeFeature.cs
@@ -1,0 +1,10 @@
+﻿#if NETSTANDARD2_0
+
+namespace System.Runtime.CompilerServices;
+
+static class RuntimeFeature
+{
+    public static bool IsDynamicCodeSupported => true;
+}
+
+#endif


### PR DESCRIPTION
Contributes to #4799

Now, there are 3 issues with ILinker:
1. For some reason it doesn't get rid of NpgsqlDataReader.GetValues (even though it's not called) (upd: it's called by `DbEnumerator`, which we return from `GetEnumerator`, https://github.com/dotnet/linker/issues/3189)
2. NpgsqlDataReader.GetFieldValue is never called with T as object, yet ReadAsObject (which is only called with T as object) is never removed
3. Sometimes (RecordHandler.Read) ILinked doesn't realise that `RuntimeFeature.IsDynamicCodeSupported` makes sure nothing below is called with AOT, yet it's still preserved.

~Probably a good idea to also check with .NET 8 (I've compiled on windows with .NET 7.0.1).~
Same thing with .NET 8.

cc @roji @MichalStrehovsky