### PR TITLE
Remove unknown pgtype dependency

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -368,7 +368,7 @@ public sealed class FieldDescription
                 // For text we'll fall back to any available text converter for the expected clr type or throw.
                 if (!typeInfo.TryBind(Field, DataFormat, out converterInfo))
                 {
-                    typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.UnknownPgType, _serializerOptions);
+                    typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgType, _serializerOptions);
                     converterInfo = typeInfo.Bind(Field, DataFormat);
                     lastColumnInfo = new(converterInfo, DataFormat, type != converterInfo.TypeToConvert || converterInfo.IsBoxingConverter);
                 }

--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -228,6 +228,11 @@ public abstract class NpgsqlDatabaseInfo
 
     internal void ProcessTypes()
     {
+        var unspecified = new PostgresBaseType(DataTypeName.Unspecified, Oid.Unspecified);
+        ByOID[Oid.Unspecified.Value] = unspecified;
+        ByFullName[unspecified.DataTypeName.Value] = unspecified;
+        ByName[unspecified.InternalName] = unspecified;
+
         foreach (var type in GetTypes())
         {
             ByOID[type.OID] = type;

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -25,11 +25,13 @@ public sealed class PgSerializerOptions
         _resolverChain = resolverChain ?? new();
         _timeZoneProvider = timeZoneProvider;
         DatabaseInfo = databaseInfo;
-        UnknownPgType = databaseInfo.GetPostgresType("unknown");
+        UnspecifiedDBNullTypeInfo = new(this, new Converters.Internal.VoidConverter(), DataTypeName.Unspecified, unboxedType: typeof(DBNull));
     }
 
-    // Represents the 'unknown' type, which can be used for reading and writing arbitrary text values.
-    public PostgresType UnknownPgType { get; }
+    internal PgTypeInfo UnspecifiedDBNullTypeInfo { get; }
+
+    PostgresType? _textPgType;
+    internal PostgresType TextPgType => _textPgType ??= DatabaseInfo.GetPostgresType(DataTypeNames.Text);
 
     // Used purely for type mapping, where we don't have a full set of types but resolvers might know enough.
     readonly bool _introspectionInstance;

--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -48,9 +48,9 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
     internal static DataTypeName ValidatedName(string fullyQualifiedDataTypeName)
         => new(fullyQualifiedDataTypeName, validated: true);
 
-    // Includes schema unless it's pg_catalog.
+    // Includes schema unless it's pg_catalog or the name is unspecified.
     public string DisplayName =>
-        Value.StartsWith("pg_catalog", StringComparison.Ordinal)
+        Value.StartsWith("pg_catalog", StringComparison.Ordinal) || Value == Unspecified
             ? UnqualifiedDisplayName
             : Schema + "." + UnqualifiedDisplayName;
 

--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -63,11 +63,13 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
     public string Value => _value is null ? ThrowDefaultException() : _value;
 
     static string ThrowDefaultException() =>
-        throw new InvalidOperationException($"This operation cannot be performed on a default instance of {nameof(DataTypeName)}.");
+        throw new InvalidOperationException($"This operation cannot be performed on a default value of {nameof(DataTypeName)}.");
 
     public static implicit operator string(DataTypeName value) => value.Value;
 
-    public bool IsDefault => _value is null;
+    // This contains two invalid sql identifiers (schema and name are both separate identifiers, and would both have to be quoted to be valid).
+    // Given this is an invalid name it's fine for us to represent a fully qualified 'unspecified' name with it.
+    public static DataTypeName Unspecified => new("-.-", validated: true);
 
     public bool IsArray => UnqualifiedNameSpan.StartsWith("_".AsSpan(), StringComparison.Ordinal);
 

--- a/src/Npgsql/Internal/Postgres/Oid.cs
+++ b/src/Npgsql/Internal/Postgres/Oid.cs
@@ -9,6 +9,7 @@ public readonly struct Oid: IEquatable<Oid>
     public static explicit operator uint(Oid oid) => oid.Value;
     public static implicit operator Oid(uint oid) => new(oid);
     public uint Value { get; init; }
+    public static Oid Unspecified => new(0);
 
     public override string ToString() => Value.ToString();
     public bool Equals(Oid other) => Value == other.Value;

--- a/src/Npgsql/Internal/Postgres/PgTypeId.cs
+++ b/src/Npgsql/Internal/Postgres/PgTypeId.cs
@@ -15,8 +15,8 @@ public readonly struct PgTypeId: IEquatable<PgTypeId>
     public PgTypeId(Oid oid) => _oid = oid;
 
     [MemberNotNullWhen(true, nameof(_dataTypeName))]
-    public bool IsDataTypeName => !_dataTypeName.IsDefault;
-    public bool IsOid => _dataTypeName.IsDefault;
+    public bool IsDataTypeName => _dataTypeName != default;
+    public bool IsOid => _dataTypeName == default;
 
     public DataTypeName DataTypeName
         => IsDataTypeName ? _dataTypeName : throw new InvalidOperationException("This value does not describe a DataTypeName.");
@@ -42,4 +42,6 @@ public readonly struct PgTypeId: IEquatable<PgTypeId>
     public override int GetHashCode() => IsOid ? _oid.GetHashCode() : _dataTypeName.GetHashCode();
     public static bool operator ==(PgTypeId left, PgTypeId right) => left.Equals(right);
     public static bool operator !=(PgTypeId left, PgTypeId right) => !left.Equals(right);
+
+    internal bool IsUnspecified => IsOid && _oid == Oid.Unspecified || _dataTypeName == DataTypeName.Unspecified;
 }

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -40,10 +40,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     internal string TrimmedName { get; private protected set; } = PositionalName;
     internal const string PositionalName = "";
 
-    internal PgTypeInfo? TypeInfo { get; private set; }
+    private protected PgTypeInfo? TypeInfo { get; private set; }
 
     internal PgTypeId PgTypeId { get; private set; }
-    internal PgConverter? Converter { get; private set; }
+    private protected PgConverter? Converter { get; private set; }
 
     internal DataFormat Format { get; private protected set; }
     private protected Size? WriteSize { get; set; }
@@ -278,7 +278,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         get => _value;
         set
         {
-            if (value is null || _value?.GetType() != value.GetType())
+            if (ShouldResetObjectTypeInfo(value))
                 ResetTypeInfo();
             else
                 ResetBindingInfo();
@@ -497,6 +497,17 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
     Type? GetValueType(Type staticValueType) => staticValueType != typeof(object) ? staticValueType : Value?.GetType();
 
+    internal bool ShouldResetObjectTypeInfo(object? value)
+    {
+        var currentType = TypeInfo?.Type;
+        if (currentType is null || value is null)
+            return false;
+
+        var valueType = value.GetType();
+        // We don't want to reset the type info when the value is a DBNull, we're able to write it out with any type info.
+        return valueType != typeof(DBNull) && currentType != valueType;
+    }
+
     internal void GetResolutionInfo(out PgTypeInfo? typeInfo, out PgConverter? converter, out PgTypeId pgTypeId)
     {
         typeInfo = TypeInfo;
@@ -540,6 +551,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 pgTypeId = options.ToCanonicalTypeId(pgType.GetRepresentationalType());
             }
 
+            var unspecifiedDBNull = false;
             var valueType = StaticValueType;
             if (valueType == typeof(object))
             {
@@ -551,14 +563,23 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 }
 
                 // We treat object typed DBNull values as default info.
+                // Unless we don't have a pgTypeId either, at which point we'll use an 'unspecified' PgTypeInfo to help us write a NULL.
                 if (valueType == typeof(DBNull))
                 {
-                    valueType = null;
-                    pgTypeId ??= options.ToCanonicalTypeId(options.UnknownPgType);
+                    if (pgTypeId is null)
+                    {
+                        unspecifiedDBNull = true;
+                        typeInfo = options.UnspecifiedDBNullTypeInfo;
+                    }
+                    else
+                        valueType = null;
                 }
             }
 
-            TypeInfo = typeInfo = AdoSerializerHelpers.GetTypeInfoForWriting(valueType, pgTypeId, options, _npgsqlDbType);
+            if (!unspecifiedDBNull)
+                typeInfo = AdoSerializerHelpers.GetTypeInfoForWriting(valueType, pgTypeId, options, _npgsqlDbType);
+
+            TypeInfo = typeInfo;
         }
 
         // This step isn't part of BindValue because we need to know the PgTypeId beforehand for things like SchemaOnly with null values.
@@ -566,7 +587,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         // TODO we could expose a property on a Converter/TypeInfo to indicate whether it's immutable, at that point we can reuse.
         if (!previouslyResolved || typeInfo!.IsResolverInfo)
         {
-            ResetBindingInfo(); // No need for ResetConverterResolution as we'll mutate those fields directly afterwards.
+            ResetBindingInfo();
             var resolution = ResolveConverter(typeInfo!);
             Converter = resolution.Converter;
             PgTypeId = resolution.PgTypeId;
@@ -735,11 +756,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected void ResetTypeInfo()
     {
         TypeInfo = null;
-        ResetConverterResolution();
-    }
-
-    void ResetConverterResolution()
-    {
         _asObject = false;
         Converter = null;
         PgTypeId = default;

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -26,7 +26,7 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
         get => _typedValue;
         set
         {
-            if (typeof(T) == typeof(object) && (value is null || _typedValue?.GetType() != value.GetType()))
+            if (typeof(T) == typeof(object) && ShouldResetObjectTypeInfo(value))
                 ResetTypeInfo();
             else
                 ResetBindingInfo();

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
+using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Tests;
 
@@ -691,6 +692,71 @@ public class NpgsqlParameterTest : TestBase
 
         Assert.That(reader.Read(), Is.True);
         Assert.That(reader.GetFieldValue<int?>(0), Is.Null);
+    }
+
+    [Test]
+    public void DBNull_reuses_type_info([Values]bool generic)
+    {
+        // Bootstrap datasource.
+        using (var _ = OpenConnection()) {}
+
+        var param = generic ? new NpgsqlParameter<object> { Value = "value" } : new NpgsqlParameter { Value = "value" };
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var typeInfo, out _, out _);
+        Assert.That(typeInfo, Is.Not.Null);
+
+        // Make sure we don't reset the type info when setting DBNull.
+        param.Value = DBNull.Value;
+        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        Assert.That(typeInfo, Is.SameAs(secondTypeInfo));
+
+        // Make sure we don't resolve a different type info either.
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        Assert.That(secondTypeInfo, Is.SameAs(thirdTypeInfo));
+    }
+
+    [Test]
+    public void DBNull_followed_by_non_null_reresolves([Values]bool generic)
+    {
+        // Bootstrap datasource.
+        using (var _ = OpenConnection()) {}
+
+        var param = generic ? new NpgsqlParameter<object> { Value = DBNull.Value } : new NpgsqlParameter { Value = DBNull.Value };
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var typeInfo, out _, out var pgTypeId);
+        Assert.That(typeInfo, Is.Not.Null);
+        Assert.That(pgTypeId.IsUnspecified, Is.True);
+
+        param.Value = "value";
+        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        Assert.That(secondTypeInfo, Is.Null);
+
+        // Make sure we don't resolve the same type info either.
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        Assert.That(typeInfo, Is.Not.SameAs(thirdTypeInfo));
+    }
+
+    [Test]
+    public void Changing_value_type_reresolves([Values]bool generic)
+    {
+        // Bootstrap datasource.
+        using (var _ = OpenConnection()) {}
+
+        var param = generic ? new NpgsqlParameter<object> { Value = "value" } : new NpgsqlParameter { Value = "value" };
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var typeInfo, out _, out _);
+        Assert.That(typeInfo, Is.Not.Null);
+
+        param.Value = 1;
+        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        Assert.That(secondTypeInfo, Is.Null);
+
+        // Make sure we don't resolve a different type info either.
+        param.ResolveTypeInfo(DataSource.SerializerOptions);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        Assert.That(typeInfo, Is.Not.SameAs(thirdTypeInfo));
     }
 
 #if NeedsPorting


### PR DESCRIPTION
Brings our compat with pg-likes back to <= 7.x levels. 

These changes also improve object parameter cache re-use when writing db nulls and non-nulls of a constant type via the same parameter instance. This will feed into improvements to binary importer perf in a later pr.

Fixes #5503