### PR TITLE
Use Search Path to filter for custom type resolutions on connection open

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -199,7 +200,9 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
     internal async Task<List<PostgresType>> LoadBackendTypes(NpgsqlConnector conn, NpgsqlTimeout timeout, bool async)
     {
         var versionQuery = "SELECT version();";
-        var schemasFormatted = conn.Settings.SearchPath?.Split(',').Select(x => $"'{x}'");
+        // Regular expression pattern for valid PostgreSQL schema name
+        var schemaNamePattern = @"^[a-zA-Z_][a-zA-Z0-9_]*$";
+        var schemasFormatted = conn.Settings.SearchPath?.Split(',').Select( x => x.Trim().ToLowerInvariant()).Where( x => Regex.IsMatch(x,schemaNamePattern) ).Select( x => $"'{x.Trim().ToLowerInvariant()}'" );
         var loadTypesQuery = GenerateLoadTypesQuery(SupportsRangeTypes, SupportsMultirangeTypes, conn.Settings.LoadTableComposites, schemasFormatted);
         var loadCompositeTypesQuery = GenerateLoadCompositeTypesQuery(conn.Settings.LoadTableComposites, schemasFormatted);
         var loadEnumFieldsQuery = SupportsEnumTypes

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -142,7 +143,7 @@ FROM (
 ) AS t
 JOIN pg_namespace AS ns ON (ns.oid = typnamespace)
 WHERE
-    ns.nspname IN ('information_schema', 'pg_catalog', 'public'{(schemas?.Count() > 0 ? $", {string.Join(", ", schemas)}" : "")}) AND (
+    {(schemas?.Count() > 0 ? $"ns.nspname IN ('information_schema', 'pg_catalog', 'public', {string.Join(", ", schemas)}) AND (" : "(")}
     typtype IN ('b', 'r', 'm', 'e', 'd') OR -- Base, range, multirange, enum, domain
     (typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "relkind='c'")}) OR -- User-defined free-standing composites (not table composites) by default
     (typtype = 'p' AND typname IN ('record', 'void', 'unknown')) OR -- Some special supported pseudo-types
@@ -171,7 +172,7 @@ JOIN pg_class AS cls ON (cls.oid = typ.typrelid)
 JOIN pg_attribute AS att ON (att.attrelid = typ.typrelid)
 WHERE
   (typ.typtype = 'c' AND {(loadTableComposites ? "ns.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')" : "cls.relkind='c'")}) AND
-  ns.nspname IN ('information_schema', 'pg_catalog', 'public'{(schemas?.Count() > 0 ? $", {string.Join(", ", schemas)}" : "")}) AND 
+  {(schemas?.Count() > 0 ? $"ns.nspname IN ('information_schema', 'pg_catalog', 'public', {string.Join(", ", schemas)}) AND " : "")}
   attnum > 0 AND     -- Don't load system attributes
   NOT attisdropped
 ORDER BY typ.oid, att.attnum;";

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -656,6 +656,64 @@ public class ConnectionTests : MultiplexingTestBase
         Assert.That(() => conn.Open(), Throws.Exception.TypeOf<InvalidOperationException>());
     }
 
+    [Test]
+    [TestCase("test_schema_1", "test_schema_2")]
+    [TestCase("test_schema_3", "test_schema_4")]
+    public async Task Set_SearchPath_And_Load_Relevant_Composite_Types(string testSchema, string otherSchema)
+    {
+        using var conn1 = new NpgsqlConnection(ConnectionString);
+        await conn1.OpenAsync();
+        using var trans = await conn1.BeginTransactionAsync();
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {otherSchema} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {testSchema}");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {otherSchema}");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {testSchema}.test_type_1 AS (id int)");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {otherSchema}.test_type_2 AS (id int, name text)");
+        await trans.CommitAsync();
+        await conn1.CloseAsync();
+
+        var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            SearchPath = $"{testSchema}, public"
+        }.ToString();
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
+        using var dataSource = dataSourceBuilder.Build();
+        using var conn = await dataSource.OpenConnectionAsync();
+        Assert.True(dataSource.DatabaseInfo.CompositeTypes.Any(x => x.Name == "test_type_1"));
+        Assert.False(dataSource.DatabaseInfo.CompositeTypes.Any( x => x.Name == "test_type_2"));
+
+        await conn.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema} CASCADE");
+        await conn.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {otherSchema} CASCADE");
+    }
+
+    [Test]
+    [TestCase("test_schema_1", "test_schema_2")]
+    public async Task Clear_SearchPath_And_Load_All_Composite_Types(string testSchema1, string testSchema2)
+    {
+        using var conn1 = new NpgsqlConnection(ConnectionString);
+        await conn1.OpenAsync();
+        using var trans = await conn1.BeginTransactionAsync();
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema1} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema2} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {testSchema1}");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {testSchema2}");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {testSchema1}.test_type_1 AS (id int)");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {testSchema2}.test_type_2 AS (id int, name text)");
+        await trans.CommitAsync();
+        await conn1.CloseAsync();
+
+        var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            SearchPath = string.Empty
+        }.ToString();
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
+        using var dataSource = dataSourceBuilder.Build();
+        using var conn = await dataSource.OpenConnectionAsync();
+        Assert.True(dataSource.DatabaseInfo.CompositeTypes.Any(x => x.Name == "test_type_1"));
+        Assert.True(dataSource.DatabaseInfo.CompositeTypes.Any(x => x.Name == "test_type_2"));
+    }
+
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/703")]
     public async Task No_database_defaults_to_username()
     {

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -397,15 +397,15 @@ public class ConnectionTests : MultiplexingTestBase
 
     #region ConnectionString - Host
 
-    [TestCase("127.0.0.1", ExpectedResult = new [] { "127.0.0.1:5432" })]
-    [TestCase("127.0.0.1:5432", ExpectedResult = new [] { "127.0.0.1:5432" })]
-    [TestCase("::1", ExpectedResult = new [] { "::1:5432" })]
-    [TestCase("[::1]", ExpectedResult = new [] { "[::1]:5432" })]
-    [TestCase("[::1]:5432", ExpectedResult = new [] { "[::1]:5432" })]
-    [TestCase("localhost", ExpectedResult = new [] { "localhost:5432" })]
-    [TestCase("localhost:5432", ExpectedResult = new [] { "localhost:5432" })]
+    [TestCase("127.0.0.1", ExpectedResult = new[] { "127.0.0.1:5432" })]
+    [TestCase("127.0.0.1:5432", ExpectedResult = new[] { "127.0.0.1:5432" })]
+    [TestCase("::1", ExpectedResult = new[] { "::1:5432" })]
+    [TestCase("[::1]", ExpectedResult = new[] { "[::1]:5432" })]
+    [TestCase("[::1]:5432", ExpectedResult = new[] { "[::1]:5432" })]
+    [TestCase("localhost", ExpectedResult = new[] { "localhost:5432" })]
+    [TestCase("localhost:5432", ExpectedResult = new[] { "localhost:5432" })]
     [TestCase("127.0.0.1,127.0.0.1:5432,::1,[::1],[::1]:5432,localhost,localhost:5432",
-        ExpectedResult = new []
+        ExpectedResult = new[]
         {
             "127.0.0.1:5432",
             "127.0.0.1:5432",
@@ -685,6 +685,33 @@ public class ConnectionTests : MultiplexingTestBase
 
         await conn.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema} CASCADE");
         await conn.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {otherSchema} CASCADE");
+    }
+
+    [Test]
+    [TestCase("test_schema_1", "test_schema_2")]
+    public async Task Set_SearchPath_And_Load_All_Composite_Types(string testSchema1, string testSchema2)
+    {
+        using var conn1 = new NpgsqlConnection(ConnectionString);
+        await conn1.OpenAsync();
+        using var trans = await conn1.BeginTransactionAsync();
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema1} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"DROP SCHEMA IF EXISTS {testSchema2} CASCADE");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {testSchema1}");
+        await conn1.ExecuteNonQueryAsync($"CREATE SCHEMA {testSchema2}");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {testSchema1}.test_type_1 AS (id int)");
+        await conn1.ExecuteNonQueryAsync($"CREATE TYPE {testSchema2}.test_type_2 AS (id int, name text)");
+        await trans.CommitAsync();
+        await conn1.CloseAsync();
+
+        var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            SearchPath = $"{testSchema1}, {testSchema2}"
+        }.ToString();
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
+        using var dataSource = dataSourceBuilder.Build();
+        using var conn = await dataSource.OpenConnectionAsync();
+        Assert.True(dataSource.DatabaseInfo.CompositeTypes.Any(x => x.Name == "test_type_1"));
+        Assert.True(dataSource.DatabaseInfo.CompositeTypes.Any(x => x.Name == "test_type_2"));
     }
 
     [Test]


### PR DESCRIPTION
Use Search Path to filter for custom type resolutions on connection open, so that it skips any schemas not in search path. (information_schema, pg_catalog and public is included always)

This is relevant for large number of schemas with custom types, to get significant increase in connection time.