### PR TITLE
Add [Experimental] to converter-related APIs

### DIFF
--- a/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
+++ b/src/Npgsql.GeoJSON/Npgsql.GeoJSON.csproj
@@ -5,6 +5,7 @@
     <PackageTags>npgsql;postgresql;postgres;postgis;geojson;spatial;ado;ado.net;database;sql</PackageTags>
     <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
+++ b/src/Npgsql.Json.NET/Npgsql.Json.NET.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -6,6 +6,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql/Internal/BufferRequirements.cs
+++ b/src/Npgsql/Internal/BufferRequirements.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct BufferRequirements : IEquatable<BufferRequirements>
 {
     readonly Size _read;

--- a/src/Npgsql/Internal/DataFormat.cs
+++ b/src/Npgsql/Internal/DataFormat.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public enum DataFormat : byte
 {
     Binary,

--- a/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
@@ -6,6 +6,7 @@ using Npgsql.PostgresTypes;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 [RequiresDynamicCode("A dynamic type info resolver may need to construct a generic converter for a statically unknown type.")]
 public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
 {

--- a/src/Npgsql/Internal/HackyEnumTypeMapping.cs
+++ b/src/Npgsql/Internal/HackyEnumTypeMapping.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Npgsql.Internal;
@@ -8,10 +9,10 @@ using NpgsqlTypes;
 
 namespace Npgsql.Internal;
 
-
 /// <summary>
 /// Hacky temporary measure used by EFCore.PG to extract user-configured enum mappings. Accessed via reflection only.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class HackyEnumTypeMapping
 {
     public HackyEnumTypeMapping(Type enumClrType, string pgTypeName, INpgsqlNameTranslator nameTranslator)

--- a/src/Npgsql/Internal/INpgsqlDatabaseInfoFactory.cs
+++ b/src/Npgsql/Internal/INpgsqlDatabaseInfoFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Npgsql.Util;
 
 namespace Npgsql.Internal;
@@ -8,6 +9,7 @@ namespace Npgsql.Internal;
 /// and the types it contains. When first connecting to a database, Npgsql will attempt to load information
 /// about it via this factory.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public interface INpgsqlDatabaseInfoFactory
 {
     /// <summary>

--- a/src/Npgsql/Internal/IPgTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/IPgTypeInfoResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -6,6 +7,7 @@ namespace Npgsql.Internal;
 /// <summary>
 /// An Npgsql resolver for type info. Used by Npgsql to read and write values to PostgreSQL.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public interface IPgTypeInfoResolver
 {
     /// <summary>

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -29,6 +30,7 @@ namespace Npgsql.Internal;
 /// Represents a connection to a PostgreSQL backend. Unlike NpgsqlConnection objects, which are
 /// exposed to users, connectors are internal to Npgsql and are recycled by the connection pool.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed partial class NpgsqlConnector
 {
     #region Fields and Properties

--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -12,6 +12,7 @@ namespace Npgsql.Internal;
 /// Base class for implementations which provide information about PostgreSQL and PostgreSQL-like databases
 /// (e.g. type definitions, capabilities...).
 /// </summary>
+[Experimental(NpgsqlDiagnostics.DatabaseInfoExperimental)]
 public abstract class NpgsqlDatabaseInfo
 {
     #region Fields

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -17,6 +18,7 @@ namespace Npgsql.Internal;
 /// A buffer used by Npgsql to read data from the socket efficiently.
 /// Provides methods which decode different values types and tracks the current position.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 sealed partial class NpgsqlReadBuffer : IDisposable
 {
     #region Fields and Properties

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgBufferedConverter<T> : PgConverter<T>
 {
     protected PgBufferedConverter(bool customDbNullPredicate = false) : base(customDbNullPredicate) { }

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgConverter
 {
     internal DbNullPredicate DbNullPredicateKind { get; }

--- a/src/Npgsql/Internal/PgConverterResolver.cs
+++ b/src/Npgsql/Internal/PgConverterResolver.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgConverterResolver
 {
     private protected PgConverterResolver() { }

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public class PgReader
 {
     // We don't want to add a ton of memory pressure for large strings.

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -8,6 +9,7 @@ using Npgsql.PostgresTypes;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class PgSerializerOptions
 {
     /// <summary>

--- a/src/Npgsql/Internal/PgStreamingConverter.cs
+++ b/src/Npgsql/Internal/PgStreamingConverter.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgStreamingConverter<T> : PgConverter<T>
 {
     protected PgStreamingConverter(bool customDbNullPredicate = false) : base(customDbNullPredicate) { }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -4,6 +4,7 @@ using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public class PgTypeInfo
 {
     readonly bool _canBinaryConvert;

--- a/src/Npgsql/Internal/PgTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/PgTypeInfoResolverFactory.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgTypeInfoResolverFactory
 {
     public abstract IPgTypeInfoResolver CreateResolver();

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -92,6 +93,7 @@ sealed class NpgsqlBufferWriter : IStreamingWriter<byte>
         => new(_buffer.Flush(async: true, cancellationToken));
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class PgWriter
 {
     readonly IBufferWriter<byte> _writer;
@@ -557,6 +559,7 @@ public sealed class PgWriter
 }
 
 // No-op for now.
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public struct NestedWriteScope : IDisposable
 {
     public void Dispose()

--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Npgsql.Internal.Postgres;
 
 /// <summary>
 /// Represents the fully-qualified name of a PostgreSQL type.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 [DebuggerDisplay("{DisplayName,nq}")]
 public readonly struct DataTypeName : IEquatable<DataTypeName>
 {

--- a/src/Npgsql/Internal/Postgres/Field.cs
+++ b/src/Npgsql/Internal/Postgres/Field.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Npgsql.Internal.Postgres;
 
 /// Base field type shared between tables and composites.
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct Field
 {
     public Field(string name, PgTypeId pgTypeId, int typeModifier)

--- a/src/Npgsql/Internal/Postgres/Oid.cs
+++ b/src/Npgsql/Internal/Postgres/Oid.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Npgsql.Internal.Postgres;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct Oid: IEquatable<Oid>
 {
     public Oid(uint value) => Value = value;

--- a/src/Npgsql/Internal/Postgres/PgTypeId.cs
+++ b/src/Npgsql/Internal/Postgres/PgTypeId.cs
@@ -6,6 +6,7 @@ namespace Npgsql.Internal.Postgres;
 /// <summary>
 /// A discriminated union of <see cref="Oid" /> and <see cref="DataTypeName" />.
 /// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct PgTypeId: IEquatable<PgTypeId>
 {
     readonly DataTypeName _dataTypeName;

--- a/src/Npgsql/Internal/Size.cs
+++ b/src/Npgsql/Internal/Size.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public enum SizeKind
 {
     Unknown = 0,
@@ -10,6 +12,7 @@ public enum SizeKind
     UpperBound
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 public readonly struct Size : IEquatable<Size>
 {

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -19,8 +19,10 @@ namespace Npgsql.Internal;
 /// <param name="resolvedDataTypeName">
 /// Signals whether a resolver based TypeInfo can keep its PgTypeId undecided or whether it should follow mapping.DataTypeName.
 /// </param>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public delegate PgTypeInfo TypeInfoFactory(PgSerializerOptions options, TypeInfoMapping mapping, bool resolvedDataTypeName);
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public enum MatchRequirement
 {
     /// Match when the clr type and datatype name both match.
@@ -33,6 +35,7 @@ public enum MatchRequirement
 }
 
 /// A factory for well-known PgConverters.
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public static class PgConverterFactory
 {
     public static PgConverter<T[]> CreateArrayMultirangeConverter<T>(PgConverter<T> rangeConverter, PgSerializerOptions options) where T : notnull
@@ -55,6 +58,7 @@ public static class PgConverterFactory
 }
 
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct TypeInfoMapping
 {
     public TypeInfoMapping(Type type, string dataTypeName, TypeInfoFactory factory)
@@ -99,6 +103,7 @@ public readonly struct TypeInfoMapping
     }
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class TypeInfoMappingCollection
 {
     readonly TypeInfoMappingCollection? _baseCollection;
@@ -731,6 +736,7 @@ public sealed class TypeInfoMappingCollection
         => throw new InvalidOperationException($"Boxing converters are not supported, manually construct a mapping over a casting converter{(resolver ? " resolver" : "")} instead.");
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public static class TypeInfoMappingHelpers
 {
     internal static bool TryResolveFullyQualifiedName(PgSerializerOptions options, string dataTypeName, out DataTypeName fqDataTypeName)

--- a/src/Npgsql/Internal/ValueMetadata.cs
+++ b/src/Npgsql/Internal/ValueMetadata.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Npgsql.Internal;
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct ValueMetadata
 {
     public required DataFormat Format { get; init; }

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -8,6 +8,8 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2017</NoWarn>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
+    <NoWarn>$(NoWarn);NPG9002</NoWarn> <!-- DatabaseInfo-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Npgsql/NpgsqlDiagnostics.cs
+++ b/src/Npgsql/NpgsqlDiagnostics.cs
@@ -1,0 +1,7 @@
+namespace Npgsql;
+
+static class NpgsqlDiagnostics
+{
+    public const string ConvertersExperimental = "NPG9001";
+    public const string DatabaseInfoExperimental = "NPG9002";
+}

--- a/src/Npgsql/Shims/ExperimentalAttribute.cs
+++ b/src/Npgsql/Shims/ExperimentalAttribute.cs
@@ -1,0 +1,21 @@
+#if !NET8_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Indicates that an API is experimental and it may change in the future.</summary>
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false)]
+public sealed class ExperimentalAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.CodeAnalysis.ExperimentalAttribute" /> class, specifying the ID that the compiler will use when reporting a use of the API the attribute applies to.</summary>
+    /// <param name="diagnosticId">The ID that the compiler will use when reporting a use of the API the attribute applies to.</param>
+    public ExperimentalAttribute(string diagnosticId) => this.DiagnosticId = diagnosticId;
+
+    /// <summary>Gets the ID that the compiler will use when reporting a use of the API the attribute applies to.</summary>
+    /// <returns>The unique diagnostic ID.</returns>
+    public string DiagnosticId { get; }
+
+    /// <summary>Gets or sets the URL for corresponding documentation.
+    /// The API accepts a format string instead of an actual URL, creating a generic URL that includes the diagnostic ID.</summary>
+    /// <returns>The format string that represents a URL to corresponding documentation.</returns>
+    public string? UrlFormat { get; set; }
+}
+#endif

--- a/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
+++ b/test/Npgsql.Benchmarks/Npgsql.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <DebugType>portable</DebugType>
     <AssemblyName>Npgsql.Benchmarks</AssemblyName>
     <OutputType>Exe</OutputType>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Npgsql.Tests/Npgsql.Tests.csproj
+++ b/test/Npgsql.Tests/Npgsql.Tests.csproj
@@ -12,5 +12,7 @@
   </ItemGroup>
   <PropertyGroup>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->
+    <NoWarn>$(NoWarn);NPG9002</NoWarn> <!-- DatabaseInfo-related APIs are experimental -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
@NinoFloris as discussed offline.. I basically slapped the attribute on all converter-related public type under the Internal directory. Note that there's a different diagnostic ID for DatabaseInfo, which is another external extensibility API which I don't think should be considered too stable (though it hasn't changed so much).

Closes #5620