### PR TITLE
Optimize connection usage in tests

### DIFF
--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -131,7 +131,7 @@ public class CommandTests : MultiplexingTestBase
     [NonParallelizable] // Disables sql rewriting
     public async Task Legacy_batching_is_not_supported_when_EnableSqlParsing_is_disabled()
     {
-        using var _ = DisableSqlRewriting(ClearDataSources);
+        using var _ = DisableSqlRewriting();
 
         using var conn = await OpenConnectionAsync();
         using var cmd = new NpgsqlCommand("SELECT 1; SELECT 2", conn);
@@ -143,7 +143,7 @@ public class CommandTests : MultiplexingTestBase
     [NonParallelizable] // Disables sql rewriting
     public async Task Positional_parameters_are_supported_when_EnableSqlParsing_is_disabled()
     {
-        using var _ = DisableSqlRewriting(ClearDataSources);
+        using var _ = DisableSqlRewriting();
 
         using var conn = await OpenConnectionAsync();
         using var cmd = new NpgsqlCommand("SELECT $1", conn);
@@ -155,7 +155,7 @@ public class CommandTests : MultiplexingTestBase
     [NonParallelizable] // Disables sql rewriting
     public async Task Named_parameters_are_not_supported_when_EnableSqlParsing_is_disabled()
     {
-        using var _ = DisableSqlRewriting(ClearDataSources);
+        using var _ = DisableSqlRewriting();
 
         using var conn = await OpenConnectionAsync();
         using var cmd = new NpgsqlCommand("SELECT @p", conn);

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1046,10 +1046,10 @@ LANGUAGE 'plpgsql'");
     [Test]
     public async Task Clone_with_data_source()
     {
-        await using var connection = await SharedDataSource.OpenConnectionAsync();
+        await using var connection = await DataSource.OpenConnectionAsync();
         await using var clonedConnection = (NpgsqlConnection)((ICloneable)connection).Clone();
 
-        Assert.That(clonedConnection.NpgsqlDataSource, Is.SameAs(SharedDataSource));
+        Assert.That(clonedConnection.NpgsqlDataSource, Is.SameAs(DataSource));
         Assert.DoesNotThrowAsync(() => clonedConnection.OpenAsync());
     }
 

--- a/test/Npgsql.Tests/DataSourceTests.cs
+++ b/test/Npgsql.Tests/DataSourceTests.cs
@@ -185,7 +185,7 @@ public class DataSourceTests : TestBase
     [Test]
     public async Task Cannot_access_connection_transaction_on_data_source_command()
     {
-        await using var command = SharedDataSource.CreateCommand();
+        await using var command = DataSource.CreateCommand();
 
         Assert.That(() => command.Connection, Throws.Exception.TypeOf<NotSupportedException>());
         Assert.That(() => command.Connection = null, Throws.Exception.TypeOf<NotSupportedException>());
@@ -199,7 +199,7 @@ public class DataSourceTests : TestBase
     [Test]
     public async Task Cannot_access_connection_transaction_on_data_source_batch()
     {
-        await using var batch = SharedDataSource.CreateBatch();
+        await using var batch = DataSource.CreateBatch();
 
         Assert.That(() => batch.Connection, Throws.Exception.TypeOf<NotSupportedException>());
         Assert.That(() => batch.Connection = null, Throws.Exception.TypeOf<NotSupportedException>());

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -957,7 +957,7 @@ public class MultipleHostsTests : TestBase
     [NonParallelizable] // Disables sql rewriting
     public async Task Multiple_hosts_with_disabled_sql_rewriting()
     {
-        using var _ = DisableSqlRewriting(ClearDataSources);
+        using var _ = DisableSqlRewriting();
 
         var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
         {

--- a/test/Npgsql.Tests/StoredProcedureTests.cs
+++ b/test/Npgsql.Tests/StoredProcedureTests.cs
@@ -15,17 +15,17 @@ public class StoredProcedureTests : TestBase
     [TestCase(true, true)]
     public async Task With_input_parameters(bool withPositional, bool withNamed)
     {
-        var table = await CreateTempTable(SharedDataSource, "foo int, bar int");
-        var sproc = await GetTempProcedureName(SharedDataSource);
+        var table = await CreateTempTable(DataSource, "foo int, bar int");
+        var sproc = await GetTempProcedureName(DataSource);
 
-        await SharedDataSource.ExecuteNonQueryAsync(@$"
+        await DataSource.ExecuteNonQueryAsync(@$"
 CREATE PROCEDURE {sproc}(a int, b int)
 LANGUAGE SQL
 AS $$
     INSERT INTO {table} VALUES (a, b);
 $$");
 
-        await using (var command = SharedDataSource.CreateCommand(sproc))
+        await using (var command = DataSource.CreateCommand(sproc))
         {
             command.CommandType = CommandType.StoredProcedure;
 
@@ -40,7 +40,7 @@ $$");
             await command.ExecuteNonQueryAsync();
         }
 
-        await using (var command = SharedDataSource.CreateCommand($"SELECT * FROM {table}"))
+        await using (var command = DataSource.CreateCommand($"SELECT * FROM {table}"))
         await using (var reader = await command.ExecuteReaderAsync())
         {
             await reader.ReadAsync();
@@ -55,11 +55,11 @@ $$");
     [TestCase(true, true)]
     public async Task With_output_parameters(bool withPositional, bool withNamed)
     {
-        MinimumPgVersion(SharedDataSource, "14.0", "Stored procedure OUT parameters are only support starting with version 14");
+        MinimumPgVersion(DataSource, "14.0", "Stored procedure OUT parameters are only support starting with version 14");
 
-        var sproc = await GetTempProcedureName(SharedDataSource);
+        var sproc = await GetTempProcedureName(DataSource);
 
-        await SharedDataSource.ExecuteNonQueryAsync(@$"
+        await DataSource.ExecuteNonQueryAsync(@$"
 CREATE PROCEDURE {sproc}(a int, OUT out1 int, OUT out2 int, b int)
 LANGUAGE plpgsql
 AS $$
@@ -68,7 +68,7 @@ BEGIN
     out2 = b;
 END$$");
 
-        await using var command = SharedDataSource.CreateCommand(sproc);
+        await using var command = DataSource.CreateCommand(sproc);
         command.CommandType = CommandType.StoredProcedure;
 
         command.Parameters.Add(new() { Value = 8 });
@@ -96,9 +96,9 @@ END$$");
     [TestCase(true, true)]
     public async Task With_input_output_parameters(bool withPositional, bool withNamed)
     {
-        var sproc = await GetTempProcedureName(SharedDataSource);
+        var sproc = await GetTempProcedureName(DataSource);
 
-        await SharedDataSource.ExecuteNonQueryAsync(@$"
+        await DataSource.ExecuteNonQueryAsync(@$"
 CREATE PROCEDURE {sproc}(a int, INOUT inout1 int, INOUT inout2 int, b int)
 LANGUAGE plpgsql
 AS $$
@@ -107,7 +107,7 @@ BEGIN
     inout2 = inout2 + b;
 END$$");
 
-        await using var command = SharedDataSource.CreateCommand(sproc);
+        await using var command = DataSource.CreateCommand(sproc);
         command.CommandType = CommandType.StoredProcedure;
 
         command.Parameters.Add(new() { Value = 8 });

--- a/test/Npgsql.Tests/Support/TestBase.cs
+++ b/test/Npgsql.Tests/Support/TestBase.cs
@@ -464,8 +464,6 @@ public abstract class TestBase
 
     #region Utilities for use by tests
 
-    protected static readonly NpgsqlDataSource SharedDataSource = NpgsqlDataSource.Create(TestUtil.ConnectionString);
-
     protected virtual NpgsqlDataSourceBuilder CreateDataSourceBuilder()
         => new(ConnectionString);
 
@@ -497,7 +495,12 @@ public abstract class TestBase
             {
                 if (!DataSources.TryGetValue(connectionString, out dataSource))
                 {
-                    DataSources[connectionString] = dataSource = NpgsqlDataSource.Create(connectionString);
+                    var canonicalConnectionString = new NpgsqlConnectionStringBuilder(connectionString).ToString();
+                    if (!DataSources.TryGetValue(canonicalConnectionString, out dataSource))
+                    {
+                        DataSources[canonicalConnectionString] = dataSource = NpgsqlDataSource.Create(connectionString);
+                    }
+                    DataSources[connectionString] = dataSource;
                 }
             }
         }
@@ -528,8 +531,6 @@ public abstract class TestBase
         => GetDataSource(ConnectionString);
 
     protected virtual NpgsqlDataSource DataSource => DefaultDataSource;
-
-    protected void ClearDataSources() => DataSources.Clear();
 
     protected virtual NpgsqlConnection CreateConnection()
         => DataSource.CreateConnection();

--- a/test/Npgsql.Tests/TestUtil.cs
+++ b/test/Npgsql.Tests/TestUtil.cs
@@ -19,7 +19,7 @@ public static class TestUtil
     /// test database.
     /// </summary>
     public const string DefaultConnectionString =
-        "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;SSL Mode=Disable";
+        "Host=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;SSL Mode=Disable;Multiplexing=False";
 
     /// <summary>
     /// The connection string that will be used when opening the connection to the tests database.
@@ -387,10 +387,9 @@ CREATE TABLE {tableName} ({columns});");
         return new DeferredExecutionDisposable(() => CultureInfo.CurrentCulture = oldCulture);
     }
 
-    internal static IDisposable DisableSqlRewriting(Action clearDataSources)
+    internal static IDisposable DisableSqlRewriting()
     {
 #if DEBUG
-        clearDataSources();
         NpgsqlCommand.EnableSqlRewriting = false;
         return new DeferredExecutionDisposable(() => NpgsqlCommand.EnableSqlRewriting = true);
 #else

--- a/test/Npgsql.Tests/Types/DateTimeInfinityTests.cs
+++ b/test/Npgsql.Tests/Types/DateTimeInfinityTests.cs
@@ -11,7 +11,7 @@ namespace Npgsql.Tests.Types;
 [TestFixture(false)]
 [NonParallelizable]
 #endif
-public class DateTimeInfinityTests : TestBase, IDisposable
+public sealed class DateTimeInfinityTests : TestBase, IDisposable
 {
     [Test]
     public async Task TimestampTz_write()
@@ -209,14 +209,18 @@ public class DateTimeInfinityTests : TestBase, IDisposable
                 "DateTimeInfinityTests rely on the Npgsql.DisableDateTimeInfinityConversions AppContext switch and can only be run in DEBUG builds");
         }
 #endif
-        // The switch is baked into the serializer options, so clear the sources on change here.
-        ClearDataSources();
+
+        DataSource = NpgsqlDataSource.Create(ConnectionString);
     }
+
+    protected override NpgsqlDataSource DataSource { get; }
 
     public void Dispose()
     {
 #if DEBUG
         DisableDateTimeInfinityConversions = false;
 #endif
+
+        DataSource.Dispose();
     }
 }

--- a/test/Npgsql.Tests/Types/LegacyDateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/LegacyDateTimeTests.cs
@@ -76,6 +76,7 @@ public class LegacyDateTimeTests : TestBase
     public void Teardown()
     {
         LegacyTimestampBehavior = false;
+        _dataSource.Dispose();
         NpgsqlDataSourceBuilder.ResetGlobalMappings(overwrite: true);
     }
 #endif

--- a/test/Npgsql.Tests/Types/MultirangeTests.cs
+++ b/test/Npgsql.Tests/Types/MultirangeTests.cs
@@ -175,4 +175,7 @@ public class MultirangeTests : TestBase
         await using var conn = await OpenConnectionAsync();
         MinimumPgVersion(conn, "14.0", "Multirange types were introduced in PostgreSQL 14");
     }
+
+    [OneTimeTearDown]
+    public void TearDown() => DataSource.Dispose();
 }

--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -467,4 +467,7 @@ class RangeTests : MultiplexingTestBase
         {
             builder.ConnectionStringBuilder.Timezone = "Europe/Berlin";
         });
+
+    [OneTimeTearDown]
+    public void TearDown() => DataSource.Dispose();
 }


### PR DESCRIPTION
This pr doesn't fix `MultirangeTests` and `RangeTests` (due to them having `NonParallelizable` test their pools are disposed too late), but it does alleviate things a bit. 