### PR TITLE
Implement Logical Streaming Replication Protocol V4

### DIFF
--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -11,14 +11,16 @@ Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V1 = 1 -> Npgsql.Replication
 Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V2 = 2 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
 Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V3 = 3 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
 Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V4 = 4 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
-*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
 Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, Npgsql.Replication.PgOutput.PgOutputProtocolVersion protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
-*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
 Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, Npgsql.Replication.PgOutput.PgOutputProtocolVersion protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
-*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.ProtocolVersion.get -> ulong
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
 Npgsql.Replication.PgOutput.PgOutputReplicationOptions.ProtocolVersion.get -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
-*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.Streaming.get -> bool?
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.ProtocolVersion.get -> ulong
 Npgsql.Replication.PgOutput.PgOutputReplicationOptions.StreamingMode.get -> Npgsql.Replication.PgOutput.PgOutputStreamingMode?
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.Streaming.get -> bool?
 Npgsql.Replication.PgOutput.PgOutputStreamingMode
 Npgsql.Replication.PgOutput.PgOutputStreamingMode.Off = 0 -> Npgsql.Replication.PgOutput.PgOutputStreamingMode
 Npgsql.Replication.PgOutput.PgOutputStreamingMode.On = 1 -> Npgsql.Replication.PgOutput.PgOutputStreamingMode

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -3,3 +3,23 @@ Npgsql.NpgsqlSlimDataSourceBuilder.EnableGeometricTypes() -> Npgsql.NpgsqlSlimDa
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableJsonTypes() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableNetworkTypes() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.Replication.PgOutput.ReplicationValue.GetFieldName() -> string!
+Npgsql.Replication.PgOutput.Messages.ParallelStreamAbortMessage
+Npgsql.Replication.PgOutput.Messages.ParallelStreamAbortMessage.AbortLsn.get -> NpgsqlTypes.NpgsqlLogSequenceNumber
+Npgsql.Replication.PgOutput.Messages.ParallelStreamAbortMessage.AbortTimestamp.get -> System.DateTime
+Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V1 = 1 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V2 = 2 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V3 = 3 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+Npgsql.Replication.PgOutput.PgOutputProtocolVersion.V4 = 4 -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(string! publicationName, Npgsql.Replication.PgOutput.PgOutputProtocolVersion protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null) -> void
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.PgOutputReplicationOptions(System.Collections.Generic.IEnumerable<string!>! publicationNames, Npgsql.Replication.PgOutput.PgOutputProtocolVersion protocolVersion, bool? binary = null, Npgsql.Replication.PgOutput.PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null) -> void
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.ProtocolVersion.get -> ulong
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.ProtocolVersion.get -> Npgsql.Replication.PgOutput.PgOutputProtocolVersion
+*REMOVED*Npgsql.Replication.PgOutput.PgOutputReplicationOptions.Streaming.get -> bool?
+Npgsql.Replication.PgOutput.PgOutputReplicationOptions.StreamingMode.get -> Npgsql.Replication.PgOutput.PgOutputStreamingMode?
+Npgsql.Replication.PgOutput.PgOutputStreamingMode
+Npgsql.Replication.PgOutput.PgOutputStreamingMode.Off = 0 -> Npgsql.Replication.PgOutput.PgOutputStreamingMode
+Npgsql.Replication.PgOutput.PgOutputStreamingMode.On = 1 -> Npgsql.Replication.PgOutput.PgOutputStreamingMode
+Npgsql.Replication.PgOutput.PgOutputStreamingMode.Parallel = 2 -> Npgsql.Replication.PgOutput.PgOutputStreamingMode

--- a/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
+++ b/src/Npgsql/Replication/PgOutput/Messages/StreamAbortMessage.cs
@@ -4,9 +4,9 @@ using System;
 namespace Npgsql.Replication.PgOutput.Messages;
 
 /// <summary>
-/// Logical Replication Protocol stream abort message
+/// Logical Replication Protocol stream abort message for Logical Streaming Replication Protocol versions 2-3
 /// </summary>
-public sealed class StreamAbortMessage : TransactionControlMessage
+public class StreamAbortMessage : TransactionControlMessage
 {
     /// <summary>
     /// Xid of the subtransaction (will be same as xid of the transaction for top-level transactions).
@@ -20,6 +20,33 @@ public sealed class StreamAbortMessage : TransactionControlMessage
     {
         base.Populate(walStart, walEnd, serverClock, transactionXid);
         SubtransactionXid = subtransactionXid;
+        return this;
+    }
+}
+
+/// <summary>
+/// Logical Replication Protocol stream abort message for Logical Streaming Replication Protocol versions 4+
+/// </summary>
+public sealed class ParallelStreamAbortMessage : StreamAbortMessage
+{
+    /// <summary>
+    /// The LSN of the abort.
+    /// </summary>
+    public NpgsqlLogSequenceNumber AbortLsn { get; private set; }
+
+    /// <summary>
+    /// Abort timestamp of the transaction.
+    /// </summary>
+    public DateTime AbortTimestamp { get; private set; }
+
+    internal ParallelStreamAbortMessage() {}
+
+    internal ParallelStreamAbortMessage Populate(NpgsqlLogSequenceNumber walStart, NpgsqlLogSequenceNumber walEnd, DateTime serverClock,
+        uint transactionXid, uint subtransactionXid, NpgsqlLogSequenceNumber abortLsn, DateTime abortTimestamp)
+    {
+        base.Populate(walStart, walEnd, serverClock, transactionXid, subtransactionXid);
+        AbortLsn = abortLsn;
+        AbortTimestamp = abortTimestamp;
         return this;
     }
 }

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -86,7 +86,7 @@ sealed class PgOutputAsyncEnumerable : IAsyncEnumerable<PgOutputReplicationMessa
             _streamPrepareMessage = new();
         }
 
-        if (_protocolVersion == PgOutputProtocolVersion.V4)
+        if (_protocolVersion >= PgOutputProtocolVersion.V4)
         {
             _parallelStreamAbortMessage = new();
         }

--- a/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputAsyncEnumerable.cs
@@ -76,7 +76,6 @@ sealed class PgOutputAsyncEnumerable : IAsyncEnumerable<PgOutputReplicationMessa
             _streamStartMessage = new();
             _streamStopMessage = new();
             _streamCommitMessage = new();
-            _streamAbortMessage = new();
         }
         if (_protocolVersion >= PgOutputProtocolVersion.V3)
         {

--- a/src/Npgsql/Replication/PgOutput/PgOutputProtocolVersion.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputProtocolVersion.cs
@@ -1,0 +1,30 @@
+﻿namespace Npgsql.Replication.PgOutput;
+
+/// <summary>
+/// The Logical Streaming Replication Protocol version.
+/// </summary>
+public enum PgOutputProtocolVersion : ulong
+{
+    /// <summary>
+    /// Version 1 is supported for server version 10 and above.
+    /// </summary>
+    V1 = 1UL,
+
+    /// <summary>
+    /// Version 2 is supported only for server version 14 and above, and it allows
+    /// streaming of large in-progress transactions.
+    /// </summary>
+    V2 = 2UL,
+
+    /// <summary>
+    /// Version 3 is supported only for server version 15 and above, and it allows
+    /// streaming of two-phase commits.
+    /// </summary>
+    V3 = 3UL,
+
+    /// <summary>
+    /// Version 4 is supported only for server version 16 and above, and it allows
+    /// streams of large in-progress transactions to be applied in parallel.
+    /// </summary>
+    V4 = 4UL
+}

--- a/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
@@ -15,11 +15,11 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="publicationName">The publication names to include into the stream</param>
     /// <param name="protocolVersion">The version of the logical streaming replication protocol</param>
     /// <param name="binary">Send values in binary representation</param>
-    /// <param name="streaming">Enable streaming of in-progress transactions</param>
+    /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    public PgOutputReplicationOptions(string publicationName, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null)
-        : this(new List<string> { publicationName ?? throw new ArgumentNullException(nameof(publicationName)) }, protocolVersion, binary, streaming, messages, twoPhase)
+    public PgOutputReplicationOptions(string publicationName, PgOutputProtocolVersion protocolVersion, bool? binary = null, PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
+        : this(new List<string> { publicationName ?? throw new ArgumentNullException(nameof(publicationName)) }, protocolVersion, binary, streamingMode, messages, twoPhase)
     { }
 
     /// <summary>
@@ -28,10 +28,10 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="publicationNames">The publication names to include into the stream</param>
     /// <param name="protocolVersion">The version of the logical streaming replication protocol</param>
     /// <param name="binary">Send values in binary representation</param>
-    /// <param name="streaming">Enable streaming of in-progress transactions</param>
+    /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    public PgOutputReplicationOptions(IEnumerable<string> publicationNames, ulong protocolVersion, bool? binary = null, bool? streaming = null, bool? messages = null, bool? twoPhase = null)
+    public PgOutputReplicationOptions(IEnumerable<string> publicationNames, PgOutputProtocolVersion protocolVersion, bool? binary = null, PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
     {
         var publicationNamesList = new List<string>(publicationNames);
         if (publicationNamesList.Count < 1)
@@ -46,7 +46,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
         PublicationNames = publicationNamesList;
         ProtocolVersion = protocolVersion;
         Binary = binary;
-        Streaming = streaming;
+        StreamingMode = streamingMode;
         Messages = messages;
         TwoPhase = twoPhase;
     }
@@ -54,7 +54,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <summary>
     /// The version of the Logical Streaming Replication Protocol
     /// </summary>
-    public ulong ProtocolVersion { get; }
+    public PgOutputProtocolVersion ProtocolVersion { get; }
 
     /// <summary>
     /// The publication names to stream
@@ -74,10 +74,11 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// Enable streaming of in-progress transactions
     /// </summary>
     /// <remarks>
-    /// This works as of logical streaming replication protocol version 2 (PostgreSQL 14+)
+    /// <see cref="PgOutputStreamingMode.On"/> works as of logical streaming replication protocol version 2 (PostgreSQL 14+),
+    /// <see cref="PgOutputStreamingMode.Parallel"/> works as of logical streaming replication protocol version 4 (PostgreSQL 16+),
     /// </remarks>
     // See: https://github.com/postgres/postgres/commit/464824323e57dc4b397e8b05854d779908b55304
-    public bool? Streaming { get; }
+    public PgOutputStreamingMode? StreamingMode { get; }
 
     /// <summary>
     /// Write logical decoding messages into the replication stream
@@ -100,13 +101,19 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
 
     internal IEnumerable<KeyValuePair<string, string?>> GetOptionPairs()
     {
-        yield return new KeyValuePair<string, string?>("proto_version", ProtocolVersion.ToString(CultureInfo.InvariantCulture));
+        yield return new KeyValuePair<string, string?>("proto_version", ((ulong)ProtocolVersion).ToString(CultureInfo.InvariantCulture));
         yield return new KeyValuePair<string, string?>("publication_names", "\"" + string.Join("\",\"", PublicationNames) + "\"");
 
         if (Binary != null)
             yield return new KeyValuePair<string, string?>("binary", Binary.Value ? "on" : "off");
-        if (Streaming != null)
-            yield return new KeyValuePair<string, string?>("streaming", Streaming.Value ? "on" : "off");
+        if (StreamingMode != null)
+            yield return new KeyValuePair<string, string?>("streaming", StreamingMode.Value switch
+            {
+                PgOutputStreamingMode.Off => "off",
+                PgOutputStreamingMode.On => "on",
+                PgOutputStreamingMode.Parallel => "parallel",
+                _ => throw new ArgumentOutOfRangeException($"Unknown {nameof(PgOutputStreamingMode)} value: {StreamingMode.Value}")
+            });
         if (Messages != null)
             yield return new KeyValuePair<string, string?>("messages", Messages.Value ? "on" : "off");
         if (TwoPhase != null)
@@ -118,12 +125,12 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
         => other != null && (
             ReferenceEquals(this, other) ||
             ProtocolVersion == other.ProtocolVersion && PublicationNames.Equals(other.PublicationNames) && Binary == other.Binary &&
-            Streaming == other.Streaming && Messages == other.Messages && TwoPhase == other.TwoPhase);
+            StreamingMode == other.StreamingMode && Messages == other.Messages && TwoPhase == other.TwoPhase);
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
         => obj is PgOutputReplicationOptions other && other.Equals(this);
 
     /// <inheritdoc />
-    public override int GetHashCode() => HashCode.Combine(ProtocolVersion, PublicationNames, Binary, Streaming, Messages, TwoPhase);
+    public override int GetHashCode() => HashCode.Combine(ProtocolVersion, PublicationNames, Binary, StreamingMode, Messages, TwoPhase);
 }

--- a/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
@@ -107,6 +107,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
         if (Binary != null)
             yield return new KeyValuePair<string, string?>("binary", Binary.Value ? "on" : "off");
         if (StreamingMode != null)
+        {
             yield return new KeyValuePair<string, string?>("streaming", StreamingMode.Value switch
             {
                 PgOutputStreamingMode.Off => "off",
@@ -114,6 +115,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
                 PgOutputStreamingMode.Parallel => "parallel",
                 _ => throw new ArgumentOutOfRangeException($"Unknown {nameof(PgOutputStreamingMode)} value: {StreamingMode.Value}")
             });
+        }
         if (Messages != null)
             yield return new KeyValuePair<string, string?>("messages", Messages.Value ? "on" : "off");
         if (TwoPhase != null)

--- a/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
@@ -18,9 +18,29 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    public PgOutputReplicationOptions(string publicationName, PgOutputProtocolVersion protocolVersion, bool? binary = null, PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
-        : this(new List<string> { publicationName ?? throw new ArgumentNullException(nameof(publicationName)) }, protocolVersion, binary, streamingMode, messages, twoPhase)
-    { }
+    [Obsolete]
+    public PgOutputReplicationOptions(string publicationName, ulong protocolVersion, bool? binary = null,
+        PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
+        : this([publicationName ?? throw new ArgumentNullException(nameof(publicationName))], (PgOutputProtocolVersion)protocolVersion,
+            binary, streamingMode, messages, twoPhase)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="PgOutputReplicationOptions"/>.
+    /// </summary>
+    /// <param name="publicationName">The publication names to include into the stream</param>
+    /// <param name="protocolVersion">The version of the logical streaming replication protocol</param>
+    /// <param name="binary">Send values in binary representation</param>
+    /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
+    /// <param name="messages">Write logical decoding messages into the replication stream</param>
+    /// <param name="twoPhase">Enable streaming of prepared transactions</param>
+    public PgOutputReplicationOptions(string publicationName, PgOutputProtocolVersion protocolVersion, bool? binary = null,
+        PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
+        : this([publicationName ?? throw new ArgumentNullException(nameof(publicationName))], protocolVersion, binary, streamingMode,
+            messages, twoPhase)
+    {
+    }
 
     /// <summary>
     /// Creates a new instance of <see cref="PgOutputReplicationOptions"/>.
@@ -31,7 +51,24 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    public PgOutputReplicationOptions(IEnumerable<string> publicationNames, PgOutputProtocolVersion protocolVersion, bool? binary = null, PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
+    [Obsolete]
+    public PgOutputReplicationOptions(IEnumerable<string> publicationNames, ulong protocolVersion, bool? binary = null,
+        PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
+        : this(publicationNames, (PgOutputProtocolVersion)protocolVersion, binary, streamingMode, messages, twoPhase)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="PgOutputReplicationOptions"/>.
+    /// </summary>
+    /// <param name="publicationNames">The publication names to include into the stream</param>
+    /// <param name="protocolVersion">The version of the logical streaming replication protocol</param>
+    /// <param name="binary">Send values in binary representation</param>
+    /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
+    /// <param name="messages">Write logical decoding messages into the replication stream</param>
+    /// <param name="twoPhase">Enable streaming of prepared transactions</param>
+    public PgOutputReplicationOptions(IEnumerable<string> publicationNames, PgOutputProtocolVersion protocolVersion, bool? binary = null,
+        PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
     {
         var publicationNamesList = new List<string>(publicationNames);
         if (publicationNamesList.Count < 1)
@@ -78,6 +115,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <see cref="PgOutputStreamingMode.Parallel"/> works as of logical streaming replication protocol version 4 (PostgreSQL 16+),
     /// </remarks>
     // See: https://github.com/postgres/postgres/commit/464824323e57dc4b397e8b05854d779908b55304
+    // and https://github.com/postgres/postgres/commit/216a784829c2c5f03ab0c43e009126cbb819e9b2
     public PgOutputStreamingMode? StreamingMode { get; }
 
     /// <summary>

--- a/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputReplicationOptions.cs
@@ -18,7 +18,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    [Obsolete]
+    [Obsolete("Please switch to the overloads that take a PgOutputProtocolVersion value instead.")]
     public PgOutputReplicationOptions(string publicationName, ulong protocolVersion, bool? binary = null,
         PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
         : this([publicationName ?? throw new ArgumentNullException(nameof(publicationName))], (PgOutputProtocolVersion)protocolVersion,
@@ -51,7 +51,7 @@ public class PgOutputReplicationOptions : IEquatable<PgOutputReplicationOptions>
     /// <param name="streamingMode">Enable streaming of in-progress transactions</param>
     /// <param name="messages">Write logical decoding messages into the replication stream</param>
     /// <param name="twoPhase">Enable streaming of prepared transactions</param>
-    [Obsolete]
+    [Obsolete("Please switch to the overloads that take a PgOutputProtocolVersion value instead.")]
     public PgOutputReplicationOptions(IEnumerable<string> publicationNames, ulong protocolVersion, bool? binary = null,
         PgOutputStreamingMode? streamingMode = null, bool? messages = null, bool? twoPhase = null)
         : this(publicationNames, (PgOutputProtocolVersion)protocolVersion, binary, streamingMode, messages, twoPhase)

--- a/src/Npgsql/Replication/PgOutput/PgOutputStreamingMode.cs
+++ b/src/Npgsql/Replication/PgOutput/PgOutputStreamingMode.cs
@@ -1,0 +1,23 @@
+﻿namespace Npgsql.Replication.PgOutput;
+
+/// <summary>
+/// Option to enable streaming of in-progress transactions.
+/// Minimum protocol version 2 is required to turn it on. Minimum protocol version 4 is required for the "parallel" option.
+/// </summary>
+public enum PgOutputStreamingMode
+{
+    /// <summary>
+    /// Disable streaming of in-progress transactions
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Enable streaming of in-progress transactions
+    /// </summary>
+    On,
+
+    /// <summary>
+    /// Enable streaming of in-progress transactions and enable sending extra information with some messages to be used for parallelisation
+    /// </summary>
+    Parallel
+}

--- a/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/PgOutputReplicationTests.cs
@@ -798,10 +798,12 @@ CREATE PUBLICATION {publicationName} FOR TABLE {tableName};
 
                 // Rollback Transaction 2
                 if (IsStreaming)
+                {
                     Assert.That(messages.Current,
                         _streamingMode == PgOutputStreamingMode.On
                             ? Is.TypeOf<StreamAbortMessage>()
                             : Is.TypeOf<ParallelStreamAbortMessage>());
+                }
 
                 streamingCts.Cancel();
                 await AssertReplicationCancellation(messages);


### PR DESCRIPTION
Closes #5760

Since the `streaming` [replication parameter](https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS) is now an enum instead of a bool I adjusted `PgOutputReplicationOptions` to follow that change wich is breaking change in our API.
While breaking the API I also made the protocol version an enum.