### PR TITLE
Fix GetColumnSchema when called via IDbColumnSchemaGenerator interface.

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1792,7 +1792,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         var columns = GetColumnSchema();
         var result = new DbColumn[columns.Count];
         var i = 0;
-        foreach (var column in result)
+        foreach (var column in columns)
             result[i++] = column;
 
         return new ReadOnlyCollection<DbColumn>(result);


### PR DESCRIPTION
NpgsqlDataReader would return a schema containing `null` columns when called via the interface.