### PR TITLE
Treat pg_users.user_sysid as uint rather than int

### DIFF
--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -293,7 +293,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
     {
         var users = new DataTable("Users") { Locale = CultureInfo.InvariantCulture };
 
-        users.Columns.AddRange(new[] { new DataColumn("user_name"), new DataColumn("user_sysid", typeof(int)) });
+        users.Columns.AddRange(new[] { new DataColumn("user_name"), new DataColumn("user_sysid", typeof(uint)) });
 
         var getUsers = new StringBuilder();
 


### PR DESCRIPTION
The data in this field can be in the range of 0 to 4,294,967,295. Before this patch, if there was a value larger than 2,147,483,647 this operation would fail with the following error.

```
System.ArgumentException : Value was either too large or too small for an Int32.Couldn't store &lt;3233629770&gt; in user_sysid Column.  Expected type is Int32.
   at System.Data.DataColumn.set_Item(Int32 record, Object value)
   at System.Data.DataTable.NewRecordFromArray(Object[] value)
   at System.Data.DataTable.LoadDataRow(Object[] values, Boolean fAcceptChanges)
   at Npgsql.NpgsqlDataAdapter.Fill(DataTable dataTable, NpgsqlDataReader dataReader, Boolean async, CancellationToken cancellationToken) in /mnt/data1/npgsql/src/Npgsql/NpgsqlDataAdapter.cs:line 199
   at Npgsql.NpgsqlDataAdapter.Fill(DataTable dataTable, Boolean async, CancellationToken cancellationToken) in /mnt/data1/npgsql/src/Npgsql/NpgsqlDataAdapter.cs:line 158
   at Npgsql.NpgsqlDataAdapter.Fill(DataTable dataTable, Boolean async, CancellationToken cancellationToken) in /mnt/data1/npgsql/src/Npgsql/NpgsqlDataAdapter.cs:line 166
   at Npgsql.NpgsqlSchema.GetUsers(NpgsqlConnection conn, String[] restrictions, Boolean async, CancellationToken cancellationToken) in /mnt/data1/npgsql/src/Npgsql/NpgsqlSchema.cs:line 304
   at Npgsql.Tests.SchemaTests.GetSchema(NpgsqlConnection conn, String collectionName) in /mnt/data1/npgsql/test/Npgsql.Tests/SchemaTests.cs:line 545
```