### PR TITLE
Check the message after sending a PasswordMessage

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -19,16 +19,14 @@ partial class NpgsqlConnector
 {
     async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
     {
-        var authenticated = false;
-        while (!authenticated)
+        while (true)
         {
             timeout.CheckAndApply(this);
             var msg = ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
             switch (msg.AuthRequestType)
             {
             case AuthenticationRequestType.AuthenticationOk:
-                authenticated = true;
-                break;
+                return;
 
             case AuthenticationRequestType.AuthenticationCleartextPassword:
                 await AuthenticateCleartext(username, async, cancellationToken);
@@ -45,8 +43,7 @@ partial class NpgsqlConnector
             case AuthenticationRequestType.AuthenticationGSS:
             case AuthenticationRequestType.AuthenticationSSPI:
                 await AuthenticateGSS(async);
-                authenticated = true;
-                break;
+                return;
 
             case AuthenticationRequestType.AuthenticationGSSContinue:
                 throw new NpgsqlException("Can't start auth cycle with AuthenticationGSSContinue");

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -19,35 +19,41 @@ partial class NpgsqlConnector
 {
     async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
     {
-        timeout.CheckAndApply(this);
-        var msg = ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
-        switch (msg.AuthRequestType)
+        var authenticated = false;
+        while (!authenticated)
         {
-        case AuthenticationRequestType.AuthenticationOk:
-            return;
+            timeout.CheckAndApply(this);
+            var msg = ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
+            switch (msg.AuthRequestType)
+            {
+            case AuthenticationRequestType.AuthenticationOk:
+                authenticated = true;
+                break;
 
-        case AuthenticationRequestType.AuthenticationCleartextPassword:
-            await AuthenticateCleartext(username, async, cancellationToken);
-            return;
+            case AuthenticationRequestType.AuthenticationCleartextPassword:
+                await AuthenticateCleartext(username, async, cancellationToken);
+                break;
 
-        case AuthenticationRequestType.AuthenticationMD5Password:
-            await AuthenticateMD5(username, ((AuthenticationMD5PasswordMessage)msg).Salt, async, cancellationToken);
-            return;
+            case AuthenticationRequestType.AuthenticationMD5Password:
+                await AuthenticateMD5(username, ((AuthenticationMD5PasswordMessage)msg).Salt, async, cancellationToken);
+                break;
 
-        case AuthenticationRequestType.AuthenticationSASL:
-            await AuthenticateSASL(((AuthenticationSASLMessage)msg).Mechanisms, username, async, cancellationToken);
-            return;
+            case AuthenticationRequestType.AuthenticationSASL:
+                await AuthenticateSASL(((AuthenticationSASLMessage)msg).Mechanisms, username, async, cancellationToken);
+                break;
 
-        case AuthenticationRequestType.AuthenticationGSS:
-        case AuthenticationRequestType.AuthenticationSSPI:
-            await AuthenticateGSS(async);
-            return;
+            case AuthenticationRequestType.AuthenticationGSS:
+            case AuthenticationRequestType.AuthenticationSSPI:
+                await AuthenticateGSS(async);
+                authenticated = true;
+                break;
 
-        case AuthenticationRequestType.AuthenticationGSSContinue:
-            throw new NpgsqlException("Can't start auth cycle with AuthenticationGSSContinue");
+            case AuthenticationRequestType.AuthenticationGSSContinue:
+                throw new NpgsqlException("Can't start auth cycle with AuthenticationGSSContinue");
 
-        default:
-            throw new NotSupportedException($"Authentication method not supported (Received: {msg.AuthRequestType})");
+            default:
+                throw new NotSupportedException($"Authentication method not supported (Received: {msg.AuthRequestType})");
+            }
         }
     }
 
@@ -62,7 +68,6 @@ partial class NpgsqlConnector
 
         await WritePassword(encoded, async, cancellationToken);
         await Flush(async, cancellationToken);
-        ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
     }
 
     async Task AuthenticateSASL(List<string> mechanisms, string username, bool async, CancellationToken cancellationToken = default)
@@ -204,10 +209,6 @@ partial class NpgsqlConnector
         if (scramFinalServerMsg.ServerSignature != Convert.ToBase64String(serverSignature))
             throw new NpgsqlException("[SCRAM] Unable to verify server signature");
 
-        var okMsg = ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
-        if (okMsg.AuthRequestType != AuthenticationRequestType.AuthenticationOk)
-            throw new NpgsqlException("[SASL] Expected AuthenticationOK message");
-
 
         static string GetNonce()
         {
@@ -281,7 +282,6 @@ partial class NpgsqlConnector
 
         await WritePassword(result, async, cancellationToken);
         await Flush(async, cancellationToken);
-        ExpectAny<AuthenticationRequestMessage>(await ReadMessage(async), this);
     }
 
 #if NET7_0_OR_GREATER


### PR DESCRIPTION
This PR fixes an issue that Npgsql fails to connect to a PostgreSQL cluster via PgPool-II as both the client and the server fall into waiting status.

# Issue description
Npgsql currently assumes the message sent from the server after sending `PasswordMessage` to be `AuthenticationOk`.  
However, this assumption doesn't always stand as the server may send some other messages other than `AuthenticationOk` such as another authentication request.  

That occurs when Npgsql is trying to connect to a PgPool-II server, where the following procedure is required as PgPool-II wants to have the password in both Cleartext and MD5 formats:
1. [Client -> Server] `StartupMessage`
2. [Server -> Client] `AuthenticationCleartextPassword`
3. [Client -> Server] `PasswordMessage`
4. **[Server -> Client] `AuthenticationMD5Password`**
5. **[Client -> Server] `PasswordMessage`**
6. [Server -> Client] `AuthenticationOk`
7. [Server -> Client] `ReadyForQuery`

With the current implementation of Npgsql, the `AuthenticationMD5Password` sent by PgPool-II is erroneously considered to be `AuthenticationOk` by Npgsql. At this point, Npgsql waits for `ReadyForQuery` and PgPool-II waits for `PasswordMessage`, which causes a timeout error.

# Solution description
Clients such as psql and pgAdmin can connect to PgPool-II just fine with the procedure above, so making Npgsql check the message sent from the server after `PasswordMessage` seems to be a solution.


Thank you for checking out this PR. Please let me know if there's anything is missing or needs improvements with this PR.