### PR TITLE
Fix a possible timeout with gss/sspi auth

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -303,10 +303,10 @@ partial class NpgsqlConnector
             if (response is not AuthenticationGSSContinueMessage gssMsg)
                 throw new NpgsqlException($"Received unexpected authentication request message {response.AuthRequestType}");
             data = authContext.GetOutgoingBlob(gssMsg.AuthenticationData.AsSpan(), out statusCode)!;
-            if (statusCode != NegotiateAuthenticationStatusCode.Completed && statusCode != NegotiateAuthenticationStatusCode.ContinueNeeded)
+            if (statusCode is not NegotiateAuthenticationStatusCode.Completed and not NegotiateAuthenticationStatusCode.ContinueNeeded)
                 throw new NpgsqlException($"Error while authenticating GSS/SSPI: {statusCode}");
             // We might get NegotiateAuthenticationStatusCode.Completed but the data will not be null
-            // This can happen if it's the first cycle, in which case we have to send that data to complete handshake
+            // This can happen if it's the first cycle, in which case we have to send that data to complete handshake (#4888)
             if (data is null)
                 continue;
             await WritePassword(data, 0, data.Length, async, UserCancellationToken);


### PR DESCRIPTION
Fixes #4888

In some cases `NegotiateAuthentication.GetOutgoingBlob` can return `NegotiateAuthenticationStatusCode.Completed` but with not-null data. This can happen on the first cycle, in which case we have to send that data first to pg, otherwise we'll fail with a timeout.