### PR TITLE
Trimming and Aot annotations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Compatible from net6.0 onwards (we get warnings otherwise). This implies IsTrimmable as well -->
-    <IsTrimmable Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')) ">true</IsTrimmable>
+    <IsAotCompatible Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')) ">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Compatible from net6.0 onwards (we get warnings otherwise). This implies IsTrimmable as well -->
+    <IsTrimmable Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')) ">true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.DependencyInjection/NpgsqlServiceCollectionExtensions.cs
+++ b/src/Npgsql.DependencyInjection/NpgsqlServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -29,6 +30,8 @@ public static class NpgsqlServiceCollectionExtensions
     /// Defaults to <see cref="ServiceLifetime.Singleton" />.
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static IServiceCollection AddNpgsqlDataSource(
         this IServiceCollection serviceCollection,
         string connectionString,
@@ -51,6 +54,8 @@ public static class NpgsqlServiceCollectionExtensions
     /// Defaults to <see cref="ServiceLifetime.Singleton" />.
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static IServiceCollection AddNpgsqlDataSource(
         this IServiceCollection serviceCollection,
         string connectionString,
@@ -76,6 +81,8 @@ public static class NpgsqlServiceCollectionExtensions
     /// Defaults to <see cref="ServiceLifetime.Singleton" />.
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static IServiceCollection AddMultiHostNpgsqlDataSource(
         this IServiceCollection serviceCollection,
         string connectionString,
@@ -100,6 +107,8 @@ public static class NpgsqlServiceCollectionExtensions
     /// Defaults to <see cref="ServiceLifetime.Singleton" />.
     /// </param>
     /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static IServiceCollection AddMultiHostNpgsqlDataSource(
         this IServiceCollection serviceCollection,
         string connectionString,
@@ -108,6 +117,8 @@ public static class NpgsqlServiceCollectionExtensions
         => AddNpgsqlMultiHostDataSourceCore(
             serviceCollection, connectionString, dataSourceBuilderAction: null, connectionLifetime, dataSourceLifetime);
 
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     static IServiceCollection AddNpgsqlDataSourceCore(
         this IServiceCollection serviceCollection,
         string connectionString,
@@ -132,6 +143,8 @@ public static class NpgsqlServiceCollectionExtensions
         return serviceCollection;
     }
 
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     static IServiceCollection AddNpgsqlMultiHostDataSourceCore(
         this IServiceCollection serviceCollection,
         string connectionString,

--- a/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
+++ b/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
 using Newtonsoft.Json;
@@ -23,6 +24,8 @@ public static class NpgsqlJsonNetExtensions
     /// <param name="jsonClrTypes">
     /// A list of CLR types to map to PostgreSQL <c>json</c> (no need to specify <see cref="NpgsqlDbType.Json" />).
     /// </param>
+    [RequiresUnreferencedCode("Json serializer may perform reflection on trimmed types.")]
+    [RequiresDynamicCode("Serializing arbitary types to json can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static INpgsqlTypeMapper UseJsonNet(
         this INpgsqlTypeMapper mapper,
         JsonSerializerSettings? settings = null,

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeInfo.cs
@@ -20,7 +20,7 @@ sealed class CompositeInfo<T>
             }
 
         var parameterSum = 0;
-        for(var i = constructorParameters - 1; i > 0; i--)
+        for (var i = constructorParameters - 1; i > 0; i--)
             parameterSum += i;
 
         var argumentsSum = 0;

--- a/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
+++ b/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
@@ -11,6 +11,7 @@ using NpgsqlTypes;
 
 namespace Npgsql.Internal.Composites;
 
+[RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
 static class ReflectionCompositeInfoFactory
 {
     public static CompositeInfo<T> CreateCompositeInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(

--- a/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
+++ b/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
@@ -154,7 +154,7 @@ static class ReflectionCompositeInfoFactory
     static Expression UnboxAny(Expression expression, Type type)
         => type.IsValueType ? Expression.Unbox(expression, type) : Expression.Convert(expression, type, null);
 
-#if NET8_0_OR_GREATER
+#if !NETSTANDARD
     [DynamicDependency("TypedValue", typeof(StrongBox<>))]
     [DynamicDependency("Length", typeof(StrongBox[]))]
 #endif

--- a/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
+++ b/src/Npgsql/Internal/Composites/ReflectionCompositeInfoFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,7 +13,8 @@ namespace Npgsql.Internal.Composites;
 
 static class ReflectionCompositeInfoFactory
 {
-    public static CompositeInfo<T> CreateCompositeInfo<T>(PostgresCompositeType pgType, INpgsqlNameTranslator nameTranslator, PgSerializerOptions options)
+    public static CompositeInfo<T> CreateCompositeInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        PostgresCompositeType pgType, INpgsqlNameTranslator nameTranslator, PgSerializerOptions options)
     {
         var pgFields = pgType.Fields;
         var propertyMap = MapProperties<T>(pgFields, nameTranslator);
@@ -86,8 +88,8 @@ static class ReflectionCompositeInfoFactory
 
         Debug.Assert(compositeFields.All(x => x is not null));
 
-        var constructor = constructorInfo is null ? null : CreateStrongBoxConstructor<T>(constructorInfo);
-        return new CompositeInfo<T>(compositeFields!, constructorInfo is null ? null : constructorParameters.Length, constructor);
+        var constructor = constructorInfo is null ? _ => Activator.CreateInstance<T>() : CreateStrongBoxConstructor<T>(constructorInfo);
+        return new CompositeInfo<T>(compositeFields!, constructorInfo is null ? 0 : constructorParameters.Length, constructor);
 
         // We have to map the pg type back to the composite field type, as we've resolved based on the representational pg type.
         PgConverterResolution MapResolution(PostgresCompositeType.Field field, PgConverterResolution resolution)
@@ -151,6 +153,11 @@ static class ReflectionCompositeInfoFactory
     static Expression UnboxAny(Expression expression, Type type)
         => type.IsValueType ? Expression.Unbox(expression, type) : Expression.Convert(expression, type, null);
 
+#if NET8_0_OR_GREATER
+    [DynamicDependency("TypedValue", typeof(StrongBox<>))]
+    [DynamicDependency("Length", typeof(StrongBox[]))]
+#endif
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "DynamicDependencies in place for the System.Linq.Expression.Property calls")]
     static Func<StrongBox[], T> CreateStrongBoxConstructor<T>(ConstructorInfo constructorInfo)
     {
         var values = Expression.Parameter(typeof(StrongBox[]), "values");
@@ -187,7 +194,7 @@ static class ReflectionCompositeInfoFactory
         => (CompositeFieldInfo)Activator.CreateInstance(
             typeof(CompositeFieldInfo<>).MakeGenericType(type), name, converterResolution, getter, setter)!;
 
-    static Dictionary<int, PropertyInfo> MapProperties<T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
+    static Dictionary<int, PropertyInfo> MapProperties<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
     {
         var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
         var propertiesAndNames = properties.Select(x =>
@@ -215,7 +222,7 @@ static class ReflectionCompositeInfoFactory
         return result;
     }
 
-    static Dictionary<int, FieldInfo> MapFields<T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
+    static Dictionary<int, FieldInfo> MapFields<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
     {
         var clrFields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Instance);
         var clrFieldsAndNames = clrFields.Select(x =>
@@ -243,7 +250,7 @@ static class ReflectionCompositeInfoFactory
         return result;
     }
 
-    static (ConstructorInfo? ConstructorInfo, int[] ParameterFieldMap) MapBestMatchingConstructor<T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
+    static (ConstructorInfo? ConstructorInfo, int[] ParameterFieldMap) MapBestMatchingConstructor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IReadOnlyList<PostgresCompositeType.Field> fields, INpgsqlNameTranslator nameTranslator)
     {
         ConstructorInfo? clrDefaultConstructor = null;
         foreach (var constructor in typeof(T).GetConstructors().OrderByDescending(x => x.GetParameters().Length))

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
@@ -65,6 +66,7 @@ sealed class CastingConverterResolver<T> : PgComposingConverterResolver<T>
 
 static class CastingTypeInfoExtensions
 {
+    [RequiresDynamicCode("Changing boxing converters to their non-boxing counterpart can require creating new generic types or methods, which requires creating code at runtime. This may not be AOT  when AOT compiling")]
     internal static PgTypeInfo ToNonBoxing(this PgTypeInfo typeInfo)
     {
         if (!typeInfo.IsBoxing)

--- a/src/Npgsql/Internal/Converters/SystemTextJsonConverter.cs
+++ b/src/Npgsql/Internal/Converters/SystemTextJsonConverter.cs
@@ -20,9 +20,8 @@ sealed class SystemTextJsonConverter<T, TBase> : PgStreamingConverter<T?> where 
 
     public SystemTextJsonConverter(bool jsonb, Encoding textEncoding, JsonSerializerOptions serializerOptions)
     {
-        // We do GetTypeInfo calls directly so we need a resolver.
         if (serializerOptions.TypeInfoResolver is null)
-            serializerOptions.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
+            throw new InvalidOperationException("System.Text.Json serialization requires a type info resolver, make sure to set-it up beforehand.");
 
         _jsonb = jsonb;
         _textEncoding = textEncoding;

--- a/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
@@ -6,7 +6,6 @@ using Npgsql.PostgresTypes;
 
 namespace Npgsql.Internal;
 
-[RequiresUnreferencedCode("A dynamic type info resolver may perform reflection on types that were trimmed if not referenced directly.")]
 [RequiresDynamicCode("A dynamic type info resolver may need to construct a generic converter for a statically unknown type.")]
 public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
 {
@@ -43,6 +42,7 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
 
     protected abstract DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options);
 
+    [RequiresDynamicCode("A dynamic type info resolver may need to construct a generic converter for a statically unknown type.")]
     protected class DynamicMappingCollection
     {
         TypeInfoMappingCollection? _mappings;

--- a/src/Npgsql/Internal/Resolvers/SystemTextJsonTypeInfoResolvers.cs
+++ b/src/Npgsql/Internal/Resolvers/SystemTextJsonTypeInfoResolvers.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Npgsql.Internal.Converters;
 using Npgsql.Internal.Postgres;
 
@@ -13,12 +15,18 @@ class SystemTextJsonTypeInfoResolver : IPgTypeInfoResolver
     public SystemTextJsonTypeInfoResolver(JsonSerializerOptions? serializerOptions = null)
         => AddTypeInfos(Mappings, serializerOptions);
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Only used to request rooted and statically known types (JsonDocument,JsonElement etc).")]
+    [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Only used to request rooted and statically known types  (JsonDocument,JsonElement etc).")]
     static void AddTypeInfos(TypeInfoMappingCollection mappings, JsonSerializerOptions? serializerOptions = null)
     {
 #if NET7_0_OR_GREATER
         serializerOptions ??= JsonSerializerOptions.Default;
 #else
-        serializerOptions ??= new JsonSerializerOptions();
+        if (serializerOptions is null)
+        {
+            serializerOptions = new JsonSerializerOptions();
+            serializerOptions.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
+        }
 #endif
 
         // Jsonb is the first default for JsonDocument

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -380,9 +380,10 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         get => _userFacingConnectionString;
 
-        [RequiresUnreferencedCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
-        [RequiresDynamicCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
-        [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC and RDC to DbConnection.")]
+        [RequiresUnreferencedCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+        [RequiresDynamicCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to DbConnection.")]
+        [UnconditionalSuppressMessage("Aot", "IL3051", Justification = "At the Npgsql level we cannot add RDC to DbConnection.")]
         set
         {
             CheckClosed();

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -127,6 +127,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// Initializes a new instance of <see cref="NpgsqlConnection"/> with the given connection string.
     /// </summary>
     /// <param name="connectionString">The connection used to open the PostgreSQL database.</param>
+
+    [RequiresUnreferencedCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public NpgsqlConnection(string? connectionString) : this()
         => ConnectionString = connectionString;
 
@@ -167,6 +170,8 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <returns>A task representing the asynchronous operation.</returns>
     public override Task OpenAsync(CancellationToken cancellationToken) => Open(async: true, cancellationToken);
 
+    [RequiresUnreferencedCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     void SetupDataSource()
     {
         // Fast path: a pool already corresponds to this exact version of the connection string.
@@ -374,6 +379,10 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     public override string ConnectionString
     {
         get => _userFacingConnectionString;
+
+        [RequiresUnreferencedCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+        [RequiresDynamicCode("NpgsqlConnection uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC and RDC to DbConnection.")]
         set
         {
             CheckClosed();
@@ -1732,6 +1741,8 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// in the Restrictions collection.
     /// </param>
     /// <returns>The collection specified.</returns>
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchemaAsync.")]
     public override DataTable GetSchema(string? collectionName, string?[]? restrictions)
         => NpgsqlSchema.GetSchema(async: false, this, collectionName, restrictions).GetAwaiter().GetResult();
 
@@ -1742,7 +1753,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The collection specified.</returns>
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
 #if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchemaAsync.")]
     public override Task<DataTable> GetSchemaAsync(CancellationToken cancellationToken = default)
 #else
     public Task<DataTable> GetSchemaAsync(CancellationToken cancellationToken = default)
@@ -1757,7 +1770,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The collection specified.</returns>
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
 #if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchemaAsync.")]
     public override Task<DataTable> GetSchemaAsync(string collectionName, CancellationToken cancellationToken = default)
 #else
     public Task<DataTable> GetSchemaAsync(string collectionName, CancellationToken cancellationToken = default)
@@ -1776,7 +1791,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
     /// <returns>The collection specified.</returns>
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
 #if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchemaAsync.")]
     public override Task<DataTable> GetSchemaAsync(string collectionName, string?[]? restrictions, CancellationToken cancellationToken = default)
 #else
     public Task<DataTable> GetSchemaAsync(string collectionName, string?[]? restrictions, CancellationToken cancellationToken = default)
@@ -1822,6 +1839,8 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// (password, SSL callbacks) while changing other connection parameters (e.g.
     /// database or pooling)
     /// </summary>
+    [RequiresUnreferencedCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public NpgsqlConnection CloneWith(string connectionString)
     {
         CheckDisposed();
@@ -1870,7 +1889,14 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <summary>
     /// DB provider factory.
     /// </summary>
-    protected override DbProviderFactory DbProviderFactory => NpgsqlFactory.Instance;
+    protected override DbProviderFactory DbProviderFactory
+    {
+        [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+        [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to DbProviderFactory.")]
+        [UnconditionalSuppressMessage("Aot", "IL3051", Justification = "At the Npgsql level we cannot add RDC to DbProviderFactory.")]
+        get => NpgsqlFactory.Instance;
+    }
 
     /// <summary>
     /// Clears the connection pool. All idle physical connections in the pool of the given connection are

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1721,8 +1721,8 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <summary>
     /// Returns the supported collections
     /// </summary>
-    [UnconditionalSuppressMessage(
-        "Composite type mapping currently isn't trimming-safe, and warnings are generated at the MapComposite level.", "IL2026")]
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchema.")]
     public override DataTable GetSchema()
         => GetSchema("MetaDataCollections", null);
 
@@ -1731,6 +1731,8 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// </summary>
     /// <param name="collectionName">The collection name.</param>
     /// <returns>The collection specified.</returns>
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "At the Npgsql level we cannot add RUC to GetSchema.")]
     public override DataTable GetSchema(string? collectionName) => GetSchema(collectionName, null);
 
     /// <summary>

--- a/src/Npgsql/NpgsqlDataAdapter.cs
+++ b/src/Npgsql/NpgsqlDataAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -61,6 +62,8 @@ public sealed class NpgsqlDataAdapter : DbDataAdapter
     /// </summary>
     /// <param name="selectCommandText"></param>
     /// <param name="selectConnectionString"></param>
+    [RequiresUnreferencedCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("ConnectionString based NpgsqlConnections use reflection to handle various PostgreSQL types like records, unmapped enums, etc. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public NpgsqlDataAdapter(string selectCommandText, string selectConnectionString)
         : this(selectCommandText, new NpgsqlConnection(selectConnectionString)) {}
 
@@ -140,6 +143,7 @@ public sealed class NpgsqlDataAdapter : DbDataAdapter
     }
 
     // Temporary implementation, waiting for official support in System.Data via https://github.com/dotnet/runtime/issues/22109
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     internal async Task<int> Fill(DataTable dataTable, bool async, CancellationToken cancellationToken = default)
     {
         var command = SelectCommand;
@@ -172,6 +176,7 @@ public sealed class NpgsqlDataAdapter : DbDataAdapter
         }
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     async Task<int> Fill(DataTable dataTable, NpgsqlDataReader dataReader, bool async, CancellationToken cancellationToken = default)
     {
         dataTable.BeginLoadData();

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1829,10 +1829,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 #endif
         => GetSchemaTable(async: true, cancellationToken);
 
-#if NET8_0_OR_GREATER
-    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties, typeof(Type))]
-#endif
-    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "DynamicDependency on Type in place.")]
+     [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "typeof(Type).TypeInitializer is not used.")]
     async Task<DataTable?> GetSchemaTable(bool async, CancellationToken cancellationToken = default)
     {
         if (FieldCount == 0) // No resultset

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -207,12 +207,16 @@ public abstract class NpgsqlDataSource : DbDataSource
     /// <summary>
     /// Creates a new <see cref="NpgsqlDataSource" /> for the given <paramref name="connectionString" />.
     /// </summary>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static NpgsqlDataSource Create(string connectionString)
         => new NpgsqlDataSourceBuilder(connectionString).Build();
 
     /// <summary>
     /// Creates a new <see cref="NpgsqlDataSource" /> for the given <paramref name="connectionStringBuilder" />.
     /// </summary>
+    [RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+    [RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public static NpgsqlDataSource Create(NpgsqlConnectionStringBuilder connectionStringBuilder)
         => Create(connectionStringBuilder.ToString());
 

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -17,6 +17,8 @@ namespace Npgsql;
 /// <summary>
 /// Provides a simple API for configuring and creating an <see cref="NpgsqlDataSource" />, from which database connections can be obtained.
 /// </summary>
+[RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+[RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
 public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
 {
     static UnsupportedTypeInfoResolver<NpgsqlDataSourceBuilder> UnsupportedTypeInfoResolver { get; } = new();
@@ -298,6 +300,8 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
     /// <param name="jsonClrTypes">
     /// A list of CLR types to map to PostgreSQL <c>json</c> (no need to specify <see cref="NpgsqlDbType.Json" />).
     /// </param>
+    [RequiresUnreferencedCode("Json serializer may perform reflection on trimmed types.")]
+    [RequiresDynamicCode("Serializing arbitary types to json can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public NpgsqlDataSourceBuilder UseSystemTextJson(
         JsonSerializerOptions? serializerOptions = null,
         Type[]? jsonbClrTypes = null,
@@ -309,7 +313,7 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
     {
         _internalBuilder.MapEnum<TEnum>(pgName, nameTranslator);
@@ -317,34 +321,34 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    public bool UnmapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
         => _internalBuilder.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _internalBuilder.MapComposite<T>(pgName, nameTranslator);
         return this;
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _internalBuilder.MapComposite(clrType, pgName, nameTranslator);
         return this;
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _internalBuilder.UnmapComposite<T>(pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public bool UnmapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _internalBuilder.UnmapComposite(clrType, pgName, nameTranslator);
 
     #endregion Type mapping

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -17,8 +17,8 @@ namespace Npgsql;
 /// <summary>
 /// Provides a simple API for configuring and creating an <see cref="NpgsqlDataSource" />, from which database connections can be obtained.
 /// </summary>
-[RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
-[RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
+[RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums, etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+[RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums, etc. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
 public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
 {
     static UnsupportedTypeInfoResolver<NpgsqlDataSourceBuilder> UnsupportedTypeInfoResolver { get; } = new();

--- a/src/Npgsql/NpgsqlFactory.cs
+++ b/src/Npgsql/NpgsqlFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace Npgsql;
 
@@ -9,6 +8,8 @@ namespace Npgsql;
 /// A factory to create instances of various Npgsql objects.
 /// </summary>
 [Serializable]
+[RequiresUnreferencedCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums etc. Use NpgsqlSlimDataSourceBuilder to start with a reduced - reflection free - set and opt into what your app specifically requires.")]
+[RequiresDynamicCode("NpgsqlDataSource uses reflection to handle various PostgreSQL types like records, unmapped enums. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
 public sealed class NpgsqlFactory : DbProviderFactory, IServiceProvider
 {
     /// <summary>

--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -52,7 +53,11 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
                 : new UnpooledDataSource(poolSettings, dataSourceConfig);
         }
 
-        var targetSessionAttributeValues = (TargetSessionAttributes[])Enum.GetValues(typeof(TargetSessionAttributes));
+#if NETSTANDARD
+        var targetSessionAttributeValues = Enum.GetValues(typeof(TargetSessionAttributes)).Cast<TargetSessionAttributes>().ToArray();
+#else
+        var targetSessionAttributeValues = Enum.GetValues<TargetSessionAttributes>().ToArray();
+#endif
         var highestValue = 0;
         foreach (var value in targetSessionAttributeValues)
             if ((int)value > highestValue)

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -293,10 +294,11 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     }
 
     /// <inheritdoc />
+    [UnconditionalSuppressMessage("ILLink", "IL2093", Justification = "No members are dynamically accessed by Npgsql via NpgsqlNestedDataReader.GetFieldType.")]
     public override Type GetFieldType(int ordinal)
     {
         var column = CheckRowAndColumn(ordinal);
-        return column.ObjectOrDefaultTypeInfo.Type;
+        return column.ObjectOrDefaultInfo.TypeToConvert;
     }
 
     /// <inheritdoc />

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -342,7 +342,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     [DbProviderSpecificTypeProperty(true)]
     public NpgsqlDbType NpgsqlDbType
     {
-        [RequiresUnreferencedCode("The NpgsqlDbType getter isn't trimming-safe")]
         get
         {
             if (_npgsqlDbType.HasValue)

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Threading;
@@ -17,6 +18,7 @@ namespace Npgsql;
 /// </summary>
 static class NpgsqlSchema
 {
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     public static Task<DataTable> GetSchema(bool async, NpgsqlConnection conn, string? collectionName, string?[]? restrictions, CancellationToken cancellationToken = default)
     {
         if (collectionName is null)
@@ -154,6 +156,7 @@ static class NpgsqlSchema
     static string RemoveSpecialChars(string paramName)
         => paramName.Replace("(", "").Replace(")", "").Replace(".", "");
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetDatabases(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var databases = new DataTable("Databases") { Locale = CultureInfo.InvariantCulture };
@@ -175,6 +178,7 @@ static class NpgsqlSchema
         return databases;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetSchemata(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var schemata = new DataTable("Schemata") { Locale = CultureInfo.InvariantCulture };
@@ -201,7 +205,7 @@ SELECT * FROM (
         return schemata;
     }
 
-
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetTables(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var tables = new DataTable("Tables") { Locale = CultureInfo.InvariantCulture };
@@ -229,6 +233,7 @@ WHERE
         return tables;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetColumns(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var columns = new DataTable("Columns") { Locale = CultureInfo.InvariantCulture };
@@ -269,6 +274,7 @@ JOIN pg_type AS typ ON typnamespace = ns.oid AND typname = udt_name");
         return columns;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetViews(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var views = new DataTable("Views") { Locale = CultureInfo.InvariantCulture };
@@ -290,6 +296,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
         return views;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetUsers(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var users = new DataTable("Users") { Locale = CultureInfo.InvariantCulture };
@@ -307,6 +314,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')");
         return users;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetIndexes(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var indexes = new DataTable("Indexes") { Locale = CultureInfo.InvariantCulture };
@@ -340,6 +348,7 @@ WHERE
         return indexes;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetIndexColumns(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var indexColumns = new DataTable("IndexColumns") { Locale = CultureInfo.InvariantCulture };
@@ -380,6 +389,7 @@ WHERE
         return indexColumns;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetConstraints(NpgsqlConnection conn, string?[]? restrictions, string? constraintType, bool async, CancellationToken cancellationToken = default)
     {
         var getConstraints = new StringBuilder(@"
@@ -423,6 +433,7 @@ FROM
         return table;
     }
 
+    [RequiresUnreferencedCode("Members from serialized types or types used in expressions may be trimmed if not referenced directly.")]
     static async Task<DataTable> GetConstraintColumns(NpgsqlConnection conn, string?[]? restrictions, bool async, CancellationToken cancellationToken = default)
     {
         var getConstraintColumns = new StringBuilder(@"

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -260,7 +260,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     public INpgsqlNameTranslator DefaultNameTranslator { get; set; } = GlobalTypeMapper.Instance.DefaultNameTranslator;
 
     /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
     {
         _userTypeMapper.MapEnum<TEnum>(pgName, nameTranslator);
@@ -268,34 +268,34 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    public bool UnmapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
         => _userTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _userTypeMapper.MapComposite(typeof(T), pgName, nameTranslator);
         return this;
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping isn't trimming-safe.")]
-    public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _userTypeMapper.MapComposite(clrType, pgName, nameTranslator);
         return this;
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping isn't trimming-safe.")]
-    public bool UnmapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(clrType, pgName, nameTranslator);
 
     /// <summary>
@@ -373,6 +373,8 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     /// A list of CLR types to map to PostgreSQL <c>json</c> (no need to specify <see cref="NpgsqlDbType.Json" />).
     /// </param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    [RequiresUnreferencedCode("Json serializer may perform reflection on trimmed types.")]
+    [RequiresDynamicCode("Serializing arbitary types to json can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public NpgsqlSlimDataSourceBuilder UseSystemTextJson(
         JsonSerializerOptions? serializerOptions = null,
         Type[]? jsonbClrTypes = null,

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -273,6 +273,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         => _userTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
@@ -281,11 +282,13 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
@@ -294,6 +297,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(clrType, pgName, nameTranslator);

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -80,7 +80,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <summary>
     /// The <see cref="TypeConverter"/> used by <see cref="Parse"/> to convert <see cref="string"/> bounds into <typeparamref name="T"/>.
     /// </summary>
-    static readonly TypeConverter BoundConverter = TypeDescriptor.GetConverter(typeof(T));
+    static TypeConverter? BoundConverter;
 
     /// <summary>
     /// True if <typeparamref name="T"/> implements <see cref="IEquatable{T}"/>; otherwise, false.
@@ -375,6 +375,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/rangetypes.html
     /// </remarks>
+    [RequiresUnreferencedCode("Parse implementations for certain types of T may require members that have been trimmed.")]
     public static NpgsqlRange<T> Parse(string value)
     {
         if (value is null)
@@ -429,6 +430,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
             string.Equals(upperSegment, NullLiteral, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(upperSegment, UpperInfinityLiteral, StringComparison.OrdinalIgnoreCase);
 
+        BoundConverter ??= TypeDescriptor.GetConverter(typeof(T));
         var lower = lowerInfinite ? default : (T?)BoundConverter.ConvertFromString(lowerSegment);
         var upper = upperInfinite ? default : (T?)BoundConverter.ConvertFromString(upperSegment);
 
@@ -438,6 +440,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <summary>
     /// Represents a type converter for <see cref="NpgsqlRange{T}" />.
     /// </summary>
+    [RequiresUnreferencedCode("ConvertFrom implementations for certain types of T may require members that have been trimmed.")]
     public class RangeTypeConverter : TypeConverter
     {
         /// <summary>

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -216,14 +216,17 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => MapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => UnmapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
@@ -241,6 +244,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -172,7 +172,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where TEnum : struct, Enum
+    public INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where TEnum : struct, Enum
     {
         _lock.EnterWriteLock();
         try
@@ -194,7 +194,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    public bool UnmapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where TEnum : struct, Enum
+    public bool UnmapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where TEnum : struct, Enum
     {
         _lock.EnterWriteLock();
         try
@@ -216,18 +216,16 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => MapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public bool UnmapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => UnmapComposite(typeof(T), pgName, nameTranslator);
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public INpgsqlTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _lock.EnterWriteLock();
         try
@@ -243,8 +241,8 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
     }
 
     /// <inheritdoc />
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public bool UnmapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _lock.EnterWriteLock();
         try

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -82,6 +82,7 @@ public interface INpgsqlTypeMapper
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
     /// <typeparam name="T">The .NET type to be mapped</typeparam>
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
@@ -97,6 +98,7 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
     /// </param>
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
@@ -120,6 +122,7 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     INpgsqlTypeMapper MapComposite(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  Type clrType,
         string? pgName = null,
@@ -137,6 +140,7 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     bool UnmapComposite(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] Type clrType,
         string? pgName = null,

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -41,7 +41,7 @@ public interface INpgsqlTypeMapper
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
     /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
-    INpgsqlTypeMapper MapEnum<TEnum>(
+    INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum;
@@ -57,7 +57,7 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
-    bool UnmapEnum<TEnum>(
+    bool UnmapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum;
@@ -82,8 +82,7 @@ public interface INpgsqlTypeMapper
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
     /// <typeparam name="T">The .NET type to be mapped</typeparam>
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    INpgsqlTypeMapper MapComposite<T>(
+    INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
 
@@ -98,8 +97,7 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>
     /// </param>
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    bool UnmapComposite<T>(
+    bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
 
@@ -122,9 +120,8 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
     INpgsqlTypeMapper MapComposite(
-        Type clrType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]  Type clrType,
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
 
@@ -140,9 +137,8 @@ public interface INpgsqlTypeMapper
     /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
     /// Defaults to <see cref="DefaultNameTranslator" />.
     /// </param>
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
     bool UnmapComposite(
-        Type clrType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] Type clrType,
         string? pgName = null,
         INpgsqlNameTranslator? nameTranslator = null);
 

--- a/src/Npgsql/TypeMapping/UserTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/UserTypeMapper.cs
@@ -57,6 +57,7 @@ sealed class UserTypeMapper
         where TEnum : struct, Enum
         => Unmap(typeof(TEnum), out _, pgName, nameTranslator ?? DefaultNameTranslator);
 
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public UserTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : class
     {
@@ -65,6 +66,7 @@ sealed class UserTypeMapper
         return this;
     }
 
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     public UserTypeMapper MapStructComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : struct
     {
@@ -74,6 +76,7 @@ sealed class UserTypeMapper
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "MapStructComposite and MapComposite have identical DAM annotations to clrType.")]
+    [RequiresDynamicCode("MapComposite switches between MapStructComposite and MapComposite at runtime based on clr type. This can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
     public UserTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
@@ -137,6 +140,7 @@ sealed class UserTypeMapper
             => _mappings.Find(type, dataTypeName, options);
     }
 
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     sealed class CompositeMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T> : UserTypeMapping where T : class
     {
         readonly INpgsqlNameTranslator _nameTranslator;
@@ -161,6 +165,7 @@ sealed class UserTypeMapper
         }
     }
 
+    [RequiresDynamicCode("Serializing arbitary types can require creating new generic types or methods. This may not work when AOT compiling.")]
     sealed class StructCompositeMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T> : UserTypeMapping where T : struct
     {
         readonly INpgsqlNameTranslator _nameTranslator;

--- a/src/Npgsql/TypeMapping/UserTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/UserTypeMapper.cs
@@ -44,7 +44,7 @@ sealed class UserTypeMapper
 
     public UserTypeMapper Clone() => new(_mappings) { DefaultNameTranslator = DefaultNameTranslator };
 
-    public UserTypeMapper MapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public UserTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
     {
         Unmap(typeof(TEnum), out var resolvedName, pgName, nameTranslator);
@@ -52,26 +52,30 @@ sealed class UserTypeMapper
         return this;
     }
 
-    public bool UnmapEnum<TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    public bool UnmapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
         => Unmap(typeof(TEnum), out _, pgName, nameTranslator ?? DefaultNameTranslator);
 
-    public UserTypeMapper MapComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : class
+    public UserTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : class
     {
         Unmap(typeof(T), out var resolvedName, pgName, nameTranslator);
         Items.Add(new CompositeMapping<T>(resolvedName, nameTranslator ?? DefaultNameTranslator));
         return this;
     }
 
-    public UserTypeMapper MapStructComposite<T>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : struct
+    public UserTypeMapper MapStructComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
+        string? pgName = null, INpgsqlNameTranslator? nameTranslator = null) where T : struct
     {
         Unmap(typeof(T), out var resolvedName, pgName, nameTranslator);
         Items.Add(new StructCompositeMapping<T>(resolvedName, nameTranslator ?? DefaultNameTranslator));
         return this;
     }
 
-    [RequiresUnreferencedCode("Composite type mapping currently isn't trimming-safe.")]
-    public UserTypeMapper MapComposite(Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    [UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "MapStructComposite and MapComposite have identical DAM annotations to clrType.")]
+    public UserTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         if (clrType.IsConstructedGenericType && clrType.GetGenericTypeDefinition() == typeof(Nullable<>))
             throw new ArgumentException("Cannot map nullable.", nameof(clrType));
@@ -133,7 +137,7 @@ sealed class UserTypeMapper
             => _mappings.Find(type, dataTypeName, options);
     }
 
-    sealed class CompositeMapping<T> : UserTypeMapping where T : class
+    sealed class CompositeMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T> : UserTypeMapping where T : class
     {
         readonly INpgsqlNameTranslator _nameTranslator;
 
@@ -157,7 +161,7 @@ sealed class UserTypeMapper
         }
     }
 
-    sealed class StructCompositeMapping<T> : UserTypeMapping where T : struct
+    sealed class StructCompositeMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] T> : UserTypeMapping where T : struct
     {
         readonly INpgsqlNameTranslator _nameTranslator;
 
@@ -185,12 +189,12 @@ sealed class UserTypeMapper
     {
         internal INpgsqlNameTranslator NameTranslator { get; }
 
-        public EnumMapping(string pgTypeName, Type enumClrType, INpgsqlNameTranslator nameTranslator)
+        public EnumMapping(string pgTypeName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]Type enumClrType, INpgsqlNameTranslator nameTranslator)
             : base(pgTypeName, enumClrType)
             => NameTranslator = nameTranslator;
     }
 
-    sealed class EnumMapping<TEnum> : EnumMapping
+    sealed class EnumMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum> : EnumMapping
         where TEnum : struct, Enum
     {
         readonly Dictionary<TEnum, string> _enumToLabel = new();

--- a/src/Npgsql/VolatileResourceManager.cs
+++ b/src/Npgsql/VolatileResourceManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Transactions;
 using Microsoft.Extensions.Logging;
@@ -95,6 +96,8 @@ sealed class VolatileResourceManager : ISinglePhaseNotification
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Changing Enlist to be false does not affect potentially trimmed out functionality.")]
+    [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Changing Enlist to be false does not cause dynamic codegen.")]
     public void Commit(Enlistment enlistment)
     {
         CheckDisposed();


### PR DESCRIPTION
Another draft based on https://github.com/npgsql/npgsql/pull/5123 so be sure to just look at the last commits.

These are the remaining missing annotations to be able to switch `/src` to `IsAotCompatible:true`

 I've detailed the cases that need special mention below:

First off, all our GetSchema and descendants are marked as RUC `RequiresUnreferencedCode`, this is because the alternative is marking any Type accessible via GetFieldType (so basically any type we have a mapping for) as `DynamicallyAccessedMembers.PublicFields | PublicProperties`. That IMO is very excessive to enable just that crappy feature. I hope we might be able to find a more palatable alternative...

Secondly we now have RDC `RequiresDynamicCode` and RUC on our `NpgsqlDataSourceBuilder`, as we have plenty of reflection and codegen through its default set of resolvers. This builder is referenced by `set_ConnectionString` (via SetupDataSource) and `get_DbProviderFactory` (via DbProviderFactory.CreateDataSource). However the base type defining these properties doesn't have RDC and RUC annotations so the analyzer complains that we don't match the base signature. I don't see a better solution here than suppressing that warning. We don't want to mark the entirety of NpgsqlConnection as RDC/RUC, which would normally be the approach to these mismatches.

Finally we have some antique TypeConverter crap on NpgsqlRange, this entire Parse method should probably be redone based on spans and ISpanParsable. I've marked it as RUC for now.

Closes #4414, closes #4800