### PR TITLE
Stop requiring users to specify Integrated Security

### DIFF
--- a/src/Npgsql/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/NpgsqlConnector.Auth.cs
@@ -135,9 +135,6 @@ namespace Npgsql
 #pragma warning disable CA1801 // Review unused parameters
         async Task AuthenticateGSS(bool async)
         {
-            if (!IntegratedSecurity)
-                throw new NpgsqlException("SSPI authentication but IntegratedSecurity not enabled");
-
             using (var negotiateStream = new NegotiateStream(new GSSPasswordMessageStream(this), true))
             {
                 try

--- a/src/Npgsql/NpgsqlConnector.cs
+++ b/src/Npgsql/NpgsqlConnector.cs
@@ -321,7 +321,6 @@ namespace Npgsql
         SslMode SslMode => Settings.SslMode;
         bool UseSslStream => Settings.UseSslStream;
         int ConnectionTimeout => Settings.Timeout;
-        bool IntegratedSecurity => Settings.IntegratedSecurity;
         internal bool ConvertInfinityDateTime => Settings.ConvertInfinityDateTime;
 
         int InternalCommandTimeout

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -1206,7 +1206,6 @@ namespace Npgsql.Tests
                 var builder = new NpgsqlConnectionStringBuilder(ConnectionString)
                 {
                     Pooling = false,
-                    IntegratedSecurity = false,
                     Password = null
                 };
                 using (OpenConnection(builder)) {}

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -101,7 +101,6 @@ namespace Npgsql.Tests
                 throw new Exception("Could find username");
 
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString) {
-                IntegratedSecurity = true,
                 Username = username,
                 Password = null
             }.ToString();
@@ -126,7 +125,6 @@ namespace Npgsql.Tests
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                IntegratedSecurity = true,
                 Username = null,
                 Password = null
             }.ToString();
@@ -151,7 +149,6 @@ namespace Npgsql.Tests
         {
             var connString = new NpgsqlConnectionStringBuilder(ConnectionString)
             {
-                IntegratedSecurity = true,
                 Username = null,
                 Password = null,
                 Database = null


### PR DESCRIPTION
We removed this in 8.0, but 4.x are the last versions which properly work as a VSIX/MSI, and this is blocking for some scenarios.

Backport of #4789

(cherry picked from commit 06a1f8395bf5a36d0ec9b79c871058f327a3aa25)