### PR TITLE
Implement OpenTelemetry metrics 

### DIFF
--- a/Npgsql.sln
+++ b/Npgsql.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 		README.md = README.md
 		global.json = global.json
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Npgsql.SourceGenerators", "src\Npgsql.SourceGenerators\Npgsql.SourceGenerators.csproj", "{63026A19-60B8-4906-81CB-216F30E8094B}"

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -379,7 +379,7 @@ public sealed partial class NpgsqlConnector
         _isKeepAliveEnabled = Settings.KeepAlive > 0;
         if (_isKeepAliveEnabled)
             _keepAliveTimer = new Timer(PerformKeepAlive, null, Timeout.Infinite, Timeout.Infinite);
-        
+
         DataReader = new NpgsqlDataReader(this);
 
         // TODO: Not just for automatic preparation anymore...
@@ -659,7 +659,7 @@ public sealed partial class NpgsqlConnector
                 reader.NextResult();
                 reader.Read();
             }
-                
+
             _isTransactionReadOnly = reader.GetString(0) != "off";
 
             var databaseState = UpdateDatabaseState();
@@ -1419,6 +1419,7 @@ public sealed partial class NpgsqlConnector
                     if (error != null)
                     {
                         NpgsqlEventSource.Log.CommandFailed();
+                        DataSource.MetricsReporter.ReportCommandFailed();
                         throw error;
                     }
 
@@ -2106,7 +2107,7 @@ public sealed partial class NpgsqlConnector
             Monitor.Exit(CleanupLock);
         }
     }
-        
+
     void FullCleanup()
     {
         lock (CleanupLock)
@@ -2379,7 +2380,7 @@ public sealed partial class NpgsqlConnector
         // the user query wait if a keepalive is in progress.
         // If keepalive isn't enabled, we don't use the lock and rely only on the connector's
         // state (updated via Interlocked.Exchange) to detect concurrent use, on a best-effort basis.
-        return _isKeepAliveEnabled 
+        return _isKeepAliveEnabled
             ? DoStartUserActionWithKeepAlive(newState, command, cancellationToken, attemptPgCancellation)
             : DoStartUserAction(newState, command, cancellationToken, attemptPgCancellation);
 

--- a/src/Npgsql/MetricsReporter.cs
+++ b/src/Npgsql/MetricsReporter.cs
@@ -1,0 +1,238 @@
+using System;
+
+namespace Npgsql;
+
+#if NET7_0_OR_GREATER
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// .NET docs on metric instrumentation: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation
+// OpenTelemetry semantic conventions for database metric: https://opentelemetry.io/docs/specs/otel/metrics/semantic_conventions/database-metrics
+class MetricsReporter : IDisposable
+{
+    const string Version = "0.1.0";
+
+    static readonly Meter Meter;
+
+    static readonly UpDownCounter<int> CommandsExecuting;
+    static readonly Counter<int> CommandsFailed;
+    static readonly Histogram<double> CommandDuration;
+
+    static readonly Counter<long> BytesWritten;
+    static readonly Counter<long> BytesRead;
+
+    static readonly UpDownCounter<int> PendingConnectionRequests;
+    static readonly UpDownCounter<int> ConnectionTimeouts;
+    static readonly Histogram<double> ConnectionCreateTime;
+
+    readonly NpgsqlDataSource _dataSource;
+    readonly KeyValuePair<string, object?> _poolNameTag;
+
+    static readonly List<MetricsReporter> Reporters = new();
+
+    CommandCounters _commandCounters;
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct CommandCounters
+    {
+        [FieldOffset(0)] internal int CommandsStarted;
+        [FieldOffset(4)] internal int PreparedCommandsStarted;
+        [FieldOffset(0)] internal long All;
+    }
+
+    static MetricsReporter()
+    {
+        Meter = new("Npgsql", Version);
+
+        // TODO: Add units
+        CommandsExecuting =
+            Meter.CreateUpDownCounter<int>("db.client.commands.executing", "The number of currently executing database commands.");
+        CommandsFailed
+            = Meter.CreateCounter<int>("db.client.commands.failed", "The number of database commands which have failed.");
+        CommandDuration
+            = Meter.CreateHistogram<double>("db.client.commands.duration", "ms", "The duration of database commands, in milliseconds.");
+
+        BytesWritten = Meter.CreateCounter<long>("db.client.commands.bytes_read", "The number of bytes read.");
+        BytesRead = Meter.CreateCounter<long>("db.client.commands.bytes_written", "The number of bytes written.");
+
+        PendingConnectionRequests = Meter.CreateUpDownCounter<int>(
+            "db.client.connections.pending_requests",
+            "The number of pending requests for an open connection, cumulative for the entire pool.");
+        ConnectionTimeouts = Meter.CreateUpDownCounter<int>(
+            "db.client.connections.timeouts",
+            "The number of connection timeouts that have occurred trying to obtain a connection from the pool.");
+        ConnectionCreateTime
+            = Meter.CreateHistogram<double>("db.client.connections.create_time", "ms", "The time it took to create a new connection.");
+
+        // Observable metrics; these are for values we already track internally (and efficiently) inside the connection pool implementation.
+        Meter.CreateObservableUpDownCounter(
+            "db.client.connections.usage",
+            GetConnectionUsage,
+            "The number of connections that are currently in state described by the state attribute.");
+
+        // It's a bit ridiculous to manage "max connections" as an observable counter, given that it never changes for a given pool.
+        // However, we can't simply report it once at startup, since clients who connect later wouldn't have it. And since reporting it
+        // repeatedly isn't possible because we need to provide incremental figures, we just manage it as an observable counter.
+        Meter.CreateObservableUpDownCounter(
+            "db.client.connections.max",
+            GetMaxConnections,
+            "The maximum number of open connections allowed.");
+
+        Meter.CreateObservableUpDownCounter(
+            "db.client.commands.prepared_ratio",
+            GetPreparedCommandsRatio,
+            "%",
+            "The ratio of prepared command executions.");
+    }
+
+    public MetricsReporter(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+        _poolNameTag = new KeyValuePair<string, object?>("pool.name", dataSource.Name);
+
+        lock (Reporters)
+        {
+            Reporters.Add(this);
+            Reporters.Sort((x,y) => string.Compare(x._dataSource.Name, y._dataSource.Name, StringComparison.Ordinal));
+        }
+    }
+
+    internal long ReportCommandStart()
+    {
+        CommandsExecuting.Add(1, _poolNameTag);
+        Interlocked.Increment(ref _commandCounters.CommandsStarted);
+
+        return CommandDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
+    }
+
+    internal void ReportCommandStop(long startTimestamp)
+    {
+        CommandsExecuting.Add(-1, _poolNameTag);
+
+        if (CommandDuration.Enabled && startTimestamp > 0)
+        {
+            var duration = Stopwatch.GetElapsedTime(startTimestamp);
+            CommandDuration.Record(duration.TotalMilliseconds, _poolNameTag);
+        }
+    }
+
+    internal void CommandStartPrepared() => Interlocked.Increment(ref _commandCounters.PreparedCommandsStarted);
+
+    internal void ReportCommandFailed() => CommandsFailed.Add(1, _poolNameTag);
+
+    internal void ReportBytesWritten(long bytesWritten) => BytesWritten.Add(bytesWritten, _poolNameTag);
+    internal void ReportBytesRead(long bytesRead) => BytesRead.Add(bytesRead, _poolNameTag);
+
+    internal void ReportConnectionPoolTimeout()
+        => ConnectionTimeouts.Add(1, _poolNameTag);
+
+    internal void ReportPendingConnectionRequestStart()
+        => PendingConnectionRequests.Add(1, _poolNameTag);
+    internal void ReportPendingConnectionRequestStop()
+        => PendingConnectionRequests.Add(-1, _poolNameTag);
+
+    internal void ReportConnectionCreateTime(TimeSpan duration)
+        => ConnectionCreateTime.Record(duration.TotalMilliseconds, _poolNameTag);
+
+    static IEnumerable<Measurement<int>> GetConnectionUsage()
+    {
+        lock (Reporters)
+        {
+            var measurements = new List<Measurement<int>>();
+
+            for (var i = 0; i < Reporters.Count; i++)
+            {
+                var reporter = Reporters[i];
+
+                if (reporter._dataSource is PoolingDataSource poolingDataSource)
+                {
+                    var stats = poolingDataSource.Statistics;
+
+                    measurements.Add(new Measurement<int>(
+                        stats.Idle,
+                        reporter._poolNameTag,
+                        new KeyValuePair<string, object?>("state", "idle")));
+
+                    measurements.Add(new Measurement<int>(
+                        stats.Busy,
+                        reporter._poolNameTag,
+                        new KeyValuePair<string, object?>("state", "used")));
+                }
+            }
+
+            return measurements;
+        }
+    }
+
+    static IEnumerable<Measurement<int>> GetMaxConnections()
+    {
+        lock (Reporters)
+        {
+            var measurements = new List<Measurement<int>>();
+
+            foreach (var reporter in Reporters)
+            {
+                if (reporter._dataSource is PoolingDataSource poolingDataSource)
+                {
+                    measurements.Add(new Measurement<int>(poolingDataSource.MaxConnections, reporter._poolNameTag));
+                }
+            }
+
+            return measurements;
+        }
+    }
+
+    static IEnumerable<Measurement<double>> GetPreparedCommandsRatio()
+    {
+        lock (Reporters)
+        {
+            var measurements = new Measurement<double>[Reporters.Count];
+
+            for (var i = 0; i < Reporters.Count; i++)
+            {
+                var reporter = Reporters[i];
+
+                var counters = new CommandCounters
+                {
+                    All = Interlocked.Exchange(ref reporter._commandCounters.All, default)
+                };
+
+                measurements[i] = new Measurement<double>(
+                    (double)counters.PreparedCommandsStarted / counters.CommandsStarted * 100,
+                    reporter._poolNameTag);
+            }
+
+            return measurements;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (Reporters)
+        {
+            Reporters.Remove(this);
+            Reporters.Sort((x,y) => string.Compare(x._dataSource.Name, y._dataSource.Name, StringComparison.Ordinal));
+        }
+    }
+}
+#else
+// Unfortunately, UpDownCounter is only supported starting with net7.0, and since a lot of the metrics rely on it,
+class MetricsReporter : IDisposable
+{
+    public MetricsReporter(NpgsqlDataSource _) {}
+    internal long ReportCommandStart() => 0;
+    internal void ReportCommandStop(long startTimestamp) {}
+    internal void CommandStartPrepared() {}
+    internal void ReportCommandFailed() {}
+    internal void ReportBytesWritten(long bytesWritten) {}
+    internal void ReportBytesRead(long bytesRead) {}
+    internal void ReportConnectionPoolTimeout() {}
+    internal void ReportPendingConnectionRequestStart() {}
+    internal void ReportPendingConnectionRequestStop() {}
+    internal void ReportConnectionCreateTime(TimeSpan duration) {}
+    public void Dispose() {}
+}
+#endif

--- a/src/Npgsql/MetricsReporter.cs
+++ b/src/Npgsql/MetricsReporter.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 // .NET docs on metric instrumentation: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation
 // OpenTelemetry semantic conventions for database metric: https://opentelemetry.io/docs/specs/otel/metrics/semantic_conventions/database-metrics
-class MetricsReporter : IDisposable
+sealed class MetricsReporter : IDisposable
 {
     const string Version = "0.1.0";
 
@@ -55,8 +55,8 @@ class MetricsReporter : IDisposable
         CommandDuration
             = Meter.CreateHistogram<double>("db.client.commands.duration", "ms", "The duration of database commands, in milliseconds.");
 
-        BytesWritten = Meter.CreateCounter<long>("db.client.commands.bytes_read", "The number of bytes read.");
-        BytesRead = Meter.CreateCounter<long>("db.client.commands.bytes_written", "The number of bytes written.");
+        BytesWritten = Meter.CreateCounter<long>("db.client.commands.bytes_written", "The number of bytes written.");
+        BytesRead = Meter.CreateCounter<long>("db.client.commands.bytes_read", "The number of bytes read.");
 
         PendingConnectionRequests = Meter.CreateUpDownCounter<int>(
             "db.client.connections.pending_requests",
@@ -214,13 +214,12 @@ class MetricsReporter : IDisposable
         lock (Reporters)
         {
             Reporters.Remove(this);
-            Reporters.Sort((x,y) => string.Compare(x._dataSource.Name, y._dataSource.Name, StringComparison.Ordinal));
         }
     }
 }
 #else
 // Unfortunately, UpDownCounter is only supported starting with net7.0, and since a lot of the metrics rely on it,
-class MetricsReporter : IDisposable
+sealed class MetricsReporter : IDisposable
 {
     public MetricsReporter(NpgsqlDataSource _) {}
     internal long ReportCommandStart() => 0;

--- a/src/Npgsql/NpgsqlActivitySource.cs
+++ b/src/Npgsql/NpgsqlActivitySource.cs
@@ -4,20 +4,12 @@ using System.Data;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 
 namespace Npgsql;
 
 static class NpgsqlActivitySource
 {
-    static readonly ActivitySource Source;
-
-    static NpgsqlActivitySource()
-    {
-        var assembly = typeof(NpgsqlActivitySource).Assembly;
-        var version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "0.0.0";
-        Source = new("Npgsql", version);
-    }
+    static readonly ActivitySource Source = new("Npgsql", "0.1.0");
 
     internal static bool IsEnabled => Source.HasListeners();
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -232,7 +232,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
                 foreach (var hostPool in multiHostConnectorPool.Pools)
                     NpgsqlEventSource.Log.DataSourceCreated(hostPool);
             else
+            {
                 NpgsqlEventSource.Log.DataSourceCreated(newDataSource);
+            }
         }
         else
             newDataSource.Dispose();
@@ -853,7 +855,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             return Task.CompletedTask;
         }
 
-        return CloseAsync(async);            
+        return CloseAsync(async);
     }
 
     async Task CloseAsync(bool async)
@@ -914,7 +916,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
                     // We're already doing the same in the NpgsqlConnector.Reset for pooled connections
                     // TODO: move reset logic to ConnectorSource.Return
                     connector.Transaction?.UnbindIfNecessary();
-                }  
+                }
 
                 if (Settings.Multiplexing)
                 {
@@ -1228,7 +1230,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         using (NoSynchronizationContextScope.Enter())
             return BeginBinaryExport(copyToCommand, async: true, cancellationToken);
-    } 
+    }
 
     async Task<NpgsqlBinaryExporter> BeginBinaryExport(string copyToCommand, bool async, CancellationToken cancellationToken = default)
     {

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -19,6 +19,15 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
 {
     readonly NpgsqlSlimDataSourceBuilder _internalBuilder;
 
+    /// <summary>
+    /// A diagnostics name used by Npgsql when generating tracing, logging and metrics.
+    /// </summary>
+    public string? Name
+    {
+        get => _internalBuilder.Name;
+        set => _internalBuilder.Name = value;
+    }
+
     /// <inheritdoc />
     public INpgsqlNameTranslator DefaultNameTranslator
     {

--- a/src/Npgsql/NpgsqlDataSourceConfiguration.cs
+++ b/src/Npgsql/NpgsqlDataSourceConfiguration.cs
@@ -11,6 +11,7 @@ using Npgsql.Internal.TypeMapping;
 namespace Npgsql;
 
 sealed record NpgsqlDataSourceConfiguration(
+    string? Name,
     NpgsqlLoggingConfiguration LoggingConfiguration,
     EncryptionHandler EncryptionHandler,
     RemoteCertificateValidationCallback? UserCertificateValidationCallback,

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -56,6 +56,11 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     public string ConnectionString => ConnectionStringBuilder.ToString();
 
     /// <summary>
+    /// A diagnostics name used by Npgsql when generating tracing, logging and metrics.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
     /// Constructs a new <see cref="NpgsqlSlimDataSourceBuilder" />, optionally starting out from the given
     /// <paramref name="connectionString"/>.
     /// </summary>
@@ -521,6 +526,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         }
 
         return new(
+            Name,
             _loggerFactory is null
                 ? NpgsqlLoggingConfiguration.NullConfiguration
                 : new NpgsqlLoggingConfiguration(_loggerFactory, _sensitiveDataLoggingEnabled),

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Npgsql.NpgsqlSlimDataSourceBuilder.EnableFullTextSearch() -> Npgsql.NpgsqlSlimDa
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableRecords() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlBinaryImporter.WriteRow(params object?[]! values) -> void
 Npgsql.NpgsqlBinaryImporter.WriteRowAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), params object?[]! values) -> System.Threading.Tasks.Task!
+Npgsql.NpgsqlDataSourceBuilder.Name.get -> string?
+Npgsql.NpgsqlDataSourceBuilder.Name.set -> void
 Npgsql.NpgsqlDataSourceBuilder.UseRootCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2? rootCertificate) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.UseRootCertificateCallback(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2!>? rootCertificateCallback) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.UseSystemTextJson(System.Text.Json.JsonSerializerOptions? serializerOptions = null, System.Type![]? jsonbClrTypes = null, System.Type![]? jsonClrTypes = null) -> Npgsql.NpgsqlDataSourceBuilder!
@@ -21,6 +23,8 @@ Npgsql.NpgsqlSlimDataSourceBuilder.EnableRanges() -> Npgsql.NpgsqlSlimDataSource
 Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+Npgsql.NpgsqlSlimDataSourceBuilder.Name.get -> string?
+Npgsql.NpgsqlSlimDataSourceBuilder.Name.set -> void
 Npgsql.NpgsqlSlimDataSourceBuilder.NpgsqlSlimDataSourceBuilder(string? connectionString = null) -> void
 Npgsql.NpgsqlSlimDataSourceBuilder.UnmapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool
 Npgsql.NpgsqlSlimDataSourceBuilder.UnmapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> bool


### PR DESCRIPTION
Tested manually for now, see below for the sources of a console app that exercises all these. ~There's some infra in progress for testing metrics, but it seems to not be out/public yet (am following up internally). We can add tests once it is.~

<details>
<summary>Console app to test metrics</summary>

```c#
Console.WriteLine($"Command-line: dotnet-counters monitor --maxHistograms 100 -p {Environment.ProcessId} Npgsql");
Console.WriteLine("Hit any key to start...");

Console.ReadKey();

await using var dataSource1 = NpgsqlDataSource.Create("Host=localhost;Username=test;Password=test");
await using var dataSource2 = new NpgsqlDataSourceBuilder("Host=localhost;Username=test;Password=test;Application Name=foo")
{
    Name = "foo"
}.Build();

while (true)
{
    var task1 = Task.WhenAll(Enumerable.Range(0, Random.Shared.Next(10)).Select(async _ =>
    {
        await using var conn = await dataSource1.OpenConnectionAsync();
        await using var command = new NpgsqlCommand("SELECT pg_sleep(1)", conn);
        if (Random.Shared.Next(3) == 0)
            await command.PrepareAsync();
        await command.ExecuteNonQueryAsync();
    }));

    var task2 = Task.WhenAll(Enumerable.Range(0, Random.Shared.Next(10)).Select(async _ =>
    {
        var sql = Random.Shared.Next(5) == 0
            ? "SELECT bad_sql"
            : "SELECT pg_sleep(1)";
        await using var command = dataSource2.CreateCommand(sql);
        try
        {
            await command.ExecuteNonQueryAsync();
        }
        catch {}
    }));

    Console.Write(".");
    await Task.WhenAll(task1, task2);
}
```

</details>

Note that unfortunately, [UpDownCounter](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.updowncounter-1?view=net-7.0) is only available starting with net7.0; since most of our metrics depend on it, it basically doesn't make sense to do anything for older TFMs. So I'm leaving the older EventSource implementation there - I've verified manually and when targeting net6.0, `dotnet counter` just shows the older EventSource counters instead of the newer OpenTelemetry ones. At some point in the future we can remove that.

Closes #3960
Closes #5108

