### PR TITLE
Allow to load nested postgres types (like range over domain)

### DIFF
--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -78,7 +78,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Input matchedType here as we don't want an NpgsqlRange over Nullable<T> (it has its own nullability tracking, for better or worse)
             var subInfo = options.GetTypeInfoInternal(
                 matchedType is null ? null : matchedType == typeof(object) ? matchedType : matchedType.GetGenericArguments()[0],
-                options.ToCanonicalTypeId(rangeType.Subtype));
+                options.ToCanonicalTypeId(rangeType.Subtype.GetRepresentationalType()));
 
             // We have no generic RangeConverterResolver so we would not know how to compose a range mapping for such infos.
             // See https://github.com/npgsql/npgsql/issues/5268

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -355,7 +355,11 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
             }
 
             if (!hasChanges)
+            {
+                _connectionLogger.LogWarning("Unable to load '{UnknownTypeCount}' Postgres types while loading database info.",
+                    unknownPostgresTypes.Count);
                 break;
+            }
         }
 
         Expect<CommandCompleteMessage>(msg, conn);


### PR DESCRIPTION
Fixes #5671

This pr also fixes an issue where we weren't able to map ranges over domains correctly. Potentially, we can remove sorting from load types query since we already do multiple passes to map them, although that only saves us about 0.2-0.3ms on postgres (2.7ms vs 3.0ms) at the potential cost of us doing multiple passes.