### PR TITLE
Column seeking rework

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1296,7 +1296,7 @@ public sealed partial class NpgsqlConnector
                 {
                     if (dataRowLoadingMode == DataRowLoadingMode.Skip)
                     {
-                        await ReadBuffer.Skip(len, async).ConfigureAwait(false);
+                        await ReadBuffer.Skip(async, len).ConfigureAwait(false);
                         continue;
                     }
                 }

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -210,7 +210,7 @@ sealed partial class NpgsqlReadBuffer
                 var pos = _buf.CumulativeReadPosition - _startPos;
                 var remaining = checked((int)(CurrentLength - pos));
                 if (remaining > 0)
-                    await _buf.Skip(remaining, async).ConfigureAwait(false);
+                    await _buf.Skip(async, remaining).ConfigureAwait(false);
             }
 
             IsDisposed = true;

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -422,7 +422,7 @@ sealed partial class NpgsqlReadBuffer : IDisposable
     /// <summary>
     /// Skip a given number of bytes.
     /// </summary>
-    public async Task Skip(int len, bool async)
+    public async Task Skip(bool async, int len)
     {
         Debug.Assert(len >= 0);
 

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -673,11 +673,11 @@ sealed partial class NpgsqlReadBuffer : IDisposable
     }
 
     ColumnStream? _lastStream;
-    public ColumnStream CreateStream(int len, bool canSeek)
+    public ColumnStream CreateStream(int len, bool canSeek, bool consumeOnDispose = true)
     {
         if (_lastStream is not { IsDisposed: true })
             _lastStream = new ColumnStream(Connector);
-        _lastStream.Init(len, canSeek, !Connector.LongRunningConnection);
+        _lastStream.Init(len, canSeek, !Connector.LongRunningConnection, consumeOnDispose);
         return _lastStream;
     }
 

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -411,10 +411,25 @@ sealed partial class NpgsqlReadBuffer : IDisposable
     }
 
     /// <summary>
-    /// Does not perform any I/O - assuming that the bytes to be skipped are in the memory buffer.
+    /// Skip a given number of bytes.
     /// </summary>
-    internal void Skip(int len)
+    internal void Skip(int len, bool allowIO = false)
     {
+        Debug.Assert(len >= 0);
+
+        if (allowIO && len > ReadBytesLeft)
+        {
+            len -= ReadBytesLeft;
+            while (len > Size)
+            {
+                ResetPosition();
+                Ensure(Size);
+                len -= Size;
+            }
+            ResetPosition();
+            Ensure(len);
+        }
+
         Debug.Assert(ReadBytesLeft >= len);
         ReadPosition += len;
     }

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -413,7 +413,7 @@ sealed partial class NpgsqlReadBuffer : IDisposable
     /// <summary>
     /// Skip a given number of bytes.
     /// </summary>
-    internal void Skip(int len, bool allowIO = false)
+    internal void Skip(int len, bool allowIO)
     {
         Debug.Assert(len >= 0);
 
@@ -430,6 +430,12 @@ sealed partial class NpgsqlReadBuffer : IDisposable
             Ensure(len);
         }
 
+        Debug.Assert(ReadBytesLeft >= len);
+        ReadPosition += len;
+    }
+
+    internal void Skip(int len)
+    {
         Debug.Assert(ReadBytesLeft >= len);
         ReadPosition += len;
     }

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -18,8 +18,8 @@ public abstract class PgBufferedConverter<T> : PgConverter<T>
 
     public sealed override T Read(PgReader reader)
     {
-        // We check IsAtStart first to speed up primitive reads.
-        if (!reader.IsAtStart && reader.ShouldBufferCurrent())
+        // We check FieldAtStart to speed up simple value reads, as field level buffering was handled by reader.StartRead() already.
+        if (!reader.FieldAtStart && reader.ShouldBufferCurrent())
             ThrowIORequired(reader.CurrentBufferRequirement);
 
         return ReadCore(reader);

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -548,7 +548,7 @@ public class PgReader
         var origOffset = FieldOffset;
         // A breaking exception unwind from a nested scope should not try to consume its remaining data.
         if (!_buffer.Connector.IsBroken)
-            await _buffer.Skip(remaining, async).ConfigureAwait(false);
+            await _buffer.Skip(async, remaining).ConfigureAwait(false);
 
         Debug.Assert(FieldRemaining == FieldSize - origOffset - remaining);
     }

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -71,7 +71,7 @@ public class PgReader
 
     internal bool IsAtStart => FieldOffset is 0;
     internal bool Resumable => _resumable;
-    public bool IsResumed => Resumable && CurrentSize != CurrentRemaining;
+    public bool IsResumed => Resumable && CurrentOffset > 0;
 
     ArrayPool<byte> ArrayPool => ArrayPool<byte>.Shared;
 
@@ -96,8 +96,8 @@ public class PgReader
         [MethodImpl(MethodImplOptions.NoInlining)]
         void Core(int count)
         {
-            if (count > FieldRemaining)
-                ThrowHelper.ThrowInvalidOperationException("Attempt to read past the end of the field.");
+            if (count > CurrentRemaining)
+                ThrowHelper.ThrowInvalidOperationException("Attempt to read past the end of the current field size.");
         }
     }
 
@@ -444,14 +444,17 @@ public class PgReader
                 _resumable = false;
             }
         }
+        else
+        {
+            _fieldStartPos = _buffer.CumulativeReadPosition;
+            _fieldConsumed = false;
+        }
 
         Debug.Assert(!_requiresCleanup, "Reader wasn't properly committed before next init");
 
-        _fieldStartPos = _buffer.CumulativeReadPosition;
-        _fieldFormat = format;
         _fieldSize = fieldLength;
+        _fieldFormat = format;
         _resumable = resumable;
-        _fieldConsumed = false;
         return this;
     }
 
@@ -565,107 +568,76 @@ public class PgReader
     }
 
     internal bool CommitHasIO(bool resuming) => Initialized && !resuming && FieldRemaining > 0;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void Commit(bool resuming)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    void Cleanup()
     {
-        if (!Initialized)
-            return;
+        if (StreamActive)
+            DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
 
-        if (resuming)
+        if (_pooledArray is not null)
         {
-            if (!Resumable)
-                ThrowHelper.ThrowInvalidOperationException("Cannot resume a non-resumable read.");
-            return;
+            ArrayPool.Return(_pooledArray);
+            _pooledArray = null;
         }
 
-        // We don't rely on CurrentRemaining, just to make sure we consume fully in the event of a nested scope not being disposed.
-        // Also shut down any streaming, pooled arrays etc.
-        if (_requiresCleanup || (!_fieldConsumed && FieldRemaining > 0))
+        if (_charsReadReader is not null)
         {
-            CommitSlow();
-            return;
+            _charsReadReader.Dispose();
+            _charsReadReader = null;
+            _charsRead = default;
         }
 
-        _fieldStartPos = -1;
-        Debug.Assert(!Initialized);
-
-        // These will always be re-initialized by Init()
-        // _fieldSize = default;
-        // _fieldFormat = default;
-        // _resumable = default;
-        // _fieldCompleted = default;
-
-        if (HasCurrent)
-        {
-            _currentStartPos = 0;
-            _currentBufferRequirement = default;
-            _currentSize = -1;
-            Debug.Assert(!HasCurrent);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void CommitSlow()
-        {
-            // Shut down any streaming and pooling going on on the column.
-            if (_requiresCleanup)
-            {
-                if (StreamActive)
-                    DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
-
-                if (_pooledArray is not null)
-                {
-                    ArrayPool.Return(_pooledArray);
-                    _pooledArray = null;
-                }
-
-                if (_charsReadReader is not null)
-                {
-                    _charsReadReader.Dispose();
-                    _charsReadReader = null;
-                    _charsRead = default;
-                }
-                _requiresCleanup = false;
-            }
-
-            Consume(async: false, count: FieldRemaining).GetAwaiter().GetResult();
-
-            _fieldStartPos = -1;
-            Debug.Assert(!Initialized);
-
-            // These will always be re-initialized by Init()
-            // _fieldSize = default;
-            // _fieldFormat = default;
-            // _resumable = default;
-            // _fieldCompleted = default;
-
-            if (HasCurrent)
-            {
-                _currentStartPos = 0;
-                _currentBufferRequirement = default;
-                _currentSize = -1;
-                Debug.Assert(!HasCurrent);
-            }
-        }
+        _requiresCleanup = false;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ValueTask CommitAsync(bool resuming)
+    void ResetCurrent()
+    {
+        _currentStartPos = 0;
+        _currentBufferRequirement = default;
+        _currentSize = -1;
+    }
+
+    internal void Restart(bool resume)
     {
         if (!Initialized)
-            return new();
+            ThrowHelper.ThrowInvalidOperationException("Cannot restart a non-initialized reader.");
 
-        if (resuming)
+        if (resume)
         {
             if (!Resumable)
                 ThrowHelper.ThrowInvalidOperationException("Cannot resume a non-resumable read.");
-            return new();
+            return;
         }
 
-        // We don't rely on CurrentRemaining, just to make sure we consume fully in the event of a nested scope not being disposed.
-        // Also shut down any streaming, pooled arrays etc.
-        if (_requiresCleanup || (!_fieldConsumed && FieldRemaining > 0))
-            return CommitSlow();
+        // Shut down any streaming and pooling going on on the column.
+        if (_requiresCleanup)
+            Cleanup();
+
+        if (HasCurrent)
+            ResetCurrent();
+
+        _fieldConsumed = false;
+        Seek(0);
+
+        Debug.Assert(Initialized);
+    }
+
+    internal void Commit()
+    {
+        if (!Initialized)
+            return;
+
+        // Shut down any streaming and pooling going on on the column.
+        if (_requiresCleanup)
+            Cleanup();
+
+        if (HasCurrent)
+            ResetCurrent();
+
+        // We make sure to fuly consume any FieldRemaining in the event of an exception or a nested scope not being disposed.
+        Debug.Assert(!HasCurrent);
+        if (!_fieldConsumed && FieldRemaining > 0)
+            Consume(async: false).GetAwaiter().GetResult();
 
         _fieldStartPos = -1;
         Debug.Assert(!Initialized);
@@ -674,41 +646,39 @@ public class PgReader
         // _fieldSize = default;
         // _fieldFormat = default;
         // _resumable = default;
-        // _fieldCompleted = default;
+        // _fieldConsumed = default;
+    }
+
+    internal ValueTask CommitAsync()
+    {
+        if (!Initialized)
+            return new();
+
+        // Shut down any streaming and pooling going on on the column.
+        if (_requiresCleanup)
+            Cleanup();
 
         if (HasCurrent)
-        {
-            _currentStartPos = 0;
-            _currentBufferRequirement = default;
-            _currentSize = -1;
-            Debug.Assert(!HasCurrent);
-        }
+            ResetCurrent();
+
+        // We make sure to fuly consume any FieldRemaining in the event of an exception or a nested scope not being disposed.
+        Debug.Assert(!HasCurrent);
+        if (!_fieldConsumed && FieldRemaining > 0)
+            return CommitAsync();
+
+        _fieldStartPos = -1;
+        Debug.Assert(!Initialized);
+
+        // These will always be re-initialized by Init()
+        // _fieldSize = default;
+        // _fieldFormat = default;
+        // _resumable = default;
+        // _fieldConsumed = default;
 
         return new();
 
-        async ValueTask CommitSlow()
+        async ValueTask CommitAsync()
         {
-            // Shut down any streaming and pooling going on on the column.
-            if (_requiresCleanup)
-            {
-                if (StreamActive)
-                    await DisposeUserActiveStream(async: true).ConfigureAwait(false);
-
-                if (_pooledArray is not null)
-                {
-                    ArrayPool.Return(_pooledArray);
-                    _pooledArray = null;
-                }
-
-                if (_charsReadReader is not null)
-                {
-                    _charsReadReader.Dispose();
-                    _charsReadReader = null;
-                    _charsRead = default;
-                }
-                _requiresCleanup = false;
-            }
-
             await Consume(async: true, count: FieldRemaining).ConfigureAwait(false);
 
             _fieldStartPos = -1;
@@ -718,15 +688,7 @@ public class PgReader
             // _fieldSize = default;
             // _fieldFormat = default;
             // _resumable = default;
-            // _fieldCompleted = default;
-
-            if (HasCurrent)
-            {
-                _currentStartPos = 0;
-                _currentBufferRequirement = default;
-                _currentSize = -1;
-                Debug.Assert(!HasCurrent);
-            }
+            // _fieldConsumed = default;
         }
     }
 

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -444,7 +444,11 @@ public class PgReader
         Debug.Assert(FieldSize >= 0);
         _fieldBufferRequirement = bufferRequirement;
         if (ShouldBuffer(bufferRequirement))
-            Buffer(bufferRequirement);
+            BufferNoInlined(bufferRequirement);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void BufferNoInlined(Size bufferRequirement)
+            => Buffer(bufferRequirement);
     }
 
     internal ValueTask StartReadAsync(Size bufferRequirement, CancellationToken cancellationToken)
@@ -521,26 +525,43 @@ public class PgReader
             Consume(offset - CurrentOffset);
     }
 
-    internal async ValueTask Consume(bool async, int? count = null, CancellationToken cancellationToken = default)
+    public void Consume(int? count = null)
     {
         if (count <= 0 || FieldSize < 0 || FieldRemaining == 0)
             return;
 
-        var remaining = count ?? CurrentRemaining;
+        var currentRemaining = CurrentRemaining;
+        var remaining = count ?? currentRemaining;
 
-        if (count > CurrentRemaining)
+        if (count > currentRemaining)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to read past the end of the current field size.");
 
         var origOffset = FieldOffset;
         // A breaking exception unwind from a nested scope should not try to consume its remaining data.
         if (!_buffer.Connector.IsBroken)
-            await _buffer.Skip(async, remaining).ConfigureAwait(false);
+            _buffer.Skip(remaining, allowIO: true);
 
         Debug.Assert(FieldRemaining == FieldSize - origOffset - remaining);
     }
 
-    public void Consume(int? count = null) => Consume(async: false, count).GetAwaiter().GetResult();
-    public ValueTask ConsumeAsync(int? count = null, CancellationToken cancellationToken = default) => Consume(async: true, count, cancellationToken);
+    public async ValueTask ConsumeAsync(int? count = null, CancellationToken cancellationToken = default)
+    {
+        if (count <= 0 || FieldSize < 0 || FieldRemaining == 0)
+            return;
+
+        var currentRemaining = CurrentRemaining;
+        var remaining = count ?? currentRemaining;
+
+        if (count > currentRemaining)
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to read past the end of the current field size.");
+
+        var origOffset = FieldOffset;
+        // A breaking exception unwind from a nested scope should not try to consume its remaining data.
+        if (!_buffer.Connector.IsBroken)
+            await _buffer.Skip(async:true, remaining).ConfigureAwait(false);
+
+        Debug.Assert(FieldRemaining == FieldSize - origOffset - remaining);
+    }
 
     [MemberNotNullWhen(true, nameof(_userActiveStream))]
     bool StreamActive => _userActiveStream is { IsDisposed: false };
@@ -608,6 +629,7 @@ public class PgReader
         Debug.Assert(Initialized);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Commit()
     {
         if (!Initialized)
@@ -623,7 +645,7 @@ public class PgReader
         // We make sure to fuly consume any FieldRemaining in the event of an exception or a nested scope not being disposed.
         Debug.Assert(!HasCurrent);
         if (!_fieldConsumed && FieldRemaining > 0)
-            Consume(async: false).GetAwaiter().GetResult();
+            Consume();
 
         _fieldStartPos = -1;
         Debug.Assert(!Initialized);
@@ -635,6 +657,7 @@ public class PgReader
         // _fieldConsumed = default;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ValueTask CommitAsync()
     {
         if (!Initialized)
@@ -665,7 +688,7 @@ public class PgReader
 
         async ValueTask CommitAsync()
         {
-            await Consume(async: true, count: FieldRemaining).ConfigureAwait(false);
+            await ConsumeAsync().ConfigureAwait(false);
 
             _fieldStartPos = -1;
             Debug.Assert(!Initialized);

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -200,7 +200,7 @@ public class PgReader
 
         length ??= CurrentRemaining;
         CheckBounds(length.GetValueOrDefault());
-        return _userActiveStream = _buffer.CreateStream(length.GetValueOrDefault(), canSeek && length <= _buffer.ReadBytesLeft);
+        return _userActiveStream = _buffer.CreateStream(length.GetValueOrDefault(), canSeek && length <= _buffer.ReadBytesLeft, consumeOnDispose: false);
     }
 
     public TextReader GetTextReader(Encoding encoding)
@@ -342,14 +342,15 @@ public class PgReader
 
     public void Rewind(int count)
     {
-        // Shut down any streaming going on on the column
-        DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
-
         if (CurrentOffset < count)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to rewind past the current field start.");
 
         if (_buffer.ReadPosition < count)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to rewind past the buffer start, some of this data is no longer part of the underlying buffer.");
+
+        // Shut down any streaming going on on the column
+        if (StreamActive)
+            DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
 
         _buffer.ReadPosition -= count;
     }
@@ -361,14 +362,10 @@ public class PgReader
     /// <returns>The stream length, if any</returns>
     async ValueTask DisposeUserActiveStream(bool async)
     {
-        if (StreamActive)
-        {
-            if (async)
-                await _userActiveStream.DisposeAsync().ConfigureAwait(false);
-            else
-                _userActiveStream.Dispose();
-        }
-
+        if (async)
+            await (_userActiveStream?.DisposeAsync() ?? new()).ConfigureAwait(false);
+        else
+            _userActiveStream?.Dispose();
         _userActiveStream = null;
     }
 
@@ -536,6 +533,9 @@ public class PgReader
         if (count > currentRemaining)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to read past the end of the current field size.");
 
+        if (StreamActive)
+            DisposeUserActiveStream(async: false).GetAwaiter().GetResult();
+
         var origOffset = FieldOffset;
         // A breaking exception unwind from a nested scope should not try to consume its remaining data.
         if (!_buffer.Connector.IsBroken)
@@ -554,6 +554,9 @@ public class PgReader
 
         if (count > currentRemaining)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count), "Attempt to read past the end of the current field size.");
+
+        if (StreamActive)
+            await DisposeUserActiveStream(async: true).ConfigureAwait(false);
 
         var origOffset = FieldOffset;
         // A breaking exception unwind from a nested scope should not try to consume its remaining data.

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -492,7 +492,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
                 else
                     PgReader.Commit(resuming: false);
                 // Finish the current CopyData message
-                await _buf.Skip(checked((int)(_endOfMessagePos - _buf.CumulativeReadPosition)), async).ConfigureAwait(false);
+                await _buf.Skip(async, checked((int)(_endOfMessagePos - _buf.CumulativeReadPosition))).ConfigureAwait(false);
                 // Read to the end
                 _connector.SkipUntil(BackendMessageCode.CopyDone);
                 // We intentionally do not pass a CancellationToken since we don't want to cancel cleanup

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -2063,7 +2063,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 _column++;
                 Debug.Assert(columnLength >= -1);
                 if (columnLength > 0)
-                    await buffer.Skip(columnLength, async).ConfigureAwait(false);
+                    await buffer.Skip(async: true, columnLength).ConfigureAwait(false);
             }
 
             await buffer.Ensure(4, async).ConfigureAwait(false);
@@ -2142,7 +2142,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 _column++;
                 Debug.Assert(columnLength >= -1);
                 if (columnLength > 0)
-                    await buffer.Skip(columnLength, async).ConfigureAwait(false);
+                    await buffer.Skip(async, columnLength).ConfigureAwait(false);
             }
         }
     }

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -637,7 +637,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             p.Value = pending.Dequeue();
         }
 
-        PgReader.Commit(resuming: false);
+        PgReader.Commit();
         State = ReaderState.BeforeResult; // Set the state back
         Buffer.ReadPosition = currentPosition; // Restore position
 
@@ -1930,8 +1930,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (currentColumn >= 0)
         {
             if (currentColumn == ordinal)
-                return HandleReread(pgReader.Resumable && resumableOp);
-            pgReader.Commit(resuming: false);
+                return HandleReread(resumableOp);
+            pgReader.Commit();
         }
 
         // Deals with forward movement
@@ -1957,13 +1957,12 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         return columnLength;
 
-        int HandleReread(bool resuming)
+        int HandleReread(bool resumableOp)
         {
             Debug.Assert(pgReader.Initialized);
             var columnLength = pgReader.FieldSize;
-            pgReader.Commit(resuming);
-            if (!resuming && columnLength > 0)
-                buffer.ReadPosition -= columnLength;
+            pgReader.Restart(pgReader.Resumable && resumableOp);
+            resumableOp = resumableOp || columnLength is -1;
             pgReader.Init(columnLength, dataFormat, resumableOp);
             return columnLength;
         }
@@ -2009,7 +2008,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (!PgReader.CommitHasIO(reread))
         {
             var columnLength = PgReader.FieldSize;
-            PgReader.Commit(reread);
+            PgReader.Commit();
             committed = true;
             if (reread)
             {
@@ -2041,9 +2040,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             {
                 Debug.Assert(ordinal != _column);
                 if (async)
-                    await PgReader.CommitAsync(reread).ConfigureAwait(false);
+                    await PgReader.CommitAsync().ConfigureAwait(false);
                 else
-                    PgReader.Commit(reread);
+                    PgReader.Commit();
             }
 
             if (reread)
@@ -2128,9 +2127,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         async Task ConsumeRowSequential(bool async)
         {
             if (async)
-                await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
+                await PgReader.CommitAsync().ConfigureAwait(false);
             else
-                PgReader.Commit(resuming: false);
+                PgReader.Commit();
 
             // Skip over the remaining columns in the row
             var buffer = Buffer;
@@ -2151,7 +2150,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     void ConsumeBufferedRow()
     {
         Debug.Assert(State is ReaderState.InResult or ReaderState.BeforeResult);
-        PgReader.Commit(resuming: false);
+        PgReader.Commit();
         Buffer.ReadPosition = _dataMsgEnd;
     }
 

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -379,7 +379,7 @@ public sealed class NpgsqlRawCopyStream : Stream, ICancelable
                     {
                         if (_leftToReadInDataMsg > 0)
                         {
-                            await _readBuf.Skip(_leftToReadInDataMsg, async).ConfigureAwait(false);
+                            await _readBuf.Skip(async, _leftToReadInDataMsg).ConfigureAwait(false);
                         }
                         _connector.SkipUntil(BackendMessageCode.ReadyForQuery);
                     }

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -185,7 +185,7 @@ public class ReplicationValue
         if (!PgReader.Initialized)
             PgReader.Init(Length, _fieldDescription.DataFormat);
         await PgReader.ConsumeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
+        await PgReader.CommitAsync().ConfigureAwait(false);
 
         _isConsumed = true;
     }

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -111,7 +111,8 @@ public class ReplicationValue
 
         using var registration = _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
 
-        var reader = PgReader.Init(Length, _fieldDescription.DataFormat);
+        var reader = PgReader;
+        reader.Init(Length, _fieldDescription.DataFormat);
         await reader.StartReadAsync(info.ConverterInfo.BufferRequirement, cancellationToken).ConfigureAwait(false);
         var result = info.AsObject
             ? (T)await info.ConverterInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
@@ -146,7 +147,8 @@ public class ReplicationValue
             throw new InvalidCastException($"Column '{_fieldDescription.Name}' is an unchanged TOASTed value (actual value not sent).");
         }
 
-        var reader = _readBuffer.PgReader.Init(Length, _fieldDescription.DataFormat);
+        var reader = PgReader;
+        reader.Init(Length, _fieldDescription.DataFormat);
         return reader.GetStream(canSeek: false);
     }
 
@@ -170,7 +172,8 @@ public class ReplicationValue
             throw new InvalidCastException($"Column '{_fieldDescription.Name}' is an unchanged TOASTed value (actual value not sent).");
         }
 
-        var reader = PgReader.Init(Length, _fieldDescription.DataFormat);
+        var reader = PgReader;
+        reader.Init(Length, _fieldDescription.DataFormat);
         reader.StartRead(info.ConverterInfo.BufferRequirement);
         var result = (TextReader)info.ConverterInfo.Converter.ReadAsObject(reader);
         reader.EndRead();

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -185,10 +185,11 @@ public class ReplicationValue
         if (_isConsumed)
             return;
 
-        if (!PgReader.Initialized)
-            PgReader.Init(Length, _fieldDescription.DataFormat);
-        await PgReader.ConsumeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await PgReader.CommitAsync().ConfigureAwait(false);
+        var reader = PgReader;
+        if (!reader.Initialized)
+            reader.Init(Length, _fieldDescription.DataFormat);
+        await reader.ConsumeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        await reader.CommitAsync().ConfigureAwait(false);
 
         _isConsumed = true;
     }

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -499,7 +499,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
                     // Our consumer may not have read the stream to the end, but it might as well have been us
                     // ourselves bypassing the stream and reading directly from the buffer in StartReplication()
                     if (!columnStream.IsDisposed && columnStream.Position < columnStream.Length && !bypassingStream)
-                        await buf.Skip(checked((int)(columnStream.Length - columnStream.Position)), true).ConfigureAwait(false);
+                        await buf.Skip(async: true, checked((int)(columnStream.Length - columnStream.Position))).ConfigureAwait(false);
 
                     continue;
                 }

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -1880,7 +1880,7 @@ LANGUAGE plpgsql VOLATILE";
                 Assert.DoesNotThrow(() => reader.EndRead());
         }
 
-        reader.Commit(resuming: false);
+        reader.Commit();
     }
 
     [Test, Description("Tests that everything goes well when a type handler generates a NpgsqlSafeReadException")]


### PR DESCRIPTION
## Column Seeking Rework

This PR reworks the split implementation we have for column seeking in NpgsqlDataReader.

Where previously we had two methods split by behavior; one for non buffered mode (sync only) and one for sequential mode (async/sync).

We now just have a sync and an async implementation, with the sync method having a tiny bit of additional validation for sequential behavior.

Fast paths should essentially be unaffected and we might even see a small speedup in TE non sequential scenarios due to streamlining column seeking but also PgReader.{Init,Commit} even more.

For the async implementation we're exploiting the fact that any rereading or rewinding necessarily means we already have the data. So we're able to fully delegate all that work to the sync implementation.

Similarly we're now always using the sync implementation if we know the row is buffered entirely.

### Async Seeking Caveat

One optimization that I introduced in 8.0 that didn't make it over is when doing an \*async sequential* seek (so mostly via IsDBNullAsync or GetFieldValueAsync). We used to try and seek up to the column that was buffered before switching to the async method, saving a small bit of time setting up the state machine and entering it.

In my opinion that complexity isn't worth carrying over. It was initially introduced because sequential seeking had no sync only method at all, impacting the super common sync methods like GetFieldValue. While the async column reading methods are rarely used. Even then the new implementation will still use the sync path when the entire row is buffered.

On the other hand \*sync sequential* seeking now uses the same heavily optimized implementation as buffered mode does.