### PR TITLE
StreamActive check should apply before any other EndRead checks

### DIFF
--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -476,7 +476,7 @@ public class PgReader
 
     internal void EndRead()
     {
-        if (_resumable)
+        if (_resumable || StreamActive)
             return;
 
         // If it was upper bound we should consume.
@@ -486,7 +486,7 @@ public class PgReader
             return;
         }
 
-        if (FieldOffset != FieldSize && !StreamActive)
+        if (FieldOffset != FieldSize)
             ThrowNotConsumedExactly();
 
         _fieldConsumed = true;
@@ -494,14 +494,14 @@ public class PgReader
 
     internal ValueTask EndReadAsync()
     {
-        if (_resumable)
+        if (_resumable || StreamActive)
             return new();
 
         // If it was upper bound we should consume.
         if (_fieldBufferRequirement is { Kind: SizeKind.UpperBound })
             return ConsumeAsync(FieldRemaining);
 
-        if (FieldOffset != FieldSize && !StreamActive)
+        if (FieldOffset != FieldSize)
             ThrowNotConsumedExactly();
 
         _fieldConsumed = true;


### PR DESCRIPTION
Improvement over the overly conservative fix in #5454