### PR TITLE
Fix output parameter population in batch commands

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -874,7 +874,10 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     batchCommand = TruncateStatementsToOne();
                     batchCommand.FinalCommandText = CommandText;
                     if (parameters is not null)
+                    {
                         batchCommand.PositionalParameters = parameters.InternalList;
+                        batchCommand._parameters = parameters;
+                    }
                 }
                 else
                 {
@@ -911,8 +914,6 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                 else
                 {
                     parser.ParseRawQuery(batchCommand, standardConformingStrings);
-                    if (batchCommand._parameters?.HasOutputParameters == true)
-                        ThrowHelper.ThrowNotSupportedException("Batches cannot cannot have out parameters");
                     ValidateParameterCount(batchCommand);
                 }
 
@@ -989,6 +990,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
             batchCommand ??= TruncateStatementsToOne();
             batchCommand.FinalCommandText = sqlBuilder.ToString();
+            batchCommand._parameters = parameters;
             batchCommand.PositionalParameters.AddRange(inputParameters);
             ValidateParameterCount(batchCommand);
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -459,8 +459,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                     continue;
                 }
 
-                if ((Command.IsWrappedByBatch && Command.InternalBatchCommands[StatementIndex]._parameters?.HasOutputParameters == true)
-                        || (!Command.IsWrappedByBatch && StatementIndex == 0 && Command._parameters?.HasOutputParameters == true))
+                if ((Command.IsWrappedByBatch || StatementIndex is 0) && Command.InternalBatchCommands[StatementIndex]._parameters?.HasOutputParameters == true)
                 {
                     // If output parameters are present and this is the first row of the resultset,
                     // we must always read it in non-sequential mode because it will be traversed twice (once
@@ -468,8 +467,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                     msg = await Connector.ReadMessage(async).ConfigureAwait(false);
                     ProcessMessage(msg);
                     if (msg.Code == BackendMessageCode.DataRow)
-                        PopulateOutputParameters(
-                            Command.IsWrappedByBatch ? Command.InternalBatchCommands[StatementIndex]._parameters! : Command._parameters!);
+                        PopulateOutputParameters(Command.InternalBatchCommands[StatementIndex]._parameters!);
                 }
                 else
                 {

--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -501,10 +501,11 @@ sealed class SqlQueryParser
             {
                 batchCommand = batchCommands[statementIndex];
                 batchCommand.Reset();
+                batchCommand._parameters = parameters;
             }
             else
             {
-                batchCommand = new NpgsqlBatchCommand();
+                batchCommand = new NpgsqlBatchCommand { _parameters = parameters };
                 batchCommands.Add(batchCommand);
             }
         }

--- a/test/Npgsql.Tests/BatchTests.cs
+++ b/test/Npgsql.Tests/BatchTests.cs
@@ -70,24 +70,6 @@ public class BatchTests : MultiplexingTestBase
         Assert.That(await reader.NextResultAsync(), Is.False);
     }
 
-    [Test]
-    public async Task Out_parameters_are_not_allowed()
-    {
-        await using var conn = await OpenConnectionAsync();
-        await using var batch = new NpgsqlBatch(conn)
-        {
-            BatchCommands =
-            {
-                new("SELECT @p1")
-                {
-                    Parameters = { new("p", 8) { Direction = ParameterDirection.InputOutput } }
-                }
-            }
-        };
-
-        Assert.That(() => batch.ExecuteReaderAsync(Behavior), Throws.Exception.TypeOf<NotSupportedException>());
-    }
-
     #endregion Parameters
 
     #region NpgsqlBatchCommand

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -548,34 +548,6 @@ public class CommandTests : MultiplexingTestBase
     #endregion
 
     [Test]
-    public async Task StoredProcedure_positional_parameters_works()
-    {
-        if (IsMultiplexing)
-            return;
-
-        await using var connection = await DataSource.OpenConnectionAsync();
-        await using var transaction = await connection.BeginTransactionAsync(IsolationLevel.Serializable);
-        await using var batch = new NpgsqlBatch(connection, transaction)
-        {
-            BatchCommands =
-            {
-                new("unknown_procedure")
-                {
-                    CommandType = CommandType.StoredProcedure,
-                    Parameters =
-                    {
-                        new() { Value = "" },
-                        new() { DbType = DbType.Int64, Direction = ParameterDirection.Output }
-                    }
-                },
-                new ("COMMIT")
-            }
-        };
-
-        Assert.ThrowsAsync<PostgresException>(() => batch.ExecuteNonQueryAsync());
-    }
-
-    [Test]
     public async Task SingleRow([Values(PrepareOrNot.NotPrepared, PrepareOrNot.Prepared)] PrepareOrNot prepare)
     {
         if (prepare == PrepareOrNot.Prepared && IsMultiplexing)

--- a/test/Npgsql.Tests/StoredProcedureTests.cs
+++ b/test/Npgsql.Tests/StoredProcedureTests.cs
@@ -191,7 +191,7 @@ END$$");
                     Parameters =
                     {
                         new() { Value = "" },
-                        new() { NpgsqlDbType = NpgsqlDbType.Bigint, Direction = ParameterDirection.Output}
+                        new() { NpgsqlDbType = NpgsqlDbType.Bigint, Direction = ParameterDirection.Output }
                     }
                 },
                 new(sproc)
@@ -200,7 +200,7 @@ END$$");
                     Parameters =
                     {
                         new() { Value = "" },
-                        new() { NpgsqlDbType = NpgsqlDbType.Bigint, Direction = ParameterDirection.Output}
+                        new() { NpgsqlDbType = NpgsqlDbType.Bigint, Direction = ParameterDirection.Output }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #5642

For batch commands we can just populate per command as each has their own parameter set.