### PR TITLE
Throw instead of saturate on Size overflow

### DIFF
--- a/src/Npgsql/Internal/Size.cs
+++ b/src/Npgsql/Internal/Size.cs
@@ -50,9 +50,9 @@ public readonly struct Size : IEquatable<Size>
             return Unknown;
 
         if (_kind is SizeKind.UpperBound || result._kind is SizeKind.UpperBound)
-            return CreateUpperBound((int)Math.Min((long)(_value + result._value), int.MaxValue));
+            return CreateUpperBound(checked(_value + result._value));
 
-        return Create((int)Math.Min((long)(_value + result._value), int.MaxValue));
+        return Create(checked(_value + result._value));
     }
 
     public static implicit operator Size(int value) => Create(value);

--- a/test/Npgsql.Tests/SizeTests.cs
+++ b/test/Npgsql.Tests/SizeTests.cs
@@ -1,0 +1,59 @@
+using System;
+using NUnit.Framework;
+using Npgsql.Internal;
+
+namespace Npgsql.Tests;
+
+public class SizeTests
+{
+    [Test]
+    public void UnknownKind() => Assert.That(Size.Unknown.Kind, Is.EqualTo(SizeKind.Unknown));
+
+    [Test]
+    public void UnknownThrowsOnValue() => Assert.Throws<InvalidOperationException>(() => _ = Size.Unknown.Value);
+
+    [Test]
+    public void Exact()
+    {
+        Assert.That(Size.Create(1).Value, Is.EqualTo(1));
+        Assert.That(Size.Create(1).Kind, Is.EqualTo(SizeKind.Exact));
+    }
+
+    [Test]
+    public void ZeroIsExactKind() => Assert.That(Size.Zero.Kind, Is.EqualTo(SizeKind.Exact));
+
+    [Test]
+    public void UpperBound()
+    {
+        Assert.That(Size.CreateUpperBound(1).Value, Is.EqualTo(1));
+        Assert.That(Size.CreateUpperBound(1).Kind, Is.EqualTo(SizeKind.UpperBound));
+    }
+
+    [Test]
+    public void CombineThrowsOnOverflow() => Assert.Throws<OverflowException>(() => Size.Create(1).Combine(int.MaxValue));
+
+    [Test]
+    public void CombineExactWorks() => Assert.That(Size.Create(1).Combine(1), Is.EqualTo(Size.Create(2)));
+
+    [Test]
+    public void CombineUpperBoundWorks() => Assert.That(Size.CreateUpperBound(1).Combine(1), Is.EqualTo(Size.CreateUpperBound(2)));
+
+    [Test]
+    public void CombineUnknownWithAnyGivesUnknown()
+    {
+        Assert.That(Size.Unknown.Combine(Size.Unknown), Is.EqualTo(Size.Unknown));
+
+        Assert.That(Size.Create(1).Combine(Size.Unknown), Is.EqualTo(Size.Unknown));
+        Assert.That(Size.Unknown.Combine(Size.Create(1)), Is.EqualTo(Size.Unknown));
+
+        Assert.That(Size.Unknown.Combine(Size.CreateUpperBound(1)), Is.EqualTo(Size.Unknown));
+        Assert.That(Size.CreateUpperBound(1).Combine(Size.Unknown), Is.EqualTo(Size.Unknown));
+    }
+
+    [Test]
+    public void CombineUpperBoundWithExactGivesUpperBound()
+    {
+        Assert.That(Size.Create(1).Combine(Size.CreateUpperBound(1)), Is.EqualTo(Size.CreateUpperBound(2)));
+        Assert.That(Size.CreateUpperBound(1).Combine(Size.Create(1)), Is.EqualTo(Size.CreateUpperBound(2)));
+    }
+}


### PR DESCRIPTION
Bug fix pulled from the first security fix approach (from the private maintainer fork).

This is not exploitable (due to a message always being more bytes than just one parameter) but we should move Size.Combine to throw when it would overflow.

This would replace https://github.com/npgsql/npgsql/pull/5723 as we don't want to saturate ever.

Fixes #5722