### PR TITLE
Properly take offset into account during single segment decode

### DIFF
--- a/src/Npgsql/Shims/EncodingExtensions.cs
+++ b/src/Npgsql/Shims/EncodingExtensions.cs
@@ -141,16 +141,20 @@ static class EncodingExtensions
 #else
             var rented = false;
             byte[] arr;
+            var offset = 0;
             var memory = bytes.First;
             if (MemoryMarshal.TryGetArray(memory, out var segment))
+            {
                 arr = segment.Array!;
+                offset = segment.Offset;
+            }
             else
             {
                 rented = true;
                 arr = ArrayPool<byte>.Shared.Rent(memory.Length);
                 bytes.First.Span.CopyTo(arr);
             }
-            var ret = encoding.GetString(arr, 0, memory.Length);
+            var ret = encoding.GetString(arr, offset, memory.Length);
             if (rented)
                 ArrayPool<byte>.Shared.Return(arr);
             return ret;


### PR DESCRIPTION
Seems like we have a painful bug here... Affects all netstandard2.0 users, e.g. netfx.