### PR TITLE
Change NpgsqlSnakeCaseNameTranslator to use InvariantCulture by default, accept culture parameter

### DIFF
--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -256,8 +256,8 @@ Npgsql.NameTranslation.NpgsqlNullNameTranslator.NpgsqlNullNameTranslator() -> vo
 Npgsql.NameTranslation.NpgsqlNullNameTranslator.TranslateMemberName(string! clrName) -> string!
 Npgsql.NameTranslation.NpgsqlNullNameTranslator.TranslateTypeName(string! clrName) -> string!
 Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator
-Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.NpgsqlSnakeCaseNameTranslator() -> void
-Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.NpgsqlSnakeCaseNameTranslator(bool legacyMode) -> void
+Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.NpgsqlSnakeCaseNameTranslator(System.Globalization.CultureInfo? culture = null) -> void
+Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.NpgsqlSnakeCaseNameTranslator(bool legacyMode, System.Globalization.CultureInfo? culture = null) -> void
 Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.TranslateMemberName(string! clrName) -> string!
 Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.TranslateTypeName(string! clrName) -> string!
 Npgsql.NoticeEventHandler
@@ -1837,7 +1837,7 @@ override sealed Npgsql.NpgsqlParameter.SourceColumnNullMapping.get -> bool
 override sealed Npgsql.NpgsqlParameter.SourceColumnNullMapping.set -> void
 override sealed Npgsql.NpgsqlParameter.SourceVersion.get -> System.Data.DataRowVersion
 override sealed Npgsql.NpgsqlParameter.SourceVersion.set -> void
-static Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.ConvertToSnakeCase(string! name) -> string!
+static Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.ConvertToSnakeCase(string! name, System.Globalization.CultureInfo! culture) -> string!
 static Npgsql.NpgsqlCommandBuilder.DeriveParameters(Npgsql.NpgsqlCommand! command) -> void
 static Npgsql.NpgsqlConnection.ClearAllPools() -> void
 static Npgsql.NpgsqlConnection.ClearPool(Npgsql.NpgsqlConnection! connection) -> void

--- a/test/Npgsql.Tests/SnakeCaseNameTranslatorTests.cs
+++ b/test/Npgsql.Tests/SnakeCaseNameTranslatorTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Npgsql.NameTranslation;
 using NUnit.Framework;
 
@@ -7,45 +9,66 @@ namespace Npgsql.Tests;
 
 public class SnakeCaseNameTranslatorTests
 {
-    [Test, TestCaseSource(typeof(SnakeCaseNameTranslatorTests), nameof(TestCases))]
-    public string TranslateTypeName(string value, bool legacyMode)
-        => new NpgsqlSnakeCaseNameTranslator(legacyMode).TranslateTypeName(value);
+    static readonly CultureInfo trTRCulture = new("tr-TR");
+    static readonly CultureInfo enUSCulture = new("en-US");
 
     [Test, TestCaseSource(typeof(SnakeCaseNameTranslatorTests), nameof(TestCases))]
-    public string TranslateMemberName(string value, bool legacyMode)
-        => new NpgsqlSnakeCaseNameTranslator(legacyMode).TranslateMemberName(value);
+    public string TranslateTypeName(CultureInfo? culture, string value, bool legacyMode)
+        => new NpgsqlSnakeCaseNameTranslator(legacyMode, culture).TranslateTypeName(value);
 
-    static IEnumerable<TestCaseData> TestCases => new (string value, string legacyResult, string result)[]
+    [Test, TestCaseSource(typeof(SnakeCaseNameTranslatorTests), nameof(TestCases))]
+    public string TranslateMemberName(CultureInfo? culture, string value, bool legacyMode)
+        => new NpgsqlSnakeCaseNameTranslator(legacyMode, culture).TranslateMemberName(value);
+
+    static IEnumerable<TestCaseData> TestCases => new (CultureInfo? culture, string value, string legacyResult, string result)[]
     {
-        ("Hi!! This is text. Time to test.", "hi!! _this is text. _time to test.", "hi_this_is_text_time_to_test"),
-        ("9999-12-31T23:59:59.9999999Z", "9999-12-31_t23:59:59.9999999_z", "9999_12_31t23_59_59_9999999z"),
-        ("FK_post_simple_blog_BlogId", "f_k_post_simple_blog__blog_id", "fk_post_simple_blog_blog_id"),
-        ("already_snake_case_ ", "already_snake_case_ ", "already_snake_case_"),
-        ("SHOUTING_CASE", "s_h_o_u_t_i_n_g__c_a_s_e", "shouting_case"),
-        ("IsJSONProperty", "is_j_s_o_n_property", "is_json_property"),
-        ("SnA__ kEcAsE", "sn_a__ k_ec_as_e", "sn_a__k_ec_as_e"),
-        ("SnA__kEcAsE", "sn_a__k_ec_as_e", "sn_a__k_ec_as_e"),
-        ("SnAkEcAsE", "sn_ak_ec_as_e", "sn_ak_ec_as_e"),
-        ("URLValue", "u_r_l_value", "url_value"),
-        ("Xml2Json", "xml2_json", "xml2json"),
-        (" IPhone ", " _i_phone ", "i_phone"),
-        ("I  Phone", "i  _phone", "i_phone"),
-        (" IPhone", " _i_phone", "i_phone"),
-        ("I Phone", "i _phone", "i_phone"),
-        ("IPhone", "i_phone", "i_phone"),
-        ("iPhone", "i_phone", "i_phone"),
-        ("IsCIA", "is_c_i_a", "is_cia"),
-        ("Person", "person", "person"),
-        ("ABC123", "a_b_c123", "abc123"),
-        ("VmQ", "vm_q", "vm_q"),
-        ("URL", "u_r_l", "url"),
-        ("AB1", "a_b1", "ab1"),
-        ("ID", "i_d", "id"),
-        ("I", "i", "i"),
-        ("", "", "")
+        (null, "Hi!! This is text. Time to test.", "hi!! _this is text. _time to test.", "hi_this_is_text_time_to_test"),
+        (null, "9999-12-31T23:59:59.9999999Z", "9999-12-31_t23:59:59.9999999_z", "9999_12_31t23_59_59_9999999z"),
+        (null, "FK_post_simple_blog_BlogId", "f_k_post_simple_blog__blog_id", "fk_post_simple_blog_blog_id"),
+        (null, "already_snake_case_ ", "already_snake_case_ ", "already_snake_case_"),
+        (null, "SHOUTING_CASE", "s_h_o_u_t_i_n_g__c_a_s_e", "shouting_case"),
+        (null, "IsJSONProperty", "is_j_s_o_n_property", "is_json_property"),
+        (null, "SnA__ kEcAsE", "sn_a__ k_ec_as_e", "sn_a__k_ec_as_e"),
+        (null, "SnA__kEcAsE", "sn_a__k_ec_as_e", "sn_a__k_ec_as_e"),
+        (null, "SnAkEcAsE", "sn_ak_ec_as_e", "sn_ak_ec_as_e"),
+        (null, "URLValue", "u_r_l_value", "url_value"),
+        (null, "Xml2Json", "xml2_json", "xml2json"),
+        (null, " IPhone ", " _i_phone ", "i_phone"),
+        (null, "I  Phone", "i  _phone", "i_phone"),
+        (null, " IPhone", " _i_phone", "i_phone"),
+        (null, "I Phone", "i _phone", "i_phone"),
+        (null, "IPhone", "i_phone", "i_phone"),
+        (null, "iPhone", "i_phone", "i_phone"),
+        (null, "IsCIA", "is_c_i_a", "is_cia"),
+        (null, "Person", "person", "person"),
+        (null, "ABC123", "a_b_c123", "abc123"),
+        (null, "VmQ", "vm_q", "vm_q"),
+        (null, "URL", "u_r_l", "url"),
+        (null, "AB1", "a_b1", "ab1"),
+        (null, "ID", "i_d", "id"),
+        (null, "I", "i", "i"),
+        (null, "", "", ""),
+        (trTRCulture, "IPhone", "ı_phone", "ı_phone"), // dotless I -> dotless ı
+        (enUSCulture, "IPhone", "i_phone", "i_phone"),
+        (CultureInfo.InvariantCulture, "IPhone", "i_phone", "i_phone"),
     }.SelectMany(x => new[]
     {
-        new TestCaseData(x.value, true).Returns(x.legacyResult),
-        new TestCaseData(x.value, false).Returns(x.result),
+        new TestCaseData(x.culture, x.value, true).Returns(x.legacyResult),
+        new TestCaseData(x.culture, x.value, false).Returns(x.result),
     });
+
+    [Test, Description("Checks translating a name with letter 'I' in Turkish locale with default setting (Invariant Culture)")]
+    public void TurkeyTest()
+    {
+        var translator = new NpgsqlSnakeCaseNameTranslator();
+
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+        var translatedMemberName = translator.TranslateMemberName("IPhone");
+        var translatedTypeName = translator.TranslateTypeName("IPhone");
+        Thread.CurrentThread.CurrentCulture = originalCulture;
+
+        Assert.AreEqual("i_phone", translatedMemberName);
+        Assert.AreEqual("i_phone", translatedTypeName);
+    }
 }

--- a/test/Npgsql.Tests/SnakeCaseNameTranslatorTests.cs
+++ b/test/Npgsql.Tests/SnakeCaseNameTranslatorTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using Npgsql.NameTranslation;
 using NUnit.Framework;
 
@@ -58,17 +57,18 @@ public class SnakeCaseNameTranslatorTests
     });
 
     [Test, Description("Checks translating a name with letter 'I' in Turkish locale with default setting (Invariant Culture)")]
+    [SetCulture("tr-TR")]
     public void TurkeyTest()
     {
         var translator = new NpgsqlSnakeCaseNameTranslator();
+        var legacyTranslator = new NpgsqlSnakeCaseNameTranslator(true);
 
-        var originalCulture = Thread.CurrentThread.CurrentCulture;
-        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
-        var translatedMemberName = translator.TranslateMemberName("IPhone");
-        var translatedTypeName = translator.TranslateTypeName("IPhone");
-        Thread.CurrentThread.CurrentCulture = originalCulture;
+        const string clrName = "IPhone";
+        const string expected = "i_phone";
 
-        Assert.AreEqual("i_phone", translatedMemberName);
-        Assert.AreEqual("i_phone", translatedTypeName);
+        Assert.AreEqual(expected, translator.TranslateMemberName(clrName));
+        Assert.AreEqual(expected, translator.TranslateTypeName(clrName));
+        Assert.AreEqual(expected, legacyTranslator.TranslateMemberName(clrName));
+        Assert.AreEqual(expected, legacyTranslator.TranslateTypeName(clrName));
     }
 }


### PR DESCRIPTION
Closes #5169 

Hi @roji, I've opened the issue (#5169) with my 2nd account, but opening the PR with my main account. I have a couple of questions:

* I've added the nullable CultureInfo to the constructor as you proposed and gave it a default value null. It will still be a breaking change but at least you can use it as before. Is it ok?
* I've added a CultureInfo parameter to the existing TestCases and set it to null for existing cases and added spesific cases to the end of the list. I can seperate them to another TestCases list in another file if you want


