### PR TITLE
Default to invariant culture when using static snake case conversion

### DIFF
--- a/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
+++ b/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
@@ -81,7 +81,7 @@ public sealed class NpgsqlSnakeCaseNameTranslator : INpgsqlNameTranslator
     /// This will be used when converting names to lower case.
     /// If <see langword="null"/> then <see cref="CultureInfo.InvariantCulture"/> will be used.
     /// </param>
-    public static string ConvertToSnakeCase(string name, CultureInfo culture)
+    public static string ConvertToSnakeCase(string name, CultureInfo? culture = null)
     {
         if (string.IsNullOrEmpty(name))
             return name;
@@ -115,7 +115,7 @@ public sealed class NpgsqlSnakeCaseNameTranslator : INpgsqlNameTranslator
                     builder.Append('_');
                 }
 
-                currentChar = char.ToLower(currentChar, culture);
+                currentChar = char.ToLower(currentChar, culture ?? CultureInfo.InvariantCulture);
                 break;
 
             case UnicodeCategory.LowercaseLetter:

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1868,7 +1868,7 @@ override sealed Npgsql.NpgsqlParameter.SourceColumnNullMapping.get -> bool
 override sealed Npgsql.NpgsqlParameter.SourceColumnNullMapping.set -> void
 override sealed Npgsql.NpgsqlParameter.SourceVersion.get -> System.Data.DataRowVersion
 override sealed Npgsql.NpgsqlParameter.SourceVersion.set -> void
-static Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.ConvertToSnakeCase(string! name, System.Globalization.CultureInfo! culture) -> string!
+static Npgsql.NameTranslation.NpgsqlSnakeCaseNameTranslator.ConvertToSnakeCase(string! name, System.Globalization.CultureInfo? culture = null) -> string!
 static Npgsql.NpgsqlCommandBuilder.DeriveParameters(Npgsql.NpgsqlCommand! command) -> void
 static Npgsql.NpgsqlConnection.ClearAllPools() -> void
 static Npgsql.NpgsqlConnection.ClearPool(Npgsql.NpgsqlConnection! connection) -> void


### PR DESCRIPTION
Culture info was introduced with #5172. Unfortunately, it wasn't implemented completely correctly - the static conversion method is exposed, and to that you _cannot_ pass null as you'd end up with `ArgumentNullException` from `char.ToLower()`.

This PR fixes that and defaults to `CultureInfo.InvariantCulture` as well.