### PR TITLE
Don't mix plural and singular <TargetFramework>

### DIFF
--- a/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
+++ b/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
@@ -4,7 +4,7 @@
         <Authors>Shay Rojansky</Authors>
         <!-- DbDataSource was introduced to .NET in net7.0. Before that Npgsql has its own built-in copy. -->
         <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net7.0</TargetFrameworks>
-        <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+        <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
         <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;di;dependency injection</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -4,7 +4,7 @@
     <Description>Json.NET plugin for Npgsql, allowing transparent serialization/deserialization of JSON objects directly to and from the database.</Description>
     <PackageTags>npgsql;postgresql;json;postgres;ado;ado.net;database;sql</PackageTags>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -5,7 +5,7 @@
     <PackageTags>npgsql;postgresql;postgres;nodatime;date;time;ado;ado;net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -6,7 +6,7 @@
     <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2017</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
This seems to throw off some tooling, e.g. the trimming/AOT analyzers