### PR TITLE
Rename EnableDynamicJsonMappings

### DIFF
--- a/src/Npgsql/Internal/Resolvers/UnsupportedTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/Resolvers/UnsupportedTypeInfoResolver.cs
@@ -31,7 +31,7 @@ sealed class UnsupportedTypeInfoResolver<TBuilder> : IPgTypeInfoResolver
                     string.Format(
                         NpgsqlStrings.DynamicJsonNotEnabled,
                         type == typeof(object) ? "<unknown>" : type.Name,
-                        nameof(INpgsqlTypeMapperExtensions.EnableDynamicJsonMappings),
+                        nameof(INpgsqlTypeMapperExtensions.EnableDynamicJson),
                         typeof(TBuilder).Name));
 
             case not null when options.DatabaseInfo.GetPostgresType(dataTypeName) is PostgresEnumType:

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -119,7 +119,7 @@ override NpgsqlTypes.NpgsqlCidr.ToString() -> string!
 *REMOVED*static NpgsqlTypes.NpgsqlInet.ToIPAddress(NpgsqlTypes.NpgsqlInet inet) -> System.Net.IPAddress!
 *REMOVED*static NpgsqlTypes.NpgsqlInet.ToNpgsqlInet(System.Net.IPAddress? ip) -> NpgsqlTypes.NpgsqlInet
 *REMOVED*Npgsql.NpgsqlDataSourceBuilder.AddTypeResolverFactory(Npgsql.Internal.TypeHandling.TypeHandlerResolverFactory! resolverFactory) -> void
-static Npgsql.INpgsqlTypeMapperExtensions.EnableDynamicJsonMappings<T>(this T mapper, System.Text.Json.JsonSerializerOptions? serializerOptions = null, System.Type![]? jsonbClrTypes = null, System.Type![]? jsonClrTypes = null) -> T
+static Npgsql.INpgsqlTypeMapperExtensions.EnableDynamicJson<T>(this T mapper, System.Text.Json.JsonSerializerOptions? serializerOptions = null, System.Type![]? jsonbClrTypes = null, System.Type![]? jsonClrTypes = null) -> T
 static Npgsql.INpgsqlTypeMapperExtensions.EnableRecordsAsTuples<T>(this T mapper) -> T
 static Npgsql.INpgsqlTypeMapperExtensions.EnableUnmappedTypes<T>(this T mapper) -> T
 static NpgsqlTypes.NpgsqlCidr.explicit operator System.Net.IPAddress!(NpgsqlTypes.NpgsqlCidr cidr) -> System.Net.IPAddress!

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapperExtensions.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapperExtensions.cs
@@ -31,7 +31,7 @@ public static class INpgsqlTypeMapperExtensions
     /// </remarks>
     [RequiresUnreferencedCode("Json serializer may perform reflection on trimmed types.")]
     [RequiresDynamicCode("Serializing arbitrary types to json can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
-    public static T EnableDynamicJsonMappings<T>(
+    public static T EnableDynamicJson<T>(
         this T mapper,
         JsonSerializerOptions? serializerOptions = null,
         Type[]? jsonbClrTypes = null,

--- a/test/Npgsql.Tests/Types/JsonDynamicTests.cs
+++ b/test/Npgsql.Tests/Types/JsonDynamicTests.cs
@@ -114,14 +114,14 @@ public class JsonDynamicTests : MultiplexingTestBase
     }
 
     [Test]
-    public async Task As_poco_supported_only_with_EnableDynamicJsonMappings()
+    public async Task As_poco_supported_only_with_EnableDynamicJson()
     {
-        // This test uses base.DataSource, which doesn't have EnableDynamicJsonMappings()
+        // This test uses base.DataSource, which doesn't have EnableDynamicJson()
 
         var errorMessage = string.Format(
             NpgsqlStrings.DynamicJsonNotEnabled,
             nameof(WeatherForecast),
-            nameof(INpgsqlTypeMapperExtensions.EnableDynamicJsonMappings),
+            nameof(INpgsqlTypeMapperExtensions.EnableDynamicJson),
             nameof(NpgsqlDataSourceBuilder));
 
         var exception = await AssertTypeUnsupportedWrite(
@@ -152,7 +152,7 @@ public class JsonDynamicTests : MultiplexingTestBase
     public async Task Poco_does_not_stomp_GetValue_string()
     {
         var dataSourceBuilder = CreateDataSourceBuilder();
-        var dataSource = dataSourceBuilder.EnableDynamicJsonMappings(null, new[] {typeof(WeatherForecast)}, new[] {typeof(WeatherForecast)}).Build();
+        var dataSource = dataSourceBuilder.EnableDynamicJson(null, new[] {typeof(WeatherForecast)}, new[] {typeof(WeatherForecast)}).Build();
         var sqlLiteral =
             IsJsonb
                 ? """{"Date": "2019-09-01T00:00:00", "Summary": "Partly cloudy", "TemperatureC": 10}"""
@@ -169,7 +169,7 @@ public class JsonDynamicTests : MultiplexingTestBase
     public async Task Custom_JsonSerializerOptions()
     {
         var dataSourceBuilder = CreateDataSourceBuilder();
-        dataSourceBuilder.EnableDynamicJsonMappings(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        dataSourceBuilder.EnableDynamicJson(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
         await using var dataSource = dataSourceBuilder.Build();
 
         await AssertTypeWrite(
@@ -193,9 +193,9 @@ public class JsonDynamicTests : MultiplexingTestBase
     {
         var dataSourceBuilder = CreateDataSourceBuilder();
         if (IsJsonb)
-            dataSourceBuilder.EnableDynamicJsonMappings(jsonbClrTypes: new[] { typeof(WeatherForecast) });
+            dataSourceBuilder.EnableDynamicJson(jsonbClrTypes: new[] { typeof(WeatherForecast) });
         else
-            dataSourceBuilder.EnableDynamicJsonMappings(jsonClrTypes: new[] { typeof(WeatherForecast) });
+            dataSourceBuilder.EnableDynamicJson(jsonClrTypes: new[] { typeof(WeatherForecast) });
         await using var dataSource = dataSourceBuilder.Build();
 
         await AssertType(
@@ -224,7 +224,7 @@ public class JsonDynamicTests : MultiplexingTestBase
             return;
 
         var dataSourceBuilder = CreateDataSourceBuilder();
-        dataSourceBuilder.EnableDynamicJsonMappings(jsonClrTypes: new[] { typeof(WeatherForecast) });
+        dataSourceBuilder.EnableDynamicJson(jsonClrTypes: new[] { typeof(WeatherForecast) });
         await using var dataSource = dataSourceBuilder.Build();
 
         await AssertType<WeatherForecast>(
@@ -251,7 +251,7 @@ public class JsonDynamicTests : MultiplexingTestBase
             return;
 
         var dataSourceBuilder = CreateDataSourceBuilder();
-        dataSourceBuilder.EnableDynamicJsonMappings(jsonClrTypes: new[] { typeof(WeatherForecast) });
+        dataSourceBuilder.EnableDynamicJson(jsonClrTypes: new[] { typeof(WeatherForecast) });
         await using var dataSource = dataSourceBuilder.Build();
 
         var value = new ExtendedDerivedWeatherForecast()
@@ -292,7 +292,7 @@ public class JsonDynamicTests : MultiplexingTestBase
             return;
 
         var dataSourceBuilder = CreateDataSourceBuilder();
-        dataSourceBuilder.EnableDynamicJsonMappings(jsonClrTypes: new[] { typeof(ExtendedDerivedWeatherForecast) });
+        dataSourceBuilder.EnableDynamicJson(jsonClrTypes: new[] { typeof(ExtendedDerivedWeatherForecast) });
         await using var dataSource = dataSourceBuilder.Build();
 
         await AssertType(
@@ -363,7 +363,7 @@ public class JsonDynamicTests : MultiplexingTestBase
     public JsonDynamicTests(MultiplexingMode multiplexingMode, NpgsqlDbType npgsqlDbType)
         : base(multiplexingMode)
     {
-        DataSource = CreateDataSource(b => b.EnableDynamicJsonMappings());
+        DataSource = CreateDataSource(b => b.EnableDynamicJson());
 
         if (npgsqlDbType == NpgsqlDbType.Jsonb)
             using (var conn = OpenConnection())


### PR DESCRIPTION
@NinoFloris as discussed offline - none of the other "Enable*" APIs - which also deal with mappings - have the Mappings suffix, so removing it from EnableDynamicJsonMappings.