### PR TITLE
Tupled record array fix

### DIFF
--- a/test/Npgsql.Tests/Types/RecordTests.cs
+++ b/test/Npgsql.Tests/Types/RecordTests.cs
@@ -45,10 +45,12 @@ public class RecordTests : MultiplexingTestBase
         Assert.That(record.Item1, Is.EqualTo(1));
         Assert.That(record.Item2, Is.EqualTo("foo"));
 
-        var array = (object[][])reader[1];
+        var array = reader.GetFieldValue<(int, string)[]>(1);
         Assert.That(array.Length, Is.EqualTo(2));
-        Assert.That(array[0][0], Is.EqualTo(1));
-        Assert.That(array[1][0], Is.EqualTo(1));
+        Assert.That(array[0].Item1, Is.EqualTo(1));
+        Assert.That(array[0].Item2, Is.EqualTo("foo"));
+        Assert.That(array[1].Item1, Is.EqualTo(1));
+        Assert.That(array[1].Item2, Is.EqualTo("foo"));
     }
 
     [Test]
@@ -66,10 +68,12 @@ public class RecordTests : MultiplexingTestBase
         Assert.That(record.Item1, Is.EqualTo(1));
         Assert.That(record.Item2, Is.EqualTo("foo"));
 
-        var array = (object[][])reader[1];
+        var array = reader.GetFieldValue<Tuple<int, string>[]>(1);
         Assert.That(array.Length, Is.EqualTo(2));
-        Assert.That(array[0][0], Is.EqualTo(1));
-        Assert.That(array[1][0], Is.EqualTo(1));
+        Assert.That(array[0].Item1, Is.EqualTo(1));
+        Assert.That(array[0].Item2, Is.EqualTo("foo"));
+        Assert.That(array[1].Item1, Is.EqualTo(1));
+        Assert.That(array[1].Item2, Is.EqualTo("foo"));
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/1238")]


### PR DESCRIPTION
Properly synthesize array mappings over the *concrete* type of the tuple not - as previously - the stand-in `{Value}Tuple<object>` type. 

Refactored to use the DynamicTypeInfoResolver infra. Its entire point is to make these kinds of resolvers easier to write (it just didn't exist at the time we wrote the tupled record resolver).

This issue wasn't noticed as we weren't testing the valuetuple and tuple array mappings correctly. 

Fixes #5518