### PR TITLE
Fix EndRead throwing exceptions when a stream is active

### DIFF
--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -486,7 +486,7 @@ public class PgReader
             return;
         }
 
-        if (FieldOffset != FieldSize)
+        if (FieldOffset != FieldSize && !StreamActive)
             ThrowNotConsumedExactly();
 
         _fieldConsumed = true;
@@ -501,7 +501,7 @@ public class PgReader
         if (_fieldBufferRequirement is { Kind: SizeKind.UpperBound })
             return ConsumeAsync(FieldRemaining);
 
-        if (FieldOffset != FieldSize)
+        if (FieldOffset != FieldSize && !StreamActive)
             ThrowNotConsumedExactly();
 
         _fieldConsumed = true;
@@ -560,9 +560,10 @@ public class PgReader
     public void Consume(int? count = null) => Consume(async: false, count).GetAwaiter().GetResult();
     public ValueTask ConsumeAsync(int? count = null, CancellationToken cancellationToken = default) => Consume(async: true, count, cancellationToken);
 
+    bool StreamActive => _userActiveStream is { IsDisposed: false };
     internal void ThrowIfStreamActive()
     {
-        if (_userActiveStream is { IsDisposed: false})
+        if (StreamActive)
             ThrowHelper.ThrowInvalidOperationException("A stream is already open for this reader");
     }
 

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -363,7 +363,7 @@ public class PgReader
     /// <returns>The stream length, if any</returns>
     async ValueTask DisposeUserActiveStream(bool async)
     {
-        if (_userActiveStream is { IsDisposed: false })
+        if (StreamActive)
         {
             if (async)
                 await _userActiveStream.DisposeAsync().ConfigureAwait(false);
@@ -560,6 +560,7 @@ public class PgReader
     public void Consume(int? count = null) => Consume(async: false, count).GetAwaiter().GetResult();
     public ValueTask ConsumeAsync(int? count = null, CancellationToken cancellationToken = default) => Consume(async: true, count, cancellationToken);
 
+    [MemberNotNullWhen(true, nameof(_userActiveStream))]
     bool StreamActive => _userActiveStream is { IsDisposed: false };
     internal void ThrowIfStreamActive()
     {
@@ -613,7 +614,7 @@ public class PgReader
             // Shut down any streaming and pooling going on on the column.
             if (_requiresCleanup)
             {
-                if (_userActiveStream is { IsDisposed: false })
+                if (StreamActive)
                     DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
 
                 if (_pooledArray is not null)
@@ -694,7 +695,7 @@ public class PgReader
             // Shut down any streaming and pooling going on on the column.
             if (_requiresCleanup)
             {
-                if (_userActiveStream is { IsDisposed: false })
+                if (StreamActive)
                     await DisposeUserActiveStream(async: true).ConfigureAwait(false);
 
                 if (_pooledArray is not null)

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1741,6 +1741,35 @@ LANGUAGE plpgsql VOLATILE";
 
     #endregion GetChars / GetTextReader
 
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/5450")]
+    public async Task EndRead_StreamActive([Values]bool async)
+    {
+        if (IsMultiplexing)
+            return;
+
+        const int columnLength = 1;
+
+        await using var conn = await OpenConnectionAsync();
+        var buffer = conn.Connector!.ReadBuffer;
+        buffer.FilledBytes += columnLength;
+        var reader = buffer.PgReader;
+        reader.Init(columnLength, DataFormat.Binary, resumable: false);
+        if (async)
+            await reader.StartReadAsync(Size.Unknown, CancellationToken.None);
+        else
+            reader.StartRead(Size.Unknown);
+
+        await using (var _ = reader.GetStream())
+        {
+            if (async)
+                Assert.DoesNotThrowAsync(async () => await reader.EndReadAsync());
+            else
+                Assert.DoesNotThrow(() => reader.EndRead());
+        }
+
+        reader.Commit(resuming: false);
+    }
+
     [Test, Description("Tests that everything goes well when a type handler generates a NpgsqlSafeReadException")]
     public async Task SafeReadException()
     {


### PR DESCRIPTION
Check whether a stream is active before throwing unconsumed exception.

This does not affect GetStream() as we're implementing that intrinsically (i.e. without converters, so no Start/EndRead).

Fixes #5450