### PR TITLE
Fix assert if array's type name length exceeds 62

### DIFF
--- a/src/Npgsql/PostgresTypes/PostgresArrayType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresArrayType.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 
 namespace Npgsql.PostgresTypes;
 
@@ -21,7 +22,7 @@ public class PostgresArrayType : PostgresType
     protected internal PostgresArrayType(string ns, string internalName, uint oid, PostgresType elementPostgresType)
         : base(ns, elementPostgresType.Name + "[]", internalName, oid)
     {
-        Debug.Assert(internalName == '_' + elementPostgresType.InternalName);
+        Debug.Assert(internalName == '_' + elementPostgresType.InternalName.Substring(0, Math.Min(62, elementPostgresType.InternalName.Length)));
         Element = elementPostgresType;
         Element.Array = this;
     }


### PR DESCRIPTION
Manually verified with a test:

```csharp
[Test]
[NonParallelizable]
public async Task SneakyTest()
{
	await using var adminConn = await OpenConnectionAsync();
	var schemaName = new string('b', adminConn.Settings.ReadBufferSize * 2);
	var typeName = new string('a', adminConn.Settings.ReadBufferSize * 2);
	await adminConn.ExecuteNonQueryAsync($"""
DROP TYPE IF EXISTS {schemaName}.{typeName} CASCADE;
DROP SCHEMA IF EXISTS {schemaName} CASCADE;
CREATE SCHEMA {schemaName};
CREATE TYPE {schemaName}.{typeName} AS (a INTEGER);
""");
	try
	{
		await using var dataSource = CreateDataSource();
		await using var conn = await dataSource.OpenConnectionAsync();
	}
	finally
	{
		await adminConn.ExecuteNonQueryAsync($"""
DROP TYPE IF EXISTS {schemaName}.{typeName} CASCADE;
DROP SCHEMA IF EXISTS {schemaName} CASCADE;
""");
	}
}
```