### PR TITLE
Add a fast path for PreparedStatementManager.TryGetAutoPrepared

### DIFF
--- a/src/Npgsql/PreparedStatementManager.cs
+++ b/src/Npgsql/PreparedStatementManager.cs
@@ -17,8 +17,6 @@ sealed class PreparedStatementManager
 
     readonly PreparedStatement?[] _candidates;
 
-    static readonly List<NpgsqlParameter> EmptyParameters = new();
-
     /// <summary>
     /// Total number of current prepared statements (whether explicit or automatic).
     /// </summary>
@@ -98,161 +96,180 @@ sealed class PreparedStatementManager
     internal PreparedStatement? TryGetAutoPrepared(NpgsqlBatchCommand batchCommand)
     {
         var sql = batchCommand.FinalCommandText!;
-        if (!BySql.TryGetValue(sql, out var pStatement))
+        // We could also test for PreparedState.BeingPrepared as it's handled the exact same way as PreparedState.Prepared
+        // But since it's so rare we'll just go through the slow path
+        if (!BySql.TryGetValue(sql, out var pStatement) || pStatement.State != PreparedState.Prepared)
+            return TryGetAutoPreparedSlow(batchCommand, pStatement);
+
+        // The statement has already been prepared (explicitly or automatically)
+        // We just need to check that the parameter types correspond, since prepared statements are
+        // only keyed by SQL (to prevent pointless allocations). If we have a mismatch, simply run unprepared.
+        if (!pStatement.DoParametersMatch(batchCommand.CurrentParametersReadOnly))
+            return null;
+        // Prevent this statement from being replaced within this batch
+        pStatement.LastUsed = long.MaxValue;
+        return pStatement;
+
+        PreparedStatement? TryGetAutoPreparedSlow(NpgsqlBatchCommand batchCommand, PreparedStatement? pStatement)
         {
-            // New candidate. Find an empty candidate slot or eject a least-used one.
-            int slotIndex = -1, leastUsages = int.MaxValue;
-            var lastUsed = long.MaxValue;
-            for (var i = 0; i < _candidates.Length; i++)
+            var sql = batchCommand.FinalCommandText!;
+            if (pStatement is null)
             {
-                var candidate = _candidates[i];
+                // New candidate. Find an empty candidate slot or eject a least-used one.
+                int slotIndex = -1, leastUsages = int.MaxValue;
+                var lastUsed = long.MaxValue;
+                for (var i = 0; i < _candidates.Length; i++)
+                {
+                    var candidate = _candidates[i];
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                    // ReSharper disable HeuristicUnreachableCode
+                    if (candidate == null)  // Found an unused candidate slot, return immediately
+                    {
+                        slotIndex = i;
+                        break;
+                    }
+                    // ReSharper restore HeuristicUnreachableCode
+                    if (candidate.Usages < leastUsages)
+                    {
+                        leastUsages = candidate.Usages;
+                        slotIndex = i;
+                        lastUsed = candidate.LastUsed;
+                    }
+                    else if (candidate.Usages == leastUsages && candidate.LastUsed < lastUsed)
+                    {
+                        slotIndex = i;
+                        lastUsed = candidate.LastUsed;
+                    }
+                }
+
+                var leastUsed = _candidates[slotIndex];
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                // ReSharper disable HeuristicUnreachableCode
-                if (candidate == null)  // Found an unused candidate slot, return immediately
-                {
-                    slotIndex = i;
-                    break;
-                }
-                // ReSharper restore HeuristicUnreachableCode
-                if (candidate.Usages < leastUsages)
-                {
-                    leastUsages = candidate.Usages;
-                    slotIndex = i;
-                    lastUsed = candidate.LastUsed;
-                }
-                else if (candidate.Usages == leastUsages && candidate.LastUsed < lastUsed)
-                {
-                    slotIndex = i;
-                    lastUsed = candidate.LastUsed;
-                }
+                if (leastUsed != null)
+                    BySql.Remove(leastUsed.Sql);
+                pStatement = BySql[sql] = _candidates[slotIndex] = PreparedStatement.CreateAutoPrepareCandidate(this, sql);
             }
 
-            var leastUsed = _candidates[slotIndex];
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (leastUsed != null)
-                BySql.Remove(leastUsed.Sql);
-            pStatement = BySql[sql] = _candidates[slotIndex] = PreparedStatement.CreateAutoPrepareCandidate(this, sql);
-        }
-
-        switch (pStatement.State)
-        {
-        case PreparedState.NotPrepared:
-        case PreparedState.Invalidated:
-            break;
-
-        case PreparedState.Prepared:
-        case PreparedState.BeingPrepared:
-            // The statement has already been prepared (explicitly or automatically), or has been selected
-            // for preparation (earlier identical statement in the same command).
-            // We just need to check that the parameter types correspond, since prepared statements are
-            // only keyed by SQL (to prevent pointless allocations). If we have a mismatch, simply run unprepared.
-            if (!pStatement.DoParametersMatch(batchCommand.CurrentParametersReadOnly))
-                return null;
-            // Prevent this statement from being replaced within this batch
-            pStatement.LastUsed = long.MaxValue;
-            return pStatement;
-
-        case PreparedState.BeingUnprepared:
-            // The statement is being replaced by an earlier statement in this same batch.
-            return null;
-
-        default:
-            Debug.Fail($"Unexpected {nameof(PreparedState)} in auto-preparation: {pStatement.State}");
-            break;
-        }
-
-        if (++pStatement.Usages < UsagesBeforePrepare)
-        {
-            // Statement still hasn't passed the usage threshold, no automatic preparation.
-            // Return null for unprepared execution.
-            pStatement.RefreshLastUsed();
-            return null;
-        }
-
-        // Bingo, we've just passed the usage threshold, statement should get prepared
-        LogMessages.AutoPreparingStatement(_commandLogger, sql, _connector.Id);
-
-        // Look for either an empty autoprepare slot, or the least recently used prepared statement which we'll replace it.
-        var oldestLastUsed = long.MaxValue;
-        var selectedIndex = -1;
-        for (var i = 0; i < AutoPrepared.Length; i++)
-        {
-            var slot = AutoPrepared[i];
-
-            if (slot is null or { State: PreparedState.Invalidated })
+            switch (pStatement.State)
             {
-                // We found a free or invalidated slot, exit the loop immediately
-                selectedIndex = i;
+            case PreparedState.NotPrepared:
+            case PreparedState.Invalidated:
                 break;
-            }
 
-            switch (slot.State)
-            {
+            // We shouldn't ever get PreparedState.Prepared since it's handled above but handle it here just in case
             case PreparedState.Prepared:
-                if (slot.LastUsed < oldestLastUsed)
-                {
-                    selectedIndex = i;
-                    oldestLastUsed = slot.LastUsed;
-                }
-                break;
-
             case PreparedState.BeingPrepared:
-                // Slot has already been selected for preparation by an earlier statement in this batch. Skip it.
-                continue;
+                // The statement has already been prepared (explicitly or automatically), or has been selected
+                // for preparation (earlier identical statement in the same command).
+                // We just need to check that the parameter types correspond, since prepared statements are
+                // only keyed by SQL (to prevent pointless allocations). If we have a mismatch, simply run unprepared.
+                if (!pStatement.DoParametersMatch(batchCommand.CurrentParametersReadOnly))
+                    return null;
+                // Prevent this statement from being replaced within this batch
+                pStatement.LastUsed = long.MaxValue;
+                return pStatement;
+
+            case PreparedState.BeingUnprepared:
+                // The statement is being replaced by an earlier statement in this same batch.
+                return null;
 
             default:
-                ThrowHelper.ThrowInvalidOperationException($"Invalid {nameof(PreparedState)} state {slot.State} encountered when scanning prepared statement slots");
+                Debug.Fail($"Unexpected {nameof(PreparedState)} in auto-preparation: {pStatement.State}");
+                break;
+            }
+
+            if (++pStatement.Usages < UsagesBeforePrepare)
+            {
+                // Statement still hasn't passed the usage threshold, no automatic preparation.
+                // Return null for unprepared execution.
+                pStatement.RefreshLastUsed();
                 return null;
             }
-        }
 
-        if (selectedIndex == -1)
-        {
-            // We're here if we couldn't find a free slot or a prepared statement to replace - this means all slots are taken by
-            // statements being prepared in this batch.
-            return null;
-        }
+            // Bingo, we've just passed the usage threshold, statement should get prepared
+            LogMessages.AutoPreparingStatement(_commandLogger, sql, _connector.Id);
 
-        if (pStatement.State != PreparedState.Invalidated)
-            RemoveCandidate(pStatement);
-
-        var oldPreparedStatement = AutoPrepared[selectedIndex];
-
-        if (oldPreparedStatement is null)
-        {
-            pStatement.Name = Encoding.ASCII.GetBytes("_auto" + selectedIndex);
-        }
-        else
-        {
-            // When executing an invalidated prepared statement, the old and the new statements are the same instance.
-            // Create a copy so that we have two distinct instances with their own states.
-            if (oldPreparedStatement == pStatement)
+            // Look for either an empty autoprepare slot, or the least recently used prepared statement which we'll replace it.
+            var oldestLastUsed = long.MaxValue;
+            var selectedIndex = -1;
+            for (var i = 0; i < AutoPrepared.Length; i++)
             {
-                oldPreparedStatement = new PreparedStatement(this, oldPreparedStatement.Sql, isExplicit: false)
+                var slot = AutoPrepared[i];
+
+                if (slot is null or { State: PreparedState.Invalidated })
                 {
-                    Name = oldPreparedStatement.Name
-                };
+                    // We found a free or invalidated slot, exit the loop immediately
+                    selectedIndex = i;
+                    break;
+                }
+
+                switch (slot.State)
+                {
+                case PreparedState.Prepared:
+                    if (slot.LastUsed < oldestLastUsed)
+                    {
+                        selectedIndex = i;
+                        oldestLastUsed = slot.LastUsed;
+                    }
+                    break;
+
+                case PreparedState.BeingPrepared:
+                    // Slot has already been selected for preparation by an earlier statement in this batch. Skip it.
+                    continue;
+
+                default:
+                    ThrowHelper.ThrowInvalidOperationException($"Invalid {nameof(PreparedState)} state {slot.State} encountered when scanning prepared statement slots");
+                    return null;
+                }
             }
 
-            pStatement.Name = oldPreparedStatement.Name;
-            pStatement.State = PreparedState.NotPrepared;
-            pStatement.StatementBeingReplaced = oldPreparedStatement;
-            oldPreparedStatement.State = PreparedState.BeingUnprepared;
+            if (selectedIndex == -1)
+            {
+                // We're here if we couldn't find a free slot or a prepared statement to replace - this means all slots are taken by
+                // statements being prepared in this batch.
+                return null;
+            }
+
+            if (pStatement.State != PreparedState.Invalidated)
+                RemoveCandidate(pStatement);
+
+            var oldPreparedStatement = AutoPrepared[selectedIndex];
+
+            if (oldPreparedStatement is null)
+            {
+                pStatement.Name = Encoding.ASCII.GetBytes("_auto" + selectedIndex);
+            }
+            else
+            {
+                // When executing an invalidated prepared statement, the old and the new statements are the same instance.
+                // Create a copy so that we have two distinct instances with their own states.
+                if (oldPreparedStatement == pStatement)
+                {
+                    oldPreparedStatement = new PreparedStatement(this, oldPreparedStatement.Sql, isExplicit: false)
+                    {
+                        Name = oldPreparedStatement.Name
+                    };
+                }
+
+                pStatement.Name = oldPreparedStatement.Name;
+                pStatement.State = PreparedState.NotPrepared;
+                pStatement.StatementBeingReplaced = oldPreparedStatement;
+                oldPreparedStatement.State = PreparedState.BeingUnprepared;
+            }
+
+            pStatement.AutoPreparedSlotIndex = selectedIndex;
+            AutoPrepared[selectedIndex] = pStatement;
+
+
+            // Make sure this statement isn't replaced by a later statement in the same batch.
+            pStatement.LastUsed = long.MaxValue;
+
+            // Note that the parameter types are only set at the moment of preparation - in the candidate phase
+            // there's no differentiation between overloaded statements, which are a pretty rare case, saving
+            // allocations.
+            pStatement.SetParamTypes(batchCommand.CurrentParametersReadOnly);
+
+            return pStatement;
         }
-
-        pStatement.AutoPreparedSlotIndex = selectedIndex;
-        AutoPrepared[selectedIndex] = pStatement;
-
-
-        // Make sure this statement isn't replaced by a later statement in the same batch.
-        pStatement.LastUsed = long.MaxValue;
-
-        // Note that the parameter types are only set at the moment of preparation - in the candidate phase
-        // there's no differentiation between overloaded statements, which are a pretty rare case, saving
-        // allocations.
-        pStatement.SetParamTypes(batchCommand.CurrentParametersReadOnly);
-
-        return pStatement;
     }
 
     void RemoveCandidate(PreparedStatement candidate)

--- a/src/Npgsql/PreparedStatementManager.cs
+++ b/src/Npgsql/PreparedStatementManager.cs
@@ -222,7 +222,7 @@ sealed class PreparedStatementManager
                 }
             }
 
-            if (selectedIndex == -1)
+            if (selectedIndex < 0)
             {
                 // We're here if we couldn't find a free slot or a prepared statement to replace - this means all slots are taken by
                 // statements being prepared in this batch.


### PR DESCRIPTION
Locally I see about 2% improvements:

```

BenchmarkDotNet v0.13.10, Windows 10 (10.0.19045.3636/22H2/2022Update)
AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
.NET SDK 8.0.100-rc.1.23455.8
  [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2


```
| Method | FastAutoPrepare | Mean     | Error    | StdDev   |
|------- |---------------- |---------:|---------:|---------:|
| **Read**   | **False**           | **28.89 μs** | **0.533 μs** | **0.499 μs** |
| **Read**   | **True**            | **28.32 μs** | **0.549 μs** | **0.514 μs** |