### PR TITLE
Fix explicit batch preparation reset

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -659,6 +659,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 ProcessRawQuery(connector.SqlQueryParser, connector.UseConformingStrings, batchCommand);
 
                 needToPrepare = batchCommand.ExplicitPrepare(connector) || needToPrepare;
+                batchCommand.ConnectorPreparedOn = connector;
             }
 
             if (logger.IsEnabled(LogLevel.Debug) && needToPrepare)

--- a/test/Npgsql.Tests/Support/PgServerMock.cs
+++ b/test/Npgsql.Tests/Support/PgServerMock.cs
@@ -228,6 +228,20 @@ class PgServerMock : IDisposable
         return this;
     }
 
+    internal PgServerMock WriteParameterDescription(params FieldDescription[] fields)
+    {
+        CheckDisposed();
+
+        _writeBuffer.WriteByte((byte)BackendMessageCode.ParameterDescription);
+        _writeBuffer.WriteInt32(1 + 4 + 2 + fields.Length * 4);
+        _writeBuffer.WriteUInt16((ushort)fields.Length);
+
+        foreach (var field in fields)
+            _writeBuffer.WriteUInt32(field.TypeOID);
+
+        return this;
+    }
+
     internal PgServerMock WriteNoData()
     {
         CheckDisposed();


### PR DESCRIPTION
Fixes #5458

Ideally we also want to at least test the same thing for autoprepare (and maybe some other cases, like adding/removing queries from batch), but that can be done separately.