### PR TITLE
Fix timestamp to be returned as Unspecified DateTime in legacy mode

### DIFF
--- a/src/Npgsql/Internal/Converters/Temporal/LegacyDateTimeConverter.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/LegacyDateTimeConverter.cs
@@ -21,8 +21,13 @@ sealed class LegacyDateTimeConverter : PgBufferedConverter<DateTime>
 
     protected override DateTime ReadCore(PgReader reader)
     {
+        if (_timestamp)
+        {
+            return PgTimestamp.Decode(reader.ReadInt64(), DateTimeKind.Unspecified, _dateTimeInfinityConversions);
+        }
+
         var dateTime = PgTimestamp.Decode(reader.ReadInt64(), DateTimeKind.Utc, _dateTimeInfinityConversions);
-        return !_timestamp && (!_dateTimeInfinityConversions || dateTime != DateTime.MaxValue && dateTime != DateTime.MinValue)
+        return !_dateTimeInfinityConversions || dateTime != DateTime.MaxValue && dateTime != DateTime.MinValue
             ? dateTime.ToLocalTime()
             : dateTime;
     }

--- a/test/Npgsql.Tests/Types/LegacyDateTimeTests.cs
+++ b/test/Npgsql.Tests/Types/LegacyDateTimeTests.cs
@@ -22,6 +22,14 @@ public class LegacyDateTimeTests : TestBase
             DbType.DateTime);
 
     [Test]
+    public async Task Timestamp_read_as_Unspecified_DateTime()
+    {
+        await using var command = DataSource.CreateCommand("SELECT '2020-03-01T10:30:00'::timestamp");
+        var dateTime = (DateTime)(await command.ExecuteScalarAsync())!;
+        Assert.That(dateTime.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+    }
+
+    [Test]
     [TestCase(DateTimeKind.Utc, TestName = "Timestamptz_write_utc_DateTime_does_not_convert")]
     [TestCase(DateTimeKind.Unspecified, TestName = "Timestamptz_write_unspecified_DateTime_does_not_convert")]
     public Task Timestamptz_write_utc_DateTime_does_not_convert(DateTimeKind kind)


### PR DESCRIPTION
Fixes #5465