### PR TITLE
Always parse the timeline id as uint

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -764,6 +764,7 @@ namespace Npgsql.Replication
                 case "text":
                     results[i] = buf.ReadString(len);
                     continue;
+                case "bigint":
                 case "integer":
                     var str = buf.ReadString(len);
                     if (!uint.TryParse(str, NumberStyles.None, null, out var num))


### PR DESCRIPTION
This is required to support PostgreSQL 16+