### PR TITLE
Make arrays opt-in (superceded)

### DIFF
--- a/src/Npgsql/Internal/TypeHandling/TypeHandlerResolverFactory.cs
+++ b/src/Npgsql/Internal/TypeHandling/TypeHandlerResolverFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Npgsql.Internal.TypeMapping;
 using Npgsql.TypeMapping;
 
@@ -15,17 +16,9 @@ public abstract class TypeHandlerResolverFactory
 
     public virtual void InsertInto(List<TypeHandlerResolverFactory> factories)
     {
-        // By default, we insert resolvers just before the built-in one, so that it can override it (e.g. JSON support which needs to
-        // override the limited support in built-in)
-        for (var i = 0; i < factories.Count; i++)
-        {
-            if (factories[i] is BuiltInTypeHandlerResolverFactory)
-            {
-                factories.Insert(i, this);
-                return;
-            }
-        }
+        // By default, insert at the end, just before the unsupported resolver.
+        Debug.Assert(factories[factories.Count - 1] is UnsupportedTypeHandlerResolverFactory);
 
-        throw new Exception("No built-in resolver factory found");
+        factories.Insert(factories.Count - 1, this);
     }
 }

--- a/src/Npgsql/Internal/TypeHandling/TypeHandlerResolverFactory.cs
+++ b/src/Npgsql/Internal/TypeHandling/TypeHandlerResolverFactory.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using Npgsql.Internal.TypeMapping;
+using Npgsql.TypeMapping;
 
 namespace Npgsql.Internal.TypeHandling;
 
@@ -9,4 +12,20 @@ public abstract class TypeHandlerResolverFactory
     public virtual TypeMappingResolver? CreateMappingResolver() => null;
 
     public virtual TypeMappingResolver? CreateGlobalMappingResolver() => null;
+
+    public virtual void InsertInto(List<TypeHandlerResolverFactory> factories)
+    {
+        // By default, we insert resolvers just before the built-in one, so that it can override it (e.g. JSON support which needs to
+        // override the limited support in built-in)
+        for (var i = 0; i < factories.Count; i++)
+        {
+            if (factories[i] is BuiltInTypeHandlerResolverFactory)
+            {
+                factories.Insert(i, this);
+                return;
+            }
+        }
+
+        throw new Exception("No built-in resolver factory found");
+    }
 }

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -317,5 +317,6 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
         _internalBuilder.AddDefaultTypeResolverFactory(new RangeTypeHandlerResolverFactory());
         _internalBuilder.AddDefaultTypeResolverFactory(new RecordTypeHandlerResolverFactory());
         _internalBuilder.AddDefaultTypeResolverFactory(new FullTextSearchTypeHandlerResolverFactory());
+        _internalBuilder.AddDefaultTypeResolverFactory(new ArrayTypeHandlerResolverFactory());
     }
 }

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -265,16 +265,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
             if (_resolverFactories[i].GetType() == type)
                 return;
 
-        for (var i = 0; i < _resolverFactories.Count; i++)
-        {
-            if (_resolverFactories[i] is BuiltInTypeHandlerResolverFactory)
-            {
-                _resolverFactories.Insert(i, resolverFactory);
-                return;
-            }
-        }
-
-        throw new Exception("No built-in resolver factory found");
+        resolverFactory.InsertInto(_resolverFactories);
     }
 
     /// <inheritdoc />
@@ -421,6 +412,15 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     public NpgsqlSlimDataSourceBuilder EnableFullTextSearch()
     {
         AddTypeResolverFactory(new FullTextSearchTypeHandlerResolverFactory());
+        return this;
+    }
+
+    /// <summary>
+    /// Sets up mappings for the arrays.
+    /// </summary>
+    public NpgsqlSlimDataSourceBuilder EnableArrays()
+    {
+        AddTypeResolverFactory(new ArrayTypeHandlerResolverFactory());
         return this;
     }
 

--- a/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
+++ b/src/Npgsql/Properties/NpgsqlStrings.Designer.cs
@@ -158,5 +158,17 @@ namespace Npgsql.Properties {
                 return ResourceManager.GetString("FullTextSearchNotEnabled", resourceCulture);
             }
         }
+        
+        internal static string RangesNotEnabled {
+            get {
+                return ResourceManager.GetString("RangesNotEnabled", resourceCulture);
+            }
+        }
+        
+        internal static string ArraysNotEnabled {
+            get {
+                return ResourceManager.GetString("ArraysNotEnabled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Npgsql/Properties/NpgsqlStrings.resx
+++ b/src/Npgsql/Properties/NpgsqlStrings.resx
@@ -75,4 +75,10 @@
     <data name="FullTextSearchNotEnabled" xml:space="preserve">
         <value>Full-text search isn't enabled; please call {0} on {1} to enable full-text search.</value>
     </data>
+    <data name="RangesNotEnabled" xml:space="preserve">
+        <value>Ranges aren't enabled; please call {0} on {1} to enable ranges.</value>
+    </data>
+    <data name="ArraysNotEnabled" xml:space="preserve">
+        <value>Arrays aren't enabled; please call {0} on {1} to enable arrays.</value>
+    </data>
 </root>

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 const Npgsql.PostgresErrorCodes.IdleSessionTimeout = "57P05" -> string!
+Npgsql.NpgsqlSlimDataSourceBuilder.EnableArrays() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableFullTextSearch() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableRecords() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlBinaryImporter.WriteRow(params object?[]! values) -> void

--- a/src/Npgsql/TypeMapping/ArrayTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/ArrayTypeHandlerResolver.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Npgsql.Internal;
+using Npgsql.Internal.TypeHandlers.InternalTypeHandlers;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.Internal.TypeMapping;
+using Npgsql.PostgresTypes;
+using NpgsqlTypes;
+
+namespace Npgsql.TypeMapping;
+
+sealed class ArrayTypeHandlerResolver : TypeHandlerResolver
+{
+    readonly TypeMapper _typeMapper;
+    readonly NpgsqlConnector _connector;
+    readonly NpgsqlDatabaseInfo _databaseInfo;
+
+    // Internal types
+    Int2VectorHandler? _int2VectorHandler;
+    OIDVectorHandler? _oidVectorHandler;
+
+    // Complex type handlers over timestamp/timestamptz (because DateTime is value-dependent)
+    NpgsqlTypeHandler? _timestampArrayHandler;
+    NpgsqlTypeHandler? _timestampTzArrayHandler;
+
+    public ArrayTypeHandlerResolver(TypeMapper typeMapper, NpgsqlConnector connector)
+    {
+        _typeMapper = typeMapper;
+        _connector = connector;
+        _databaseInfo = connector.DatabaseInfo;
+    }
+
+    public override NpgsqlTypeHandler? ResolveByDataTypeName(string typeName)
+        => typeName switch
+        {
+            "int2vector" => Int2VectorHandler(),
+            "oidvector" => OidVectorHandler(),
+
+            _ => _databaseInfo.TryGetPostgresTypeByName(typeName, out var pgType) && pgType is PostgresArrayType pgArrayType
+                ? _typeMapper.ResolveByOID(pgArrayType.Element.OID)
+                    .CreateArrayHandler(pgArrayType, _connector.Settings.ArrayNullabilityMode)
+                : null
+        };
+
+    public override NpgsqlTypeHandler? ResolveByNpgsqlDbType(NpgsqlDbType npgsqlDbType)
+    {
+        if (!npgsqlDbType.HasFlag(NpgsqlDbType.Array))
+            return null;
+
+        var elementHandler = _typeMapper.ResolveByNpgsqlDbType(npgsqlDbType & ~NpgsqlDbType.Array);
+
+        return elementHandler.PostgresType.Array is { } pgArrayType
+            ? elementHandler.CreateArrayHandler(pgArrayType, _connector.Settings.ArrayNullabilityMode)
+            : null;
+    }
+
+    public override NpgsqlTypeHandler? ResolveValueDependentValue(object value)
+    {
+        // For arrays/lists, return timestamp or timestamptz based on the kind of the first DateTime; if the user attempts to
+        // mix incompatible Kinds, that will fail during validation. For empty arrays it doesn't matter.
+        return value is IList<DateTime> array
+            ? ArrayHandler(array.Count == 0 ? DateTimeKind.Unspecified : array[0].Kind)
+            : null;
+
+        NpgsqlTypeHandler ArrayHandler(DateTimeKind kind)
+            => kind == DateTimeKind.Utc
+                ? _timestampTzArrayHandler ??= _typeMapper.ResolveByNpgsqlDbType(NpgsqlDbType.TimestampTz).CreateArrayHandler(
+                    (PostgresArrayType)PgType("timestamp with time zone[]"), _connector.Settings.ArrayNullabilityMode)
+                : _timestampArrayHandler ??= _typeMapper.ResolveByNpgsqlDbType(NpgsqlDbType.Timestamp).CreateArrayHandler(
+                    (PostgresArrayType)PgType("timestamp without time zone[]"), _connector.Settings.ArrayNullabilityMode);
+    }
+
+    public override NpgsqlTypeHandler? ResolveByClrType(Type type)
+        => type != typeof(byte[]) // We do support mapping .NET byte to PG smallint, but we want byte[][] to resolve to bytea[] by default.
+           && GetArrayListElementType(type) is { } arrayElementType
+           && _typeMapper.ResolveByClrType(arrayElementType) is { PostgresType.Array: { } pgArrayType } elementHandler
+            ? elementHandler.CreateArrayHandler(pgArrayType, _connector.Settings.ArrayNullabilityMode)
+            : null;
+
+    static Type? GetArrayListElementType(Type type)
+    {
+        var typeInfo = type.GetTypeInfo();
+        if (typeInfo.IsArray)
+            return GetUnderlyingType(type.GetElementType()!); // The use of bang operator is justified here as Type.GetElementType() only returns null for the Array base class which can't be mapped in a useful way.
+
+        var ilist = typeInfo.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
+        return ilist != null ? GetUnderlyingType(ilist.GetGenericArguments()[0]) : null;
+
+        Type GetUnderlyingType(Type t)
+            => Nullable.GetUnderlyingType(t) ?? t;
+    }
+
+    NpgsqlTypeHandler Int2VectorHandler() => _int2VectorHandler ??= new Int2VectorHandler(PgType("int2vector"), PgType("smallint"));
+    NpgsqlTypeHandler OidVectorHandler() => _oidVectorHandler ??= new OIDVectorHandler(PgType("oidvector"), PgType("oid"));
+
+    PostgresType PgType(string pgTypeName) => _databaseInfo.GetPostgresTypeByName(pgTypeName);
+}

--- a/src/Npgsql/TypeMapping/ArrayTypeHandlerResolverFactory.cs
+++ b/src/Npgsql/TypeMapping/ArrayTypeHandlerResolverFactory.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using Npgsql.Internal;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.Internal.TypeMapping;
+
+namespace Npgsql.TypeMapping;
+
+sealed class ArrayTypeHandlerResolverFactory : TypeHandlerResolverFactory
+{
+    public override TypeHandlerResolver Create(TypeMapper typeMapper, NpgsqlConnector connector)
+        => new ArrayTypeHandlerResolver(typeMapper, connector);
+
+    public override TypeMappingResolver CreateMappingResolver() => new ArrayTypeMappingResolver();
+
+    public override TypeMappingResolver CreateGlobalMappingResolver() => new ArrayTypeMappingResolver();
+
+    public override void InsertInto(List<TypeHandlerResolverFactory> factories)
+    {
+        // We need to place the array resolver after the built-in resolver, since it shouldn't resolve byte[] and string, which are
+        // both array/List. We also want it after the range resolver (if it's there), since NpgsqlRange<int> should resolve to
+        // int4multirange by default rather than to int4range[]
+        var (builtInResolverIndex, rangeResolverIndex) = (-1, -1);
+
+        for (var i = 0; i < factories.Count; i++)
+        {
+            switch (factories[i])
+            {
+            case BuiltInTypeHandlerResolverFactory:
+                builtInResolverIndex = i;
+                break;
+            case RangeTypeHandlerResolverFactory:
+                rangeResolverIndex = i;
+                break;
+            }
+        }
+
+        Debug.Assert(builtInResolverIndex != -1);
+
+        if (rangeResolverIndex != -1)
+        {
+            Debug.Assert(rangeResolverIndex > builtInResolverIndex);
+            factories.Insert(rangeResolverIndex + 1, this);
+        }
+        else
+        {
+            factories.Insert(builtInResolverIndex + 1, this);
+        }
+    }
+}

--- a/src/Npgsql/TypeMapping/ArrayTypeMappingResolver.cs
+++ b/src/Npgsql/TypeMapping/ArrayTypeMappingResolver.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.Internal.TypeMapping;
+using Npgsql.PostgresTypes;
+using NpgsqlTypes;
+using static Npgsql.Util.Statics;
+
+namespace Npgsql.TypeMapping;
+
+sealed class ArrayTypeMappingResolver : TypeMappingResolver
+{
+    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
+        => dataTypeName switch
+        {
+            // TODO: Only these types?
+            "int2vector" => new(NpgsqlDbType.Int2Vector, "int2vector"),
+            "oidvector" => new(NpgsqlDbType.Oidvector, "oidvector"),
+            "timestamp without time zone[]" => new(NpgsqlDbType.Array | NpgsqlDbType.Timestamp, "timestamp without time zone[]"),
+            "timestamp with time zone[]" => new(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, "timestamp with time zone[]"),
+            _ => null
+        };
+
+    public override string? GetDataTypeNameByClrType(Type clrType)
+        => null;
+
+    public override TypeMappingInfo? GetMappingByPostgresType(TypeMapper typeMapper, PostgresType type)
+        => GetMappingByDataTypeName(type.Name);
+
+    public override string? GetDataTypeNameByValueDependentValue(object value)
+    {
+        // In LegacyTimestampBehavior, DateTime isn't value-dependent, and handled above in ClrTypeToDataTypeNameTable like other types
+        if (LegacyTimestampBehavior)
+            return null;
+
+        // For arrays/lists, return timestamp or timestamptz based on the kind of the first DateTime; if the user attempts to
+        // mix incompatible Kinds, that will fail during validation. For empty arrays it doesn't matter.
+        if (value is IList<DateTime> array)
+        {
+            return array.Count == 0
+                ? "timestamp without time zone[]"
+                : array[0].Kind == DateTimeKind.Utc
+                    ? "timestamp with time zone[]"
+                    : "timestamp without time zone[]";
+        }
+
+        return null;
+    }
+}

--- a/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolverFactory.cs
+++ b/src/Npgsql/TypeMapping/BuiltInTypeHandlerResolverFactory.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Diagnostics;
 using Npgsql.Internal;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.Internal.TypeMapping;
@@ -10,4 +12,10 @@ sealed class BuiltInTypeHandlerResolverFactory : TypeHandlerResolverFactory
         => new BuiltInTypeHandlerResolver(connector);
 
     public override TypeMappingResolver CreateMappingResolver() => new BuiltInTypeMappingResolver();
+
+    public override void InsertInto(List<TypeHandlerResolverFactory> factories)
+    {
+        Debug.Assert(factories.Count == 0);
+        factories.Add(this);
+    }
 }

--- a/src/Npgsql/TypeMapping/BuiltInTypeMappingResolver.cs
+++ b/src/Npgsql/TypeMapping/BuiltInTypeMappingResolver.cs
@@ -67,9 +67,6 @@ sealed class BuiltInTypeMappingResolver : TypeMappingResolver
         { "timetz",                      new(NpgsqlDbType.TimeTz,      "time with time zone") },
         { "interval",                    new(NpgsqlDbType.Interval,    "interval", typeof(TimeSpan)) },
 
-        { "timestamp without time zone[]", new(NpgsqlDbType.Array | NpgsqlDbType.Timestamp,   "timestamp without time zone[]") },
-        { "timestamp with time zone[]",    new(NpgsqlDbType.Array | NpgsqlDbType.TimestampTz, "timestamp with time zone[]") },
-
         // Network types
         { "cidr",      new(NpgsqlDbType.Cidr,     "cidr") },
 #pragma warning disable 618
@@ -115,14 +112,12 @@ sealed class BuiltInTypeMappingResolver : TypeMappingResolver
         { "hstore",      new(NpgsqlDbType.Hstore,  "hstore", typeof(Dictionary<string, string?>), typeof(IDictionary<string, string?>), typeof(ImmutableDictionary<string, string?>)) },
 
         // Internal types
-        { "int2vector",  new(NpgsqlDbType.Int2Vector,   "int2vector") },
-        { "oidvector",   new(NpgsqlDbType.Oidvector,    "oidvector") },
         { "pg_lsn",      new(NpgsqlDbType.PgLsn,        "pg_lsn", typeof(NpgsqlLogSequenceNumber)) },
         { "tid",         new(NpgsqlDbType.Tid,          "tid", typeof(NpgsqlTid)) },
         { "char",        new(NpgsqlDbType.InternalChar, "char") },
 
         // Special types
-        { "unknown",  new(NpgsqlDbType.Unknown, "unknown") },
+        { "unknown",  new(NpgsqlDbType.Unknown, "unknown") }
     };
 
     static readonly Dictionary<Type, string> ClrTypeToDataTypeNameTable;
@@ -221,12 +216,6 @@ sealed class BuiltInTypeMappingResolver : TypeMappingResolver
         return value switch
         {
             DateTime dateTime => dateTime.Kind == DateTimeKind.Utc ? "timestamp with time zone" : "timestamp without time zone",
-
-            // For arrays/lists, return timestamp or timestamptz based on the kind of the first DateTime; if the user attempts to
-            // mix incompatible Kinds, that will fail during validation. For empty arrays it doesn't matter.
-            IList<DateTime> array => array.Count == 0
-                ? "timestamp without time zone[]"
-                : array[0].Kind == DateTimeKind.Utc ? "timestamp with time zone[]" : "timestamp without time zone[]",
 
             _ => null
         };

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -165,7 +165,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
                     if (HandlerResolverFactories[i].GetType() == type)
                         HandlerResolverFactories.RemoveAt(i);
 
-                resolverFactory.InsertInto(HandlerResolverFactories);
+                HandlerResolverFactories.Insert(0, resolverFactory);
             }
 
             var mappingResolver = resolverFactory.CreateMappingResolver();

--- a/src/Npgsql/TypeMapping/RangeTypeHandlerResolverFactory.cs
+++ b/src/Npgsql/TypeMapping/RangeTypeHandlerResolverFactory.cs
@@ -1,4 +1,7 @@
-﻿using Npgsql.Internal;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Npgsql.Internal;
 using Npgsql.Internal.TypeHandling;
 using Npgsql.Internal.TypeMapping;
 
@@ -12,4 +15,36 @@ sealed class RangeTypeHandlerResolverFactory : TypeHandlerResolverFactory
     public override TypeMappingResolver CreateMappingResolver() => new RangeTypeMappingResolver();
 
     public override TypeMappingResolver CreateGlobalMappingResolver() => new RangeTypeMappingResolver();
+
+    public override void InsertInto(List<TypeHandlerResolverFactory> factories)
+    {
+        // The range resolver needs to go before the array resolver (if it's there), since NpgsqlRange<int> should resolve to int4multirange
+        // by default rather than to int4range[]
+        var (builtInResolverIndex, arrayResolverIndex) = (-1, -1);
+
+        for (var i = 0; i < factories.Count; i++)
+        {
+            switch (factories[i])
+            {
+            case BuiltInTypeHandlerResolverFactory:
+                builtInResolverIndex = i;
+                break;
+            case ArrayTypeHandlerResolverFactory:
+                arrayResolverIndex = i;
+                break;
+            }
+        }
+
+        Debug.Assert(builtInResolverIndex != -1);
+
+        if (arrayResolverIndex != -1)
+        {
+            Debug.Assert(arrayResolverIndex > builtInResolverIndex);
+            factories.Insert(arrayResolverIndex, this);
+        }
+        else
+        {
+            factories.Insert(builtInResolverIndex + 1, this);
+        }
+    }
 }

--- a/src/Npgsql/TypeMapping/SystemTextJsonTypeHandlerResolverFactory.cs
+++ b/src/Npgsql/TypeMapping/SystemTextJsonTypeHandlerResolverFactory.cs
@@ -42,4 +42,20 @@ sealed class SystemTextJsonTypeHandlerResolverFactory : TypeHandlerResolverFacto
     public override TypeMappingResolver CreateMappingResolver() => new SystemTextJsonTypeMappingResolver(_userClrTypes);
 
     public override TypeMappingResolver CreateGlobalMappingResolver() => new SystemTextJsonTypeMappingResolver(userClrTypes: null);
+
+    public override void InsertInto(List<TypeHandlerResolverFactory> factories)
+    {
+        // Insert the S.T.Json resolver just before the built-in, since the built-in resolver has limited JSON support which we need
+        // to override
+        for (var i = 0; i < factories.Count; i++)
+        {
+            if (factories[i] is BuiltInTypeHandlerResolverFactory)
+            {
+                factories.Insert(i, this);
+                return;
+            }
+        }
+
+        throw new Exception("No built-in resolver factory found");
+    }
 }

--- a/src/Npgsql/TypeMapping/UnsupportedTypeHandlerResolver.cs
+++ b/src/Npgsql/TypeMapping/UnsupportedTypeHandlerResolver.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Numerics;
+using System.Reflection;
+using Npgsql.Internal;
+using Npgsql.Internal.TypeHandlers;
+using Npgsql.Internal.TypeHandlers.DateTimeHandlers;
+using Npgsql.Internal.TypeHandlers.FullTextSearchHandlers;
+using Npgsql.Internal.TypeHandlers.GeometricHandlers;
+using Npgsql.Internal.TypeHandlers.InternalTypeHandlers;
+using Npgsql.Internal.TypeHandlers.LTreeHandlers;
+using Npgsql.Internal.TypeHandlers.NetworkHandlers;
+using Npgsql.Internal.TypeHandlers.NumericHandlers;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.PostgresTypes;
+using Npgsql.Properties;
+using NpgsqlTypes;
+using static Npgsql.Util.Statics;
+
+namespace Npgsql.TypeMapping;
+
+sealed class UnsupportedTypeHandlerResolver : TypeHandlerResolver
+{
+    readonly NpgsqlDatabaseInfo _databaseInfo;
+
+    internal UnsupportedTypeHandlerResolver(NpgsqlConnector connector)
+        => _databaseInfo = connector.DatabaseInfo;
+
+    public override NpgsqlTypeHandler? ResolveByDataTypeName(string typeName)
+        => PgType(typeName) switch
+        {
+            PostgresBaseType { Name: "record" } => UnsupportedRecordHandler(),
+            PostgresBaseType { Name: "tsvector" } => UnsupportedTsVectorHandler(),
+            PostgresBaseType { Name: "tsquery" } => UnsupportedTsQueryHandler(),
+            PostgresRangeType pgRangeType => UnsupportedRangeHandler(pgRangeType),
+            PostgresArrayType pgArrayType => UnsupportedArrayHandler(pgArrayType),
+
+            _ => null
+        };
+
+    public override NpgsqlTypeHandler? ResolveByClrType(Type type)
+    {
+        switch (type.FullName)
+        {
+        case "NpgsqlTypes.NpgsqlTsVector":
+        case "NpgsqlTypes.NpgsqlTsQueryLexeme":
+        case "NpgsqlTypes.NpgsqlTsQueryAnd":
+        case "NpgsqlTypes.NpgsqlTsQueryOr":
+        case "NpgsqlTypes.NpgsqlTsQueryNot":
+        case "NpgsqlTypes.NpgsqlTsQueryEmpty":
+        case "NpgsqlTypes.NpgsqlTsQueryFollowedBy":
+            return UnsupportedTsQueryHandler();
+        default:
+            return null;
+        }
+    }
+
+    PostgresType PgType(string pgTypeName) => _databaseInfo.GetPostgresTypeByName(pgTypeName);
+
+    NpgsqlTypeHandler UnsupportedRecordHandler() => new UnsupportedHandler(PgType("record"), string.Format(
+        NpgsqlStrings.RecordsNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableRecords), nameof(NpgsqlSlimDataSourceBuilder)));
+
+    NpgsqlTypeHandler UnsupportedTsVectorHandler() => new UnsupportedHandler(PgType("tsvector"), string.Format(
+        NpgsqlStrings.FullTextSearchNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableFullTextSearch),
+        nameof(NpgsqlSlimDataSourceBuilder)));
+
+    NpgsqlTypeHandler UnsupportedTsQueryHandler() => new UnsupportedHandler(PgType("tsquery"), string.Format(
+        NpgsqlStrings.FullTextSearchNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableFullTextSearch),
+        nameof(NpgsqlSlimDataSourceBuilder)));
+
+    NpgsqlTypeHandler UnsupportedRangeHandler(PostgresRangeType pgType) => new UnsupportedHandler(pgType, string.Format(
+        NpgsqlStrings.RangesNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableRanges),
+        nameof(NpgsqlSlimDataSourceBuilder)));
+
+    NpgsqlTypeHandler UnsupportedArrayHandler(PostgresArrayType pgType) => new UnsupportedHandler(pgType, string.Format(
+        NpgsqlStrings.ArraysNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableArrays),
+        nameof(NpgsqlSlimDataSourceBuilder)));
+}

--- a/src/Npgsql/TypeMapping/UnsupportedTypeHandlerResolverFactory.cs
+++ b/src/Npgsql/TypeMapping/UnsupportedTypeHandlerResolverFactory.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Npgsql.Internal;
+using Npgsql.Internal.TypeHandling;
+using Npgsql.Internal.TypeMapping;
+
+namespace Npgsql.TypeMapping;
+
+sealed class UnsupportedTypeHandlerResolverFactory : TypeHandlerResolverFactory
+{
+    public override TypeHandlerResolver Create(TypeMapper typeMapper, NpgsqlConnector connector)
+        => new UnsupportedTypeHandlerResolver(connector);
+
+    public override TypeMappingResolver CreateMappingResolver() => new UnsupportedTypeMappingResolver();
+
+    public override void InsertInto(List<TypeHandlerResolverFactory> factories)
+        => factories.Add(this);
+
+    sealed class UnsupportedTypeMappingResolver : TypeMappingResolver
+    {
+        public override string? GetDataTypeNameByClrType(Type clrType) => null;
+        public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName) => null;
+    }
+}

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Npgsql.Internal.TypeHandlers;
+using Npgsql.Properties;
 using NpgsqlTypes;
 using NUnit.Framework;
 using static Npgsql.Tests.TestUtil;
@@ -22,138 +23,38 @@ namespace Npgsql.Tests.Types;
 /// </remarks>
 public class ArrayTests : MultiplexingTestBase
 {
-    [Test, Description("Resolves an array type handler via the different pathways")]
-    public async Task Array_resolution()
+    static readonly TestCaseData[] ArrayTestCases =
     {
-        if (IsMultiplexing)
-            Assert.Ignore("Multiplexing, ReloadTypes");
+        new TestCaseData(new[] { 1, 2, 3 }, "{1,2,3}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array)
+            .SetName("Integer_array"),
+        new TestCaseData(Array.Empty<int>(), "{}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array)
+            .SetName("Empty_array"),
+        new TestCaseData(new[,] { { 1, 2, 3 }, { 7, 8, 9 } }, "{{1,2,3},{7,8,9}}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array)
+            .SetName("Two_dimensional_array"),
+        new TestCaseData(new[] { new byte[] { 1, 2 }, new byte[] { 3, 4 } }, """{"\\x0102","\\x0304"}""", "bytea[]", NpgsqlDbType.Bytea | NpgsqlDbType.Array)
+            .SetName("Bytea_array")
+    };
 
-        await using var dataSource = CreateDataSource(csb => csb.Pooling = false);
-        await using var conn = await dataSource.OpenConnectionAsync();
-
-        // Resolve type by NpgsqlDbType
-        await using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.AddWithValue("p", NpgsqlDbType.Array | NpgsqlDbType.Integer, DBNull.Value);
-            await using var reader = await cmd.ExecuteReaderAsync();
-
-            reader.Read();
-            Assert.That(reader.GetDataTypeName(0), Is.EqualTo("integer[]"));
-        }
-
-        // Resolve type by ClrType (type inference)
-        await conn.ReloadTypesAsync();
-        await using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = Array.Empty<int>() });
-            await using var reader = await cmd.ExecuteReaderAsync();
-
-            reader.Read();
-            Assert.That(reader.GetDataTypeName(0), Is.EqualTo("integer[]"));
-        }
-
-        // Resolve type by DataTypeName
-        await conn.ReloadTypesAsync();
-        await using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.Add(new NpgsqlParameter { ParameterName="p", DataTypeName = "integer[]", Value = DBNull.Value });
-            await using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                reader.Read();
-                Assert.That(reader.GetDataTypeName(0), Is.EqualTo("integer[]"));
-            }
-        }
-
-        // Resolve type by OID (read)
-        await conn.ReloadTypesAsync();
-        await using (var cmd = new NpgsqlCommand("SELECT '{1, 3}'::INTEGER[]", conn))
-        await using (var reader = await cmd.ExecuteReaderAsync())
-        {
-            reader.Read();
-            Assert.That(reader.GetDataTypeName(0), Is.EqualTo("integer[]"));
-            Assert.That(reader.GetFieldValue<int[]>(0), Is.EqualTo(new[] { 1, 3 }));
-        }
-    }
+    [Test, TestCaseSource(nameof(ArrayTestCases))]
+    public Task Arrays<T>(T array, string sqlLiteral, string pgTypeName, NpgsqlDbType? npgsqlDbType)
+        => AssertType(array, sqlLiteral, pgTypeName, npgsqlDbType);
 
     [Test]
-    public async Task Bind_int_then_array_of_int()
+    public async Task NullableInts()
     {
-        await using var dataSource = CreateDataSource();
-        await using var conn = await dataSource.OpenConnectionAsync();
-
-        await using var cmd = new NpgsqlCommand("SELECT 1", conn);
-        _ = await cmd.ExecuteScalarAsync();
-
-        cmd.CommandText = "SELECT ARRAY[1,2]";
-        Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(new[] { 1, 2 }));
-    }
-
-    [Test, Description("Roundtrips a simple, one-dimensional array of ints")]
-    public async Task Ints()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn);
-
-        var expected = new[] { 1, 5, 9 };
-        var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-        var p3 = new NpgsqlParameter<int[]>("p3", expected);
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        cmd.Parameters.Add(p3);
-        p1.Value = expected;
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        for (var i = 0; i < cmd.Parameters.Count; i++)
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(ConnectionString)
         {
-            Assert.That(reader.GetValue(i), Is.EqualTo(expected));
-            Assert.That(reader.GetValue(i), Is.TypeOf<int[]>());
-            Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(expected));
-            Assert.That(reader.GetFieldValue<int[]>(i), Is.EqualTo(expected));
-            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Array)));
-            Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(Array)));
-        }
+            ArrayNullabilityMode = ArrayNullabilityMode.Always
+        };
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionStringBuilder.ToString());
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await AssertType(dataSource, new int?[] { 1, 2, null, 3 }, "{1,2,NULL,3}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array);
     }
 
-    [Test, Description("Roundtrips a simple, one-dimensional array of int? values")]
-    public async Task Nullable_ints()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3", conn);
-
-        var expected = new int?[] { 1, 5, null, 9 };
-        var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-        var p3 = new NpgsqlParameter<int?[]>("p3", expected);
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        cmd.Parameters.Add(p3);
-        p1.Value = expected;
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        for (var i = 0; i < cmd.Parameters.Count; i++)
-        {
-            Assert.That(reader.GetFieldValue<int?[]>(i), Is.EqualTo(expected));
-            Assert.That(reader.GetFieldValue<List<int?>>(i), Is.EqualTo(expected.ToList()));
-            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(Array)));
-            Assert.That(reader.GetProviderSpecificFieldType(i), Is.EqualTo(typeof(Array)));
-        }
-    }
-
-    [Test, Description("Checks that PG arrays containing nulls can't be read as CLR arrays of non-nullable value types.")]
+    [Test, Description("Checks that PG arrays containing nulls can't be read as CLR arrays of non-nullable value types (the default).")]
     public async Task Nullable_ints_cannot_be_read_as_non_nullable()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT '{1, NULL, 2}'::integer[]", conn);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        Assert.That(() => reader.GetFieldValue<int[]>(0), Throws.Exception.TypeOf<InvalidOperationException>());
-        Assert.That(() => reader.GetFieldValue<List<int>>(0), Throws.Exception.TypeOf<InvalidOperationException>());
-        Assert.That(() => reader.GetValue(0), Throws.Exception.TypeOf<InvalidOperationException>());
-    }
+        => await AssertTypeUnsupportedRead<InvalidOperationException>("{1,NULL,2}", "int[]");
 
     [Test, Description("Checks that PG arrays containing nulls are returned as set via ValueTypeArrayMode.")]
     [TestCase(ArrayNullabilityMode.Always)]
@@ -233,33 +134,27 @@ SELECT onedim, twodim FROM (VALUES
         }
     }
 
+    // Note that PG normalizes empty multidimensional arrays to single-dimensional, e.g. ARRAY[[], []]::integer[] returns {}.
     [Test]
-    public async Task Empty_array()
+    public async Task Write_empty_multidimensional_array()
+        => await AssertTypeWrite(new int[0, 0], "{}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array);
+
+    [Test]
+    public async Task Generic_List()
+        => await AssertType(
+            new List<int> { 1, 2, 3 }, "{1,2,3}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array, isDefaultForReading: false);
+
+    [Test, Description("Roundtrips a non-generic IList as an array")]
+    public async Task Non_generic_ArrayList()
     {
+        // Possible TODO: We don't currently support inferring from non-generic IList as a CLR type, i.e. the below works only because
+        // NpgsqlDbType is explicitly specified.
         await using var conn = await OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand("SELECT @p", conn);
-
-        cmd.Parameters.Add(new NpgsqlParameter("p", NpgsqlDbType.Array | NpgsqlDbType.Integer) { Value = Array.Empty<int>() });
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        Assert.That(reader.GetFieldValue<int[]>(0), Is.SameAs(Array.Empty<int>()));
-        Assert.That(reader.GetFieldValue<int?[]>(0), Is.SameAs(Array.Empty<int?>()));
-    }
-
-    [Test, Description("Roundtrips an empty multi-dimensional array.")]
-    public async Task Empty_multidimensional_array()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p", conn);
-
-        var expected = new int[0, 0];
-        cmd.Parameters.AddWithValue("p", NpgsqlDbType.Array | NpgsqlDbType.Integer, expected);
-
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        Assert.That(reader.GetFieldValue<int[,]>(0), Is.EqualTo(expected));
+        var expected = new ArrayList(new[] { 1, 2, 3 });
+        var p = new NpgsqlParameter("p", NpgsqlDbType.Array | NpgsqlDbType.Integer) { Value = expected };
+        cmd.Parameters.Add(p);
+        Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(expected.ToArray()));
     }
 
     [Test, Description("Verifies that an InvalidOperationException is thrown when the returned array has a different number of dimensions from what was requested.")]
@@ -348,6 +243,14 @@ SELECT onedim, twodim FROM (VALUES
         Assert.That(reader[0], Is.EqualTo(expected));
     }
 
+    [Test, Description("Reads an one-dimensional array with lower bound != 0")]
+    public Task Read_non_zero_lower_bounded()
+        => AssertTypeRead("[2:3]={ 8, 9 }", "integer[]", new[] { 8, 9 });
+
+    [Test, Description("Reads an one-dimensional array with lower bound != 0")]
+    public Task Read_non_zero_lower_bounded_multidimensional()
+        => AssertTypeRead("[2:3][2:3]={ {8,9}, {1,2} }", "integer[]", new[,] { { 8, 9 }, { 1, 2 }});
+
     [Test, Description("Roundtrips a long, one-dimensional array of strings, including a null")]
     public async Task Strings_with_null()
     {
@@ -363,129 +266,12 @@ SELECT onedim, twodim FROM (VALUES
         Assert.That(reader.GetFieldValue<string[]>(0), Is.EqualTo(expected));
     }
 
-    [Test, Description("Roundtrips a zero-dimensional array of ints, should return empty one-dimensional")]
-    public async Task Zero_dimensional()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p", conn);
-        var expected = Array.Empty<int>();
-        var p = new NpgsqlParameter("p", NpgsqlDbType.Array | NpgsqlDbType.Integer) { Value = expected };
-        cmd.Parameters.Add(p);
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-        Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetFieldValue<int[]>(0), Is.EqualTo(expected));
-        cmd.Dispose();
-    }
-
-    [Test, Description("Roundtrips a two-dimensional array of ints")]
-    public async Task Two_dimensional_ints()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
-        var expected = new[,] { { 1, 2, 3 }, { 7, 8, 9 } };
-        var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer);
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        p1.Value = expected;
-        var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-        Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetProviderSpecificValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetFieldValue<int[,]>(0), Is.EqualTo(expected));
-    }
-
-    [Test, Description("Reads an one-dimensional array with lower bound != 0")]
-    public async Task Read_non_zero_lower_bounded()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using (var cmd = new NpgsqlCommand("SELECT '[2:3]={ 8, 9 }'::INT[]", conn))
-        await using (var reader = await cmd.ExecuteReaderAsync())
-        {
-            reader.Read();
-            Assert.That(reader.GetFieldValue<int[]>(0), Is.EqualTo(new[] {8, 9}));
-        }
-
-        await using (var cmd = new NpgsqlCommand("SELECT '[2:3][2:3]={ {8,9}, {1,2} }'::INT[][]", conn))
-        await using (var reader = await cmd.ExecuteReaderAsync())
-        {
-            reader.Read();
-            Assert.That(reader.GetFieldValue<int[,]>(0), Is.EqualTo(new[,] {{8, 9}, {1, 2}}));
-        }
-    }
-
-    [Test, Description("Roundtrips a one-dimensional array of bytea values")]
-    public async Task Array_of_byte_arrays()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
-        var expected = new[] { new byte[] { 1, 2 }, new byte[] { 3, 4, } };
-        var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Array | NpgsqlDbType.Bytea);
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        p1.Value = expected;
-        await using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-        Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetFieldValue<byte[][]>(0), Is.EqualTo(expected));
-        Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(Array)));
-        Assert.That(reader.GetProviderSpecificFieldType(0), Is.EqualTo(typeof(Array)));
-    }
-
-
-    [Test, Description("Roundtrips a non-generic IList as an array")]
-    // ReSharper disable once InconsistentNaming
-    public async Task IList_non_generic()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p", conn);
-        var expected = new ArrayList(new[] { 1, 2, 3 });
-        var p = new NpgsqlParameter("p", NpgsqlDbType.Array | NpgsqlDbType.Integer) { Value = expected };
-        cmd.Parameters.Add(p);
-        Assert.That(await cmd.ExecuteScalarAsync(), Is.EqualTo(expected.ToArray()));
-    }
-
-    [Test, Description("Roundtrips a generic List as an array")]
-    // ReSharper disable once InconsistentNaming
-    public async Task IList_generic()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1, @p2", conn);
-        var expected = new[] { 1, 2, 3 }.ToList();
-        var p1 = new NpgsqlParameter { ParameterName = "p1", Value = expected };
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = expected };
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-        Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-        Assert.That(reader.GetFieldValue<List<int>>(1), Is.EqualTo(expected));
-    }
-
-    [Test, Description("Tests for failure when reading a generic IList from a multidimensional array")]
-    // ReSharper disable once InconsistentNaming
-    public async Task IList_generic_fails_for_multidimensional_array()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var cmd = new NpgsqlCommand("SELECT @p1", conn);
-        var expected = new[,] { { 1, 2 }, { 3, 4 } };
-        var p1 = new NpgsqlParameter { ParameterName = "p1", Value = expected };
-        cmd.Parameters.Add(p1);
-        await using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-        Assert.That(reader.GetValue(0), Is.EqualTo(expected));
-        var exception = Assert.Throws<NotSupportedException>(() =>
-        {
-            reader.GetFieldValue<List<int>>(0);
-        })!;
-        Assert.That(exception.Message, Is.EqualTo("Can't read multidimensional array as List<Int32>"));
-    }
+    [Test]
+    public async Task Reading_multidimensional_array_as_List_is_not_supported()
+        => await AssertTypeUnsupportedRead<List<int>, NotSupportedException>("{{1,2},{3,4}}", "integer[]");
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/844")]
-    public async Task IEnumerable_throws_friendly_exception()
+    public async Task Writing_IEnumerable_is_not_supported()
     {
         await using var conn = await OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand("SELECT @p1", conn);
@@ -508,12 +294,9 @@ SELECT onedim, twodim FROM (VALUES
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/960")]
     public async Task Jagged_arrays_not_supported()
     {
-        var jagged = new int[2][];
-        jagged[0] = new[] { 8 };
-        jagged[1] = new[] { 8, 10 };
         await using var conn = await OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand("SELECT @p1", conn);
-        cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer, jagged);
+        cmd.Parameters.AddWithValue("p1", NpgsqlDbType.Array | NpgsqlDbType.Integer, new[] { new[] { 8 }, new[] { 8, 10 } });
         Assert.That(async () => await cmd.ExecuteNonQueryAsync(), Throws.Exception
             .TypeOf<Exception>()
             .With.Message.Contains("jagged"));
@@ -526,17 +309,6 @@ SELECT onedim, twodim FROM (VALUES
         await AssertIListRoundtrips(conn, new[] { 1, 2, 3 });
         await AssertIListRoundtrips(conn, new IntList { 1, 2, 3 });
         await AssertIListRoundtrips(conn, new MisleadingIntList<string>() { 1, 2, 3 });
-    }
-
-    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1546")]
-    public void Generic_List_get_NpgsqlDbType()
-    {
-        var p = new NpgsqlParameter
-        {
-            ParameterName = "p1",
-            Value = new List<int> { 1, 2, 3 }
-        };
-        Assert.That(p.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Array | NpgsqlDbType.Integer));
     }
 
     [Test, Description("Roundtrips one-dimensional and two-dimensional arrays of a PostgreSQL domain.")]
@@ -627,6 +399,31 @@ CREATE DOMAIN pg_temp.int_array_2d  AS int[][] CHECK(array_length(VALUE, 2) = 2)
         reader.Read();
         Assert.That(reader.GetDataTypeName(0), Is.EqualTo("integer[]"));
         Assert.That(reader[0], Is.EqualTo(value.ToArray()));
+    }
+
+    [Test]
+    public async Task Arrays_not_supported_by_default_on_NpgsqlSlimSourceBuilder()
+    {
+        var errorMessage = string.Format(
+            NpgsqlStrings.ArraysNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableArrays), nameof(NpgsqlSlimDataSourceBuilder));
+
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var exception = await AssertTypeUnsupportedRead<int[], NotSupportedException>("{1,2,3}", "integer[]", dataSource);
+        Assert.That(exception.Message, Is.EqualTo(errorMessage));
+        exception = await AssertTypeUnsupportedWrite<int[], NotSupportedException>(new[] { 1, 2, 3 }, "integer[]", dataSource);
+        Assert.That(exception.Message, Is.EqualTo(errorMessage));
+    }
+
+    [Test]
+    public async Task NpgsqlSlimSourceBuilder_EnableRanges()
+    {
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        dataSourceBuilder.EnableRanges();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await AssertType(new[] { 1, 2, 3 }, "{1,2,3}", "integer[]", NpgsqlDbType.Integer | NpgsqlDbType.Array);
     }
 
     class IntList : List<int> { }

--- a/test/Npgsql.Tests/Types/FullTextSearchTests.cs
+++ b/test/Npgsql.Tests/Types/FullTextSearchTests.cs
@@ -62,31 +62,35 @@ public class FullTextSearchTests : MultiplexingTestBase
         => AssertType(query, sqlLiteral, "tsquery", NpgsqlDbType.TsQuery);
 
     [Test]
-    public async Task Full_text_search_supported_only_with_EnableFullTextSearch([Values] bool enableFullTextSearch)
+    public async Task Full_text_search_not_supported_by_default_on_NpgsqlSlimSourceBuilder()
     {
-        var errorMessage = string.Format(NpgsqlStrings.FullTextSearchNotEnabled, "EnableFullTextSearch", "NpgsqlSlimDataSourceBuilder");
+        var errorMessage = string.Format(
+            NpgsqlStrings.FullTextSearchNotEnabled,
+            nameof(NpgsqlSlimDataSourceBuilder.EnableFullTextSearch),
+            nameof(NpgsqlSlimDataSourceBuilder));
 
         var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
-        if (enableFullTextSearch)
-            dataSourceBuilder.EnableFullTextSearch();
         await using var dataSource = dataSourceBuilder.Build();
 
-        if (enableFullTextSearch)
-        {
-            await AssertType<NpgsqlTsQuery>(new NpgsqlTsQueryLexeme("a"), "'a'", "tsquery", NpgsqlDbType.TsQuery);
-            await AssertType(NpgsqlTsVector.Parse("'1'"), "'1'", "tsvector", NpgsqlDbType.TsVector);
-        }
-        else
-        {
-            var exception = await AssertTypeUnsupportedRead<NpgsqlTsQuery, NotSupportedException>("a", "tsquery", dataSource);
-            Assert.AreEqual(errorMessage, exception.Message);
-            exception = await AssertTypeUnsupportedWrite<NpgsqlTsQuery, NotSupportedException>(new NpgsqlTsQueryLexeme("a"), pgTypeName: null, dataSource);
-            Assert.AreEqual(errorMessage, exception.Message);
+        var exception = await AssertTypeUnsupportedRead<NpgsqlTsQuery, NotSupportedException>("a", "tsquery", dataSource);
+        Assert.AreEqual(errorMessage, exception.Message);
+        exception = await AssertTypeUnsupportedWrite<NpgsqlTsQuery, NotSupportedException>(new NpgsqlTsQueryLexeme("a"), pgTypeName: null, dataSource);
+        Assert.AreEqual(errorMessage, exception.Message);
 
-            exception = await AssertTypeUnsupportedRead<NpgsqlTsVector, NotSupportedException>("1", "tsvector", dataSource);
-            Assert.AreEqual(errorMessage, exception.Message);
-            exception = await AssertTypeUnsupportedWrite<NpgsqlTsVector, NotSupportedException>(NpgsqlTsVector.Parse("'1'"), pgTypeName: null, dataSource);
-            Assert.AreEqual(errorMessage, exception.Message);
-        }
+        exception = await AssertTypeUnsupportedRead<NpgsqlTsVector, NotSupportedException>("1", "tsvector", dataSource);
+        Assert.AreEqual(errorMessage, exception.Message);
+        exception = await AssertTypeUnsupportedWrite<NpgsqlTsVector, NotSupportedException>(NpgsqlTsVector.Parse("'1'"), pgTypeName: null, dataSource);
+        Assert.AreEqual(errorMessage, exception.Message);
+    }
+
+    [Test]
+    public async Task NpgsqlSlimSourceBuilder_EnableFullTextSearch()
+    {
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        dataSourceBuilder.EnableFullTextSearch();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await AssertType<NpgsqlTsQuery>(new NpgsqlTsQueryLexeme("a"), "'a'", "tsquery", NpgsqlDbType.TsQuery);
+        await AssertType(NpgsqlTsVector.Parse("'1'"), "'1'", "tsvector", NpgsqlDbType.TsVector);
     }
 }

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -134,18 +134,9 @@ class MiscTypeTests : MultiplexingTestBase
         => AssertTypeUnsupportedWrite<object[], NotSupportedException>(new object[] { 1, "foo" }, "record");
 
     [Test]
-    public async Task Records_supported_only_with_EnableRecords([Values] bool withMappings)
+    public async Task Records_not_supported_by_default_on_NpgsqlSlimSourceBuilder()
     {
-        Func<IResolveConstraint> assertExpr = () => withMappings
-            ? Throws.Nothing
-            : Throws.Exception
-                .TypeOf<NotSupportedException>()
-                .With.Property("Message")
-                .EqualTo(string.Format(NpgsqlStrings.RecordsNotEnabled, "EnableRecords", "NpgsqlSlimDataSourceBuilder"));
-
         var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
-        if (withMappings)
-            dataSourceBuilder.EnableRecords();
         await using var dataSource = dataSourceBuilder.Build();
         await using var conn = await dataSource.OpenConnectionAsync();
         await using var cmd = conn.CreateCommand();
@@ -155,8 +146,35 @@ class MiscTypeTests : MultiplexingTestBase
         await using var reader = await cmd.ExecuteReaderAsync();
         await reader.ReadAsync();
 
-        Assert.That(() => reader.GetValue(0), assertExpr());
-        Assert.That(() => reader.GetFieldValue<object[]>(0), assertExpr());
+        Assert.That(() => reader.GetValue(0), AssertExpr());
+        Assert.That(() => reader.GetFieldValue<object[]>(0), AssertExpr());
+
+        IResolveConstraint AssertExpr() =>
+            Throws.Exception.TypeOf<NotSupportedException>()
+                .With.Property("Message")
+                .EqualTo(
+                    string.Format(
+                        NpgsqlStrings.RecordsNotEnabled,
+                        nameof(NpgsqlSlimDataSourceBuilder.EnableRecords),
+                        nameof(NpgsqlSlimDataSourceBuilder)));
+    }
+
+    [Test]
+    public async Task NpgsqlSlimSourceBuilder_EnableRecords()
+    {
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        dataSourceBuilder.EnableRecords();
+        await using var dataSource = dataSourceBuilder.Build();
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+
+        // RecordHandler doesn't support writing, so we only check for reading
+        cmd.CommandText = "SELECT ('one'::text, 2)";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        await reader.ReadAsync();
+
+        Assert.That(() => reader.GetValue(0), Throws.Nothing);
+        Assert.That(() => reader.GetFieldValue<object[]>(0), Throws.Nothing);
     }
 
     #endregion Record

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Globalization;
 using System.Threading.Tasks;
+using Npgsql.Properties;
 using Npgsql.Util;
 using NpgsqlTypes;
 using NUnit.Framework;
@@ -16,83 +17,62 @@ namespace Npgsql.Tests.Types;
 /// </remarks>
 class RangeTests : MultiplexingTestBase
 {
-    [Test, NUnit.Framework.Description("Resolves a range type handler via the different pathways")]
-    public async Task Range_resolution()
+    static readonly TestCaseData[] RangeTestCases =
     {
-        if (IsMultiplexing)
-            Assert.Ignore("Multiplexing, ReloadTypes");
+        new TestCaseData(new NpgsqlRange<int>(1, true, 10, false), "[1,10)", "int4range", NpgsqlDbType.IntegerRange)
+            .SetName("IntegerRange"),
+        new TestCaseData(new NpgsqlRange<long>(1, true, 10, false), "[1,10)", "int8range", NpgsqlDbType.BigIntRange)
+            .SetName("BigIntRange"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, true, 10, false), "[1,10)", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("NumericRange"),
+        new TestCaseData(new NpgsqlRange<DateTime>(
+                    new DateTime(2020, 1, 1, 12, 0, 0), true,
+                    new DateTime(2020, 1, 3, 13, 0, 0), false),
+                """["2020-01-01 12:00:00","2020-01-03 13:00:00")""", "tsrange", NpgsqlDbType.TimestampRange)
+            .SetName("TimestampRange"),
+        new TestCaseData(new NpgsqlRange<DateTime>(
+                    new DateTime(2020, 1, 1, 12, 0, 0, DateTimeKind.Utc), true,
+                    new DateTime(2020, 1, 3, 13, 0, 0, DateTimeKind.Utc), false),
+                """["2020-01-01 12:00:00+00","2020-01-03 13:00:00+00")""", "tstzrange", NpgsqlDbType.TimestampTzRange)
+            .SetName("TimestampTzRange"),
 
-        await using var dataSource = CreateDataSource(csb => csb.Pooling = false);
-        await using var conn = await OpenConnectionAsync();
 
-        // Resolve type by NpgsqlDbType
-        using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.AddWithValue("p", NpgsqlDbType.Range | NpgsqlDbType.Integer, DBNull.Value);
-            using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                reader.Read();
-                Assert.That(reader.GetDataTypeName(0), Is.EqualTo("int4range"));
-            }
-        }
+        // Note that numrange is a non-discrete range, and therefore doesn't undergo normalization to inclusive/exclusive in PG
+        new TestCaseData(NpgsqlRange<decimal>.Empty, "empty", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("EmptyRange"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, true, 10, true), "[1,10]", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("Inclusive"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, false, 10, false), "(1,10)", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("Exclusive"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, true, 10, false), "[1,10)", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("InclusiveExclusive"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, false, 10, true), "(1,10]", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("ExclusiveInclusive"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, false, true, 10, false, false), "(,10)", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("InfiniteLowerBound"),
+        new TestCaseData(new NpgsqlRange<decimal>(1, true, false, 10, false, true), "[1,)", "numrange", NpgsqlDbType.NumericRange)
+            .SetName("InfiniteUpperBound")
+    };
 
-        // Resolve type by ClrType (type inference)
-        conn.ReloadTypes();
-        using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.Add(new NpgsqlParameter { ParameterName = "p", Value = new NpgsqlRange<int>(3, 5) });
-            using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                reader.Read();
-                Assert.That(reader.GetDataTypeName(0), Is.EqualTo("int4range"));
-            }
-        }
-
-        // Resolve type by DataTypeName
-        conn.ReloadTypes();
-        using (var cmd = new NpgsqlCommand("SELECT @p", conn))
-        {
-            cmd.Parameters.Add(new NpgsqlParameter { ParameterName="p", DataTypeName = "int4range", Value = DBNull.Value });
-            using (var reader = await cmd.ExecuteReaderAsync())
-            {
-                reader.Read();
-                Assert.That(reader.GetDataTypeName(0), Is.EqualTo("int4range"));
-            }
-        }
-
-        // Resolve type by OID (read)
-        conn.ReloadTypes();
-        using (var cmd = new NpgsqlCommand("SELECT int4range(3, 5)", conn))
-        using (var reader = await cmd.ExecuteReaderAsync())
-        {
-            reader.Read();
-            Assert.That(reader.GetDataTypeName(0), Is.EqualTo("int4range"));
-            Assert.That(reader.GetFieldValue<NpgsqlRange<int>>(0), Is.EqualTo(new NpgsqlRange<int>(3, true, 5, false)));
-        }
-    }
+    [Test, TestCaseSource(nameof(RangeTestCases))]
+    public Task Range<T>(T range, string sqlLiteral, string pgTypeName, NpgsqlDbType? npgsqlDbType)
+        => AssertType(range, sqlLiteral, pgTypeName, npgsqlDbType);
 
     [Test]
-    public async Task Range()
-    {
-        using var conn = await OpenConnectionAsync();
-        using var cmd = new NpgsqlCommand("SELECT @p1, @p2, @p3, @p4", conn);
-        var p1 = new NpgsqlParameter("p1", NpgsqlDbType.Range | NpgsqlDbType.Integer) { Value = NpgsqlRange<int>.Empty };
-        var p2 = new NpgsqlParameter { ParameterName = "p2", Value = new NpgsqlRange<int>(1, 10) };
-        var p3 = new NpgsqlParameter { ParameterName = "p3", Value = new NpgsqlRange<int>(1, false, 10, false) };
-        var p4 = new NpgsqlParameter { ParameterName = "p4", Value = new NpgsqlRange<int>(0, false, true, 10, false, false) };
-        Assert.That(p2.NpgsqlDbType, Is.EqualTo(NpgsqlDbType.Range | NpgsqlDbType.Integer));
-        cmd.Parameters.Add(p1);
-        cmd.Parameters.Add(p2);
-        cmd.Parameters.Add(p3);
-        cmd.Parameters.Add(p4);
-        using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
+    public Task DateRange_with_DateTime()
+        => AssertType(new NpgsqlRange<DateTime>(
+                new DateTime(2020, 1, 1, 0, 0, 0), true,
+                new DateTime(2020, 1, 3, 0, 0, 0), false),
+            "[2020-01-01,2020-01-03)", "daterange", NpgsqlDbType.DateRange,
+            isDefaultForWriting: false);
 
-        Assert.That(reader[0].ToString(), Is.EqualTo("empty"));
-        Assert.That(reader[1].ToString(), Is.EqualTo("[1,11)"));
-        Assert.That(reader[2].ToString(), Is.EqualTo("[2,10)"));
-        Assert.That(reader[3].ToString(), Is.EqualTo("(,10)"));
-    }
+#if NET6_0_OR_GREATER
+    [Test]
+    public Task DateRange_with_DateOnly()
+        => AssertType(
+            new NpgsqlRange<DateOnly>(new DateOnly(2020, 1, 1), true, new DateOnly(2020, 1, 3), false),
+            "[2020-01-01,2020-01-03)", "daterange", NpgsqlDbType.DateRange, isDefaultForReading: false);
+#endif
 
     [Test]
     [NonParallelizable]
@@ -240,11 +220,37 @@ class RangeTests : MultiplexingTestBase
                 new(3, lowerBoundIsInclusive: true, 4, upperBoundIsInclusive: false),
                 new(5, lowerBoundIsInclusive: true, 6, upperBoundIsInclusive: false)
             },
-            @"{""[3,4)"",""[5,6)""}",
+            """{"[3,4)","[5,6)"}""",
             "int4range[]",
             NpgsqlDbType.IntegerRange | NpgsqlDbType.Array,
             isDefaultForWriting: !supportsMultirange,
             isNpgsqlDbTypeInferredFromClrType: false);
+    }
+
+    [Test]
+    public async Task Ranges_not_supported_by_default_on_NpgsqlSlimSourceBuilder()
+    {
+        var errorMessage = string.Format(
+            NpgsqlStrings.RangesNotEnabled, nameof(NpgsqlSlimDataSourceBuilder.EnableRanges), nameof(NpgsqlSlimDataSourceBuilder));
+
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var exception = await AssertTypeUnsupportedRead<NpgsqlRange<int>, NotSupportedException>("[1,10)", "int4range", dataSource);
+        Assert.That(exception.Message, Is.EqualTo(errorMessage));
+        exception = await AssertTypeUnsupportedWrite<NpgsqlRange<int>, NotSupportedException>(
+            new NpgsqlRange<int>(1, true, 10, false), "int4range", dataSource);
+        Assert.That(exception.Message, Is.EqualTo(errorMessage));
+    }
+
+    [Test]
+    public async Task NpgsqlSlimSourceBuilder_EnableRanges()
+    {
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        dataSourceBuilder.EnableRanges();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await AssertType(new NpgsqlRange<int>(1, true, 10, false), "[1,10)", "int4range", NpgsqlDbType.IntegerRange);
     }
 
     protected override NpgsqlConnection OpenConnection()


### PR DESCRIPTION
Based on @vonzshik's work in #5009. Notes:

* Split the "unsupported" stuff out of the built-in resolver, and put it in a new dedicated resolver that's always at the very end.
* Each type handler resolver factory now determines where it inserts itself in the resolver chain. The range and array resolvers insert themselves after built-in (byte[]/string must be resolved by built-in), but before the last unsupported handler; range must come before array (because multiranges have precedence over arrays of ranges).
* Lots of test cleanup, don't be too alarmed by the PR size :)

Closes #4988