### PR TITLE
Set the default Connection Lifetime to one hour

### DIFF
--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -777,13 +777,17 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     /// <summary>
     /// The total maximum lifetime of connections (in seconds). Connections which have exceeded this value will be
     /// destroyed instead of returned from the pool. This is useful in clustered configurations to force load
-    /// balancing between a running server and a server just brought online.
+    /// balancing between a running server and a server just brought online. It can also be useful to prevent
+    /// runaway memory growth of connections at the PostgreSQL server side, because in some cases very long lived
+    /// connections slowly consume more and more memory over time.
+    /// Defaults to 3600 seconds (1 hour).
     /// </summary>
-    /// <value>The time (in seconds) to wait, or 0 to to make connections last indefinitely (the default).</value>
+    /// <value>The time (in seconds) to wait, or 0 to to make connections last indefinitely.</value>
     [Category("Pooling")]
     [Description("The total maximum lifetime of connections (in seconds).")]
     [DisplayName("Connection Lifetime")]
     [NpgsqlConnectionStringProperty("Load Balance Timeout")]
+    [DefaultValue(3600)]
     public int ConnectionLifetime
     {
         get => _connectionLifetime;


### PR DESCRIPTION
Connection Lifetime can also be used to limit memory growth of
PostgreSQL connection. Certain caches only grow over time, the most
common example is the cache for table metadata: the "relcache". For
systems with many tables (often times due to partitioning) this relcache
slowly grows larger and larger. By putting a 1 hour limit on a
connection lifetime such excessive growth is limited, since this is
especially an issue with very long lived connections (multi-day).

This same 1 hour limit is used for PgBouncer its equivalent
server_lifetime config option. (I'm the maintainer of PgBouncer)
