### PR TITLE
Changed year to 2024

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <Copyright>Copyright 2023 © The Npgsql Development Team</Copyright>
+    <Copyright>Copyright 2024 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/npgsql/npgsql</PackageProjectUrl>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2002-2023, Npgsql
+Copyright (c) 2002-2024, Npgsql
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement


### PR DESCRIPTION
I was doing a research about dependency difference between various .NET targets and found that the year is a bit outdated in `props` and the license. So, here's my small contribution.