### PR TITLE
Rewrite type handler lookup

### DIFF
--- a/src/Npgsql.GeoJSON/Internal/GeoJSONTypeHandlerResolver.cs
+++ b/src/Npgsql.GeoJSON/Internal/GeoJSONTypeHandlerResolver.cs
@@ -76,8 +76,8 @@ public class GeoJSONTypeHandlerResolver : TypeHandlerResolver
                 ? "geography"
                 : "geometry";
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => dataTypeName switch

--- a/src/Npgsql.Json.NET/Internal/JsonNetTypeHandlerResolver.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonNetTypeHandlerResolver.cs
@@ -44,8 +44,8 @@ public class JsonNetTypeHandlerResolver : TypeHandlerResolver
     internal static string? ClrTypeToDataTypeName(Type type, Dictionary<Type, string> clrTypes)
         => clrTypes.TryGetValue(type, out var dataTypeName) ? dataTypeName : null;
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => dataTypeName switch

--- a/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteTypeHandlerResolver.cs
+++ b/src/Npgsql.NetTopologySuite/Internal/NetTopologySuiteTypeHandlerResolver.cs
@@ -58,8 +58,8 @@ public class NetTopologySuiteTypeHandlerResolver : TypeHandlerResolver
                 ? "geography"
                 : "geometry";
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => dataTypeName switch

--- a/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
+++ b/src/Npgsql.NodaTime/Internal/NodaTimeTypeHandlerResolver.cs
@@ -178,8 +178,8 @@ public class NodaTimeTypeHandlerResolver : TypeHandlerResolver
         return null;
     }
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => dataTypeName switch

--- a/src/Npgsql/Internal/TypeHandling/TypeHandlerResolver.cs
+++ b/src/Npgsql/Internal/TypeHandling/TypeHandlerResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using Npgsql.PostgresTypes;
 
 namespace Npgsql.Internal.TypeHandling;
 
@@ -18,6 +19,12 @@ public abstract class TypeHandlerResolver
     /// </summary>
     public abstract NpgsqlTypeHandler? ResolveByClrType(Type type);
 
+    /// <summary>
+    /// Resolves a type handler given a PostgreSQL type.
+    /// </summary>
+    public virtual NpgsqlTypeHandler? ResolveByPostgresType(PostgresType type)
+        => ResolveByDataTypeName(type.Name);
+
     public virtual NpgsqlTypeHandler? ResolveValueDependentValue(object value) => null;
 
     public virtual NpgsqlTypeHandler? ResolveValueTypeGenerically<T>(T value) => null;
@@ -26,5 +33,5 @@ public abstract class TypeHandlerResolver
     /// Gets type mapping information for a given PostgreSQL type.
     /// Invoked in scenarios when mapping information is required, rather than a type handler for reading or writing.
     /// </summary>
-    public abstract TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName);
+    public abstract TypeMappingInfo? GetMappingByPostgresType(PostgresType type);
 }

--- a/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolver.cs
@@ -650,8 +650,8 @@ sealed class BuiltInTypeHandlerResolver : TypeHandlerResolver
     internal static string? ClrTypeToDataTypeName(Type type)
         => ClrTypeToDataTypeNameTable.TryGetValue(type, out var dataTypeName) ? dataTypeName : null;
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => Mappings.TryGetValue(dataTypeName, out var mapping) ? mapping : null;

--- a/src/Npgsql/TypeMapping/JsonTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/JsonTypeHandlerResolver.cs
@@ -49,8 +49,8 @@ sealed class JsonTypeHandlerResolver : TypeHandlerResolver
             ? "jsonb"
             : clrTypes is not null && clrTypes.TryGetValue(type, out var dataTypeName) ? dataTypeName : null;
 
-    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
-        => DoGetMappingByDataTypeName(dataTypeName);
+    public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type)
+        => DoGetMappingByDataTypeName(type.Name);
 
     internal static TypeMappingInfo? DoGetMappingByDataTypeName(string dataTypeName)
         => dataTypeName switch

--- a/src/Npgsql/TypeMapping/TypeMapper.cs
+++ b/src/Npgsql/TypeMapping/TypeMapper.cs
@@ -391,96 +391,101 @@ sealed class TypeMapper
         if (_handlersByClrType.TryGetValue(type, out var handler))
             return handler;
 
-        lock (_writeLock)
+        return ResolveLong(type);
+
+        NpgsqlTypeHandler ResolveLong(Type type)
         {
-            foreach (var resolver in _resolvers)
+            lock (_writeLock)
             {
-                try
+                foreach (var resolver in _resolvers)
                 {
-                    if ((handler = resolver.ResolveByClrType(type)) is not null)
-                        return _handlersByClrType[type] = handler;
+                    try
+                    {
+                        if (resolver.ResolveByClrType(type) is { } handler)
+                            return _handlersByClrType[type] = handler;
+                    }
+                    catch (Exception e)
+                    {
+                        _commandLogger.LogError(e, $"Type resolver {resolver.GetType().Name} threw exception while resolving value with type {type}");
+                    }
                 }
-                catch (Exception e)
+
+                // Try to see if it is an array type
+                var arrayElementType = GetArrayListElementType(type);
+                if (arrayElementType is not null)
                 {
-                    _commandLogger.LogError(e, $"Type resolver {resolver.GetType().Name} threw exception while resolving value with type {type}");
+                    // With PG14, we map arrays over range types to PG multiranges by default, not to regular arrays over ranges.
+                    if (arrayElementType.IsGenericType &&
+                        arrayElementType.GetGenericTypeDefinition() == typeof(NpgsqlRange<>) &&
+                        DatabaseInfo.Version.IsGreaterOrEqual(14))
+                    {
+                        var subtypeType = arrayElementType.GetGenericArguments()[0];
+
+                        return ResolveByClrType(subtypeType) is
+                            { PostgresType : { Range : { Multirange: { } pgMultirangeType } } } subtypeHandler
+                            ? _handlersByClrType[type] = subtypeHandler.CreateMultirangeHandler(pgMultirangeType)
+                            : throw new NotSupportedException($"The CLR range type {type} isn't supported by Npgsql or your PostgreSQL.");
+                    }
+
+                    if (ResolveByClrType(arrayElementType) is not { } elementHandler)
+                        throw new ArgumentException($"Array type over CLR type {arrayElementType.Name} isn't supported by Npgsql");
+
+                    if (elementHandler.PostgresType.Array is not { } pgArrayType)
+                        throw new ArgumentException(
+                            $"No array type could be found in the database for element {elementHandler.PostgresType}");
+
+                    return _handlersByClrType[type] =
+                        elementHandler.CreateArrayHandler(pgArrayType, Connector.Settings.ArrayNullabilityMode);
                 }
-            }
 
-            // Try to see if it is an array type
-            var arrayElementType = GetArrayListElementType(type);
-            if (arrayElementType is not null)
-            {
-                // With PG14, we map arrays over range types to PG multiranges by default, not to regular arrays over ranges.
-                if (arrayElementType.IsGenericType &&
-                    arrayElementType.GetGenericTypeDefinition() == typeof(NpgsqlRange<>) &&
-                    DatabaseInfo.Version.IsGreaterOrEqual(14))
+                if (Nullable.GetUnderlyingType(type) is { } underlyingType && ResolveByClrType(underlyingType) is { } underlyingHandler)
+                    return _handlersByClrType[type] = underlyingHandler;
+
+                if (type.IsEnum)
                 {
-                    var subtypeType = arrayElementType.GetGenericArguments()[0];
+                    return DatabaseInfo.GetPostgresTypeByName(GetPgName(type, _defaultNameTranslator)) is PostgresEnumType pgEnumType
+                        ? _handlersByClrType[type] = new UnmappedEnumHandler(pgEnumType, _defaultNameTranslator, Connector.TextEncoding)
+                        : throw new NotSupportedException(
+                            $"Could not find a PostgreSQL enum type corresponding to {type.Name}. " +
+                            "Consider mapping the enum before usage, refer to the documentation for more details.");
+                }
 
-                    return ResolveByClrType(subtypeType) is
-                        { PostgresType : { Range : { Multirange: { } pgMultirangeType } } } subtypeHandler
-                        ? _handlersByClrType[type] = subtypeHandler.CreateMultirangeHandler(pgMultirangeType)
+                // TODO: We can make the following compatible with reflection-free mode by having NpgsqlRange implement some interface, and
+                // check for that.
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(NpgsqlRange<>))
+                {
+                    var subtypeType = type.GetGenericArguments()[0];
+
+                    return ResolveByClrType(subtypeType) is { PostgresType : { Range : { } pgRangeType } } subtypeHandler
+                        ? _handlersByClrType[type] = subtypeHandler.CreateRangeHandler(pgRangeType)
                         : throw new NotSupportedException($"The CLR range type {type} isn't supported by Npgsql or your PostgreSQL.");
                 }
 
-                if (ResolveByClrType(arrayElementType) is not { } elementHandler)
-                    throw new ArgumentException($"Array type over CLR type {arrayElementType.Name} isn't supported by Npgsql");
+                if (typeof(IEnumerable).IsAssignableFrom(type))
+                    throw new NotSupportedException("IEnumerable parameters are not supported, pass an array or List instead");
 
-                if (elementHandler.PostgresType.Array is not { } pgArrayType)
-                    throw new ArgumentException(
-                        $"No array type could be found in the database for element {elementHandler.PostgresType}");
-
-                return _handlersByClrType[type] =
-                    elementHandler.CreateArrayHandler(pgArrayType, Connector.Settings.ArrayNullabilityMode);
+                throw new NotSupportedException($"The CLR type {type} isn't natively supported by Npgsql or your PostgreSQL. " +
+                                                $"To use it with a PostgreSQL composite you need to specify {nameof(NpgsqlParameter.DataTypeName)} or to map it, please refer to the documentation.");
             }
 
-            if (Nullable.GetUnderlyingType(type) is { } underlyingType && ResolveByClrType(underlyingType) is { } underlyingHandler)
-                return _handlersByClrType[type] = underlyingHandler;
-
-            if (type.IsEnum)
+            static Type? GetArrayListElementType(Type type)
             {
-                return DatabaseInfo.GetPostgresTypeByName(GetPgName(type, _defaultNameTranslator)) is PostgresEnumType pgEnumType
-                    ? _handlersByClrType[type] = new UnmappedEnumHandler(pgEnumType, _defaultNameTranslator, Connector.TextEncoding)
-                    : throw new NotSupportedException(
-                        $"Could not find a PostgreSQL enum type corresponding to {type.Name}. " +
-                        "Consider mapping the enum before usage, refer to the documentation for more details.");
-            }
+                var typeInfo = type.GetTypeInfo();
+                if (typeInfo.IsArray)
+                    return GetUnderlyingType(type.GetElementType()!); // The use of bang operator is justified here as Type.GetElementType() only returns null for the Array base class which can't be mapped in a useful way.
 
-            // TODO: We can make the following compatible with reflection-free mode by having NpgsqlRange implement some interface, and
-            // check for that.
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(NpgsqlRange<>))
-            {
-                var subtypeType = type.GetGenericArguments()[0];
+                var ilist = typeInfo.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
+                if (ilist != null)
+                    return GetUnderlyingType(ilist.GetGenericArguments()[0]);
 
-                return ResolveByClrType(subtypeType) is { PostgresType : { Range : { } pgRangeType } } subtypeHandler
-                    ? _handlersByClrType[type] = subtypeHandler.CreateRangeHandler(pgRangeType)
-                    : throw new NotSupportedException($"The CLR range type {type} isn't supported by Npgsql or your PostgreSQL.");
-            }
+                if (typeof(IList).IsAssignableFrom(type))
+                    throw new NotSupportedException("Non-generic IList is a supported parameter, but the NpgsqlDbType parameter must be set on the parameter");
 
-            if (typeof(IEnumerable).IsAssignableFrom(type))
-                throw new NotSupportedException("IEnumerable parameters are not supported, pass an array or List instead");
+                return null;
 
-            throw new NotSupportedException($"The CLR type {type} isn't natively supported by Npgsql or your PostgreSQL. " +
-                                            $"To use it with a PostgreSQL composite you need to specify {nameof(NpgsqlParameter.DataTypeName)} or to map it, please refer to the documentation.");
-        }
-
-        static Type? GetArrayListElementType(Type type)
-        {
-            var typeInfo = type.GetTypeInfo();
-            if (typeInfo.IsArray)
-                return GetUnderlyingType(type.GetElementType()!); // The use of bang operator is justified here as Type.GetElementType() only returns null for the Array base class which can't be mapped in a useful way.
-
-            var ilist = typeInfo.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
-            if (ilist != null)
-                return GetUnderlyingType(ilist.GetGenericArguments()[0]);
-
-            if (typeof(IList).IsAssignableFrom(type))
-                throw new NotSupportedException("Non-generic IList is a supported parameter, but the NpgsqlDbType parameter must be set on the parameter");
-
-            return null;
-
-            Type GetUnderlyingType(Type t)
-                => Nullable.GetUnderlyingType(t) ?? t;
+                Type GetUnderlyingType(Type t)
+                    => Nullable.GetUnderlyingType(t) ?? t;
+            }   
         }
     }
 

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2187,7 +2187,7 @@ class ExplodingTypeHandlerResolverFactory : TypeHandlerResolverFactory
         public override NpgsqlTypeHandler? ResolveByDataTypeName(string typeName) =>
             typeName == "integer" ? new ExplodingTypeHandler(null!, _safe) : null;
         public override NpgsqlTypeHandler? ResolveByClrType(Type type) => null;
-        public override TypeMappingInfo GetMappingByDataTypeName(string dataTypeName) => throw new NotImplementedException();
+        public override TypeMappingInfo GetMappingByPostgresType(PostgresType type) => throw new NotImplementedException();
     }
 }
 

--- a/test/Npgsql.Tests/TypeMapperTests.cs
+++ b/test/Npgsql.Tests/TypeMapperTests.cs
@@ -184,7 +184,7 @@ CREATE EXTENSION citext SCHEMA ""{schemaName}""");
                 => type == typeof(string) ? new TextHandler(_pgCitextType, _connector.TextEncoding) : null;
             public override NpgsqlTypeHandler? ResolveByDataTypeName(string typeName) => null;
 
-            public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName) => throw new NotSupportedException();
+            public override TypeMappingInfo? GetMappingByPostgresType(PostgresType type) => throw new NotSupportedException();
         }
     }
 


### PR DESCRIPTION
Closes #4481
Closes #4429

The main reason for this PR is to unblock #4899. In that PR ranges are resolved by a separate resolver, which isn't compatible with NodaTime resolver. Specifically, while reading a range of timestamptz right now we first attempt to find the type by it's full name (which fails), then by it's name (at which point NodaTime's resolver gives the handler back). After, if everything else fails, we have a special logic for complex types (including ranges). In #4899 range's resolver finds the type by it's full name and because it's a range type it gives the range handler back. With this PR we'll be able to immediately check in NodaTime's resolver by name.