### PR TITLE
Improve text handling

### DIFF
--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -424,13 +424,11 @@ public sealed partial class NpgsqlWriteBuffer : IDisposable
         WritePosition += TextEncoding.GetBytes(chars, offset, charCount, Buffer, WritePosition);
     }
 
-#if !NETSTANDARD2_0
     internal void WriteChars(ReadOnlySpan<char> chars)
     {
         Debug.Assert(TextEncoding.GetByteCount(chars) <= WriteSpaceLeft);
         WritePosition += TextEncoding.GetBytes(chars, Buffer.AsSpan(WritePosition));
     }
-#endif
 
     public void WriteBytes(ReadOnlySpan<byte> buf)
     {

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -174,12 +174,12 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     /// <inheritdoc />
     public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
     {
-        if (dataOffset < 0 || dataOffset > int.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(dataOffset), dataOffset, $"dataOffset must be between {0} and {int.MaxValue}");
+        if (dataOffset is < 0 or > int.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(dataOffset), dataOffset, $"dataOffset must be between 0 and {int.MaxValue}");
         if (buffer != null && (bufferOffset < 0 || bufferOffset >= buffer.Length + 1))
-            throw new IndexOutOfRangeException($"bufferOffset must be between {0} and {(buffer.Length)}");
+            throw new IndexOutOfRangeException($"bufferOffset must be between 0 and {buffer.Length}");
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))
-            throw new IndexOutOfRangeException($"length must be between {0} and {buffer.Length - bufferOffset}");
+            throw new IndexOutOfRangeException($"length must be between 0 and {buffer.Length - bufferOffset}");
 
         var field = CheckRowAndColumnAndSeek(ordinal);
         var handler = field.Handler;
@@ -190,9 +190,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             throw new InvalidCastException("field is null");
 
         var dataOffset2 = (int)dataOffset;
-        if (dataOffset2 > field.Length)
-            throw new ArgumentOutOfRangeException(nameof(dataOffset),
-                $"attempting to read out of bounds from the column data, dataOffset must be between {0} and {field.Length}");
+        if (dataOffset2 >= field.Length)
+            ThrowHelper.ThrowArgumentOutOfRange_OutOfColumnBounds(nameof(dataOffset), field.Length);
 
         Buffer.ReadPosition += dataOffset2;
 

--- a/src/Npgsql/Shims/EncodingExtensions.cs
+++ b/src/Npgsql/Shims/EncodingExtensions.cs
@@ -1,0 +1,212 @@
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace System.Text;
+
+static class EncodingExtensions
+{
+#if NETSTANDARD2_0
+    public static unsafe int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+    {
+        fixed (char* charsPtr = chars)
+        {
+            return encoding.GetByteCount(charsPtr, chars.Length);
+        }
+    }
+
+    public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        fixed (char* charsPtr = chars)
+        fixed (byte* bytesPtr = bytes)
+        {
+            return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+        }
+    }
+
+    public static unsafe int GetCharCount(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* bytesPtr = bytes)
+        {
+            return encoding.GetCharCount(bytesPtr, bytes.Length);
+        }
+    }
+
+    public static unsafe int GetCharCount(this Decoder encoding, ReadOnlySpan<byte> bytes, bool flush)
+    {
+        fixed (byte* bytesPtr = bytes)
+        {
+            return encoding.GetCharCount(bytesPtr, bytes.Length, flush);
+        }
+    }
+
+    public static unsafe int GetChars(this Decoder encoding, ReadOnlySpan<byte> bytes, Span<char> chars, bool flush)
+    {
+        fixed (byte* bytesPtr = bytes)
+        fixed (char* charsPtr = chars)
+        {
+            return encoding.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length, flush);
+        }
+    }
+
+    public static unsafe int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars)
+    {
+        fixed (byte* bytesPtr = bytes)
+        fixed (char* charsPtr = chars)
+        {
+            return encoding.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
+        }
+    }
+
+    public static unsafe void Convert(this Encoder encoder, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
+    {
+        fixed (char* charsPtr = chars)
+        fixed (byte* bytesPtr = bytes)
+        {
+            encoder.Convert(charsPtr, chars.Length, bytesPtr, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
+        }
+    }
+
+    public static unsafe void Convert(this Decoder encoder, ReadOnlySpan<byte> bytes, Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed)
+    {
+        fixed (byte* bytesPtr = bytes)
+        fixed (char* charsPtr = chars)
+        {
+            encoder.Convert(bytesPtr, bytes.Length, charsPtr, chars.Length, flush, out bytesUsed, out charsUsed, out completed);
+        }
+    }
+#endif
+
+#if NETSTANDARD
+    /// <summary>
+    /// Decodes the specified <see cref="ReadOnlySequence{Byte}"/> to <see langword="char"/>s using the specified <see cref="Encoding"/>
+    /// and outputs the result to <paramref name="chars"/>.
+    /// </summary>
+    /// <param name="encoding">The <see cref="Encoding"/> which represents how the data in <paramref name="bytes"/> is encoded.</param>
+    /// <param name="bytes">The <see cref="ReadOnlySequence{Byte}"/> to decode to characters.</param>
+    /// <param name="chars">The destination buffer to which the decoded characters will be written.</param>
+    /// <returns>The number of chars written to <paramref name="chars"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="chars"/> is not large enough to contain the encoded form of <paramref name="bytes"/>.</exception>
+    /// <exception cref="DecoderFallbackException">Thrown if <paramref name="bytes"/> contains data that cannot be decoded and <paramref name="encoding"/> is configured
+    /// to throw an exception when such data is seen.</exception>
+    public static int GetChars(this Encoding encoding, in ReadOnlySequence<byte> bytes, Span<char> chars)
+    {
+        if (encoding is null)
+            throw new ArgumentNullException(nameof(encoding));
+
+        if (bytes.IsSingleSegment)
+        {
+            // If the incoming sequence is single-segment, one-shot this.
+
+            return encoding.GetChars(bytes.First.Span, chars);
+        }
+        else
+        {
+            // If the incoming sequence is multi-segment, create a stateful Decoder
+            // and use it as the workhorse. On the final iteration we'll pass flush=true.
+
+            ReadOnlySequence<byte> remainingBytes = bytes;
+            int originalCharsLength = chars.Length;
+            Decoder decoder = encoding.GetDecoder();
+            bool isFinalSegment;
+
+            do
+            {
+                var firstSpan = remainingBytes.First.Span;
+                var next = remainingBytes.GetPosition(firstSpan.Length);
+                isFinalSegment = remainingBytes.IsSingleSegment;
+
+                int charsWrittenJustNow = decoder.GetChars(firstSpan, chars, flush: isFinalSegment);
+                chars = chars.Slice(charsWrittenJustNow);
+                remainingBytes = remainingBytes.Slice(next);
+            } while (!isFinalSegment);
+
+            return originalCharsLength - chars.Length; // total number of chars we wrote
+        }
+    }
+
+    public static string GetString(this Encoding encoding, in ReadOnlySequence<byte> bytes)
+    {
+        if (encoding is null)
+            throw new ArgumentNullException(nameof(encoding));
+
+        // If the incoming sequence is single-segment, one-shot this.
+        if (bytes.IsSingleSegment)
+        {
+#if NETSTANDARD2_1
+            return encoding.GetString(bytes.First.Span);
+#else
+            var rented = false;
+            byte[] arr;
+            var memory = bytes.First;
+            if (MemoryMarshal.TryGetArray(memory, out var segment))
+                arr = segment.Array!;
+            else
+            {
+                rented = true;
+                arr = ArrayPool<byte>.Shared.Rent(memory.Length);
+                bytes.First.Span.CopyTo(arr);
+            }
+            var ret = encoding.GetString(arr, 0, memory.Length);
+            if (rented)
+                ArrayPool<byte>.Shared.Return(arr);
+            return ret;
+#endif
+        }
+
+        // If the incoming sequence is multi-segment, create a stateful Decoder
+        // and use it as the workhorse. On the final iteration we'll pass flush=true.
+
+        var decoder = encoding.GetDecoder();
+
+        // Maintain a list of all the segments we'll need to concat together.
+        // These will be released back to the pool at the end of the method.
+
+        var listOfSegments = new List<(char[], int)>();
+        var totalCharCount = 0;
+
+        var remainingBytes = bytes;
+        bool isFinalSegment;
+
+        do
+        {
+            var firstSpan = remainingBytes.First.Span;
+            var next = remainingBytes.GetPosition(firstSpan.Length);
+            isFinalSegment = remainingBytes.IsSingleSegment;
+
+            var charCountThisIteration = decoder.GetCharCount(firstSpan, flush: isFinalSegment); // could throw ArgumentException if overflow would occur
+            var rentedArray = ArrayPool<char>.Shared.Rent(charCountThisIteration);
+            var actualCharsWrittenThisIteration = decoder.GetChars(firstSpan, rentedArray, flush: isFinalSegment);
+            listOfSegments.Add((rentedArray, actualCharsWrittenThisIteration));
+
+            totalCharCount += actualCharsWrittenThisIteration;
+            if (totalCharCount < 0)
+            {
+                // If we overflowed, call string.Create, passing int.MaxValue.
+                // This will end up throwing the expected OutOfMemoryException
+                // since strings are limited to under int.MaxValue elements in length.
+
+                totalCharCount = int.MaxValue;
+                break;
+            }
+
+            remainingBytes = remainingBytes.Slice(next);
+        } while (!isFinalSegment);
+
+        // Now build up the string to return, then release all of our scratch buffers
+        // back to the shared pool.
+        var chars = ArrayPool<char>.Shared.Rent(totalCharCount);
+        var span = chars.AsSpan();
+        foreach (var (array, length) in listOfSegments)
+        {
+            array.AsSpan(0, length).CopyTo(span);
+            ArrayPool<char>.Shared.Return(array);
+            span = span.Slice(length);
+        }
+
+        var str = new string(chars);
+        ArrayPool<char>.Shared.Return(chars);
+        return str;
+    }
+#endif
+}

--- a/src/Npgsql/ThrowHelper.cs
+++ b/src/Npgsql/ThrowHelper.cs
@@ -53,6 +53,10 @@ static class ThrowHelper
         throw new InvalidCastException($"Column '{field.Name}' is null.");
 
     [DoesNotReturn]
+    internal static void ThrowArgumentOutOfRange_OutOfColumnBounds(string paramName, int columnLength) =>
+        throw new ArgumentOutOfRangeException(paramName, $"The value is out of bounds from the column data, dataOffset must be between 0 and {columnLength}");
+
+    [DoesNotReturn]
     internal static void ThrowInvalidOperationException_NoPropertyGetter(Type type, MemberInfo property) =>
         throw new InvalidOperationException($"Composite type '{type}' cannot be written because the '{property}' property has no getter.");
 
@@ -75,7 +79,7 @@ static class ThrowHelper
     [DoesNotReturn]
     internal static void ThrowNpgsqlOperationInProgressException(NpgsqlCommand command)
         => throw new NpgsqlOperationInProgressException(command);
-    
+
     [DoesNotReturn]
     internal static void ThrowNpgsqlOperationInProgressException(ConnectorState state)
         => throw new NpgsqlOperationInProgressException(state);


### PR DESCRIPTION
Some of this is in preparation of the converter pr, there might be more of these to keep that PR somewhat reviewable. 

Note I made a semantics change, which I think makes sense, and which NpgsqlNestedReader already conforms to. 
When a user passes a dataOffset larger or equal to the column length we probably want to throw an out of range exception.

All the encoder polyfills will be used in the converter pr as well, for the meantime I suggest just leaving them in but if anybody feels strongly about it I can trim it down to just the used ones. 