### PR TITLE
fix(#5674): buffer over-read with ArrayNullabilityMode.PerInstance

### DIFF
--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -628,6 +628,12 @@ sealed class PolymorphicArrayConverter<TBase> : PgStreamingConverter<TBase>
         _nullableElementCollectionConverter = nullableElementCollectionConverter;
     }
 
+    public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        bufferRequirements = BufferRequirements.Create(sizeof(int) + sizeof(int));
+        return format is DataFormat.Binary;
+    }
+
     public override TBase Read(PgReader reader)
     {
         _ = reader.ReadInt32();

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -630,7 +630,7 @@ sealed class PolymorphicArrayConverter<TBase> : PgStreamingConverter<TBase>
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
     {
-        bufferRequirements = BufferRequirements.Create(sizeof(int) + sizeof(int));
+        bufferRequirements = BufferRequirements.Create(read: sizeof(int) + sizeof(int), write: Size.Unknown);
         return format is DataFormat.Binary;
     }
 


### PR DESCRIPTION
`CanConvert` was not overridden for `PolymorphicArrayConverter<T>`, but 8 bytes but be read-ahead in order to populate `containsNulls` in `Read`/`ReadAsync`.

Resolves #5674