### PR TITLE
Move flush to prevent unwanted flushes

### DIFF
--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -356,12 +356,12 @@ public sealed class PgWriter
     {
         while (!buffer.IsEmpty)
         {
+            if (Remaining is 0)
+                Flush(allowWhenNonBlocking: allowMixedIO);
             var write = Math.Min(buffer.Length, Remaining);
             buffer.Slice(0, write).CopyTo(Span);
             Advance(write);
             buffer = buffer.Slice(write);
-            if (Remaining is 0)
-                Flush(allowWhenNonBlocking: allowMixedIO);
         }
     }
 
@@ -383,12 +383,12 @@ public sealed class PgWriter
         {
             while (!buffer.IsEmpty)
             {
+                if (Remaining is 0)
+                    await FlushAsync(cancellationToken).ConfigureAwait(false);
                 var write = Math.Min(buffer.Length, Remaining);
                 buffer.Span.Slice(0, write).CopyTo(Span);
                 Advance(write);
                 buffer = buffer.Slice(write);
-                if (Remaining is 0)
-                    await FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -377,14 +377,14 @@ public sealed class PgWriter
             return new();
         }
 
-        return Core(buffer, cancellationToken);
+        return Core(allowMixedIO, buffer, cancellationToken);
 
-        async ValueTask Core(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        async ValueTask Core(bool allowMixedIO, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             while (!buffer.IsEmpty)
             {
                 if (Remaining is 0)
-                    await FlushAsync(cancellationToken).ConfigureAwait(false);
+                    await FlushAsync(allowWhenBlocking: allowMixedIO, cancellationToken).ConfigureAwait(false);
                 var write = Math.Min(buffer.Length, Remaining);
                 buffer.Span.Slice(0, write).CopyTo(Span);
                 Advance(write);

--- a/test/Npgsql.Tests/WriteBufferTests.cs
+++ b/test/Npgsql.Tests/WriteBufferTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Npgsql.Internal;
 using NUnit.Framework;
 
@@ -7,6 +8,20 @@ namespace Npgsql.Tests;
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)] // Parallel access to a single buffer
 class WriteBufferTests
 {
+    [Test]
+    public void Buffered_full_buffer_no_flush()
+    {
+        WriteBuffer.WritePosition += WriteBuffer.WriteSpaceLeft - sizeof(int);
+        var writer = WriteBuffer.GetWriter(null!, FlushMode.NonBlocking);
+        Assert.That(writer.ShouldFlush(sizeof(int)), Is.False);
+
+        Assert.DoesNotThrow(() =>
+        {
+            Span<byte> intBytes = stackalloc byte[4];
+            writer.WriteBytes(intBytes);
+        });
+    }
+
     [Test]
     public void GetWriter_Full_Buffer()
     {


### PR DESCRIPTION
There exists an edge case where we write into the last portion of the buffer exactly ending up with 0 remaining at which point we'll flush inadvertently in the sync version of the method.

For BufferedConverters in particular we'll produce intermittent errors due to the FlushMode not matching up in the case of async callers.

Fixes https://github.com/npgsql/npgsql/issues/5382

Also seems to have missed some part of the implementation of allowMixedIO for the async case. It was not needed to fix our NTS converter issue but it should still be fixed.