### PR TITLE
Add SupportsSavepoints property to NpgsqlTransaction

### DIFF
--- a/Npgsql.sln.DotSettings
+++ b/Npgsql.sln.DotSettings
@@ -123,6 +123,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=regtype/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=resultset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Roundtrips/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=savepoints/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sproc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subrange/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subtransaction/@EntryIndexedValue">True</s:Boolean>

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -357,7 +357,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     }
 
     /// <summary>
-    /// Indicates whether or not SavePoints are supported in this transaction
+    /// Indicates whether this transaction supports database savepoints.
     /// </summary>
 #if NET5_0_OR_GREATER
     public override bool SupportsSavepoints
@@ -365,7 +365,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     public bool SupportsSavepoints
 #endif
     {
-        get { return _connector.DatabaseInfo.SupportsTransactions; }
+        get => _connector.DatabaseInfo.SupportsTransactions;
     }
 
     #endregion

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -356,6 +356,18 @@ public sealed class NpgsqlTransaction : DbTransaction
             return Release(name, true, cancellationToken);
     }
 
+    /// <summary>
+    /// Indicates whether or not SavePoints are supported in this transaction
+    /// </summary>
+#if NET5_0_OR_GREATER
+    public override bool SupportsSavepoints
+#else
+    public bool SupportsSavepoints
+#endif
+    {
+        get { return _connector.DatabaseInfo.SupportsTransactions; }
+    }
+
     #endregion
 
     #region Dispose

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1741,6 +1741,7 @@ override Npgsql.NpgsqlTransaction.RollbackAsync(string! name, System.Threading.C
 override Npgsql.NpgsqlTransaction.RollbackAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 override Npgsql.NpgsqlTransaction.Save(string! name) -> void
 override Npgsql.NpgsqlTransaction.SaveAsync(string! name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+override Npgsql.NpgsqlTransaction.SupportsSavepoints.get -> bool
 override Npgsql.PostgresException.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override Npgsql.PostgresException.IsTransient.get -> bool
 override Npgsql.PostgresException.SqlState.get -> string!


### PR DESCRIPTION
Overrides same `DbTransaction` property in Net 5.0+ 
https://learn.microsoft.com/en-us/dotnet/api/system.data.common.dbtransaction.supportssavepoints?view=net-5.0#system-data-common-dbtransaction-supportssavepoints