### PR TITLE
Hacky exposing of enum type mappings for EFCore.PG

### DIFF
--- a/src/Npgsql/Internal/HackyEnumTypeMapping.cs
+++ b/src/Npgsql/Internal/HackyEnumTypeMapping.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Npgsql.Internal;
+using Npgsql.PostgresTypes;
+using NpgsqlTypes;
+
+namespace Npgsql.Internal;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+/// <summary>
+/// Hacky temporary measure used by EFCore.PG to extract user-configured enum mappings. Accessed via reflection only.
+/// </summary>
+public sealed class HackyEnumTypeMapping
+{
+    public HackyEnumTypeMapping(Type enumClrType, string pgTypeName, INpgsqlNameTranslator nameTranslator)
+    {
+        EnumClrType = enumClrType;
+        PgTypeName = pgTypeName;
+        NameTranslator = nameTranslator;
+    }
+
+    public string PgTypeName { get; }
+    public Type EnumClrType { get; }
+    public INpgsqlNameTranslator NameTranslator { get; }
+}

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -79,6 +80,8 @@ public abstract class NpgsqlDataSource : DbDataSource
 
     readonly INpgsqlNameTranslator _defaultNameTranslator;
 
+    internal List<HackyEnumTypeMapping>? _hackyEnumTypeMappings;
+
     internal NpgsqlDataSource(
         NpgsqlConnectionStringBuilder settings,
         NpgsqlDataSourceConfiguration dataSourceConfig)
@@ -99,6 +102,7 @@ public abstract class NpgsqlDataSource : DbDataSource
                 _periodicPasswordSuccessRefreshInterval,
                 _periodicPasswordFailureRefreshInterval,
                 var resolverChain,
+                _hackyEnumTypeMappings,
                 _defaultNameTranslator,
                 ConnectionInitializer,
                 ConnectionInitializerAsync)

--- a/src/Npgsql/NpgsqlDataSourceConfiguration.cs
+++ b/src/Npgsql/NpgsqlDataSourceConfiguration.cs
@@ -18,6 +18,7 @@ sealed record NpgsqlDataSourceConfiguration(
     TimeSpan PeriodicPasswordSuccessRefreshInterval,
     TimeSpan PeriodicPasswordFailureRefreshInterval,
     IEnumerable<IPgTypeInfoResolver> ResolverChain,
+    List<HackyEnumTypeMapping> HackyEnumMappings,
     INpgsqlNameTranslator DefaultNameTranslator,
     Action<NpgsqlConnection>? ConnectionInitializer,
     Func<NpgsqlConnection, Task>? ConnectionInitializerAsync);

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -517,6 +517,7 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
             _periodicPasswordSuccessRefreshInterval,
             _periodicPasswordFailureRefreshInterval,
             Resolvers(),
+            HackyEnumMappings(),
             DefaultNameTranslator,
             _syncConnectionInitializer,
             _asyncConnectionInitializer);
@@ -534,6 +535,21 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
             resolvers.AddRange(_resolverChain);
 
             return resolvers;
+        }
+
+        List<HackyEnumTypeMapping> HackyEnumMappings()
+        {
+            var mappings = new List<HackyEnumTypeMapping>();
+
+            if (_userTypeMapper.Items.Count > 0)
+                foreach (var userTypeMapping in _userTypeMapper.Items)
+                    if (userTypeMapping is UserTypeMapper.EnumMapping enumMapping)
+                        mappings.Add(new(enumMapping.ClrType, enumMapping.PgTypeName, enumMapping.NameTranslator));
+
+            if (GlobalTypeMapper.Instance.HackyEnumTypeMappings.Count > 0)
+                mappings.AddRange(GlobalTypeMapper.Instance.HackyEnumTypeMappings);
+
+            return mappings;
         }
     }
 

--- a/src/Npgsql/TypeMapping/UserTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/UserTypeMapper.cs
@@ -181,14 +181,23 @@ sealed class UserTypeMapper
         }
     }
 
-    sealed class EnumMapping<TEnum> : UserTypeMapping
+    internal abstract class EnumMapping : UserTypeMapping
+    {
+        internal INpgsqlNameTranslator NameTranslator { get; }
+
+        public EnumMapping(string pgTypeName, Type enumClrType, INpgsqlNameTranslator nameTranslator)
+            : base(pgTypeName, enumClrType)
+            => NameTranslator = nameTranslator;
+    }
+
+    sealed class EnumMapping<TEnum> : EnumMapping
         where TEnum : struct, Enum
     {
         readonly Dictionary<TEnum, string> _enumToLabel = new();
         readonly Dictionary<string, TEnum> _labelToEnum = new();
 
         public EnumMapping(string pgTypeName, INpgsqlNameTranslator nameTranslator)
-            : base(pgTypeName, typeof(TEnum))
+            : base(pgTypeName, typeof(TEnum), nameTranslator)
         {
             foreach (var field in typeof(TEnum).GetFields(BindingFlags.Static | BindingFlags.Public))
             {


### PR DESCRIPTION
This is a 100% awful PR - it's just there to make EFCore.PG 8.0 work. We should definitely think about how we clean this up in the future.