### PR TITLE
Consume the stream in LogicalDecodingMessage if the API consumer doesn't

### DIFF
--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -123,6 +123,7 @@ sealed class PgOutputAsyncEnumerable : IAsyncEnumerable<PgOutputReplicationMessa
                 data.Init(checked((int)length), canSeek: false, commandScoped: false);
                 yield return _logicalDecodingMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
                     flags, messageLsn, prefix, data);
+                await data.DisposeAsync().ConfigureAwait(false);
                 continue;
             }
             case BackendReplicationMessageCode.Commit:

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -641,10 +641,11 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
             }, nameof(Dispose_while_replicating));
 
     [Platform(Exclude = "MacOsX", Reason = "Test is flaky in CI on Mac, see https://github.com/npgsql/npgsql/issues/5294")]
-    [TestCase(true)]
-    [TestCase(false)]
+    [TestCase(true, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
     [Test(Description = "Tests whether logical decoding messages get replicated as Logical Replication Protocol Messages on PostgreSQL 14 and above")]
-    public Task LogicalDecodingMessage(bool writeMessages)
+    public Task LogicalDecodingMessage(bool writeMessages, bool readMessages)
         => SafeReplicationTest(
             async (slotName, tableName, publicationName) =>
             {
@@ -689,9 +690,12 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     Assert.That(msg.Flags, Is.EqualTo(1));
                     Assert.That(msg.Prefix, Is.EqualTo(prefix));
                     Assert.That(msg.Data.Length, Is.EqualTo(transactionalMessage.Length));
-                    var buffer = new MemoryStream();
-                    await msg.Data.CopyToAsync(buffer, CancellationToken.None);
-                    Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                    if (readMessages)
+                    {
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                    }
                 }
 
                 // Relation
@@ -712,9 +716,12 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     Assert.That(msg.Flags, Is.EqualTo(0));
                     Assert.That(msg.Prefix, Is.EqualTo(prefix));
                     Assert.That(msg.Data.Length, Is.EqualTo(nonTransactionalMessage.Length));
-                    var buffer = new MemoryStream();
-                    await msg.Data.CopyToAsync(buffer, CancellationToken.None);
-                    Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                    if (readMessages)
+                    {
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                    }
                 }
 
                 if (IsStreaming)
@@ -737,9 +744,12 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                         Assert.That(msg.Flags, Is.EqualTo(1));
                         Assert.That(msg.Prefix, Is.EqualTo(prefix));
                         Assert.That(msg.Data.Length, Is.EqualTo(transactionalMessage.Length));
-                        var buffer = new MemoryStream();
-                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
-                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                        if (readMessages)
+                        {
+                            var buffer = new MemoryStream();
+                            await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                            Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(transactionalMessage));
+                        }
                     }
 
                     // Further inserts
@@ -767,9 +777,13 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
                     Assert.That(msg.Flags, Is.EqualTo(0));
                     Assert.That(msg.Prefix, Is.EqualTo(prefix));
                     Assert.That(msg.Data.Length, Is.EqualTo(nonTransactionalMessage.Length));
-                    var buffer = new MemoryStream();
-                    await msg.Data.CopyToAsync(buffer, CancellationToken.None);
-                    Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                    if (readMessages)
+                    {
+                        var buffer = new MemoryStream();
+                        await msg.Data.CopyToAsync(buffer, CancellationToken.None);
+                        Assert.That(rc.Encoding.GetString(buffer.ToArray()), Is.EqualTo(nonTransactionalMessage));
+                    }
+
                     if (IsStreaming)
                         await messages.MoveNextAsync();
                 }


### PR DESCRIPTION
Closes #5208
