### PR TITLE
Add stream support for text types

### DIFF
--- a/src/Npgsql/Internal/Resolvers/AdoTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/Resolvers/AdoTypeInfoResolver.cs
@@ -80,6 +80,9 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Text,
             static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
             MatchRequirement.DataTypeName);
+        mappings.AddType<Stream>(DataTypeNames.Text,
+            static (options, mapping, _) => new PgTypeInfo(options, new StreamByteaConverter(), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+            mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
         //Special mappings, these have no corresponding array mapping.
         mappings.AddType<TextReader>(DataTypeNames.Text,
             static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
@@ -106,6 +109,9 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
             mappings.AddStructType<ReadOnlyMemory<byte>>(dataTypeName,
                 static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
                 MatchRequirement.DataTypeName);
+            mappings.AddType<Stream>(dataTypeName,
+                static (options, mapping, _) => new PgTypeInfo(options, new StreamByteaConverter(), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+                mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(dataTypeName,
                 static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
@@ -127,6 +133,9 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Jsonb,
             static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<ReadOnlyMemory<byte>>(jsonbVersion, new ReadOnlyMemoryByteaConverter())),
             MatchRequirement.DataTypeName);
+        mappings.AddType<Stream>(DataTypeNames.Jsonb,
+            static (options, mapping, _) => new PgTypeInfo(options, new VersionPrefixedTextConverter<Stream>(jsonbVersion, new StreamByteaConverter()), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+            mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
         //Special mappings, these have no corresponding array mapping.
         mappings.AddType<TextReader>(DataTypeNames.Jsonb,
             static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonbVersion, new TextReaderTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
@@ -153,7 +162,7 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Bytea,
             static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()));
         mappings.AddType<Stream>(DataTypeNames.Bytea,
-            static (options, mapping, _) => new PgTypeInfo(options, new StreamByteaConverter(), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type),
+            static (options, mapping, _) => new PgTypeInfo(options, new StreamByteaConverter(), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
             mapping => mapping with { TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
 
         // Varbit
@@ -336,6 +345,7 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         mappings.AddStructArrayType<char>(DataTypeNames.Text);
         mappings.AddArrayType<byte[]>(DataTypeNames.Text);
         mappings.AddStructArrayType<ReadOnlyMemory<byte>>(DataTypeNames.Text);
+        mappings.AddArrayType<Stream>(DataTypeNames.Text);
 
         // Alternative text types
         foreach(var dataTypeName in new[] { "citext", DataTypeNames.Varchar,
@@ -346,6 +356,7 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
             mappings.AddStructArrayType<char>(dataTypeName);
             mappings.AddArrayType<byte[]>(dataTypeName);
             mappings.AddStructArrayType<ReadOnlyMemory<byte>>(dataTypeName);
+            mappings.AddArrayType<Stream>(dataTypeName);
         }
 
         // Jsonb
@@ -353,6 +364,7 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         mappings.AddStructArrayType<char>(DataTypeNames.Jsonb);
         mappings.AddArrayType<byte[]>(DataTypeNames.Jsonb);
         mappings.AddStructArrayType<ReadOnlyMemory<byte>>(DataTypeNames.Jsonb);
+        mappings.AddArrayType<Stream>(DataTypeNames.Jsonb);
 
         // Jsonpath
         mappings.AddArrayType<string>(DataTypeNames.Jsonpath);
@@ -360,6 +372,7 @@ class AdoTypeInfoResolver : IPgTypeInfoResolver
         // Bytea
         mappings.AddArrayType<byte[]>(DataTypeNames.Bytea);
         mappings.AddStructArrayType<ReadOnlyMemory<byte>>(DataTypeNames.Bytea);
+        mappings.AddArrayType<Stream>(DataTypeNames.Bytea);
 
         // Varbit
         // Object mapping first.

--- a/test/Npgsql.Tests/Types/ByteaTests.cs
+++ b/test/Npgsql.Tests/Types/ByteaTests.cs
@@ -54,7 +54,7 @@ public class ByteaTests : MultiplexingTestBase
     [Test]
     public Task Write_as_MemoryStream()
         => AssertTypeWrite(
-            () => new MemoryStream(new byte[] { 1, 2, 3 }), "\\x010203", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false, skipArrayCheck: true);
+            () => new MemoryStream(new byte[] { 1, 2, 3 }), "\\x010203", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
 
     [Test]
     public Task Write_as_MemoryStream_truncated()
@@ -67,7 +67,7 @@ public class ByteaTests : MultiplexingTestBase
         };
 
         return AssertTypeWrite(
-            msFactory, "\\x020304", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false, skipArrayCheck: true);
+            msFactory, "\\x020304", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
     }
 
     [Test]
@@ -79,7 +79,7 @@ public class ByteaTests : MultiplexingTestBase
         var expectedSql = "\\x" + ToHex(bytes);
 
         await AssertTypeWrite(
-            () => new MemoryStream(bytes), expectedSql, "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false, skipArrayCheck: true);
+            () => new MemoryStream(bytes), expectedSql, "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
     }
 
     [Test]
@@ -92,7 +92,7 @@ public class ByteaTests : MultiplexingTestBase
             await File.WriteAllBytesAsync(filePath, new byte[] { 1, 2, 3 });
 
             await AssertTypeWrite(
-                () => FileStreamFactory(filePath, fsList), "\\x010203", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false, skipArrayCheck: true);
+                () => FileStreamFactory(filePath, fsList), "\\x010203", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
         }
         finally
         {
@@ -128,7 +128,7 @@ public class ByteaTests : MultiplexingTestBase
             var expectedSql = "\\x" + ToHex(bytes);
 
             await AssertTypeWrite(
-                () => FileStreamFactory(filePath, fsList), expectedSql, "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false, skipArrayCheck: true);
+                () => FileStreamFactory(filePath, fsList), expectedSql, "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
         }
         finally
         {

--- a/test/Npgsql.Tests/Types/JsonTests.cs
+++ b/test/Npgsql.Tests/Types/JsonTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Data;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -61,6 +63,10 @@ public class JsonTests : MultiplexingTestBase
     public async Task Write_as_ArraySegment_of_char()
         => await AssertTypeWrite(new ArraySegment<char>("""{"K": "V"}""".ToCharArray()), """{"K": "V"}""", PostgresType, NpgsqlDbType,
             isDefault: false);
+
+    [Test]
+    public Task As_MemoryStream()
+        => AssertTypeWrite(() => new MemoryStream("""{"K": "V"}"""u8.ToArray()), """{"K": "V"}""", PostgresType, NpgsqlDbType, isDefault: false);
 
     [Test]
     public async Task As_JsonDocument()

--- a/test/Npgsql.Tests/Types/TextTests.cs
+++ b/test/Npgsql.Tests/Types/TextTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NpgsqlTypes;
@@ -51,6 +52,10 @@ public class TextTests : MultiplexingTestBase
 
         await AssertType("foo", "foo", "citext", NpgsqlDbType.Citext, inferredDbType: DbType.String, isDefaultForWriting: false);
     }
+
+    [Test]
+    public Task Text_as_MemoryStream()
+        => AssertTypeWrite(() => new MemoryStream("foo"u8.ToArray()), "foo", "text", NpgsqlDbType.Text, DbType.String, isDefault: false);
 
     [Test]
     public async Task Text_long()


### PR DESCRIPTION
Also add their array variants. If people want to send arrays of MemoryStreams, then why not.

Supersedes https://github.com/npgsql/npgsql/pull/4623