### PR TITLE
Wrap GetHostAddresses/Async calls to catch SocketException

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -914,10 +914,17 @@ public sealed partial class NpgsqlConnector
 
     void Connect(NpgsqlTimeout timeout)
     {
-        // Note that there aren't any timeout-able or cancellable DNS methods
-        var endpoints = NpgsqlConnectionStringBuilder.IsUnixSocket(Host, Port, out var socketPath)
-            ? new EndPoint[] { new UnixDomainSocketEndPoint(socketPath) }
-            : IPAddressesToEndpoints(Dns.GetHostAddresses(Host), Port);
+        var isUnixSocket = NpgsqlConnectionStringBuilder.IsUnixSocket(Host, Port, out var socketPath);
+
+        EndPoint[]? endpoints;
+        if (isUnixSocket) endpoints = [new UnixDomainSocketEndPoint(socketPath!)];
+        else
+        {
+            // Note that there aren't any timeout-able or cancellable DNS methods
+            try { endpoints = IPAddressesToEndpoints(Dns.GetHostAddresses(Host), Port); }
+            catch (SocketException ex) { throw new NpgsqlException(ex.Message, ex); }
+        } 
+        
         timeout.Check();
 
         // Give each endpoint an equal share of the remaining time
@@ -982,8 +989,11 @@ public sealed partial class NpgsqlConnector
 
     async Task ConnectAsync(NpgsqlTimeout timeout, CancellationToken cancellationToken)
     {
-        Task<IPAddress[]> GetHostAddressesAsync(CancellationToken ct) =>
-            Dns.GetHostAddressesAsync(Host, ct);
+        async Task<IPAddress[]> GetHostAddressesAsync(CancellationToken ct) 
+        {
+            try { return await Dns.GetHostAddressesAsync(Host, ct).ConfigureAwait(false); }
+            catch (SocketException ex) { throw new NpgsqlException(ex.Message, ex); }
+        }
 
         // Whether the framework and/or the OS platform support Dns.GetHostAddressesAsync cancellation API or they do not,
         // we always fake-cancel the operation with the help of TaskTimeoutAndCancellation.ExecuteAsync. It stops waiting

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -315,6 +316,38 @@ public class ConnectionTests : MultiplexingTestBase
         var cts = new CancellationTokenSource(1000);
         Assert.That(async () => await conn.OpenAsync(cts.Token), Throws.Exception.TypeOf<OperationCanceledException>());
         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+    }
+
+    [Test]
+    public void Bad_hostname()
+    {
+        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.that.does.not.exist");
+        using var conn = dataSource.CreateConnection();
+
+        Assert.That(
+            () => conn.Open(),
+            Throws.Exception
+                .TypeOf<NpgsqlException>()
+                .With
+                .Property(nameof(NpgsqlException.InnerException))
+                .TypeOf<SocketException>()
+        );
+    }
+
+    [Test]
+    public void Bad_hostname_async()
+    {
+        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.that.does.not.exist");
+        using var conn = dataSource.CreateConnection();
+
+        Assert.That(
+            async () => await conn.OpenAsync(),
+            Throws.Exception
+                .TypeOf<NpgsqlException>()
+                .With
+                .Property(nameof(NpgsqlException.InnerException))
+                .TypeOf<SocketException>()
+        );
     }
 
     #endregion


### PR DESCRIPTION
Closes #5606.

The GetHostAddresses method also throws:
- `ArgumentOutOfRangeException`, if the host name exceeds 255 chars;
- `ArgumentNullException`, if the host name is null;
- `ArgumentException`, if the host address is an invalid IP address.

Should we catch and wrap these other exceptions as well?