### PR TITLE
Lazy mapping setup

### DIFF
--- a/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
@@ -27,6 +27,9 @@ public static class NpgsqlNetTopologySuiteExtensions
         Ordinates handleOrdinates = Ordinates.None,
         bool geographyAsDefault = false)
     {
+        // TODO opt-in of arrays.
+        // Reverse order
+        mapper.AddTypeInfoResolver(new NetTopologySuiteArrayTypeInfoResolver(coordinateSequenceFactory, precisionModel, handleOrdinates, geographyAsDefault));
         mapper.AddTypeInfoResolver(new NetTopologySuiteTypeInfoResolver(coordinateSequenceFactory, precisionModel, handleOrdinates, geographyAsDefault));
         return mapper;
     }

--- a/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
@@ -15,6 +15,9 @@ public static class NpgsqlNodaTimeExtensions
     /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
     public static INpgsqlTypeMapper UseNodaTime(this INpgsqlTypeMapper mapper)
     {
+        // TODO opt-in of arrays.
+        // Reverse order
+        mapper.AddTypeInfoResolver(new NodaTimeArrayTypeInfoResolver());
         mapper.AddTypeInfoResolver(new NodaTimeTypeInfoResolver());
         return mapper;
     }

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -383,7 +383,10 @@ public sealed class FieldDescription
             }
             if (odfInfo.TypeToConvert == type)
             {
-                lastColumnInfo = new(odfInfo, DataFormat, odfInfo.IsBoxingConverter);
+                // As TypeInfoMappingCollection is always adding object mappings for
+                // default/datatypename mappings, we'll also check Converter.TypeToConvert.
+                // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
+                lastColumnInfo = new(odfInfo, DataFormat, odfInfo.IsBoxingConverter && odfInfo.Converter.TypeToConvert != type);
                 return;
             }
         }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -244,7 +244,7 @@ public class PgTypeInfo
 
 public sealed class PgResolverTypeInfo : PgTypeInfo
 {
-    internal readonly PgConverterResolver _converterResolver;
+    readonly PgConverterResolver _converterResolver;
 
     public PgResolverTypeInfo(PgSerializerOptions options, PgConverterResolver converterResolver, PgTypeId? pgTypeId, Type? unboxedType = null)
         : base(options,
@@ -278,6 +278,8 @@ public sealed class PgResolverTypeInfo : PgTypeInfo
 
     public PgConverterResolution GetDefaultResolution(PgTypeId? pgTypeId)
         => _converterResolver.GetDefaultInternal(ValidateResolution, Options.PortableTypeIds, pgTypeId ?? PgTypeId);
+
+    public PgConverterResolver GetConverterResolver() => _converterResolver;
 }
 
 public readonly struct PgConverterResolution

--- a/src/Npgsql/Internal/Resolvers/RangeTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/Resolvers/RangeTypeInfoResolver.cs
@@ -144,14 +144,14 @@ class RangeTypeInfoResolver : IPgTypeInfoResolver
             }
             else
             {
-                mappings.AddType<NpgsqlRange<DateTime>[]>(DataTypeNames.TsMultirange,
+                mappings.AddResolverType<NpgsqlRange<DateTime>[]>(DataTypeNames.TsMultirange,
                     static (options, mapping, dataTypeNameMatch) => mapping.CreateInfo(options,
                         DateTimeConverterResolver.CreateMultirangeResolver<NpgsqlRange<DateTime>[], NpgsqlRange<DateTime>>(options,
                             options.GetCanonicalTypeId(DataTypeNames.TsTzMultirange),
                             options.GetCanonicalTypeId(DataTypeNames.TsMultirange),
                             options.EnableDateTimeInfinityConversions), dataTypeNameMatch),
                     isDefault: true);
-                mappings.AddType<List<NpgsqlRange<DateTime>>>(DataTypeNames.TsMultirange,
+                mappings.AddResolverType<List<NpgsqlRange<DateTime>>>(DataTypeNames.TsMultirange,
                     static (options, mapping, dataTypeNameMatch) => mapping.CreateInfo(options,
                         DateTimeConverterResolver.CreateMultirangeResolver<List<NpgsqlRange<DateTime>>, NpgsqlRange<DateTime>>(options,
                             options.GetCanonicalTypeId(DataTypeNames.TsTzMultirange),
@@ -189,14 +189,14 @@ class RangeTypeInfoResolver : IPgTypeInfoResolver
             }
             else
             {
-                mappings.AddType<NpgsqlRange<DateTime>[]>(DataTypeNames.TsTzMultirange,
+                mappings.AddResolverType<NpgsqlRange<DateTime>[]>(DataTypeNames.TsTzMultirange,
                     static (options, mapping, dataTypeNameMatch) => mapping.CreateInfo(options,
                         DateTimeConverterResolver.CreateMultirangeResolver<NpgsqlRange<DateTime>[], NpgsqlRange<DateTime>>(options,
                             options.GetCanonicalTypeId(DataTypeNames.TsTzMultirange),
                             options.GetCanonicalTypeId(DataTypeNames.TsMultirange),
                             options.EnableDateTimeInfinityConversions), dataTypeNameMatch),
                     isDefault: true);
-                mappings.AddType<List<NpgsqlRange<DateTime>>>(DataTypeNames.TsTzMultirange,
+                mappings.AddResolverType<List<NpgsqlRange<DateTime>>>(DataTypeNames.TsTzMultirange,
                     static (options, mapping, dataTypeNameMatch) => mapping.CreateInfo(options,
                         DateTimeConverterResolver.CreateMultirangeResolver<List<NpgsqlRange<DateTime>>, NpgsqlRange<DateTime>>(options,
                             options.GetCanonicalTypeId(DataTypeNames.TsTzMultirange),

--- a/src/Npgsql/Internal/Resolvers/UnsupportedTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/Resolvers/UnsupportedTypeInfoResolver.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using Npgsql.Internal.Postgres;
 using Npgsql.PostgresTypes;
 using Npgsql.Properties;
-using Npgsql.TypeMapping;
 
 namespace Npgsql.Internal.Resolvers;
 

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -153,7 +153,7 @@ public sealed class TypeInfoMappingCollection
         return fallback?.Factory(options, fallback.Value, dataTypeName is not null);
     }
 
-    bool TryFindMapping(Type type, string dataTypeName, out TypeInfoMapping value)
+    bool TryGetMapping(Type type, string dataTypeName, out TypeInfoMapping value)
     {
         foreach (var mapping in _baseCollection?._items ?? _items)
         {
@@ -170,8 +170,8 @@ public sealed class TypeInfoMappingCollection
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    TypeInfoMapping FindMapping(Type type, string dataTypeName)
-        => TryFindMapping(type, dataTypeName, out var info) ? info : throw new InvalidOperationException($"Could not find mapping for {type} <-> {dataTypeName}");
+    TypeInfoMapping GetMapping(Type type, string dataTypeName)
+        => TryGetMapping(type, dataTypeName, out var info) ? info : throw new InvalidOperationException($"Could not find mapping for {type} <-> {dataTypeName}");
 
     // Helper to eliminate generic display class duplication.
     static TypeInfoFactory CreateComposedFactory(Type mappingType, TypeInfoMapping innerMapping, Func<TypeInfoMapping, PgTypeInfo, PgConverter> mapper, bool copyPreferredFormat = false, bool supportsWriting = true)
@@ -180,7 +180,7 @@ public sealed class TypeInfoMappingCollection
             var innerInfo = innerMapping.Factory(options, innerMapping, dataTypeNameMatch);
             var converter = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var writingSupported = supportsWriting && innerInfo.SupportsWriting && mapping.Type != typeof(object);
+            var writingSupported = supportsWriting && innerInfo.SupportsWriting;
             var unboxedType = ComputeUnboxedType(defaultType: mappingType, converter.TypeToConvert, mapping.Type);
 
             return new PgTypeInfo(options, converter, TypeInfoMappingHelpers.ResolveFullyQualifiedName(options, mapping.DataTypeName), unboxedType)
@@ -197,7 +197,7 @@ public sealed class TypeInfoMappingCollection
             var innerInfo = (PgResolverTypeInfo)innerMapping.Factory(options, innerMapping, dataTypeNameMatch);
             var resolver = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var writingSupported = supportsWriting && innerInfo.SupportsWriting && mapping.Type != typeof(object);
+            var writingSupported = supportsWriting && innerInfo.SupportsWriting;
             var unboxedType = ComputeUnboxedType(defaultType: mappingType, resolver.TypeToConvert, mapping.Type);
             // We include the data type name if the inner info did so as well.
             // This way we can rely on its logic around resolvedDataTypeName, including when it ignores that flag.
@@ -267,26 +267,41 @@ public sealed class TypeInfoMappingCollection
     public void AddType<T>(string dataTypeName, TypeInfoFactory createInfo, Func<TypeInfoMapping, TypeInfoMapping>? configure) where T : class
     {
         var mapping = new TypeInfoMapping(typeof(T), dataTypeName, createInfo);
-        _items.Add(configure?.Invoke(mapping) ?? mapping);
+        mapping = configure?.Invoke(mapping) ?? mapping;
+        if (typeof(T) != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
+            _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
+                CreateComposedFactory(typeof(T), mapping, static (_, info) => info.GetResolution().Converter, copyPreferredFormat: true))
+            {
+                MatchRequirement = mapping.MatchRequirement
+            });
+        _items.Add(mapping);
     }
 
-    // Aliased to AddType at this time.
     public void AddResolverType<T>(string dataTypeName, TypeInfoFactory createInfo, bool isDefault = false) where T : class
-        => AddType<T>(dataTypeName, createInfo, GetDefaultConfigure(isDefault));
+        => AddResolverType<T>(dataTypeName, createInfo, GetDefaultConfigure(isDefault));
 
-    // Aliased to AddType at this time.
     public void AddResolverType<T>(string dataTypeName, TypeInfoFactory createInfo, MatchRequirement matchRequirement) where T : class
-        => AddType<T>(dataTypeName, createInfo, GetDefaultConfigure(matchRequirement));
+        => AddResolverType<T>(dataTypeName, createInfo, GetDefaultConfigure(matchRequirement));
 
-    // Aliased to AddType at this time.
     public void AddResolverType<T>(string dataTypeName, TypeInfoFactory createInfo, Func<TypeInfoMapping, TypeInfoMapping>? configure) where T : class
-        => AddType<T>(dataTypeName, createInfo, configure);
+    {
+        var mapping = new TypeInfoMapping(typeof(T), dataTypeName, createInfo);
+        mapping = configure?.Invoke(mapping) ?? mapping;
+        if (typeof(T) != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
+            _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
+                CreateComposedFactory(typeof(T), mapping, static (_, info) => info.GetConverterResolver(), copyPreferredFormat: true))
+            {
+                MatchRequirement = mapping.MatchRequirement
+            });
+        _items.Add(mapping);
+    }
+
 
     public void AddArrayType<TElement>(string elementDataTypeName) where TElement : class
-        => AddArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping: false);
+        => AddArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping: false);
 
     public void AddArrayType<TElement>(string elementDataTypeName, bool suppressObjectMapping) where TElement : class
-        => AddArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping);
+        => AddArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping);
 
     public void AddArrayType<TElement>(TypeInfoMapping elementMapping) where TElement : class
         => AddArrayType<TElement>(elementMapping, suppressObjectMapping: false);
@@ -299,7 +314,7 @@ public sealed class TypeInfoMappingCollection
 
         var arrayDataTypeName = GetArrayDataTypeName(elementMapping.DataTypeName);
 
-        AddArrayType(elementMapping, typeof(TElement[]), CreateArrayBasedConverter<TElement>, arrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryFindMapping(typeof(object), arrayDataTypeName, out _));
+        AddArrayType(elementMapping, typeof(TElement[]), CreateArrayBasedConverter<TElement>, arrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryGetMapping(typeof(object), arrayDataTypeName, out _));
         AddArrayType(elementMapping, typeof(List<TElement>), CreateListBasedConverter<TElement>, listTypeMatchPredicate, suppressObjectMapping: true);
 
         void AddArrayType(TypeInfoMapping elementMapping, Type type, Func<TypeInfoMapping, PgTypeInfo, PgConverter> converter, Func<Type?, bool>? typeMatchPredicate = null, bool suppressObjectMapping = false)
@@ -323,10 +338,10 @@ public sealed class TypeInfoMappingCollection
     }
 
     public void AddResolverArrayType<TElement>(string elementDataTypeName) where TElement : class
-        => AddResolverArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping: false);
+        => AddResolverArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping: false);
 
     public void AddResolverArrayType<TElement>(string elementDataTypeName, bool suppressObjectMapping) where TElement : class
-        => AddResolverArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping);
+        => AddResolverArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), suppressObjectMapping);
 
     public void AddResolverArrayType<TElement>(TypeInfoMapping elementMapping) where TElement : class
         => AddResolverArrayType<TElement>(elementMapping, suppressObjectMapping: false);
@@ -339,7 +354,7 @@ public sealed class TypeInfoMappingCollection
 
         var arrayDataTypeName = GetArrayDataTypeName(elementMapping.DataTypeName);
 
-        AddResolverArrayType(elementMapping, typeof(TElement[]), CreateArrayBasedConverterResolver<TElement>, arrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryFindMapping(typeof(object), arrayDataTypeName, out _));
+        AddResolverArrayType(elementMapping, typeof(TElement[]), CreateArrayBasedConverterResolver<TElement>, arrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryGetMapping(typeof(object), arrayDataTypeName, out _));
         AddResolverArrayType(elementMapping, typeof(List<TElement>), CreateListBasedConverterResolver<TElement>, listTypeMatchPredicate, suppressObjectMapping: true);
 
         void AddResolverArrayType(TypeInfoMapping elementMapping, Type type, Func<TypeInfoMapping, PgResolverTypeInfo, PgConverterResolver> converter, Func<Type?, bool>? typeMatchPredicate = null, bool suppressObjectMapping = false)
@@ -380,6 +395,12 @@ public sealed class TypeInfoMappingCollection
     {
         var mapping = new TypeInfoMapping(type, dataTypeName, createInfo);
         mapping = configure?.Invoke(mapping) ?? mapping;
+        if (type != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
+            _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
+                CreateComposedFactory(type, mapping, static (_, info) => info.GetResolution().Converter, copyPreferredFormat: true))
+            {
+                MatchRequirement = mapping.MatchRequirement
+            });
         _items.Add(mapping);
         _items.Add(new TypeInfoMapping(nullableType, dataTypeName,
             CreateComposedFactory(nullableType, mapping, nullableConverter, copyPreferredFormat: true))
@@ -394,10 +415,10 @@ public sealed class TypeInfoMappingCollection
     }
 
     public void AddStructArrayType<TElement>(string elementDataTypeName) where TElement : struct
-        => AddStructArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), FindMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping: false);
+        => AddStructArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), GetMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping: false);
 
     public void AddStructArrayType<TElement>(string elementDataTypeName, bool suppressObjectMapping) where TElement : struct
-        => AddStructArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), FindMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping);
+        => AddStructArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), GetMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping);
 
     public void AddStructArrayType<TElement>(TypeInfoMapping elementMapping, TypeInfoMapping nullableElementMapping) where TElement : struct
         => AddStructArrayType<TElement>(elementMapping, nullableElementMapping, suppressObjectMapping: false);
@@ -415,7 +436,7 @@ public sealed class TypeInfoMappingCollection
 
         AddStructArrayType(elementMapping, nullableElementMapping, typeof(TElement[]), typeof(TElement?[]),
             CreateArrayBasedConverter<TElement>, CreateArrayBasedConverter<TElement?>,
-            arrayTypeMatchPredicate, nullableArrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryFindMapping(typeof(object), arrayDataTypeName, out _));
+            arrayTypeMatchPredicate, nullableArrayTypeMatchPredicate, suppressObjectMapping: suppressObjectMapping || TryGetMapping(typeof(object), arrayDataTypeName, out _));
 
         // Don't add the object converter for the list based converter.
         AddStructArrayType(elementMapping, nullableElementMapping, typeof(List<TElement>), typeof(List<TElement?>),
@@ -490,6 +511,12 @@ public sealed class TypeInfoMappingCollection
     {
         var mapping = new TypeInfoMapping(type, dataTypeName, createInfo);
         mapping = configure?.Invoke(mapping) ?? mapping;
+        if (type != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
+            _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
+                CreateComposedFactory(type, mapping, static (_, info) => info.GetConverterResolver(), copyPreferredFormat: true))
+            {
+                MatchRequirement = mapping.MatchRequirement
+            });
         _items.Add(mapping);
         _items.Add(new TypeInfoMapping(nullableType, dataTypeName,
             CreateComposedFactory(nullableType, mapping, nullableConverter, copyPreferredFormat: true))
@@ -504,10 +531,10 @@ public sealed class TypeInfoMappingCollection
     }
 
     public void AddResolverStructArrayType<TElement>(string elementDataTypeName) where TElement : struct
-        => AddResolverStructArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), FindMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping: false);
+        => AddResolverStructArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), GetMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping: false);
 
     public void AddResolverStructArrayType<TElement>(string elementDataTypeName, bool suppressObjectMapping) where TElement : struct
-        => AddResolverStructArrayType<TElement>(FindMapping(typeof(TElement), elementDataTypeName), FindMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping);
+        => AddResolverStructArrayType<TElement>(GetMapping(typeof(TElement), elementDataTypeName), GetMapping(typeof(TElement?), elementDataTypeName), suppressObjectMapping);
 
     public void AddResolverStructArrayType<TElement>(TypeInfoMapping elementMapping, TypeInfoMapping nullableElementMapping) where TElement : struct
         => AddResolverStructArrayType<TElement>(elementMapping, nullableElementMapping, suppressObjectMapping: false);
@@ -524,7 +551,7 @@ public sealed class TypeInfoMappingCollection
 
         AddResolverStructArrayType(elementMapping, nullableElementMapping, typeof(TElement[]), typeof(TElement?[]),
             CreateArrayBasedConverterResolver<TElement>,
-            CreateArrayBasedConverterResolver<TElement?>, suppressObjectMapping: suppressObjectMapping || TryFindMapping(typeof(object), arrayDataTypeName, out _), arrayTypeMatchPredicate, nullableArrayTypeMatchPredicate);
+            CreateArrayBasedConverterResolver<TElement?>, suppressObjectMapping: suppressObjectMapping || TryGetMapping(typeof(object), arrayDataTypeName, out _), arrayTypeMatchPredicate, nullableArrayTypeMatchPredicate);
 
         // Don't add the object converter for the list based converter.
         AddResolverStructArrayType(elementMapping, nullableElementMapping, typeof(List<TElement>), typeof(List<TElement?>),
@@ -579,7 +606,7 @@ public sealed class TypeInfoMappingCollection
         }
 
     public void AddPolymorphicResolverArrayType(string elementDataTypeName, Func<PgSerializerOptions, Func<PgConverterResolution, PgConverter>> elementToArrayConverterFactory)
-        => AddPolymorphicResolverArrayType(FindMapping(typeof(object), elementDataTypeName), elementToArrayConverterFactory);
+        => AddPolymorphicResolverArrayType(GetMapping(typeof(object), elementDataTypeName), elementToArrayConverterFactory);
 
     public void AddPolymorphicResolverArrayType(TypeInfoMapping elementMapping, Func<PgSerializerOptions, Func<PgConverterResolution, PgConverter>> elementToArrayConverterFactory)
     {

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -66,6 +66,10 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
             new JsonArrayTypeInfoResolver(),
             new RangeArrayTypeInfoResolver(),
             new RecordArrayTypeInfoResolver(),
+            new FullTextSearchArrayTypeInfoResolver(),
+            new NetworkArrayTypeInfoResolver(),
+            new GeometricArrayTypeInfoResolver(),
+            new LTreeArrayTypeInfoResolver()
         }, overwrite);
 
     static NpgsqlDataSourceBuilder()
@@ -86,6 +90,10 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
             AddTypeInfoResolver(UnsupportedTypeInfoResolver);
 
             // Reverse order arrays.
+            AddTypeInfoResolver(new LTreeArrayTypeInfoResolver());
+            AddTypeInfoResolver(new GeometricArrayTypeInfoResolver());
+            AddTypeInfoResolver(new NetworkArrayTypeInfoResolver());
+            AddTypeInfoResolver(new FullTextSearchArrayTypeInfoResolver());
             AddTypeInfoResolver(new RecordArrayTypeInfoResolver());
             AddTypeInfoResolver(new RangeArrayTypeInfoResolver());
             AddTypeInfoResolver(new JsonArrayTypeInfoResolver());

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -492,7 +492,10 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     {
         if (column.LastConverterInfo is { IsDefault: false } lastInfo && lastInfo.TypeToConvert == type)
         {
-            asObject = lastInfo.IsBoxingConverter;
+            // As TypeInfoMappingCollection is always adding object mappings for
+            // default/datatypename mappings, we'll also check Converter.TypeToConvert.
+            // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
+            asObject = lastInfo.IsBoxingConverter && lastInfo.Converter.TypeToConvert != type;
             return lastInfo;
         }
 
@@ -506,7 +509,10 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
 
             if (odfInfo.TypeToConvert == type)
             {
-                asObject = odfInfo.IsBoxingConverter;
+                // As TypeInfoMappingCollection is always adding object mappings for
+                // default/datatypename mappings, we'll also check Converter.TypeToConvert.
+                // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
+                asObject = odfInfo.IsBoxingConverter && odfInfo.Converter.TypeToConvert != type;
                 return odfInfo;
             }
         }

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -89,7 +89,7 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
         // If we're object typed we should support DBNull, call into base BindCore.
         if (typeof(T) == typeof(object) || TypeInfo!.IsBoxing || _useSubStream)
         {
-            base.BindCore(TypeInfo!.IsBoxing || _useSubStream || allowNullReference);
+            base.BindCore(typeof(T) != typeof(object) && (TypeInfo!.IsBoxing || _useSubStream || allowNullReference));
             return;
         }
 

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -342,6 +342,11 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public NpgsqlSlimDataSourceBuilder EnableArrays()
     {
+        AddTypeInfoResolver(new LTreeArrayTypeInfoResolver());
+        AddTypeInfoResolver(new GeometricArrayTypeInfoResolver());
+        AddTypeInfoResolver(new NetworkArrayTypeInfoResolver());
+        AddTypeInfoResolver(new FullTextSearchArrayTypeInfoResolver());
+        AddTypeInfoResolver(new RecordArrayTypeInfoResolver());
         AddTypeInfoResolver(new RangeArrayTypeInfoResolver());
         AddTypeInfoResolver(new ExtraConversionsArrayTypeInfoResolver());
         AddTypeInfoResolver(new AdoArrayTypeInfoResolver());

--- a/test/Npgsql.Tests/Types/LTreeTests.cs
+++ b/test/Npgsql.Tests/Types/LTreeTests.cs
@@ -42,6 +42,17 @@ public class LTreeTests : MultiplexingTestBase
         dataSourceBuilder.EnableLTree();
         await using var dataSource = dataSourceBuilder.Build();
 
+        await AssertType(dataSource, "Top.Science.Astronomy", "Top.Science.Astronomy", "ltree", NpgsqlDbType.LTree, isDefaultForWriting: false, skipArrayCheck: true);
+    }
+
+    [Test]
+    public async Task NpgsqlSlimSourceBuilder_EnableArrays()
+    {
+        var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(ConnectionString);
+        dataSourceBuilder.EnableLTree();
+        dataSourceBuilder.EnableArrays();
+        await using var dataSource = dataSourceBuilder.Build();
+
         await AssertType(dataSource, "Top.Science.Astronomy", "Top.Science.Astronomy", "ltree", NpgsqlDbType.LTree, isDefaultForWriting: false);
     }
 

--- a/test/Npgsql.Tests/Types/MiscTypeTests.cs
+++ b/test/Npgsql.Tests/Types/MiscTypeTests.cs
@@ -62,14 +62,14 @@ class MiscTypeTests : MultiplexingTestBase
         }
 
         // Setting non-generic NpgsqlParameter.Value to null is not allowed, only DBNull.Value
-        await using (var cmd = new NpgsqlCommand("SELECT @p::TEXT", conn))
+        await using (var cmd = new NpgsqlCommand("SELECT @p4::TEXT", conn))
         {
             cmd.Parameters.AddWithValue("p4", NpgsqlDbType.Text, null!);
             Assert.That(async () => await cmd.ExecuteReaderAsync(), Throws.Exception.TypeOf<InvalidOperationException>());
         }
 
         // Setting generic NpgsqlParameter<object>.Value to null is not allowed, only DBNull.Value
-        await using (var cmd = new NpgsqlCommand("SELECT @p::TEXT", conn))
+        await using (var cmd = new NpgsqlCommand("SELECT @p4::TEXT", conn))
         {
             cmd.Parameters.Add(new NpgsqlParameter<object>("p4", NpgsqlDbType.Text) { Value = null! });
             Assert.That(async () => await cmd.ExecuteReaderAsync(), Throws.Exception.TypeOf<InvalidOperationException>());


### PR DESCRIPTION
@vonzshik take a look, this does what I mentioned in https://github.com/npgsql/npgsql/pull/5359#issuecomment-1784175666

As long as users request types that can be resolved by resolvers in the front we don't initialize anything past them, including the array resolvers. Obviously any unknown type would end up materializing the entire chain but in normal cases we'll be able to delay a lot of setup.

This should contribute again to https://github.com/aspnet/Benchmarks/issues/1922

Second commit is a necessity to prevent full materialization on any read. During reads we call GetObjectOrDefaultInfo and it would iterate all resolvers trying to find an object mapping, which normally default mappings wouldn't come with, materializing the entire chain.