### PR TITLE
fix(deps): Bump devcontainer and add postgis.

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:alpine
-RUN apk update && \
-    apk add --no-cache openssl
+FROM postgres
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openssl postgresql-16-postgis-3

--- a/.devcontainer/db/init-db.sh
+++ b/.devcontainer/db/init-db.sh
@@ -19,7 +19,11 @@ echo "Configuring md5 authentication in $PGDATA/pg_hba.conf"
 echo 'local all all trust' > $PGDATA/pg_hba.conf
 echo "host all all all md5" >> $PGDATA/pg_hba.conf
 
-# Standard test account for Npgsql
-psql -U postgres -c "CREATE USER npgsql_tests SUPERUSER PASSWORD 'npgsql_tests'"
-psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
-psql -U postgres -c "CREATE EXTENSION ltree" npgsql_tests
+# Standard test account for Npgsql and enable extensions
+psql -U postgres <<EOF
+    CREATE USER npgsql_tests SUPERUSER PASSWORD 'npgsql_tests';
+    CREATE DATABASE npgsql_tests OWNER npgsql_tests;
+    CREATE EXTENSION ltree npgsql_tests;
+    CREATE EXTENSION IF NOT EXISTS plpgsql npsql_tests;
+    CREATE EXTENSION postgis npgsql_tests;
+EOF

--- a/.devcontainer/db/init-db.sh
+++ b/.devcontainer/db/init-db.sh
@@ -24,6 +24,5 @@ psql -U postgres <<EOF
     CREATE USER npgsql_tests SUPERUSER PASSWORD 'npgsql_tests';
     CREATE DATABASE npgsql_tests OWNER npgsql_tests;
     CREATE EXTENSION ltree npgsql_tests;
-    CREATE EXTENSION IF NOT EXISTS plpgsql npsql_tests;
     CREATE EXTENSION postgis npgsql_tests;
 EOF

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   npgsql-dev:
     # Source for tags: https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-    image: mcr.microsoft.com/dotnet/sdk:8.0.100-preview.7
+    image: mcr.microsoft.com/dotnet/sdk:8.0.100
     volumes:
       - ..:/workspace:cached
     tty: true


### PR DESCRIPTION
closes https://github.com/npgsql/npgsql/issues/5413. mainly, the solution builds successfully and tests run as stated [here](https://www.npgsql.org/doc/dev/tests.html#run-the-test-suite)

- [x] Bump sdk in dev container
- [x] Refactor init script to simplify commands
- [x] Install `postgis`
- [x] Use vanilla postgres instead of alpine

I reverted [this change](https://github.com/npgsql/npgsql/pull/2988) that switched to alpine because the installation workflow was (or appeared) simpler. for a development environment, it may make sense to favor simpler setup vs optimization. There's a postgis docker container, but it seemed "wrong" to use that as the base image here

As mentioned in [the issue](https://github.com/npgsql/npgsql/issues/5413#issuecomment-1817808428), the `devcontainer` setup may not be the best solution long term

Note: I can create separate PR to bump the dev container if necessary