### PR TITLE
Address trimming/AOT warnings

### DIFF
--- a/src/Npgsql/Internal/ResolverFactories/UnsupportedTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnsupportedTypeInfoResolver.cs
@@ -17,10 +17,7 @@ sealed class UnsupportedTypeInfoResolver<TBuilder> : IPgTypeInfoResolver
         FullTextSearchTypeInfoResolverFactory.ThrowIfUnsupported<TBuilder>(type, dataTypeName, options);
         LTreeTypeInfoResolverFactory.ThrowIfUnsupported<TBuilder>(type, dataTypeName, options);
 
-        // The compiler can't see that these method(s) are completely safe, other methods force the attributes on the type(s).
-#pragma warning disable IL3050, IL2026
-        JsonDynamicTypeInfoResolverFactory.ThrowIfUnsupported<TBuilder>(type, dataTypeName, options);
-#pragma warning restore IL3050, IL2026
+        JsonDynamicTypeInfoResolverFactory.Support.ThrowIfUnsupported<TBuilder>(type, dataTypeName);
 
         switch (dataTypeName is null ? null : options.DatabaseInfo.GetPostgresType(dataTypeName.GetValueOrDefault()))
         {

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -15,6 +15,10 @@ namespace Npgsql;
 /// Provides a simple way to create and manage the contents of connection strings used by
 /// the <see cref="NpgsqlConnection"/> class.
 /// </summary>
+[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2112:ReflectionToRequiresUnreferencedCode",
+    Justification = "Suppressing the same warnings as suppressed in the base DbConnectionStringBuilder. See https://github.com/dotnet/runtime/issues/97057")]
+[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2113:ReflectionToRequiresUnreferencedCode",
+    Justification = "Suppressing the same warnings as suppressed in the base DbConnectionStringBuilder. See https://github.com/dotnet/runtime/issues/97057")]
 public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBuilder, IDictionary<string, object?>
 {
     #region Fields


### PR DESCRIPTION
- Split ThrowIfUnsupported out into a nested class of JsonDynamicTypeInfoResolverFactory to avoid erroneous warnings.
- Suppress warnings on NpgsqlConnectionStringBuilder to match base DbConnectionStringBuilder suppressions. See https://github.com/dotnet/runtime/issues/97057 for an explanation of why these warnings happen.

Fix #5577

cc @roji @NinoFloris 