### PR TITLE
Reuse parameter index for all case permutations

### DIFF
--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -9,7 +9,7 @@ sealed class SqlQueryParser
 {
     static NpgsqlParameterCollection EmptyParameters { get; } = new();
 
-    readonly Dictionary<string, int> _paramIndexMap = new();
+    readonly Dictionary<string, int> _paramIndexMap = new(StringComparer.OrdinalIgnoreCase);
     readonly StringBuilder _rewrittenSql = new();
 
     /// <summary>

--- a/test/Npgsql.Tests/NpgsqlParameterCollectionTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterCollectionTests.cs
@@ -228,6 +228,15 @@ public class NpgsqlParameterCollectionTests
     }
 
     [Test]
+    public void Throw_multiple_positions_same_instance()
+    {
+        using var cmd = new NpgsqlCommand("SELECT $1, $2");
+        var p = new NpgsqlParameter("", "Hello world");
+        cmd.Parameters.Add(p);
+        Assert.Throws<InvalidOperationException>(() => cmd.Parameters.Add(p));
+    }
+
+    [Test]
     public void IndexOf_falls_back_to_first_insensitive_match([Values] bool manyParams)
     {
         if (_compatMode == CompatMode.OnePass)

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace Npgsql.Tests;
 
@@ -433,6 +434,15 @@ public class NpgsqlParameterTest : TestBase
         Assert.AreEqual(NpgsqlDbType.Bytea, p.NpgsqlDbType, "#J3");
         p.Value = DBNull.Value;
         Assert.AreEqual(NpgsqlDbType.Bytea, p.NpgsqlDbType, "#J4");
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/5428")]
+    public async Task Match_param_index_case_insensitively()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand("SELECT @p,@P", conn);
+        cmd.Parameters.AddWithValue("p", "Hello world");
+        await cmd.ExecuteNonQueryAsync();
     }
 
     [Test]


### PR DESCRIPTION
Fixes #5428

Given we bind before we write, and reset all the bind info after writing we can't have multiple param indices pointing to the same parameter instance. 

This is already guarded against for positional via the NpgsqlParameterCollection ownership check (can't add the same instance twice as it's already part of a collection). While for multiple same cased name references we already folded those to the same index.