### PR TITLE
Move byte and sbyte from extra conversions

### DIFF
--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -56,6 +56,11 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Numeric
             mappings.AddStructType<short>(DataTypeNames.Int2,
                 static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<short>()), isDefault: true);
+            // Clr byte/sbyte maps to 'int2' as there is no byte type in PostgreSQL.
+            mappings.AddStructType<byte>(DataTypeNames.Int2,
+                static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<byte>()), isDefault: true);
+            mappings.AddStructType<sbyte>(DataTypeNames.Int2,
+                static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<sbyte>()), isDefault: true);
             mappings.AddStructType<int>(DataTypeNames.Int4,
                 static (options, mapping, _) => mapping.CreateInfo(options, new Int4Converter<int>()), isDefault: true);
             mappings.AddStructType<long>(DataTypeNames.Int8,
@@ -286,7 +291,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new InternalCharConverter<char>()),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<byte>(DataTypeNames.Char,
-                static (options, mapping, _) => mapping.CreateInfo(options, new InternalCharConverter<byte>()));
+                static (options, mapping, _) => mapping.CreateInfo(options, new InternalCharConverter<byte>()),
+                MatchRequirement.DataTypeName);
 
             // Xid8
             mappings.AddStructType<ulong>(DataTypeNames.Xid8,
@@ -317,7 +323,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new PgLsnConverter()),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<ulong>(DataTypeNames.PgLsn,
-                static (options, mapping, _) => mapping.CreateInfo(options, new UInt64Converter()));
+                static (options, mapping, _) => mapping.CreateInfo(options, new UInt64Converter()),
+                MatchRequirement.DataTypeName);
 
             return mappings;
         }
@@ -350,6 +357,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             // Numeric
             mappings.AddStructArrayType<short>(DataTypeNames.Int2);
+            mappings.AddStructArrayType<byte>(DataTypeNames.Int2);
+            mappings.AddStructArrayType<sbyte>(DataTypeNames.Int2);
             mappings.AddStructArrayType<int>(DataTypeNames.Int4);
             mappings.AddStructArrayType<long>(DataTypeNames.Int8);
             mappings.AddStructArrayType<float>(DataTypeNames.Float4);

--- a/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
@@ -26,10 +26,6 @@ sealed class ExtraConversionResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<int>()));
             mappings.AddStructType<long>(DataTypeNames.Int2,
                 static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<long>()));
-            mappings.AddStructType<byte>(DataTypeNames.Int2,
-                static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<byte>()));
-            mappings.AddStructType<sbyte>(DataTypeNames.Int2,
-                static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<sbyte>()));
             mappings.AddStructType<float>(DataTypeNames.Int2,
                 static (options, mapping, _) => mapping.CreateInfo(options, new Int2Converter<float>()));
             mappings.AddStructType<double>(DataTypeNames.Int2,
@@ -161,8 +157,6 @@ sealed class ExtraConversionResolverFactory : PgTypeInfoResolverFactory
             // Int2
             mappings.AddStructArrayType<int>(DataTypeNames.Int2);
             mappings.AddStructArrayType<long>(DataTypeNames.Int2);
-            mappings.AddStructArrayType<byte>(DataTypeNames.Int2);
-            mappings.AddStructArrayType<sbyte>(DataTypeNames.Int2);
             mappings.AddStructArrayType<float>(DataTypeNames.Int2);
             mappings.AddStructArrayType<double>(DataTypeNames.Int2);
             mappings.AddStructArrayType<decimal>(DataTypeNames.Int2);

--- a/test/Npgsql.Tests/Types/NumericTypeTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTypeTests.cs
@@ -20,10 +20,12 @@ public class NumericTypeTests : MultiplexingTestBase
     public async Task Int16()
     {
         await AssertType((short)8, "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16);
+        // Clr byte/sbyte maps to 'int2' as there is no byte type in PostgreSQL, byte[] maps to bytea however.
+        await AssertType((byte)8, "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefaultForReading: false, skipArrayCheck: true);
+        await AssertType((sbyte)8, "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefaultForReading: false);
 
         await AssertType(8,       "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);
         await AssertType(8L,      "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);
-        await AssertType((byte)8, "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);
         await AssertType(8F,      "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);
         await AssertType(8D,      "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);
         await AssertType(8M,      "8", "smallint", NpgsqlDbType.Smallint, DbType.Int16, isDefault: false);


### PR DESCRIPTION
They should have some mapping by default, also fixes the test that made us miss this before release.

Fixes #5521