### PR TITLE
Consistently handle TimeLineID as UInt32 everywhere

### DIFF
--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -35,11 +35,11 @@ Npgsql.NpgsqlSlimDataSourceBuilder.UseRootCertificate(System.Security.Cryptograp
 Npgsql.NpgsqlSlimDataSourceBuilder.UseRootCertificateCallback(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2!>? rootCertificateCallback) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.UseSystemTextJson(System.Text.Json.JsonSerializerOptions? serializerOptions = null, System.Type![]? jsonbClrTypes = null, System.Type![]? jsonClrTypes = null) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.UseUserCertificateValidationCallback(System.Net.Security.RemoteCertificateValidationCallback! userCertificateValidationCallback) -> Npgsql.NpgsqlSlimDataSourceBuilder!
-Npgsql.Replication.ReplicationConnection.TimelineHistory(ulong tli, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Npgsql.Replication.TimelineHistoryFile>!
-Npgsql.Replication.ReplicationSystemIdentification.Timeline.get -> ulong
+Npgsql.Replication.PhysicalReplicationConnection.StartReplication(Npgsql.Replication.PhysicalReplicationSlot? slot, NpgsqlTypes.NpgsqlLogSequenceNumber walLocation, System.Threading.CancellationToken cancellationToken, uint timeline = 0) -> System.Collections.Generic.IAsyncEnumerable<Npgsql.Replication.XLogDataMessage!>!
+Npgsql.Replication.PhysicalReplicationConnection.StartReplication(NpgsqlTypes.NpgsqlLogSequenceNumber walLocation, System.Threading.CancellationToken cancellationToken, uint timeline = 0) -> System.Collections.Generic.IAsyncEnumerable<Npgsql.Replication.XLogDataMessage!>!
+Npgsql.Replication.PhysicalReplicationSlot.PhysicalReplicationSlot(string! slotName, NpgsqlTypes.NpgsqlLogSequenceNumber? restartLsn = null, uint? restartTimeline = null) -> void
+Npgsql.Replication.PhysicalReplicationSlot.RestartTimeline.get -> uint?
 override Npgsql.NpgsqlBatch.Dispose() -> void
-*REMOVED*Npgsql.Replication.ReplicationConnection.TimelineHistory(uint tli, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Npgsql.Replication.TimelineHistoryFile>!
-*REMOVED*Npgsql.Replication.ReplicationSystemIdentification.Timeline.get -> uint
 *REMOVED*static NpgsqlTypes.NpgsqlBox.Parse(string! s) -> NpgsqlTypes.NpgsqlBox
 *REMOVED*static NpgsqlTypes.NpgsqlCircle.Parse(string! s) -> NpgsqlTypes.NpgsqlCircle
 *REMOVED*static NpgsqlTypes.NpgsqlLine.Parse(string! s) -> NpgsqlTypes.NpgsqlLine
@@ -55,3 +55,7 @@ override Npgsql.NpgsqlBatch.Dispose() -> void
 *REMOVED*override Npgsql.NpgsqlNestedDataReader.GetProviderSpecificFieldType(int ordinal) -> System.Type!
 *REMOVED*override Npgsql.NpgsqlNestedDataReader.GetProviderSpecificValue(int ordinal) -> object!
 *REMOVED*override Npgsql.NpgsqlNestedDataReader.GetProviderSpecificValues(object![]! values) -> int
+*REMOVED*Npgsql.Replication.PhysicalReplicationConnection.StartReplication(Npgsql.Replication.PhysicalReplicationSlot? slot, NpgsqlTypes.NpgsqlLogSequenceNumber walLocation, System.Threading.CancellationToken cancellationToken, ulong timeline = 0) -> System.Collections.Generic.IAsyncEnumerable<Npgsql.Replication.XLogDataMessage!>!
+*REMOVED*Npgsql.Replication.PhysicalReplicationConnection.StartReplication(NpgsqlTypes.NpgsqlLogSequenceNumber walLocation, System.Threading.CancellationToken cancellationToken, ulong timeline = 0) -> System.Collections.Generic.IAsyncEnumerable<Npgsql.Replication.XLogDataMessage!>!
+*REMOVED*Npgsql.Replication.PhysicalReplicationSlot.PhysicalReplicationSlot(string! slotName, NpgsqlTypes.NpgsqlLogSequenceNumber? restartLsn = null, ulong? restartTimeline = null) -> void
+*REMOVED*Npgsql.Replication.PhysicalReplicationSlot.RestartTimeline.get -> ulong?

--- a/src/Npgsql/Replication/PhysicalReplicationConnection.cs
+++ b/src/Npgsql/Replication/PhysicalReplicationConnection.cs
@@ -119,7 +119,7 @@ public sealed class PhysicalReplicationConnection : ReplicationConnection
     public IAsyncEnumerable<XLogDataMessage> StartReplication(PhysicalReplicationSlot? slot,
         NpgsqlLogSequenceNumber walLocation,
         CancellationToken cancellationToken,
-        ulong timeline = default)
+        uint timeline = default)
     {
         using (NoSynchronizationContextScope.Enter())
             return StartPhysicalReplication(slot, walLocation, cancellationToken, timeline);
@@ -127,7 +127,7 @@ public sealed class PhysicalReplicationConnection : ReplicationConnection
         async IAsyncEnumerable<XLogDataMessage> StartPhysicalReplication(PhysicalReplicationSlot? slot,
             NpgsqlLogSequenceNumber walLocation,
             [EnumeratorCancellation] CancellationToken cancellationToken,
-            ulong timeline)
+            uint timeline)
         {
             var builder = new StringBuilder("START_REPLICATION");
             if (slot != null)
@@ -162,7 +162,7 @@ public sealed class PhysicalReplicationConnection : ReplicationConnection
     /// <returns>A <see cref="Task{T}"/> representing an <see cref="IAsyncEnumerable{NpgsqlXLogDataMessage}"/> that
     /// can be used to stream WAL entries in form of <see cref="XLogDataMessage"/> instances.</returns>
     public IAsyncEnumerable<XLogDataMessage> StartReplication(
-        NpgsqlLogSequenceNumber walLocation, CancellationToken cancellationToken, ulong timeline = default)
+        NpgsqlLogSequenceNumber walLocation, CancellationToken cancellationToken, uint timeline = default)
         => StartReplication(slot: null, walLocation: walLocation, timeline: timeline, cancellationToken: cancellationToken);
 
     /// <summary>

--- a/src/Npgsql/Replication/PhysicalReplicationSlot.cs
+++ b/src/Npgsql/Replication/PhysicalReplicationSlot.cs
@@ -17,7 +17,7 @@ public class PhysicalReplicationSlot : ReplicationSlot
     /// <param name="slotName">The name of the existing replication slot</param>
     /// <param name="restartLsn">The replication slot's <c>restart_lsn</c></param>
     /// <param name="restartTimeline">The timeline ID associated to <c>restart_lsn</c>, following the current timeline history.</param>
-    public PhysicalReplicationSlot(string slotName, NpgsqlLogSequenceNumber? restartLsn = null, ulong? restartTimeline = null)
+    public PhysicalReplicationSlot(string slotName, NpgsqlLogSequenceNumber? restartLsn = null, uint? restartTimeline = null)
         : base(slotName)
     {
         RestartLsn = restartLsn;
@@ -32,5 +32,5 @@ public class PhysicalReplicationSlot : ReplicationSlot
     /// <summary>
     /// The timeline ID associated to <c>restart_lsn</c>, following the current timeline history.
     /// </summary>
-    public ulong? RestartTimeline { get; }
+    public uint? RestartTimeline { get; }
 }

--- a/src/Npgsql/Replication/ReplicationSystemIdentification.cs
+++ b/src/Npgsql/Replication/ReplicationSystemIdentification.cs
@@ -7,7 +7,7 @@ namespace Npgsql.Replication;
 /// </summary>
 public class ReplicationSystemIdentification
 {
-    internal ReplicationSystemIdentification(string systemId, ulong timeline, NpgsqlLogSequenceNumber xLogPos, string dbName)
+    internal ReplicationSystemIdentification(string systemId, uint timeline, NpgsqlLogSequenceNumber xLogPos, string dbName)
     {
         SystemId = systemId;
         Timeline = timeline;
@@ -24,7 +24,7 @@ public class ReplicationSystemIdentification
     /// <summary>
     /// Current timeline ID. Also useful to check that the standby is consistent with the master.
     /// </summary>
-    public ulong Timeline { get; }
+    public uint Timeline { get; }
 
     /// <summary>
     /// Current WAL flush location. Useful to get a known location in the write-ahead log where streaming can start.

--- a/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PhysicalReplicationTests.cs
@@ -53,7 +53,7 @@ public class PhysicalReplicationTests : SafeReplicationTestBase<PhysicalReplicat
                 await using var reader = await cmd.ExecuteReaderAsync();
                 Assert.That(reader.Read, Is.EqualTo(createSlot));
                 var expectedSlotName = createSlot ? reader.GetFieldValue<string>(reader.GetOrdinal("slot_name")) : null;
-                var expectedTli = createSlot ? unchecked((ulong?)reader.GetFieldValue<long?>(reader.GetOrdinal("timeline_id"))) : null;
+                var expectedTli = createSlot ? (uint?)reader.GetFieldValue<long?>(reader.GetOrdinal("timeline_id")) : null;
                 var expectedRestartLsn = createSlot ? reader.GetFieldValue<NpgsqlLogSequenceNumber?>(reader.GetOrdinal("restart_lsn")) : null;
                 Assert.That(reader.Read, Is.False);
                 await using var rc = await OpenReplicationConnectionAsync();


### PR DESCRIPTION
TimeLineID is an uint32 in PostgreSQL but since PostgreSQL's type system is lacking unsigned types there was no consistent mode of transmission in the streaming replication protocol and the timeline got transmitted both as integer and as bigint. As a consequence although we realized the TimeLineID's unsignedness we also had heterogenity regarding timeline id's ocurrences across Npgsql's replication API.
AS of PG 16 the backend is consistently transmitting TimeLineID as bigint that (due to being backed by an uint32 field) can only have values >= 0.
With this commit we accept TimeLineID as both integer and bigint and expose it as uint (UInt32) in all our public APIs.

Closes #5046