### PR TITLE
TraceOptions to disable  to control whether the "time-to-first-read" and "time-to-last-read" events are generated

### DIFF
--- a/src/Npgsql/NpgsqlActivitySource.cs
+++ b/src/Npgsql/NpgsqlActivitySource.cs
@@ -98,15 +98,21 @@ static class NpgsqlActivitySource
 
     internal static void ReceivedFirstResponse(Activity activity)
     {
-        if (!activity.IsAllDataRequested)
+        if (!activity.IsAllDataRequested || (NpgsqlTracingOptions.Current?.DisableFirstResponseEvent ?? false))
             return;
-
+    
         var activityEvent = new ActivityEvent("received-first-response");
         activity.AddEvent(activityEvent);
     }
 
     internal static void CommandStop(Activity activity)
     {
+        if (!(NpgsqlTracingOptions.Current?.DisableLastReadEvent ?? false))
+        {
+            var activityEvent = new ActivityEvent("received-last-response");
+            activity.AddEvent(activityEvent);
+        }
+        
         activity.SetTag("otel.status_code", "OK");
         activity.Dispose();
     }

--- a/src/Npgsql/NpgsqlActivitySource.cs
+++ b/src/Npgsql/NpgsqlActivitySource.cs
@@ -106,13 +106,7 @@ static class NpgsqlActivitySource
     }
 
     internal static void CommandStop(Activity activity)
-    {
-        if (!(NpgsqlTracingOptions.Current?.DisableLastReadEvent ?? false))
-        {
-            var activityEvent = new ActivityEvent("received-last-response");
-            activity.AddEvent(activityEvent);
-        }
-        
+    {        
         activity.SetTag("otel.status_code", "OK");
         activity.Dispose();
     }

--- a/src/Npgsql/NpgsqlTracingOptions.cs
+++ b/src/Npgsql/NpgsqlTracingOptions.cs
@@ -44,11 +44,13 @@ public class NpgsqlTracingOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether to disable the "time-to-first-read" event.
+    /// Default is false to preserve existing behavior.
     /// </summary>
-    public bool DisableFirstResponseEvent { get; set; }
+    public bool DisableFirstResponseEvent { get; set; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether to disable the "time-to-last-read" event.
+    /// Default is false to preserve existing behavior.
     /// </summary>
-    public bool DisableLastReadEvent { get; set; }    
+    public bool DisableLastReadEvent { get; set; } = false;    
 }

--- a/src/Npgsql/NpgsqlTracingOptions.cs
+++ b/src/Npgsql/NpgsqlTracingOptions.cs
@@ -41,4 +41,14 @@ public class NpgsqlTracingOptions
     /// Gets or sets a function that provides a span's name on a per <see cref="NpgsqlBatch"/> basis.
     /// </summary>
     public Func<NpgsqlBatch, string?>? ProvideSpanNameForNpgsqlBatch { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable the "time-to-first-read" event.
+    /// </summary>
+    public bool DisableFirstResponseEvent { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable the "time-to-last-read" event.
+    /// </summary>
+    public bool DisableLastReadEvent { get; set; }    
 }

--- a/src/Npgsql/NpgsqlTracingOptions.cs
+++ b/src/Npgsql/NpgsqlTracingOptions.cs
@@ -48,9 +48,4 @@ public class NpgsqlTracingOptions
     /// </summary>
     public bool DisableFirstResponseEvent { get; set; } = false;
 
-    /// <summary>
-    /// Gets or sets a value indicating whether to disable the "time-to-last-read" event.
-    /// Default is false to preserve existing behavior.
-    /// </summary>
-    public bool DisableLastReadEvent { get; set; } = false;    
 }


### PR DESCRIPTION
This pull request introduces a new configuration option to control the "time-to-first-read" event in the Npgsql library. The most important changes include adding a new property to the `NpgsqlTracingOptions` class and updating the `ReceivedFirstResponse` method to respect this new setting.

Additionally, the time-to-last-read event was removed at the suggestion of @vonzshik 

### Configuration Enhancements:

* [`src/Npgsql/NpgsqlTracingOptions.cs`](diffhunk://#diff-e3555b1bea8f96895a00eff9a7462125d6224cd6fb1601be8d1562abf306f7aaR44-R50): Added a new boolean property `DisableFirstResponseEvent` to allow users to disable the "time-to-first-read" event. The default value is set to `false` to maintain existing behavior.

### Method Updates:

* [`src/Npgsql/NpgsqlActivitySource.cs`](diffhunk://#diff-472f4042d307b9d23ac1aab6332ef284d7bc1605c2031c8015b87a657c6d69f7L101-R101): Updated the `ReceivedFirstResponse` method to check the `DisableFirstResponseEvent` property before triggering the "received-first-response" event.