### PR TITLE
Avoid duplicating stream in bytea parameters, special case MemoryStream

### DIFF
--- a/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
@@ -125,7 +125,7 @@ sealed class StreamByteaConverter : PgStreamingConverter<Stream>
         if (value.GetType() == typeof(MemoryStream) && ((MemoryStream)value).TryGetBuffer(out var segment))
             writer.WriteBytes(segment.AsSpan((int)value.Position));
         else
-            value.CopyTo(writer.GetStream(allowMixedIO: true));
+            value.CopyTo(writer.GetStream());
     }
 
     public override ValueTask WriteAsync(PgWriter writer, Stream value, CancellationToken cancellationToken = default)

--- a/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
@@ -101,7 +101,10 @@ sealed class StreamByteaConverter : PgStreamingConverter<Stream>
 
     public override Size GetSize(SizeContext context, Stream value, ref object? writeState)
     {
-        var memoryStream = new MemoryStream(value.CanSeek ? (int)(value.Length - value.Position) : 0);
+        if (value.CanSeek)
+            return checked((int)(value.Length - value.Position));
+
+        var memoryStream = new MemoryStream();
         value.CopyTo(memoryStream);
         writeState = memoryStream;
         return checked((int)memoryStream.Length);
@@ -109,16 +112,43 @@ sealed class StreamByteaConverter : PgStreamingConverter<Stream>
 
     public override void Write(PgWriter writer, Stream value)
     {
-        if (!((MemoryStream)writer.Current.WriteState!).TryGetBuffer(out var segment))
-            throw new InvalidOperationException();
-        writer.WriteBytes(segment.AsSpan());
+        if (writer.Current.WriteState is not null)
+        {
+            if (!((MemoryStream)writer.Current.WriteState!).TryGetBuffer(out var writeStateSegment))
+                throw new InvalidOperationException();
+
+            writer.WriteBytes(writeStateSegment.AsSpan());
+        }
+
+        // Non-derived MemoryStream fast path
+        if (value.GetType() == typeof(MemoryStream) && ((MemoryStream)value).TryGetBuffer(out var segment))
+            writer.WriteBytes(segment.AsSpan((int)value.Position));
+        else
+            value.CopyTo(writer.GetStream(allowMixedIO: true));
     }
 
     public override ValueTask WriteAsync(PgWriter writer, Stream value, CancellationToken cancellationToken = default)
     {
-        if (!((MemoryStream)writer.Current.WriteState!).TryGetBuffer(out var segment))
-            throw new InvalidOperationException();
+        if (writer.Current.WriteState is not null)
+        {
+            if (!((MemoryStream)writer.Current.WriteState!).TryGetBuffer(out var writeStateSegment))
+                throw new InvalidOperationException();
 
-        return writer.WriteBytesAsync(segment.AsMemory(), cancellationToken);
+            return writer.WriteBytesAsync(writeStateSegment.AsMemory(), cancellationToken);
+        }
+
+        // Non-derived MemoryStream fast path
+        if (value.GetType() == typeof(MemoryStream) && ((MemoryStream)value).TryGetBuffer(out var segment))
+        {
+            return writer.WriteBytesAsync(segment.AsMemory((int)value.Position), cancellationToken);
+        }
+        else
+        {
+#if NETSTANDARD2_0
+            return new ValueTask(value.CopyToAsync(writer.GetStream()));
+#else
+            return new ValueTask(value.CopyToAsync(writer.GetStream(), cancellationToken));
+#endif
+        }
     }
 }

--- a/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
@@ -118,6 +118,7 @@ sealed class StreamByteaConverter : PgStreamingConverter<Stream>
                 throw new InvalidOperationException();
 
             writer.WriteBytes(writeStateSegment.AsSpan());
+            return;
         }
 
         // Non-derived MemoryStream fast path

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -517,7 +517,7 @@ public sealed class PgWriter
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled(cancellationToken);
 
-                return _writer.WriteBytesAsync(_allowMixedIO, buffer, cancellationToken).AsTask();
+                return _writer.WriteBytesAsync(_allowMixedIO, buffer.AsMemory(offset, count), cancellationToken).AsTask();
             }
 
             _writer.WriteBytes(_allowMixedIO, new Span<byte>(buffer, offset, count));

--- a/test/Npgsql.Tests/Types/ByteaTests.cs
+++ b/test/Npgsql.Tests/Types/ByteaTests.cs
@@ -71,6 +71,24 @@ public class ByteaTests : MultiplexingTestBase
     }
 
     [Test]
+    public Task Write_as_MemoryStream_exposableArray()
+    {
+        var msFactory = () =>
+        {
+            var ms = new MemoryStream(20);
+            ms.WriteByte(1);
+            ms.WriteByte(2);
+            ms.WriteByte(3);
+            ms.WriteByte(4);
+            ms.Position = 1;
+            return ms;
+        };
+
+        return AssertTypeWrite(
+            msFactory, "\\x020304", "bytea", NpgsqlDbType.Bytea, DbType.Binary, isDefault: false);
+    }
+
+    [Test]
     public async Task Write_as_MemoryStream_long()
     {
         var rnd = new Random(1);


### PR DESCRIPTION
Passing a stream in a parameter will currently duplicate the bytes into another MemoryStream. If the stream can seek we can use it directly.

New change:
Only duplicate when the stream can't seek so we can get the length.
If the stream is MemoryStream, get its buffer directly and write the bytes out. Could do it for any class that inherits from MemoryStream but this seems safer for now.
Otherwise copy the stream to the writer stream.

Also fixed a bug in the PgWriterStream for offsets. Doesn't appear to be an issue as just NetTopologySuiteConverter is using it currently.

Existing tests were already pretty good. Just needed to add one where MemoryStream could return its internal buffer.

Observable change: Now calling `CopyToAsync` on the provided stream as well as the existing `CopyTo` call.

#5299