### PR TITLE
Fix async nullable read creating an allocation

### DIFF
--- a/src/Npgsql/Internal/Converters/AsyncHelpers.cs
+++ b/src/Npgsql/Internal/Converters/AsyncHelpers.cs
@@ -60,32 +60,29 @@ static class AsyncHelpers
         public void Invoke(Task task, CompletionSource tcs) => _continuation(task, tcs);
     }
 
-    public static unsafe ValueTask<T> ComposingReadAsync<T, TEffective>(this PgConverter<T> instance, PgConverter<TEffective> effectiveConverter, PgReader reader, CancellationToken cancellationToken)
+    public static unsafe ValueTask<T?> ReadAsyncAsNullable<T>(this PgConverter<T?> instance, PgConverter<T> effectiveConverter, PgReader reader, CancellationToken cancellationToken)
+        where T : struct
     {
-        if (!typeof(T).IsValueType && !typeof(TEffective).IsValueType)
-        {
-            var value = effectiveConverter.ReadAsync(reader, cancellationToken);
-            return Unsafe.As<ValueTask<TEffective>, ValueTask<T>>(ref value);
-        }
         // Easy if we have all the data.
         var task = effectiveConverter.ReadAsync(reader, cancellationToken);
         if (task.IsCompletedSuccessfully)
-            return new((T)(object)task.Result!);
+            return new(new T?(task.Result));
 
         // Otherwise we do one additional allocation, this allow us to share state machine codegen for all Ts.
-        var source = new CompletionSource<T>();
+        var source = new CompletionSource<T?>();
         AwaitTask(task.AsTask(), source, new(instance, &UnboxAndComplete));
         return source.Task;
 
         static void UnboxAndComplete(Task task, CompletionSource completionSource)
         {
+            // Justification: unsafe exact cast used to reduce generic duplication cost.
             Debug.Assert(task is Task<T>);
-            Debug.Assert(completionSource is CompletionSource<T>);
-            Unsafe.As<CompletionSource<T>>(completionSource).SetResult(new ValueTask<T>(Unsafe.As<Task<T>>(task)).Result);
+            Debug.Assert(completionSource is CompletionSource<T?>);
+            Unsafe.As<CompletionSource<T?>>(completionSource).SetResult(new T?(new ValueTask<T>(Unsafe.As<Task<T>>(task)).Result));
         }
     }
 
-    public static unsafe ValueTask<T> ComposingReadAsObjectAsync<T>(this PgConverter<T> instance, PgConverter effectiveConverter, PgReader reader, CancellationToken cancellationToken)
+    public static unsafe ValueTask<T> ReadAsObjectAsyncAsT<T>(this PgConverter<T> instance, PgConverter effectiveConverter, PgReader reader, CancellationToken cancellationToken)
     {
         if (!typeof(T).IsValueType)
         {

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -22,7 +22,7 @@ sealed class CastingConverter<T> : PgConverter<T>
     public override T Read(PgReader reader) => (T)_effectiveConverter.ReadAsObject(reader);
 
     public override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
-        => this.ComposingReadAsObjectAsync(_effectiveConverter, reader, cancellationToken);
+        => this.ReadAsObjectAsyncAsT(_effectiveConverter, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, T value, ref object? writeState)
         => _effectiveConverter.GetSizeAsObject(context, value!, ref writeState);

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -24,7 +24,7 @@ sealed class NullableConverter<T> : PgConverter<T?> where T : struct
         => _effectiveConverter.Read(reader);
 
     public override ValueTask<T?> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
-        => this.ComposingReadAsync(_effectiveConverter, reader, cancellationToken);
+        => this.ReadAsyncAsNullable(_effectiveConverter, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, [DisallowNull]T? value, ref object? writeState)
         => _effectiveConverter.GetSize(context, value.GetValueOrDefault(), ref writeState);


### PR DESCRIPTION
Doing (T?)(object)(T)value apparently causes the jit to emit a box, even though it knows both concrete types due to specializiation.

Fix by making the method constrained to struct so we can concretely wrap the T instead of using the unboxing support for nullables.