### PR TITLE
Add Package Source Mapping configuration

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,4 +5,10 @@
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 
+    <packageSourceMapping>
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+    </packageSourceMapping>
+
 </configuration>


### PR DESCRIPTION
I'm not sure if I'm the only one of us who has multiple package sources enabled on his system but I recently started getting [NU1507](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1507) errors when restoring packages.

To resolve those, I either have to deactivate all package sources except NuGet or add a Package Source Mapping configuration to our NuGet.config

See https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping