### PR TITLE
Decimal scale was lost when dealing with decimal zero

### DIFF
--- a/src/Npgsql/Internal/Converters/Primitive/PgNumeric.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/PgNumeric.cs
@@ -315,7 +315,7 @@ readonly struct PgNumeric
             if (Math.Abs(scale) > MaxDecimalScale)
                 throw new OverflowException("Numeric value does not fit in a System.Decimal");
 
-            if (digitCount == 0)
+            if (digitCount == 0 && !((sign is SignPositive or SignNegative) && scale > 0)) // handle 0 with scale, ie 0.00 
                 return sign switch
                 {
                     SignPositive or SignNegative => decimal.Zero,
@@ -336,7 +336,7 @@ readonly struct PgNumeric
             var digitScale = (weight + 1 - digitCount) * NumericBaseLog10;
             var scaleDifference = scale < 0 ? digitScale : digitScale + scale;
 
-            var digit = digits[digitCount - 1];
+            var digit = digitCount == 0 ? 0 : digits[digitCount - 1];
             if (digitCount == MaxDecimalNumericDigits)
             {
                 // On the max group we adjust the base based on the scale difference, to prevent overflow for valid values.

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -207,7 +207,8 @@ public class NumericTests : MultiplexingTestBase
         using var rdr = await cmd.ExecuteReaderAsync();
         await rdr.ReadAsync();
         var value = rdr.GetFieldValue<decimal>(0);
-        Assert.That(value.ToString(), Is.EqualTo(0.00M.ToString()));
+
+        Assert.That(value.Scale, Is.EqualTo(2));
     }
 
     public NumericTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) {}

--- a/test/Npgsql.Tests/Types/NumericTests.cs
+++ b/test/Npgsql.Tests/Types/NumericTests.cs
@@ -196,5 +196,19 @@ public class NumericTests : MultiplexingTestBase
         Assert.That(rdr.GetFieldValue<BigInteger>(1), Is.EqualTo(num));
     }
 
+    [Test]
+    public async Task NumericZero_WithScale()
+    {
+        // Scale should not be lost when dealing with 0
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand("SELECT @p", conn);
+        var param = new NpgsqlParameter("p", DbType.Decimal, 10, null, ParameterDirection.Input, false, 10, 2, DataRowVersion.Default, 0.00M);
+        cmd.Parameters.Add(param);
+        using var rdr = await cmd.ExecuteReaderAsync();
+        await rdr.ReadAsync();
+        var value = rdr.GetFieldValue<decimal>(0);
+        Assert.That(value.ToString(), Is.EqualTo(0.00M.ToString()));
+    }
+
     public NumericTests(MultiplexingMode multiplexingMode) : base(multiplexingMode) {}
 }


### PR DESCRIPTION
Hi ! I had an issue when dealing with decimal zero with scale defined (ie 0.00M).
Those fields were converted to plain 0M, loosing the scale.

I've added a "naive" fix to address this issue and a test showcasing the issue. I'm sorry to provide comparison with string representation, but I couldn't find a proper way to check if 0.00M is a zero with 2 decimal places also 0.

BTW I want to thank you for the great work here !