### PR TITLE
Add opt-in granular read side bounds checks

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -21,7 +21,11 @@ sealed partial class NpgsqlReadBuffer : IDisposable
 {
     #region Fields and Properties
 
+#if DEBUG
+    internal static readonly bool BufferBoundsChecks = true;
+#else
     internal static readonly bool BufferBoundsChecks = Statics.EnableDiagnostics;
+#endif
 
     public NpgsqlConnection Connection => Connector.Connection!;
     internal readonly NpgsqlConnector Connector;

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -87,11 +87,17 @@ public class PgReader
         _currentSize = size;
     }
 
-    [Conditional("DEBUG")]
     void CheckBounds(int count)
     {
-        if (count > FieldRemaining)
-            ThrowHelper.ThrowInvalidOperationException("Attempt to read past the end of the field.");
+        if (NpgsqlReadBuffer.BufferBoundsChecks)
+            Core(count);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void Core(int count)
+        {
+            if (count > FieldRemaining)
+                ThrowHelper.ThrowInvalidOperationException("Attempt to read past the end of the field.");
+        }
     }
 
     public byte ReadByte()

--- a/src/Npgsql/Util/Statics.cs
+++ b/src/Npgsql/Util/Statics.cs
@@ -10,16 +10,19 @@ namespace Npgsql.Util;
 static class Statics
 {
 #if DEBUG
+    internal static bool EnableDiagnostics;
     internal static bool LegacyTimestampBehavior;
     internal static bool DisableDateTimeInfinityConversions;
 #else
+    internal static readonly bool EnableDiagnostics;
     internal static readonly bool LegacyTimestampBehavior;
     internal static readonly bool DisableDateTimeInfinityConversions;
 #endif
 
     static Statics()
     {
-        LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out var enabled) && enabled;
+        EnableDiagnostics = AppContext.TryGetSwitch("Npgsql.EnableDiagnostics", out var enabled) && enabled;
+        LegacyTimestampBehavior = AppContext.TryGetSwitch("Npgsql.EnableLegacyTimestampBehavior", out enabled) && enabled;
         DisableDateTimeInfinityConversions = AppContext.TryGetSwitch("Npgsql.DisableDateTimeInfinityConversions", out enabled) && enabled;
     }
 


### PR DESCRIPTION
It should be basically free until enabled, the way this is structured, even on NativeAOT.