### PR TITLE
Add SupportsReading plumbing

### DIFF
--- a/src/Npgsql/Internal/AdoSerializerHelpers.cs
+++ b/src/Npgsql/Internal/AdoSerializerHelpers.cs
@@ -16,6 +16,8 @@ static class AdoSerializerHelpers
         try
         {
             typeInfo = type == typeof(object) ? options.GetObjectOrDefaultTypeInfo(postgresType) : options.GetTypeInfo(type, postgresType);
+            if (typeInfo is { SupportsReading: false })
+                typeInfo = null;
         }
         catch (Exception ex)
         {
@@ -38,6 +40,8 @@ static class AdoSerializerHelpers
         try
         {
             typeInfo = type is null ? options.GetDefaultTypeInfo(pgTypeId!.Value) : options.GetTypeInfo(type, pgTypeId);
+            if (typeInfo is { SupportsWriting: false })
+                typeInfo = null;
         }
         catch (Exception ex)
         {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -20,6 +20,7 @@ public class PgTypeInfo
         Options = options;
         IsBoxing = unboxedType is not null;
         Type = unboxedType ?? type;
+        SupportsReading = GetDefaultSupportsReading(type, unboxedType);
         SupportsWriting = true;
     }
 
@@ -53,6 +54,7 @@ public class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
+    public bool SupportsReading { get; init; }
     public bool SupportsWriting { get; init; }
     public DataFormat? PreferredFormat { get; init; }
 
@@ -240,6 +242,11 @@ public class PgTypeInfo
             throw new ArgumentOutOfRangeException();
         }
     }
+
+    // We assume a boxing type info does not support reading as the converter won't be able to produce the derived type statically.
+    // Cases like Array converters unboxing to int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
+    internal static bool GetDefaultSupportsReading(Type type, Type? unboxedType)
+        => unboxedType is null || unboxedType == type;
 }
 
 public sealed class PgResolverTypeInfo : PgTypeInfo

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -86,10 +86,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<GetChars>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new GetCharsTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new GetCharsTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
 
             // Alternative text types
@@ -113,10 +113,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                     mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
                 //Special mappings, these have no corresponding array mapping.
                 mappings.AddType<TextReader>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
+                    static (options, mapping, _) => mapping.CreateInfo(options, new TextReaderTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                     MatchRequirement.DataTypeName);
                 mappings.AddStructType<GetChars>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new GetCharsTextConverter(options.TextEncoding), supportsWriting: false, preferredFormat: DataFormat.Text),
+                    static (options, mapping, _) => mapping.CreateInfo(options, new GetCharsTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                     MatchRequirement.DataTypeName);
             }
 
@@ -137,10 +137,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonbVersion, new TextReaderTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonbVersion, new TextReaderTextConverter(options.TextEncoding)), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<GetChars>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<GetChars>(jsonbVersion, new GetCharsTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<GetChars>(jsonbVersion, new GetCharsTextConverter(options.TextEncoding)), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
 
             // Jsonpath
@@ -149,10 +149,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<string>(jsonpathVersion, new StringTextConverter(options.TextEncoding))), isDefault: true);
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Jsonpath,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonpathVersion, new TextReaderTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonpathVersion, new TextReaderTextConverter(options.TextEncoding)), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<GetChars>(DataTypeNames.Jsonpath,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<GetChars>(jsonpathVersion, new GetCharsTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<GetChars>(jsonpathVersion, new GetCharsTextConverter(options.TextEncoding)), preferredFormat: DataFormat.Text, supportsReading: null, supportsWriting: false),
                 MatchRequirement.DataTypeName);
 
             // Bytea

--- a/src/Npgsql/Internal/ResolverFactories/NetworkTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/NetworkTypeInfoResolverFactory.cs
@@ -31,13 +31,10 @@ sealed class NetworkTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName });
 
             // inet
-            // This is one of the rare mappings that force us to use reflection for a lack of any alternative.
             // There are certain IPAddress values like Loopback or Any that return a *private* derived type (see https://github.com/dotnet/runtime/issues/27870).
-            // However we still need to be able to resolve an exactly typed converter for those values.
-            // We do so by wrapping our converter in a casting converter constructed over the derived type.
-            // Finally we add a custom predicate to be able to match any type which values are assignable to IPAddress.
             mappings.AddType<IPAddress>(DataTypeNames.Inet,
-                CreateInfo,
+                static (options, mapping, _) => new PgTypeInfo(options, new IPAddressConverter(), new DataTypeName(mapping.DataTypeName),
+                    unboxedType: mapping.Type != typeof(IPAddress) ? mapping.Type : null),
                 mapping => mapping with
                 {
                     MatchRequirement = MatchRequirement.Single,
@@ -49,21 +46,6 @@ sealed class NetworkTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // cidr
             mappings.AddStructType<NpgsqlCidr>(DataTypeNames.Cidr,
                 static (options, mapping, _) => mapping.CreateInfo(options, new NpgsqlCidrConverter()), isDefault: true);
-
-            // Code is split out to a local method as suppression attributes on lambdas aren't properly handled by the ILLink analyzer yet.
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050",
-                Justification = "MakeGenericType is safe because the target will only ever be a reference type.")]
-            static PgTypeInfo CreateInfo(PgSerializerOptions options, TypeInfoMapping resolvedMapping, bool _)
-            {
-                var derivedType = resolvedMapping.Type != typeof(IPAddress);
-                PgConverter converter = new IPAddressConverter();
-                if (derivedType)
-                    // There is not much more we can do, the deriving type IPAddress+ReadOnlyIPAddress isn't public.
-                    converter = (PgConverter)Activator.CreateInstance(typeof(CastingConverter<>).MakeGenericType(resolvedMapping.Type),
-                        converter)!;
-
-                return resolvedMapping.CreateInfo(options, converter);
-            }
 
             return mappings;
         }

--- a/src/Npgsql/Internal/ResolverFactories/TupledRecordTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/TupledRecordTypeInfoResolverFactory.cs
@@ -23,9 +23,9 @@ sealed class TupledRecordTypeInfoResolverFactory : PgTypeInfoResolverFactory
         public PgTypeInfo? GetTypeInfo(Type? type, DataTypeName? dataTypeName, PgSerializerOptions options)
             => Mappings.Find(type, dataTypeName, options);
 
-        // Stand-in type, type match predicate does the actual work.
         static TypeInfoMappingCollection AddMappings(TypeInfoMappingCollection mappings)
         {
+            // Stand-in type, type match predicate does the actual work.
             mappings.AddType<Tuple<object>>(DataTypeNames.Record, Factory,
                 mapping => mapping with
                 {
@@ -34,6 +34,7 @@ sealed class TupledRecordTypeInfoResolverFactory : PgTypeInfoResolverFactory
                                                  && type.FullName.StartsWith("System.Tuple", StringComparison.Ordinal)
                 });
 
+            // Stand-in type, type match predicate does the actual work.
             mappings.AddStructType<ValueTuple<object>>(DataTypeNames.Record, Factory,
                     mapping => mapping with
                     {

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -94,7 +94,7 @@ sealed partial class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 (options, mapping, _) => mapping.CreateInfo(options,
                     (PgConverter)Activator.CreateInstance(typeof(RangeConverter<>).MakeGenericType(subInfo.Type),
                         subInfo.GetResolution().Converter)!,
-                    preferredFormat: subInfo.PreferredFormat, supportsWriting: subInfo.SupportsWriting),
+                    preferredFormat: subInfo.PreferredFormat, supportsReading: null, supportsWriting: subInfo.SupportsWriting),
                 mapping => mapping with { MatchRequirement = MatchRequirement.Single });
         }
     }
@@ -146,7 +146,7 @@ sealed partial class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
             return CreateCollection().AddMapping(type, dataTypeName,
                 (options, mapping, _) => mapping.CreateInfo(options,
                     (PgConverter)Activator.CreateInstance(typeof(MultirangeConverter<,>).MakeGenericType(type, subInfo.Type), subInfo.GetResolution().Converter)!,
-                    preferredFormat: subInfo.PreferredFormat, supportsWriting: subInfo.SupportsWriting),
+                    preferredFormat: subInfo.PreferredFormat, supportsReading: null, supportsWriting: subInfo.SupportsWriting),
                 mapping => mapping with { MatchRequirement = MatchRequirement.Single });
         }
     }

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -186,7 +186,7 @@ public sealed class TypeInfoMappingCollection
         => TryGetMapping(type, dataTypeName, out var info) ? info : throw new InvalidOperationException($"Could not find mapping for {type} <-> {dataTypeName}");
 
     // Helper to eliminate generic display class duplication.
-    static TypeInfoFactory CreateComposedFactory(Type mappingType, TypeInfoMapping innerMapping, Func<TypeInfoMapping, PgTypeInfo, PgConverter> mapper, bool copyPreferredFormat = false, bool supportsWriting = true)
+    static TypeInfoFactory CreateComposedFactory(Type mappingType, TypeInfoMapping innerMapping, Func<TypeInfoMapping, PgTypeInfo, PgConverter> mapper, bool copyPreferredFormat = false, bool? supportsReading = null, bool? supportsWriting = null)
         => (options, mapping, dataTypeNameMatch) =>
         {
             var resolvedInnerMapping = innerMapping;
@@ -197,8 +197,8 @@ public sealed class TypeInfoMappingCollection
             var converter = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
             var unboxedType = ComputeUnboxedType(defaultType: mappingType, converter.TypeToConvert, mapping.Type);
-            var readingSupported = innerInfo.SupportsReading && PgTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, unboxedType);
-            var writingSupported = supportsWriting && innerInfo.SupportsWriting;
+            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, unboxedType));
+            var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
 
             return new PgTypeInfo(options, converter, options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), unboxedType)
             {
@@ -209,7 +209,7 @@ public sealed class TypeInfoMappingCollection
         };
 
     // Helper to eliminate generic display class duplication.
-    static TypeInfoFactory CreateComposedFactory(Type mappingType, TypeInfoMapping innerMapping, Func<TypeInfoMapping, PgResolverTypeInfo, PgConverterResolver> mapper, bool copyPreferredFormat = false, bool supportsWriting = true)
+    static TypeInfoFactory CreateComposedFactory(Type mappingType, TypeInfoMapping innerMapping, Func<TypeInfoMapping, PgResolverTypeInfo, PgConverterResolver> mapper, bool copyPreferredFormat = false, bool? supportsReading = null, bool? supportsWriting = null)
         => (options, mapping, dataTypeNameMatch) =>
         {
             var resolvedInnerMapping = innerMapping;
@@ -220,8 +220,8 @@ public sealed class TypeInfoMappingCollection
             var resolver = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
             var unboxedType = ComputeUnboxedType(defaultType: mappingType, resolver.TypeToConvert, mapping.Type);
-            var readingSupported = innerInfo.SupportsReading && PgTypeInfo.GetDefaultSupportsReading(resolver.TypeToConvert, unboxedType);
-            var writingSupported = supportsWriting && innerInfo.SupportsWriting;
+            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(resolver.TypeToConvert, unboxedType));
+            var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
             // We include the data type name if the inner info did so as well.
             // This way we can rely on its logic around resolvedDataTypeName, including when it ignores that flag.
             PgTypeId? pgTypeId = innerInfo.PgTypeId is not null
@@ -344,7 +344,7 @@ public sealed class TypeInfoMappingCollection
 
         void AddArrayType(TypeInfoMapping elementMapping, Type type, Func<TypeInfoMapping, PgTypeInfo, PgConverter> converter, Func<Type?, bool>? typeMatchPredicate = null, bool suppressObjectMapping = false)
         {
-            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter))
+            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter, supportsReading: true))
             {
                 MatchRequirement = elementMapping.MatchRequirement,
                 TypeMatchPredicate = typeMatchPredicate
@@ -384,7 +384,7 @@ public sealed class TypeInfoMappingCollection
 
         void AddResolverArrayType(TypeInfoMapping elementMapping, Type type, Func<TypeInfoMapping, PgResolverTypeInfo, PgConverterResolver> converter, Func<Type?, bool>? typeMatchPredicate = null, bool suppressObjectMapping = false)
         {
-            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter))
+            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter, supportsReading: true))
             {
                 MatchRequirement = elementMapping.MatchRequirement,
                 TypeMatchPredicate = typeMatchPredicate
@@ -476,12 +476,12 @@ public sealed class TypeInfoMappingCollection
         Func<Type?, bool>? typeMatchPredicate, Func<Type?, bool>? nullableTypeMatchPredicate, bool suppressObjectMapping)
     {
         var arrayDataTypeName = GetArrayDataTypeName(elementMapping.DataTypeName);
-        var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter))
+        var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter, supportsReading: true))
         {
             MatchRequirement = elementMapping.MatchRequirement,
             TypeMatchPredicate = typeMatchPredicate
         };
-        var nullableArrayMapping = new TypeInfoMapping(nullableType, arrayDataTypeName, CreateComposedFactory(nullableType, nullableElementMapping, nullableConverter))
+        var nullableArrayMapping = new TypeInfoMapping(nullableType, arrayDataTypeName, CreateComposedFactory(nullableType, nullableElementMapping, nullableConverter, supportsReading: true))
         {
             MatchRequirement = arrayMapping.MatchRequirement,
             TypeMatchPredicate = nullableTypeMatchPredicate
@@ -594,12 +594,12 @@ public sealed class TypeInfoMappingCollection
         {
             var arrayDataTypeName = GetArrayDataTypeName(elementMapping.DataTypeName);
 
-            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter))
+            var arrayMapping = new TypeInfoMapping(type, arrayDataTypeName, CreateComposedFactory(type, elementMapping, converter, supportsReading: true))
             {
                 MatchRequirement = elementMapping.MatchRequirement,
                 TypeMatchPredicate = typeMatchPredicate
             };
-            var nullableArrayMapping = new TypeInfoMapping(nullableType, arrayDataTypeName, CreateComposedFactory(nullableType, nullableElementMapping, nullableConverter))
+            var nullableArrayMapping = new TypeInfoMapping(nullableType, arrayDataTypeName, CreateComposedFactory(nullableType, nullableElementMapping, nullableConverter, supportsReading: true))
             {
                 MatchRequirement = elementMapping.MatchRequirement,
                 TypeMatchPredicate = nullableTypeMatchPredicate
@@ -647,7 +647,7 @@ public sealed class TypeInfoMappingCollection
         {
             var arrayDataTypeName = GetArrayDataTypeName(elementMapping.DataTypeName);
             var mapping = new TypeInfoMapping(type, arrayDataTypeName,
-                CreateComposedFactory(typeof(Array), elementMapping, converter, supportsWriting: false))
+                CreateComposedFactory(typeof(Array), elementMapping, converter, supportsReading: true, supportsWriting: false))
             {
                 MatchRequirement = elementMapping.MatchRequirement,
                 TypeMatchPredicate = typeMatchPredicate

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -740,6 +740,10 @@ public static class TypeInfoMappingHelpers
     internal static PostgresType GetPgType(this TypeInfoMapping mapping, PgSerializerOptions options)
         => options.DatabaseInfo.GetPostgresType(new DataTypeName(mapping.DataTypeName));
 
+    [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Defined for binary compatibility with 8.0", error: true)]
+    public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverter converter, DataFormat? preferredFormat, bool supportsWriting)
+        => mapping.CreateInfo(options, converter, preferredFormat, supportsReading: null, supportsWriting: supportsWriting);
+
     public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverter converter, DataFormat? preferredFormat = null, bool? supportsReading = null, bool? supportsWriting = null)
         => new(options, converter, new DataTypeName(mapping.DataTypeName))
         {
@@ -747,6 +751,11 @@ public static class TypeInfoMappingHelpers
             SupportsReading = supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(mapping.Type, unboxedType: null),
             SupportsWriting = supportsWriting ?? true
         };
+
+    [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Defined for binary compatibility with 8.0", error: true)]
+    public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverterResolver resolver, bool includeDataTypeName, DataFormat? preferredFormat, bool supportsWriting)
+        => mapping.CreateInfo(options, resolver, includeDataTypeName, preferredFormat, supportsReading: null, supportsWriting: supportsWriting);
+
     public static PgResolverTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverterResolver resolver, bool includeDataTypeName = true, DataFormat? preferredFormat = null, bool? supportsReading = null, bool? supportsWriting = null)
         => new(options, resolver, includeDataTypeName ? new DataTypeName(mapping.DataTypeName) : null)
         {

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -740,6 +740,9 @@ public static class TypeInfoMappingHelpers
     internal static PostgresType GetPgType(this TypeInfoMapping mapping, PgSerializerOptions options)
         => options.DatabaseInfo.GetPostgresType(new DataTypeName(mapping.DataTypeName));
 
+    public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverter converter)
+        => mapping.CreateInfo(options, converter, preferredFormat: null, supportsReading: null, supportsWriting: null);
+
     [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Defined for binary compatibility with 8.0", error: true)]
     public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverter converter, DataFormat? preferredFormat, bool supportsWriting)
         => mapping.CreateInfo(options, converter, preferredFormat, supportsReading: null, supportsWriting: supportsWriting);
@@ -751,6 +754,9 @@ public static class TypeInfoMappingHelpers
             SupportsReading = supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(mapping.Type, unboxedType: null),
             SupportsWriting = supportsWriting ?? true
         };
+
+    public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverterResolver resolver)
+        => mapping.CreateInfo(options, resolver, includeDataTypeName: true, preferredFormat: null, supportsReading: null, supportsWriting: null);
 
     [EditorBrowsable(EditorBrowsableState.Never), Obsolete("Defined for binary compatibility with 8.0", error: true)]
     public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConverterResolver resolver, bool includeDataTypeName, DataFormat? preferredFormat, bool supportsWriting)

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -597,9 +597,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (TypeInfo is null)
             ThrowHelper.ThrowInvalidOperationException($"Missing type info, {nameof(ResolveTypeInfo)} needs to be called before {nameof(Bind)}.");
 
-        if (!TypeInfo.SupportsWriting)
-            ThrowHelper.ThrowNotSupportedException($"Cannot write values for parameters of type '{TypeInfo.Type}' and postgres type '{TypeInfo.Options.DatabaseInfo.GetDataTypeName(PgTypeId).DisplayName}'.");
-
         // We might call this twice, once during validation and once during WriteBind, only compute things once.
         if (WriteSize is not null)
         {


### PR DESCRIPTION
See test for what used to resolve succesfully. 

Originally `StreamByteaConverter` would throw NotSupported during reading. Had it implemented the read methods though (i.e. via `reader.GetStream()`) we would start to throw at the GetFieldValueCore level trying to cast the return value from ReadAsObject (runtime type `ColumnStream`) to the requested `NetworkStream`.

In the case of IPAddressConverter we would throw inside the casting converter on read, trying to cast an IPAddress instance to whatever derived type was requested.

Better to head these cases off just after finding an info via a new read side analog of SupportsWriting.

The init default uglyness is mostly because there is no language syntax to conditionally init a property. (https://github.com/dotnet/csharplang/issues/6117) 
Adding a bunch of ifs or permutations to construct the instance is worse IMO.

I've also taken care to preserve BC for libraries like https://github.com/pgvector/pgvector-dotnet/blob/master/src/Pgvector/Npgsql/VectorTypeInfoResolverFactory.cs

It's not perfect (as can be seen by having to add `supportsReading: null` in places that now resolve to the obsolete method) but we don't have https://github.com/dotnet/csharplang/issues/7706 yet.