### PR TITLE
Stop running ci tests against pg 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        pg_major: [15, 14, 13, 12, 11, 10]
+        pg_major: [15, 14, 13, 12, 11]
         config: [Release]
         test_tfm: [net8.0]
         include:


### PR DESCRIPTION
Since it's not supported anymore