### PR TITLE
Decouple read buffer from connector

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -778,7 +778,7 @@ public sealed partial class NpgsqlConnector : IConnectionOperationControl
             }
 
             ReadBuffer = new NpgsqlReadBuffer(this, DataSource.MetricsReporter,
-                _stream, _socket, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding);
+                _stream, Settings.ReadBufferSize, TextEncoding, RelaxedTextEncoding);
             WriteBuffer = new NpgsqlWriteBuffer(this, _stream, _socket, Settings.WriteBufferSize, TextEncoding);
 
             timeout.CheckAndApply(this);

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -75,7 +75,7 @@ public class PgReader
     internal bool IsCharsRead => _charsReadOffset is not null;
 
     [DoesNotReturn, StackTraceHidden]
-    internal void ThrowAbort(Exception abortReason) => throw _buffer.Connector.Break(abortReason);
+    internal void ThrowAbort(Exception abortReason) => _buffer.ThrowAbort(abortReason);
 
     internal void Revert(int size, int startPos, Size bufferRequirement)
     {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -364,6 +364,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             for (statementIndex = ++StatementIndex; statementIndex < statements.Count; statementIndex = ++StatementIndex)
             {
                 var statement = statements[statementIndex];
+                Connector.State = ConnectorState.Executing;
 
                 IBackendMessage msg;
                 if (statement.TryGetPrepared(out var preparedStatement))
@@ -670,6 +671,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             for (StatementIndex++; StatementIndex < _statements.Count; StatementIndex++)
             {
                 var statement = _statements[StatementIndex];
+                Connector.State = ConnectorState.Executing;
                 if (statement.TryGetPrepared(out var preparedStatement))
                 {
                     // Row descriptions have already been populated in the statement objects at the

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -120,7 +120,7 @@ sealed class PgOutputAsyncEnumerable : IAsyncEnumerable<PgOutputReplicationMessa
                 await buf.EnsureAsync(4).ConfigureAwait(false);
                 var length = buf.ReadUInt32();
                 var data = (NpgsqlReadBuffer.ColumnStream)xLogData.Data;
-                data.Init(checked((int)length), canSeek: false, commandScoped: false);
+                data.Init(checked((int)length), canSeek: false);
                 yield return _logicalDecodingMessage.Populate(xLogData.WalStart, xLogData.WalEnd, xLogData.ServerClock, transactionXid,
                     flags, messageLsn, prefix, data);
                 await data.DisposeAsync().ConfigureAwait(false);

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -241,8 +241,6 @@ public abstract class ReplicationConnection : IAsyncDisposable
 
         SetTimeouts(CommandTimeout, CommandTimeout);
 
-        _npgsqlConnection.Connector!.LongRunningConnection = true;
-
         ReplicationLogger = _npgsqlConnection.Connector!.LoggingConfiguration.ReplicationLogger;
     }
 
@@ -454,8 +452,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
             }
 
             var buf = connector.ReadBuffer;
-
-            columnStream = new NpgsqlReadBuffer.ColumnStream(connector);
+            columnStream = new NpgsqlReadBuffer.ColumnStream(buf);
 
             SetTimeouts(_walReceiverTimeout, CommandTimeout);
 
@@ -490,7 +487,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
 
                     // dataLen = msg.Length - (code = 1 + walStart = 8 + walEnd = 8 + serverClock = 8)
                     var dataLen = messageLength - 25;
-                    columnStream.Init(dataLen, canSeek: false, commandScoped: false);
+                    columnStream.Init(dataLen, canSeek: false);
 
                     _cachedXLogDataMessage.Populate(new NpgsqlLogSequenceNumber(startLsn), new NpgsqlLogSequenceNumber(endLsn),
                         sendTime, columnStream);

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -51,7 +51,7 @@ public abstract class TypeHandlerBenchmarks<T>
     {
         var stream = new EndlessStream();
         _converter = handler ?? throw new ArgumentNullException(nameof(handler));
-        _readBuffer = new NpgsqlReadBuffer(null!, null, stream, null, NpgsqlReadBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
+        _readBuffer = new NpgsqlReadBuffer(stream, NpgsqlReadBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
         _writeBuffer =  new NpgsqlWriteBuffer(null, stream, null, NpgsqlWriteBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding);
         _reader = new PgReader(_readBuffer);
         _writer = new PgWriter(new NpgsqlBufferWriter(_writeBuffer));

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -51,7 +51,7 @@ public abstract class TypeHandlerBenchmarks<T>
     {
         var stream = new EndlessStream();
         _converter = handler ?? throw new ArgumentNullException(nameof(handler));
-        _readBuffer = new NpgsqlReadBuffer(null, stream, null, NpgsqlReadBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
+        _readBuffer = new NpgsqlReadBuffer(null!, null, stream, null, NpgsqlReadBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
         _writeBuffer =  new NpgsqlWriteBuffer(null, stream, null, NpgsqlWriteBuffer.MinimumSize, NpgsqlWriteBuffer.UTF8Encoding);
         _reader = new PgReader(_readBuffer);
         _writer = new PgWriter(new NpgsqlBufferWriter(_writeBuffer));

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -380,7 +380,8 @@ public class CommandTests : MultiplexingTestBase
         cancellationSource.Cancel();
 
         var exception = Assert.ThrowsAsync<OperationCanceledException>(async () => await t)!;
-        Assert.That(exception.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(exception.InnerException, Is.TypeOf<NpgsqlException>());
+        Assert.That(exception.InnerException!.InnerException, Is.TypeOf<TimeoutException>());
         Assert.That(exception.CancellationToken, Is.EqualTo(cancellationSource.Token));
 
         Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -685,7 +685,8 @@ public class MultipleHostsTests : TestBase
         var query = conn.ExecuteNonQueryAsync("SELECT 1", cancellationToken: cts.Token);
         cts.Cancel();
         var ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await query)!;
-        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(ex.InnerException, Is.TypeOf<NpgsqlException>());
+        Assert.That(ex.InnerException!.InnerException, Is.TypeOf<OperationCanceledException>());
         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
 
         state = conn.NpgsqlDataSource.GetDatabaseState();

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -88,7 +88,7 @@ class ReadBufferTests
     public void SetUp()
     {
         var stream = new MockStream();
-        ReadBuffer = new NpgsqlReadBuffer(stream, null, NpgsqlReadBuffer.DefaultSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
+        ReadBuffer = new NpgsqlReadBuffer(stream, NpgsqlReadBuffer.DefaultSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
         Writer = stream.Writer;
     }
 

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -88,7 +88,7 @@ class ReadBufferTests
     public void SetUp()
     {
         var stream = new MockStream();
-        ReadBuffer = new NpgsqlReadBuffer(null, stream, null, NpgsqlReadBuffer.DefaultSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
+        ReadBuffer = new NpgsqlReadBuffer(stream, null, NpgsqlReadBuffer.DefaultSize, NpgsqlWriteBuffer.UTF8Encoding, NpgsqlWriteBuffer.RelaxedUTF8Encoding);
         Writer = stream.Writer;
     }
 

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1922,7 +1922,7 @@ LANGUAGE plpgsql VOLATILE";
                 Is.TypeOf<PostgresException>().With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.QueryCanceled));
             Assert.That(exception.CancellationToken, Is.EqualTo(cancellationSource.Token));
 
-            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open | ConnectionState.Fetching));
+            Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Open | ConnectionState.Executing));
         }
 
         await pgMock.WriteScalarResponseAndFlush(1);
@@ -2292,7 +2292,7 @@ class ExplodingTypeHandler : PgBufferedConverter<int>
         if (_safe)
             throw new Exception("Safe read exception as requested");
 
-        reader.BreakConnection();
+        reader.ThrowAbort(new Exception("Broken"));
         return default;
     }
 }

--- a/test/Npgsql.Tests/Support/PgPostmasterMock.cs
+++ b/test/Npgsql.Tests/Support/PgPostmasterMock.cs
@@ -136,8 +136,7 @@ class PgPostmasterMock : IAsyncDisposable
         var clientSocket = await _socket.AcceptAsync();
 
         var stream = new NetworkStream(clientSocket, true);
-        var readBuffer = new NpgsqlReadBuffer(stream, clientSocket, ReadBufferSize, Encoding,
-            RelaxedEncoding);
+        var readBuffer = new NpgsqlReadBuffer(stream, ReadBufferSize, Encoding, RelaxedEncoding);
         var writeBuffer = new NpgsqlWriteBuffer(null!, stream, clientSocket, WriteBufferSize, Encoding);
 
         await readBuffer.EnsureAsync(4);

--- a/test/Npgsql.Tests/Support/PgPostmasterMock.cs
+++ b/test/Npgsql.Tests/Support/PgPostmasterMock.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Npgsql.Internal;
@@ -135,7 +136,7 @@ class PgPostmasterMock : IAsyncDisposable
         var clientSocket = await _socket.AcceptAsync();
 
         var stream = new NetworkStream(clientSocket, true);
-        var readBuffer = new NpgsqlReadBuffer(null!, stream, clientSocket, ReadBufferSize, Encoding,
+        var readBuffer = new NpgsqlReadBuffer(stream, clientSocket, ReadBufferSize, Encoding,
             RelaxedEncoding);
         var writeBuffer = new NpgsqlWriteBuffer(null!, stream, clientSocket, WriteBufferSize, Encoding);
 


### PR DESCRIPTION
To test https://github.com/npgsql/npgsql/pull/5454 I had to make a fairly unappealing test as I needed a connector to be able to use the column stream.

Additionally we also still had some unresolved uglyness around LongRunningConnection/commandscope after doing #5123.

So after we recently discussed improving localized recovery in https://github.com/npgsql/npgsql/pull/5440 I decided it was time for me to understand the cancellation mechanisms in place more deeply and improve separation.

This is one step towards recovering from timeouts/OCEs in a more localized fashion as all control is now situated in the connector. Future work would be to allow Cancel to withhold breaking the connection and instead just cancel the current operation.