### PR TITLE
User resolver PgTypeInfo reuse

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -331,7 +331,7 @@ public sealed class FieldDescription
     {
         Debug.Assert(lastColumnInfo.ConverterInfo.IsDefault || (
             ReferenceEquals(_serializerOptions, lastColumnInfo.ConverterInfo.TypeInfo.Options) && (
-                IsUnknownResultType() && lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(_serializerOptions.TextPgType) ||
+                IsUnknownResultType() && lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
                 // Normal resolution
                 lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
             ), "Cache is bleeding over");
@@ -368,7 +368,7 @@ public sealed class FieldDescription
             case DataFormat.Text when IsUnknownResultType():
             {
                 // Try to resolve some 'pg_catalog.text' type info for the expected clr type.
-                var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgType, _serializerOptions);
+                var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgTypeId, _serializerOptions);
 
                 // We start binding to DataFormat.Binary as it's the broadest supported format.
                 // The format however is irrelevant as 'pg_catalog.text' data is identical across either.
@@ -382,7 +382,7 @@ public sealed class FieldDescription
             }
             case DataFormat.Binary or DataFormat.Text:
             {
-                var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(object), PostgresType, _serializerOptions);
+                var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(object), _serializerOptions.ToCanonicalTypeId(PostgresType), _serializerOptions);
 
                 // If we don't support the DataFormat we'll just throw.
                 converterInfo = typeInfo.Bind(Field, DataFormat);

--- a/src/Npgsql/Internal/AdoSerializerHelpers.cs
+++ b/src/Npgsql/Internal/AdoSerializerHelpers.cs
@@ -2,36 +2,34 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
-using Npgsql.PostgresTypes;
 using NpgsqlTypes;
 
 namespace Npgsql.Internal;
 
 static class AdoSerializerHelpers
 {
-    public static PgTypeInfo GetTypeInfoForReading(Type type, PostgresType postgresType, PgSerializerOptions options)
-    {
-        var (typeInfo, exception) = TryGetTypeInfoForReading(type, postgresType, options);
-        return typeInfo ?? throw exception!;
-    }
-
-    static (PgTypeInfo? TypeInfo , Exception? Exception) TryGetTypeInfoForReading(Type type, PostgresType postgresType, PgSerializerOptions options)
+    public static PgTypeInfo GetTypeInfoForReading(Type type, PgTypeId pgTypeId, PgSerializerOptions options)
     {
         PgTypeInfo? typeInfo = null;
         Exception? inner = null;
         try
         {
-            typeInfo = type == typeof(object) ? options.GetObjectOrDefaultTypeInfo(postgresType) : options.GetTypeInfo(type, postgresType);
+            typeInfo = type == typeof(object) ? options.GetObjectOrDefaultTypeInfo(pgTypeId) : options.GetTypeInfoInternal(type, pgTypeId);
         }
         catch (Exception ex)
         {
             inner = ex;
         }
-        return typeInfo is not null ? (typeInfo, null) : (null, ThrowReadingNotSupported(type, postgresType.DisplayName, inner));
+        return typeInfo ?? ThrowReadingNotSupported(type, options, pgTypeId, inner);
 
         // InvalidCastException thrown to align with ADO.NET convention.
-        static Exception ThrowReadingNotSupported(Type? type, string displayName, Exception? inner = null)
-            => new InvalidCastException($"Reading{(type is null ? "" : $" as '{type.FullName}'")} is not supported for fields having DataTypeName '{displayName}'", inner);
+        [DoesNotReturn]
+        static PgTypeInfo ThrowReadingNotSupported(Type? type, PgSerializerOptions options, PgTypeId pgTypeId, Exception? inner = null)
+        {
+            throw new InvalidCastException(
+                $"Reading{(type is null ? "" : $" as '{type.FullName}'")} is not supported for fields having DataTypeName '{options.DatabaseInfo.FindPostgresType(pgTypeId)?.DisplayName ?? "unknown"}'",
+                inner);
+        }
     }
 
     public static PgTypeInfo GetTypeInfoForWriting(Type? type, PgTypeId? pgTypeId, PgSerializerOptions options, NpgsqlDbType? npgsqlDbType = null)
@@ -42,7 +40,7 @@ static class AdoSerializerHelpers
         Exception? inner = null;
         try
         {
-            typeInfo = type is null ? options.GetDefaultTypeInfo(pgTypeId!.Value) : options.GetTypeInfo(type, pgTypeId);
+            typeInfo = options.GetTypeInfoInternal(type, pgTypeId);
         }
         catch (Exception ex)
         {

--- a/src/Npgsql/Internal/AdoSerializerHelpers.cs
+++ b/src/Npgsql/Internal/AdoSerializerHelpers.cs
@@ -14,7 +14,7 @@ static class AdoSerializerHelpers
         Exception? inner = null;
         try
         {
-            typeInfo = type == typeof(object) ? options.GetObjectOrDefaultTypeInfo(pgTypeId) : options.GetTypeInfoInternal(type, pgTypeId);
+            typeInfo = type == typeof(object) ? options.GetObjectOrDefaultTypeInfoInternal(pgTypeId) : options.GetTypeInfoInternal(type, pgTypeId);
         }
         catch (Exception ex)
         {

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -98,7 +98,7 @@ sealed class ObjectConverter : PgStreamingConverter<object>
     }
 
     PgTypeInfo GetTypeInfo(Type type)
-        => _options.GetTypeInfo(type, _pgTypeId)
+        => _options.GetTypeInfoInternal(type, _pgTypeId)
            ?? throw new NotSupportedException($"Writing values of '{type.FullName}' having DataTypeName '{_options.DatabaseInfo.GetPostgresType(_pgTypeId).DisplayName}' is not supported.");
 
     sealed class WriteState

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -44,11 +44,12 @@ sealed class RecordConverter<T> : PgStreamingConverter<T>
                 _options.DatabaseInfo.GetPostgresType(typeOid).GetRepresentationalType()
                 ?? throw new NotSupportedException($"Reading isn't supported for record field {i} (unknown type OID {typeOid}");
 
-            var typeInfo = _options.GetObjectOrDefaultTypeInfo(postgresType)
+            var pgTypeId = _options.ToCanonicalTypeId(postgresType);
+            var typeInfo = _options.GetObjectOrDefaultTypeInfo(pgTypeId)
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
-            var converterInfo = typeInfo.Bind(new Field("?", _options.ToCanonicalTypeId(postgresType), -1), DataFormat.Binary);
+            var converterInfo = typeInfo.Bind(new Field("?", pgTypeId, -1), DataFormat.Binary);
             var scope = await reader.BeginNestedRead(async, length, converterInfo.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try
             {

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -45,7 +45,7 @@ sealed class RecordConverter<T> : PgStreamingConverter<T>
                 ?? throw new NotSupportedException($"Reading isn't supported for record field {i} (unknown type OID {typeOid}");
 
             var pgTypeId = _options.ToCanonicalTypeId(postgresType);
-            var typeInfo = _options.GetObjectOrDefaultTypeInfo(pgTypeId)
+            var typeInfo = _options.GetObjectOrDefaultTypeInfoInternal(pgTypeId)
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -86,8 +86,8 @@ public sealed class PgSerializerOptions
     internal PgTypeInfo? GetTypeInfoInternal(Type? type, PgTypeId? pgTypeId)
         => GetTypeInfoCore(type, pgTypeId, false);
 
-    internal PgTypeInfo? GetObjectOrDefaultTypeInfo(PgTypeId pgTypeId)
-        => GetTypeInfoCore(typeof(object), GetCanonicalTypeId(pgTypeId), true);
+    internal PgTypeInfo? GetObjectOrDefaultTypeInfoInternal(PgTypeId pgTypeId)
+        => GetTypeInfoCore(typeof(object), pgTypeId, true);
 
     public PgTypeInfo? GetDefaultTypeInfo(Type type)
         => GetTypeInfoCore(type, null, false);

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Npgsql.Internal.Postgres;
 using Npgsql.NameTranslation;
@@ -34,7 +33,7 @@ public sealed class PgSerializerOptions
     internal PgTypeInfo UnspecifiedDBNullTypeInfo { get; }
 
     PostgresType? _textPgType;
-    internal PostgresType TextPgType => _textPgType ??= DatabaseInfo.GetPostgresType(DataTypeNames.Text);
+    internal PgTypeId TextPgTypeId => ToCanonicalTypeId(_textPgType ??= DatabaseInfo.GetPostgresType(DataTypeNames.Text));
 
     // Used purely for type mapping, where we don't have a full set of types but resolvers might know enough.
     readonly bool _introspectionInstance;
@@ -84,23 +83,20 @@ public sealed class PgSerializerOptions
             ? ((TypeInfoCache<DataTypeName>)(_typeInfoCache ??= new TypeInfoCache<DataTypeName>(this))).GetOrAddInfo(type, pgTypeId?.DataTypeName, defaultTypeFallback)
             : ((TypeInfoCache<Oid>)(_typeInfoCache ??= new TypeInfoCache<Oid>(this))).GetOrAddInfo(type, pgTypeId?.Oid, defaultTypeFallback);
 
-    public PgTypeInfo? GetDefaultTypeInfo(PostgresType pgType)
-        => GetTypeInfoCore(null, ToCanonicalTypeId(pgType), false);
-
-    public PgTypeInfo? GetDefaultTypeInfo(PgTypeId pgTypeId)
-        => GetTypeInfoCore(null, pgTypeId, false);
-
-    public PgTypeInfo? GetTypeInfo(Type type, PostgresType pgType)
-        => GetTypeInfoCore(type, ToCanonicalTypeId(pgType), false);
-
-    public PgTypeInfo? GetTypeInfo(Type type, PgTypeId? pgTypeId = null)
+    internal PgTypeInfo? GetTypeInfoInternal(Type? type, PgTypeId? pgTypeId)
         => GetTypeInfoCore(type, pgTypeId, false);
 
-    public PgTypeInfo? GetObjectOrDefaultTypeInfo(PostgresType pgType)
-        => GetTypeInfoCore(typeof(object), ToCanonicalTypeId(pgType), true);
+    internal PgTypeInfo? GetObjectOrDefaultTypeInfo(PgTypeId pgTypeId)
+        => GetTypeInfoCore(typeof(object), GetCanonicalTypeId(pgTypeId), true);
 
-    public PgTypeInfo? GetObjectOrDefaultTypeInfo(PgTypeId pgTypeId)
-        => GetTypeInfoCore(typeof(object), pgTypeId, true);
+    public PgTypeInfo? GetDefaultTypeInfo(Type type)
+        => GetTypeInfoCore(type, null, false);
+
+    public PgTypeInfo? GetDefaultTypeInfo(PgTypeId pgTypeId)
+        => GetTypeInfoCore(null, GetCanonicalTypeId(pgTypeId), false);
+
+    public PgTypeInfo? GetTypeInfo(Type type, PgTypeId pgTypeId)
+        => GetTypeInfoCore(type, GetCanonicalTypeId(pgTypeId), false);
 
     // If a given type id is in the opposite form than what was expected it will be mapped according to the requirement.
     internal PgTypeId GetCanonicalTypeId(PgTypeId pgTypeId)

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -499,7 +499,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             // Probe if there is any mapping at all for this element type.
             var elementId = options.ToCanonicalTypeId(pgElementType);
-            if (options.GetDefaultTypeInfo(elementId) is null)
+            if (options.GetTypeInfoInternal(null, elementId) is null)
                 return null;
 
             var mappings = new TypeInfoMappingCollection();

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -75,11 +75,10 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 || options.DatabaseInfo.GetPostgresType(dataTypeName) is not PostgresRangeType rangeType)
                 return null;
 
-            var subInfo =
-                matchedType is null
-                    ? options.GetDefaultTypeInfo(rangeType.Subtype)
-                    // Input matchedType here as we don't want an NpgsqlRange over Nullable<T> (it has its own nullability tracking, for better or worse)
-                    : options.GetTypeInfo(matchedType == typeof(object) ? matchedType : matchedType.GetGenericArguments()[0], rangeType.Subtype);
+            // Input matchedType here as we don't want an NpgsqlRange over Nullable<T> (it has its own nullability tracking, for better or worse)
+            var subInfo = options.GetTypeInfoInternal(
+                matchedType is null ? null : matchedType == typeof(object) ? matchedType : matchedType.GetGenericArguments()[0],
+                options.ToCanonicalTypeId(rangeType.Subtype));
 
             // We have no generic RangeConverterResolver so we would not know how to compose a range mapping for such infos.
             // See https://github.com/npgsql/npgsql/issues/5268
@@ -133,10 +132,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 || options.DatabaseInfo.GetPostgresType(dataTypeName) is not PostgresMultirangeType multirangeType)
                 return null;
 
-            var subInfo =
-                type is null
-                    ? options.GetDefaultTypeInfo(multirangeType.Subrange)
-                    : options.GetTypeInfo(elementType ?? typeof(object), multirangeType.Subrange);
+            var subInfo = options.GetTypeInfoInternal(type is null ? null : elementType ?? typeof(object), options.ToCanonicalTypeId(multirangeType.Subrange));
 
             // We have no generic MultirangeConverterResolver so we would not know how to compose a range mapping for such infos.
             // See https://github.com/npgsql/npgsql/issues/5268

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -341,7 +341,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
                 // Handle plugin types via lookup.
                 : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
         }
-        var info = options.GetTypeInfo(type, pgTypeId)
+        var info = options.GetTypeInfoInternal(type, pgTypeId)
                    ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
         // Binary export has no type info so we only do caller-directed interpretation of data.

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -380,14 +380,16 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             if (i >= _columns.Count)
             {
                 var pgType = SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
-                _columns.Add(new ColumnInfo(pgType, bufferPos, AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgType, SerializerOptions), Format));
+                var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
+                _columns.Add(new ColumnInfo(pgType, bufferPos, AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), Format));
             }
             else
             {
                 var pgType = _columns[i].PostgresType.OID == typeOid
                     ? _columns[i].PostgresType
                     : SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
-                _columns[i] = new ColumnInfo(pgType, bufferPos, AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgType, SerializerOptions), Format);
+                var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
+                _columns[i] = new ColumnInfo(pgType, bufferPos, AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), Format);
             }
 
             var columnLen = PgReader.ReadInt32();
@@ -517,7 +519,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             }
         }
 
-        var converterInfo = column.Bind(AdoSerializerHelpers.GetTypeInfoForReading(type, column.PostgresType, SerializerOptions));
+        var converterInfo = column.Bind(AdoSerializerHelpers.GetTypeInfoForReading(type, SerializerOptions.ToCanonicalTypeId(column.PostgresType), SerializerOptions));
         _columns[ordinal] = column with { LastConverterInfo = converterInfo };
         asObject = converterInfo.IsBoxingConverter;
         return converterInfo;

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -794,6 +794,7 @@ FROM pg_constraint c
         // TODO: Support type name restriction
         try
         {
+            var serializerOptions = connector.SerializerOptions;
             PgSerializerOptions.IntrospectionCaller = true;
 
             var types = new List<PostgresType>();
@@ -802,7 +803,7 @@ FROM pg_constraint c
             types.AddRange(connector.DatabaseInfo.CompositeTypes);
             foreach (var baseType in types)
             {
-                if (connector.SerializerOptions.GetDefaultTypeInfo(baseType) is not { } info)
+                if (serializerOptions.GetTypeInfoInternal(null, serializerOptions.ToCanonicalTypeId(baseType)) is not { } info)
                     continue;
 
                 var row = table.Rows.Add();
@@ -817,7 +818,7 @@ FROM pg_constraint c
 
             foreach (var arrayType in connector.DatabaseInfo.ArrayTypes)
             {
-                if (connector.SerializerOptions.GetDefaultTypeInfo(arrayType) is not { } info)
+                if (serializerOptions.GetTypeInfoInternal(null, serializerOptions.ToCanonicalTypeId(arrayType)) is not { } info)
                     continue;
 
                 var row = table.Rows.Add();
@@ -836,7 +837,7 @@ FROM pg_constraint c
 
             foreach (var rangeType in connector.DatabaseInfo.RangeTypes)
             {
-                if (connector.SerializerOptions.GetDefaultTypeInfo(rangeType) is not { } info)
+                if (serializerOptions.GetTypeInfoInternal(null, serializerOptions.ToCanonicalTypeId(rangeType)) is not { } info)
                     continue;
 
                 var row = table.Rows.Add();
@@ -856,7 +857,7 @@ FROM pg_constraint c
             foreach (var multirangeType in connector.DatabaseInfo.MultirangeTypes)
             {
                 var subtypeType = multirangeType.Subrange.Subtype;
-                if (connector.SerializerOptions.GetDefaultTypeInfo(multirangeType) is not { } info)
+                if (serializerOptions.GetTypeInfoInternal(null, serializerOptions.ToCanonicalTypeId(multirangeType)) is not { } info)
                     continue;
 
                 var row = table.Rows.Add();
@@ -876,7 +877,7 @@ FROM pg_constraint c
             foreach (var domainType in connector.DatabaseInfo.DomainTypes)
             {
                 var representationalType = domainType.GetRepresentationalType();
-                if (connector.SerializerOptions.GetDefaultTypeInfo(representationalType) is not { } info)
+                if (serializerOptions.GetTypeInfoInternal(null, serializerOptions.ToCanonicalTypeId(representationalType)) is not { } info)
                     continue;
 
                 var row = table.Rows.Add();

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -35,9 +35,9 @@ sealed class DbColumnSchemaGenerator
      {(pgVersion.IsGreaterOrEqual(10) ? "attidentity != ''" : "FALSE")} AS isidentity,
      CASE WHEN typ.typtype = 'd' THEN typ.typtypmod ELSE atttypmod END AS typmod,
      CASE WHEN atthasdef THEN (SELECT pg_get_expr(adbin, cls.oid) FROM pg_attrdef WHERE adrelid = cls.oid AND adnum = attr.attnum) ELSE NULL END AS default,
-     CASE WHEN ((cls.relkind = ANY (ARRAY['r'::""char"", 'p'::""char""])) 
+     CASE WHEN ((cls.relkind = ANY (ARRAY['r'::""char"", 'p'::""char""]))
                OR ((cls.relkind = ANY (ARRAY['v'::""char"", 'f'::""char""]))
-               AND pg_column_is_updatable((cls.oid)::regclass, attr.attnum, false))) 
+               AND pg_column_is_updatable((cls.oid)::regclass, attr.attnum, false)))
   	           AND attr.attidentity NOT IN ('a') THEN 'true'::boolean
                ELSE 'false'::boolean
                END AS is_updatable,
@@ -260,7 +260,7 @@ ORDER BY attnum";
         var serializerOptions = _connection.Connector!.SerializerOptions;
 
         column.NpgsqlDbType = column.PostgresType.DataTypeName.ToNpgsqlDbType();
-        if (serializerOptions.GetObjectOrDefaultTypeInfo(serializerOptions.ToCanonicalTypeId(column.PostgresType)) is { } typeInfo)
+        if (serializerOptions.GetObjectOrDefaultTypeInfoInternal(serializerOptions.ToCanonicalTypeId(column.PostgresType)) is { } typeInfo)
         {
             column.DataType = typeInfo.Type;
             column.IsLong = column.PostgresType.DataTypeName == DataTypeNames.Bytea;

--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -260,7 +260,7 @@ ORDER BY attnum";
         var serializerOptions = _connection.Connector!.SerializerOptions;
 
         column.NpgsqlDbType = column.PostgresType.DataTypeName.ToNpgsqlDbType();
-        if (serializerOptions.GetObjectOrDefaultTypeInfo(column.PostgresType) is { } typeInfo)
+        if (serializerOptions.GetObjectOrDefaultTypeInfo(serializerOptions.ToCanonicalTypeId(column.PostgresType)) is { } typeInfo)
         {
             column.DataType = typeInfo.Type;
             column.IsLong = column.PostgresType.DataTypeName == DataTypeNames.Bytea;

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -103,7 +103,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
         DataTypeName? dataTypeName;
         try
         {
-            var typeInfo = TypeMappingOptions.GetTypeInfo(type);
+            var typeInfo = TypeMappingOptions.GetTypeInfoInternal(type, null);
             if (typeInfo is PgResolverTypeInfo info)
                 dataTypeName = info.GetObjectResolution(value).PgTypeId.DataTypeName;
             else

--- a/test/Npgsql.Benchmarks/ResolveHandler.cs
+++ b/test/Npgsql.Benchmarks/ResolveHandler.cs
@@ -30,13 +30,13 @@ public class ResolveHandler
 
     [Benchmark]
     public PgTypeInfo? ResolveDefault()
-        => _serializerOptions.GetDefaultTypeInfo(new Oid(23)); // int4
+        => _serializerOptions.GetTypeInfoInternal(null, new Oid(23)); // int4
 
     [Benchmark]
     public PgTypeInfo? ResolveType()
-        => _serializerOptions.GetTypeInfo(typeof(int));
+        => _serializerOptions.GetTypeInfoInternal(typeof(int), null);
 
     [Benchmark]
     public PgTypeInfo? ResolveBoth()
-        => _serializerOptions.GetTypeInfo(typeof(int), new Oid(23)); // int4
+        => _serializerOptions.GetTypeInfoInternal(typeof(int), new Oid(23)); // int4
 }


### PR DESCRIPTION
It's a general cleanup but it relates to https://github.com/npgsql/npgsql/issues/5725

Users inside custom resolvers - where they only have a datatypename of what they want to resolve - are unable to call `options.GetTypeInfo` with a PgTypeId as it would normally expect an Oid to be passed in (PortableTypeIds = false).

Somewhat accidentally we haven't exposed the methods that users would need to do so.

Specifically 

https://github.com/npgsql/npgsql/compare/main...NinoFloris:pgtypeinfo-reuse?expand=1#diff-afcb93fbb1e1b4b05982008eba6f3ed93423c73714bb73ef569728191f0ac0a5R99-R100

does not do a `GetCanonicalTypeId` call today. 

The reason originally for leaving out the lookups are that they are not free, while they can be easily overlooked if they happen implicitly. So to make sure we released an implementation in 8.0 without any of those we delegated that task to the caller. However... the methods for callers to do this work were not exposed publicly, leaving users without a way to do so at all.

This PR introduces internal variations of the public methods to make sure we don't regress our lookup code, keeping things explicit internally. The public variants may now do a lookup going forward allowing users to return info coming from other resolvers. Doing so is harmless for perf in a resolver (as their results will be cached).

Next up is the question whether we should expose DatabaseInfo on PgSerializerOptions. Users may need access to it to resolve PgTypeInfo for some plugin type, where the schema of the plugin is not known to the user until database types are loaded at runtime. As DataTypeName expects a fully qualified name users would be stuck. An additional argument would be that users might want to write resolvers that vary their mappings based on database version/features. I'll leave any strong opinion about these arguments in the middle for now, but I won't be against exposing it.