### PR TITLE
Turn of Code Index (rich-code-nav)

### DIFF
--- a/.github/workflows/rich-code-nav.yml
+++ b/.github/workflows/rich-code-nav.yml
@@ -1,12 +1,7 @@
 name: Rich Code Navigation
 
 on:
-  push:
-    branches:
-      - main
-      - stable
-    tags:
-      - '*'
+  workflow_dispatch:
 
 env:
   dotnet_sdk_version: '8.0.100'
@@ -38,7 +33,7 @@ jobs:
         shell: bash
 
       - name: Rich Navigation Indexing
-        uses: microsoft/RichCodeNavIndexer@v0.1
+        uses: microsoft/RichCodeNavIndexer@v0
         with:
           languages: csharp
           repo-token: ${{ github.token }}


### PR DESCRIPTION
We've noticed you're indexing this repository regularly, but this service is not currently supported in GitHub scenarios; to save you build time, we recommend turning off this additional pipeline until the service is integrated into GitHub.