### PR TITLE
Improve binary exporter perf

### DIFF
--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -134,6 +134,9 @@ sealed partial class NpgsqlReadBuffer : IDisposable
 
     #region I/O
 
+    public void Ensure(int count)
+        => Ensure(count, async: false, readingNotifications: false).GetAwaiter().GetResult();
+
     public ValueTask Ensure(int count, bool async)
         => Ensure(count, async, readingNotifications: false);
 

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -783,7 +783,7 @@ public class PgReader
 
     public void Buffer(Size bufferRequirement)
         => Buffer(GetBufferRequirementByteCount(bufferRequirement));
-    public void Buffer(int byteCount) => _buffer.Ensure(byteCount, async: false).GetAwaiter().GetResult();
+    public void Buffer(int byteCount) => _buffer.Ensure(byteCount);
 
     public ValueTask BufferAsync(Size bufferRequirement, CancellationToken cancellationToken)
         => BufferAsync(GetBufferRequirementByteCount(bufferRequirement), cancellationToken);

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -149,7 +149,10 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         // Consume and advance any active column.
         if (_column >= 0)
         {
-            await Commit(async).ConfigureAwait(false);
+            if (async)
+                await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
+            else
+                PgReader.Commit(resuming: false);
             _column++;
         }
 
@@ -194,7 +197,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// specify the type.
     /// </typeparam>
     /// <returns>The value of the column</returns>
-    public T Read<T>() => Read<T>(async: false).GetAwaiter().GetResult();
+    public T Read<T>()
+        => Read<T>(null);
 
     /// <summary>
     /// Reads the current column, returns its value and moves ahead to the next column.
@@ -207,10 +211,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// </typeparam>
     /// <returns>The value of the column</returns>
     public ValueTask<T> ReadAsync<T>(CancellationToken cancellationToken = default)
-        => Read<T>(async: true, cancellationToken);
-
-    ValueTask<T> Read<T>(bool async, CancellationToken cancellationToken = default)
-        => Read<T>(async, null, cancellationToken);
+        => ReadAsync<T>(null, cancellationToken);
 
     /// <summary>
     /// Reads the current column, returns its value according to <paramref name="type"/> and
@@ -225,7 +226,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// </param>
     /// <typeparam name="T">The .NET type of the column to be read.</typeparam>
     /// <returns>The value of the column</returns>
-    public T Read<T>(NpgsqlDbType type) => Read<T>(async: false, type, CancellationToken.None).GetAwaiter().GetResult();
+    public T Read<T>(NpgsqlDbType type)
+        => Read<T>((NpgsqlDbType?)type);
 
     /// <summary>
     /// Reads the current column, returns its value according to <paramref name="type"/> and
@@ -244,42 +246,28 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// <typeparam name="T">The .NET type of the column to be read.</typeparam>
     /// <returns>The value of the column</returns>
     public ValueTask<T> ReadAsync<T>(NpgsqlDbType type, CancellationToken cancellationToken = default)
-        => Read<T>(async: true, type, cancellationToken);
+        => ReadAsync<T>((NpgsqlDbType?)type, cancellationToken);
 
-    async ValueTask<T> Read<T>(bool async, NpgsqlDbType? type, CancellationToken cancellationToken)
+    T Read<T>(NpgsqlDbType? type)
     {
         ThrowIfNotOnRow();
 
-        using var registration = _connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
-
         if (!IsInitializedAndAtStart)
-            await MoveNextColumn(async, resumableOp: false).ConfigureAwait(false);
+            MoveNextColumn(resumableOp: false);
 
+        var reader = PgReader;
         try
         {
-            var reader = PgReader;
             if (reader.FieldSize is -1)
-                return DbNullOrThrow();
+                return DbNullOrThrow<T>();
 
-            var info = GetInfo(type, out var asObject);
+            var info = GetInfo(typeof(T), type, out var asObject);
 
-            T result;
-            if (async)
-            {
-                await reader.StartReadAsync(info.BufferRequirement, cancellationToken).ConfigureAwait(false);
-                result = asObject
-                    ? (T)await info.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-                    : await info.GetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-                await reader.EndReadAsync().ConfigureAwait(false);
-            }
-            else
-            {
-                reader.StartRead(info.BufferRequirement);
-                result = asObject
-                    ? (T)info.Converter.ReadAsObject(reader)
-                    : info.GetConverter<T>().Read(reader);
-                reader.EndRead();
-            }
+            reader.StartRead(info.BufferRequirement);
+            var result = asObject
+                ? (T)info.Converter.ReadAsObject(reader)
+                : info.GetConverter<T>().Read(reader);
+            reader.EndRead();
 
             return result;
         }
@@ -288,48 +276,82 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             // Don't delay committing the current column, just do it immediately (as opposed to on the next action: Read, IsNull, Skip).
             // Zero length columns would otherwise create an edge-case where we'd have to immediately commit as we won't know whether we're at the end.
             // To guarantee the commit happens in that case we would still need this try finally, at which point it's just better to be consistent.
-            await Commit(async).ConfigureAwait(false);
+            reader.Commit(resuming: false);
         }
+    }
 
-        static T DbNullOrThrow()
+    async ValueTask<T> ReadAsync<T>(NpgsqlDbType? type, CancellationToken cancellationToken)
+    {
+        ThrowIfNotOnRow();
+
+        using var registration = _connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
+
+        if (!IsInitializedAndAtStart)
+            await MoveNextColumnAsync(resumableOp: false).ConfigureAwait(false);
+
+        var reader = PgReader;
+        try
         {
-            // When T is a Nullable<T>, we support returning null
-            if (default(T) is null && typeof(T).IsValueType)
-                return default!;
-            throw new InvalidCastException("Column is null");
+            if (reader.FieldSize is -1)
+                return DbNullOrThrow<T>();
+
+            var info = GetInfo(typeof(T), type, out var asObject);
+
+            await reader.StartReadAsync(info.BufferRequirement, cancellationToken).ConfigureAwait(false);
+            var result = asObject
+                ? (T)await info.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+                : await info.GetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            await reader.EndReadAsync().ConfigureAwait(false);
+
+            return result;
         }
-
-        PgConverterInfo GetInfo(NpgsqlDbType? type, out bool asObject)
+        finally
         {
-            ref var cachedInfo = ref _columnInfoCache[_column];
-            var converterInfo = cachedInfo.IsDefault ? cachedInfo = CreateConverterInfo(typeof(T), type) : cachedInfo;
-            asObject = converterInfo.IsBoxingConverter;
-            return converterInfo;
+            // Don't delay committing the current column, just do it immediately (as opposed to on the next action: Read, IsNull, Skip).
+            // Zero length columns would otherwise create an edge-case where we'd have to immediately commit as we won't know whether we're at the end.
+            // To guarantee the commit happens in that case we would still need this try finally, at which point it's just better to be consistent.
+            await reader.CommitAsync(resuming: false).ConfigureAwait(false);
         }
+    }
 
-        PgConverterInfo CreateConverterInfo(Type type, NpgsqlDbType? npgsqlDbType = null)
+    static T DbNullOrThrow<T>()
+    {
+        // When T is a Nullable<T>, we support returning null
+        if (default(T) is null && typeof(T).IsValueType)
+            return default!;
+        throw new InvalidCastException("Column is null");
+    }
+
+    PgConverterInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out bool asObject)
+    {
+        ref var cachedInfo = ref _columnInfoCache[_column];
+        var converterInfo = cachedInfo.IsDefault ? cachedInfo = CreateConverterInfo(type, npgsqlDbType) : cachedInfo;
+        asObject = converterInfo.IsBoxingConverter;
+        return converterInfo;
+    }
+
+    PgConverterInfo CreateConverterInfo(Type type, NpgsqlDbType? npgsqlDbType = null)
+    {
+        var options = _connector.SerializerOptions;
+        PgTypeId? pgTypeId = null;
+        if (npgsqlDbType.HasValue)
         {
-            var options = _connector.SerializerOptions;
-            PgTypeId? pgTypeId = null;
-            if (npgsqlDbType.HasValue)
-            {
-                pgTypeId = npgsqlDbType.Value.ToDataTypeName() is { } name
-                    ? options.GetCanonicalTypeId(name)
-                    // Handle plugin types via lookup.
-                    : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
-            }
-            var info = options.GetTypeInfo(type, pgTypeId)
-                       ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
+            pgTypeId = npgsqlDbType.Value.ToDataTypeName() is { } name
+                ? options.GetCanonicalTypeId(name)
+                // Handle plugin types via lookup.
+                : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
+        }
+        var info = options.GetTypeInfo(type, pgTypeId)
+                   ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
-            // Binary export has no type info so we only do caller-directed interpretation of data.
-            return info.Bind(new Field("?",
-                info.PgTypeId ?? ((PgResolverTypeInfo)info).GetDefaultResolution(null).PgTypeId, -1), DataFormat.Binary);
+        // Binary export has no type info so we only do caller-directed interpretation of data.
+        return info.Bind(new Field("?",
+            info.PgTypeId ?? ((PgResolverTypeInfo)info).GetDefaultResolution(null).PgTypeId, -1), DataFormat.Binary);
 
-            PgTypeId GetRepresentationalOrDefault(string dataTypeName)
-            {
-                var type = options.DatabaseInfo.GetPostgresType(dataTypeName);
-                return options.ToCanonicalTypeId(type.GetRepresentationalType());
-            }
+        PgTypeId GetRepresentationalOrDefault(string dataTypeName)
+        {
+            var type = options.DatabaseInfo.GetPostgresType(dataTypeName);
+            return options.ToCanonicalTypeId(type.GetRepresentationalType());
         }
     }
 
@@ -342,7 +364,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         {
             ThrowIfNotOnRow();
             if (!IsInitializedAndAtStart)
-                return MoveNextColumn(async: false, resumableOp: true).GetAwaiter().GetResult() is -1;
+                return MoveNextColumn(resumableOp: true) is -1;
 
             return PgReader.FieldSize is - 1;
         }
@@ -351,24 +373,29 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// <summary>
     /// Skips the current column without interpreting its value.
     /// </summary>
-    public void Skip() => Skip(async: false).GetAwaiter().GetResult();
+    public void Skip()
+    {
+        ThrowIfNotOnRow();
+
+        if (!IsInitializedAndAtStart)
+            MoveNextColumn(resumableOp: false);
+
+        PgReader.Commit(resuming: false);
+    }
 
     /// <summary>
     /// Skips the current column without interpreting its value.
     /// </summary>
-    public Task SkipAsync(CancellationToken cancellationToken = default)
-        => Skip(true, cancellationToken);
-
-    async Task Skip(bool async, CancellationToken cancellationToken = default)
+    public async Task SkipAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfNotOnRow();
 
         using var registration = _connector.StartNestedCancellableOperation(cancellationToken);
 
         if (!IsInitializedAndAtStart)
-            await MoveNextColumn(async, resumableOp: false).ConfigureAwait(false);
+            await MoveNextColumnAsync(resumableOp: false).ConfigureAwait(false);
 
-        await Commit(async).ConfigureAwait(false);
+        await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
     }
 
     #endregion
@@ -377,26 +404,27 @@ public sealed class NpgsqlBinaryExporter : ICancelable
 
     bool IsInitializedAndAtStart => PgReader.Initialized && (PgReader.FieldSize is -1 || PgReader.FieldOffset is 0);
 
-    ValueTask Commit(bool async)
+    int MoveNextColumn(bool resumableOp)
     {
-        if (async)
-            return PgReader.CommitAsync(resuming: false);
-
         PgReader.Commit(resuming: false);
-        return new();
-    }
-
-    async ValueTask<int> MoveNextColumn(bool async, bool resumableOp)
-    {
-        if (async)
-            await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
-        else
-            PgReader.Commit(resuming: false);
 
         if (_column + 1 == NumColumns)
             ThrowHelper.ThrowInvalidOperationException("No more columns left in the current row");
         _column++;
-        await _buf.Ensure(4, async).ConfigureAwait(false);
+        _buf.Ensure(sizeof(int));
+        var columnLen = _buf.ReadInt32();
+        PgReader.Init(columnLen, DataFormat.Binary, resumableOp);
+        return PgReader.FieldSize;
+    }
+
+    async ValueTask<int> MoveNextColumnAsync(bool resumableOp)
+    {
+        await PgReader.CommitAsync(resuming: false).ConfigureAwait(false);
+
+        if (_column + 1 == NumColumns)
+            ThrowHelper.ThrowInvalidOperationException("No more columns left in the current row");
+        _column++;
+        await _buf.Ensure(sizeof(int), async: true).ConfigureAwait(false);
         var columnLen = _buf.ReadInt32();
         PgReader.Init(columnLen, DataFormat.Binary, resumableOp);
         return PgReader.FieldSize;

--- a/test/Npgsql.Tests/ReadBufferTests.cs
+++ b/test/Npgsql.Tests/ReadBufferTests.cs
@@ -16,14 +16,14 @@ class ReadBufferTests
         for (byte i = 0; i < 50; i++)
             Writer.WriteByte(i);
 
-        ReadBuffer.Ensure(10, async: false).GetAwaiter().GetResult();
+        ReadBuffer.Ensure(10);
         ReadBuffer.Skip(7);
         Assert.That(ReadBuffer.ReadByte(), Is.EqualTo(7));
         ReadBuffer.Skip(10);
-        ReadBuffer.Ensure(1, async: false).GetAwaiter().GetResult();
+        ReadBuffer.Ensure(1);
         Assert.That(ReadBuffer.ReadByte(), Is.EqualTo(18));
         ReadBuffer.Skip(20);
-        ReadBuffer.Ensure(1, async: false).GetAwaiter().GetResult();
+        ReadBuffer.Ensure(1);
         Assert.That(ReadBuffer.ReadByte(), Is.EqualTo(39));
     }
 
@@ -35,7 +35,7 @@ class ReadBufferTests
         Array.Reverse(bytes);
         Writer.Write(bytes);
 
-        ReadBuffer.Ensure(4, async: false).GetAwaiter().GetResult();
+        ReadBuffer.Ensure(4);
         Assert.That(ReadBuffer.ReadSingle(), Is.EqualTo(expected));
     }
 
@@ -47,7 +47,7 @@ class ReadBufferTests
         Array.Reverse(bytes);
         Writer.Write(bytes);
 
-        ReadBuffer.Ensure(8, async: false).GetAwaiter().GetResult();
+        ReadBuffer.Ensure(8);
         Assert.That(ReadBuffer.ReadDouble(), Is.EqualTo(expected));
     }
 
@@ -60,7 +60,7 @@ class ReadBufferTests
             .Write(NpgsqlWriteBuffer.UTF8Encoding.GetBytes(new string("bar")))
             .WriteByte(0);
 
-        ReadBuffer.Ensure(1, async: false);
+        ReadBuffer.Ensure(1);
 
         Assert.That(ReadBuffer.ReadNullTerminatedString(), Is.EqualTo("foo"));
         Assert.That(ReadBuffer.ReadNullTerminatedString(), Is.EqualTo("bar"));


### PR DESCRIPTION
Fixes https://github.com/npgsql/npgsql/issues/4944

After this PR, sync exporting ends up being 10% faster on my machine (M1 Max) than using sync NpgsqlDataReader + SequentialAccess. Testing was done based on the project that was linked to here https://github.com/npgsql/npgsql/issues/4944#issuecomment-1441500430.

PR mostly consists of splitting apart sync and async paths. Having sync column reads run at the highest perf is as important here as it is in NpgsqlDataReader with GetFieldValue.