### PR TITLE
Remove indices alloc from ArrayConverter

### DIFF
--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -37,6 +37,8 @@ static class IndicesExtensions
                 ThrowHelper.ThrowIndexOutOfRangeException("Cannot index into a 0-dimensional array.");
                 return ref Unsafe.NullRef<int>();
             case 1:
+                Debug.Assert(index is 0);
+                Debug.Assert(indices.Many is null);
                 return ref indices.One;
             default:
                 return ref indices.Many![index];

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -65,7 +65,7 @@ public class ArrayTests : MultiplexingTestBase
         cmd.Parameters.AddWithValue("p", new int[1, 1, 1, 1, 1, 1, 1, 1, 1]); // 9 dimensions
         Assert.That(
             () => cmd.ExecuteScalarAsync(),
-            Throws.Exception.TypeOf<ArgumentException>().With.Message.EqualTo("values (Parameter 'Postgres arrays can have at most 8 dimensions.')"));
+            Throws.Exception.TypeOf<ArgumentException>().With.Message.EqualTo("Postgres arrays can have at most 8 dimensions. (Parameter 'values')"));
     }
 
     [Test, Description("Checks that PG arrays containing nulls are returned as set via ValueTypeArrayMode.")]


### PR DESCRIPTION
Removes an array alloc for 1 dim arrays for sync and async reader/writers.