### PR TITLE
Remove unconditional async element reading cost for PG arrays

### DIFF
--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -502,7 +502,7 @@ sealed class ListBasedArrayConverter<T, TElement> : ArrayConverter<T>, IElementO
     Size? IElementOperations.GetSizeOrDbNull(SizeContext context, object collection, int[] indices, ref object? writeState)
         => _elemConverter.GetSizeOrDbNull(context.Format, context.BufferRequirement, GetValue(collection, indices[0]), ref writeState);
 
-     ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
+    ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
     {
         Debug.Assert(indices.Length is 1);
         if (!isDbNull && async && _elemConverter is PgStreamingConverter<TElement> streamingConverter)

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -431,21 +431,19 @@ sealed class ArrayBasedArrayConverter<T, TElement> : ArrayConverter<T>, IElement
     Size? IElementOperations.GetSizeOrDbNull(SizeContext context, object collection, int[] indices, ref object? writeState)
         => _elemConverter.GetSizeOrDbNull(context.Format, context.BufferRequirement, GetValue(collection, indices), ref writeState);
 
-    unsafe ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
+    ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
     {
-        TElement? result;
-        if (isDbNull)
-            result = default;
-        else if (!async)
-            result = _elemConverter.Read(reader);
-        else
-        {
-            var task = _elemConverter.ReadAsync(reader, cancellationToken);
-            if (!task.IsCompletedSuccessfully)
-                return AwaitTask(task.AsTask(), new(this, &SetResult), collection, indices);
+        if (!isDbNull && async && _elemConverter is PgStreamingConverter<TElement> streamingConverter)
+            return ReadAsync(streamingConverter, reader, collection, indices, cancellationToken);
 
-            result = task.Result;
-        }
+        SetValue(collection, indices, isDbNull ? default : _elemConverter.Read(reader));
+        return new();
+    }
+
+    unsafe ValueTask ReadAsync(PgStreamingConverter<TElement> converter, PgReader reader, object collection, int[] indices, CancellationToken cancellationToken)
+    {
+        if (converter.ReadAsyncAsTask(reader, cancellationToken, out var result) is { } task)
+            return AwaitTask(task, new(this, &SetResult), collection, indices);
 
         SetValue(collection, indices, result);
         return new();
@@ -504,33 +502,31 @@ sealed class ListBasedArrayConverter<T, TElement> : ArrayConverter<T>, IElementO
     Size? IElementOperations.GetSizeOrDbNull(SizeContext context, object collection, int[] indices, ref object? writeState)
         => _elemConverter.GetSizeOrDbNull(context.Format, context.BufferRequirement, GetValue(collection, indices[0]), ref writeState);
 
-    unsafe ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
+     ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, int[] indices, CancellationToken cancellationToken)
     {
         Debug.Assert(indices.Length is 1);
-        TElement? result;
-        if (isDbNull)
-            result = default;
-        else if (!async)
-            result = _elemConverter.Read(reader);
-        else
-        {
-            var task = _elemConverter.ReadAsync(reader, cancellationToken);
-            if (!task.IsCompletedSuccessfully)
-                return AwaitTask(task.AsTask(), new(this, &SetResult), collection, indices);
+        if (!isDbNull && async && _elemConverter is PgStreamingConverter<TElement> streamingConverter)
+            return ReadAsync(streamingConverter, reader, collection, indices, cancellationToken);
 
-            result = task.Result;
-        }
-
-        SetValue(collection, indices[0], result);
+        SetValue(collection, indices[0], isDbNull ? default : _elemConverter.Read(reader));
         return new();
-
-        // Using .Result on ValueTask is equivalent to GetAwaiter().GetResult(), this removes TaskAwaiter<TElement> rooting.
-        static void SetResult(Task task, object collection, int[] indices)
-        {
-            Debug.Assert(task is Task<TElement>);
-            SetValue(collection, indices[0], new ValueTask<TElement>(Unsafe.As<Task<TElement>>(task)).Result);
-        }
     }
+
+     unsafe ValueTask ReadAsync(PgStreamingConverter<TElement> converter, PgReader reader, object collection, int[] indices, CancellationToken cancellationToken)
+     {
+         if (converter.ReadAsyncAsTask(reader, cancellationToken, out var result) is { } task)
+             return AwaitTask(task, new(this, &SetResult), collection, indices);
+
+         SetValue(collection, indices[0], result);
+         return new();
+
+         // Using .Result on ValueTask is equivalent to GetAwaiter().GetResult(), this removes TaskAwaiter<TElement> rooting.
+         static void SetResult(Task task, object collection, int[] indices)
+         {
+             Debug.Assert(task is Task<TElement>);
+             SetValue(collection, indices[0], new ValueTask<TElement>(Unsafe.As<Task<TElement>>(task)).Result);
+         }
+     }
 
     ValueTask IElementOperations.Write(bool async, PgWriter writer, object collection, int[] indices, CancellationToken cancellationToken)
     {

--- a/src/Npgsql/Internal/PgStreamingConverter.cs
+++ b/src/Npgsql/Internal/PgStreamingConverter.cs
@@ -16,6 +16,19 @@ public abstract class PgStreamingConverter<T> : PgConverter<T>
         return format is DataFormat.Binary;
     }
 
+    // Workaround for trimming https://github.com/dotnet/runtime/issues/92850#issuecomment-1744521361
+    internal Task<T>? ReadAsyncAsTask(PgReader reader, CancellationToken cancellationToken, out T result)
+    {
+        var task = ReadAsync(reader, cancellationToken);
+        if (task.IsCompletedSuccessfully)
+        {
+            result = task.Result;
+            return null;
+        }
+        result = default!;
+        return task.AsTask();
+    }
+
     internal sealed override unsafe ValueTask<object> ReadAsObject(
         bool async, PgReader reader, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
When there are no matching instantiations of `PgStreamingConverter<TElement>` for some `List/ArrayBasedArrayConverter<TElement>` then ILC can trim out everything the async branch needs.

Given most of our primitives are implemented via `PgBufferedConverter<T>` the bulk of our async element reading code falls away here. 

Saves **400kb** when a user enables arrays for AdoTypeInfoResolver 🎉 Thank you @MichalStrehovsky!

| Scenario    | Before | After |
|-------------|--------|-------|
| Ado + arrays | 6.1mb  | 5.7mb |
| Ado    | 5.1mb  | 5.1mb |

600kb is beginning to become reasonable for the cost of rooting all these value type `T[]`,`T[,]` (and so on up to 8 dims) `List<T>` and converter instantiations.