### PR TITLE
Stop requiring users to specify Integrated Security

### DIFF
--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -221,9 +221,6 @@ namespace Npgsql
 #pragma warning disable CA1801 // Review unused parameters
         async Task AuthenticateGSS(bool async)
         {
-            if (!IntegratedSecurity)
-                throw new NpgsqlException("SSPI authentication but IntegratedSecurity not enabled");
-
             using (var negotiateStream = new NegotiateStream(new GSSPasswordMessageStream(this), true))
             {
                 try

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -297,7 +297,6 @@ namespace Npgsql
         string KerberosServiceName => Settings.KerberosServiceName;
         SslMode SslMode => Settings.SslMode;
         int ConnectionTimeout => Settings.Timeout;
-        bool IntegratedSecurity => Settings.IntegratedSecurity;
         internal bool ConvertInfinityDateTime => Settings.ConvertInfinityDateTime;
 
         int InternalCommandTimeout

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1357,7 +1357,6 @@ namespace Npgsql.Tests
             var builder = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
                 Pooling = false,
-                IntegratedSecurity = false,
                 Password = null
             };
             using (OpenConnection(builder)) { }

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -71,7 +71,6 @@ namespace Npgsql.Tests
                 throw new Exception("Could find username");
 
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
-                IntegratedSecurity = true,
                 Username = username,
                 Password = null
             }.ToString();
@@ -96,7 +95,6 @@ namespace Npgsql.Tests
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                IntegratedSecurity = true,
                 Username = null,
                 Password = null
             }.ToString();
@@ -121,7 +119,6 @@ namespace Npgsql.Tests
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                IntegratedSecurity = true,
                 Username = null,
                 Password = null,
                 Database = null


### PR DESCRIPTION
We removed this in 8.0, but 4.x are the last versions which properly work as a VSIX/MSI, and this is blocking for some scenarios.

Backport of #4789

(cherry picked from commit 941db8044ebe5c96be233a3ae94ba94bdb9c6809)