### PR TITLE
Concrete INpgsqlTypeMapper return types

### DIFF
--- a/src/Npgsql.GeoJSON/NpgsqlGeoJSONExtensions.cs
+++ b/src/Npgsql.GeoJSON/NpgsqlGeoJSONExtensions.cs
@@ -10,6 +10,7 @@ namespace Npgsql;
 /// </summary>
 public static class NpgsqlGeoJSONExtensions
 {
+    // Note: defined for binary compatibility and NpgsqlConnection.GlobalTypeMapper.
     /// <summary>
     /// Sets up GeoJSON mappings for the PostGIS types.
     /// </summary>
@@ -22,6 +23,7 @@ public static class NpgsqlGeoJSONExtensions
         return mapper;
     }
 
+    // Note: defined for binary compatibility and NpgsqlConnection.GlobalTypeMapper.
     /// <summary>
     /// Sets up GeoJSON mappings for the PostGIS types.
     /// </summary>
@@ -30,6 +32,33 @@ public static class NpgsqlGeoJSONExtensions
     /// <param name="options">Options to use when constructing objects.</param>
     /// <param name="geographyAsDefault">Specifies that the geography type is used for mapping by default.</param>
     public static INpgsqlTypeMapper UseGeoJson(this INpgsqlTypeMapper mapper, CrsMap crsMap, GeoJSONOptions options = GeoJSONOptions.None, bool geographyAsDefault = false)
+    {
+        mapper.AddTypeInfoResolverFactory(new GeoJSONTypeInfoResolverFactory(options, geographyAsDefault, crsMap));
+        return mapper;
+    }
+
+    /// <summary>
+    /// Sets up GeoJSON mappings for the PostGIS types.
+    /// </summary>
+    /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
+    /// <param name="options">Options to use when constructing objects.</param>
+    /// <param name="geographyAsDefault">Specifies that the geography type is used for mapping by default.</param>
+    public static TMapper UseGeoJson<TMapper>(this TMapper mapper, GeoJSONOptions options = GeoJSONOptions.None, bool geographyAsDefault = false)
+        where TMapper : INpgsqlTypeMapper
+    {
+        mapper.AddTypeInfoResolverFactory(new GeoJSONTypeInfoResolverFactory(options, geographyAsDefault, crsMap: null));
+        return mapper;
+    }
+
+    /// <summary>
+    /// Sets up GeoJSON mappings for the PostGIS types.
+    /// </summary>
+    /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
+    /// <param name="crsMap">A custom crs map that might contain more or less entries than the default well-known crs map.</param>
+    /// <param name="options">Options to use when constructing objects.</param>
+    /// <param name="geographyAsDefault">Specifies that the geography type is used for mapping by default.</param>
+    public static TMapper UseGeoJson<TMapper>(this TMapper mapper, CrsMap crsMap, GeoJSONOptions options = GeoJSONOptions.None, bool geographyAsDefault = false)
+        where TMapper : INpgsqlTypeMapper
     {
         mapper.AddTypeInfoResolverFactory(new GeoJSONTypeInfoResolverFactory(options, geographyAsDefault, crsMap));
         return mapper;

--- a/src/Npgsql.GeoJSON/PublicAPI.Unshipped.txt
+++ b/src/Npgsql.GeoJSON/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+static Npgsql.NpgsqlGeoJSONExtensions.UseGeoJson<TMapper>(this TMapper mapper, Npgsql.GeoJSON.CrsMap! crsMap, Npgsql.GeoJSONOptions options = Npgsql.GeoJSONOptions.None, bool geographyAsDefault = false) -> TMapper
+static Npgsql.NpgsqlGeoJSONExtensions.UseGeoJson<TMapper>(this TMapper mapper, Npgsql.GeoJSONOptions options = Npgsql.GeoJSONOptions.None, bool geographyAsDefault = false) -> TMapper

--- a/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
+++ b/src/Npgsql.Json.NET/NpgsqlJsonNetExtensions.cs
@@ -13,6 +13,7 @@ namespace Npgsql;
 /// </summary>
 public static class NpgsqlJsonNetExtensions
 {
+    // Note: defined for binary compatibility and NpgsqlConnection.GlobalTypeMapper.
     /// <summary>
     /// Sets up JSON.NET mappings for the PostgreSQL json and jsonb types.
     /// </summary>
@@ -31,6 +32,32 @@ public static class NpgsqlJsonNetExtensions
         JsonSerializerSettings? settings = null,
         Type[]? jsonbClrTypes = null,
         Type[]? jsonClrTypes = null)
+    {
+        // Reverse order
+        mapper.AddTypeInfoResolverFactory(new JsonNetPocoTypeInfoResolverFactory(jsonbClrTypes, jsonClrTypes, settings));
+        mapper.AddTypeInfoResolverFactory(new JsonNetTypeInfoResolverFactory(settings));
+        return mapper;
+    }
+
+    /// <summary>
+    /// Sets up JSON.NET mappings for the PostgreSQL json and jsonb types.
+    /// </summary>
+    /// <param name="mapper">The type mapper to set up.</param>
+    /// <param name="settings">Optional settings to customize JSON serialization.</param>
+    /// <param name="jsonbClrTypes">
+    /// A list of CLR types to map to PostgreSQL <c>jsonb</c> (no need to specify <see cref="NpgsqlDbType.Jsonb" />).
+    /// </param>
+    /// <param name="jsonClrTypes">
+    /// A list of CLR types to map to PostgreSQL <c>json</c> (no need to specify <see cref="NpgsqlDbType.Json" />).
+    /// </param>
+    [RequiresUnreferencedCode("Json serializer may perform reflection on trimmed types.")]
+    [RequiresDynamicCode("Serializing arbitrary types to json can require creating new generic types or methods, which requires creating code at runtime. This may not work when AOT compiling.")]
+    public static TMapper UseJsonNet<TMapper>(
+        this TMapper mapper,
+        JsonSerializerSettings? settings = null,
+        Type[]? jsonbClrTypes = null,
+        Type[]? jsonClrTypes = null)
+        where TMapper : INpgsqlTypeMapper
     {
         // Reverse order
         mapper.AddTypeInfoResolverFactory(new JsonNetPocoTypeInfoResolverFactory(jsonbClrTypes, jsonClrTypes, settings));

--- a/src/Npgsql.Json.NET/PublicAPI.Unshipped.txt
+++ b/src/Npgsql.Json.NET/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Npgsql.NpgsqlJsonNetExtensions.UseJsonNet<TMapper>(this TMapper mapper, Newtonsoft.Json.JsonSerializerSettings? settings = null, System.Type![]? jsonbClrTypes = null, System.Type![]? jsonClrTypes = null) -> TMapper

--- a/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
+++ b/src/Npgsql.NetTopologySuite/NpgsqlNetTopologySuiteExtensions.cs
@@ -10,6 +10,7 @@ namespace Npgsql;
 /// </summary>
 public static class NpgsqlNetTopologySuiteExtensions
 {
+    // Note: defined for binary compatibility and NpgsqlConnection.GlobalTypeMapper.
     /// <summary>
     /// Sets up NetTopologySuite mappings for the PostGIS types.
     /// </summary>
@@ -26,6 +27,28 @@ public static class NpgsqlNetTopologySuiteExtensions
         PrecisionModel? precisionModel = null,
         Ordinates handleOrdinates = Ordinates.None,
         bool geographyAsDefault = false)
+    {
+        mapper.AddTypeInfoResolverFactory(new NetTopologySuiteTypeInfoResolverFactory(coordinateSequenceFactory, precisionModel, handleOrdinates, geographyAsDefault));
+        return mapper;
+    }
+
+    /// <summary>
+    /// Sets up NetTopologySuite mappings for the PostGIS types.
+    /// </summary>
+    /// <param name="mapper">The type mapper to set up (global or connection-specific).</param>
+    /// <param name="coordinateSequenceFactory">The factory which knows how to build a particular implementation of ICoordinateSequence from an array of Coordinates.</param>
+    /// <param name="precisionModel">Specifies the grid of allowable points.</param>
+    /// <param name="handleOrdinates">Specifies the ordinates which will be handled. Not specified ordinates will be ignored.
+    /// If <see cref="F:GeoAPI.Geometries.Ordiantes.None" /> is specified, an actual value will be taken from
+    /// the <see cref="P:GeoAPI.Geometries.ICoordinateSequenceFactory.Ordinates"/> property of <paramref name="coordinateSequenceFactory"/>.</param>
+    /// <param name="geographyAsDefault">Specifies that the geography type is used for mapping by default.</param>
+    public static TMapper UseNetTopologySuite<TMapper>(
+        this TMapper mapper,
+        CoordinateSequenceFactory? coordinateSequenceFactory = null,
+        PrecisionModel? precisionModel = null,
+        Ordinates handleOrdinates = Ordinates.None,
+        bool geographyAsDefault = false)
+        where TMapper : INpgsqlTypeMapper
     {
         mapper.AddTypeInfoResolverFactory(new NetTopologySuiteTypeInfoResolverFactory(coordinateSequenceFactory, precisionModel, handleOrdinates, geographyAsDefault));
         return mapper;

--- a/src/Npgsql.NetTopologySuite/PublicAPI.Unshipped.txt
+++ b/src/Npgsql.NetTopologySuite/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Npgsql.NpgsqlNetTopologySuiteExtensions.UseNetTopologySuite<TMapper>(this TMapper mapper, NetTopologySuite.Geometries.CoordinateSequenceFactory? coordinateSequenceFactory = null, NetTopologySuite.Geometries.PrecisionModel? precisionModel = null, NetTopologySuite.Geometries.Ordinates handleOrdinates = NetTopologySuite.Geometries.Ordinates.None, bool geographyAsDefault = false) -> TMapper

--- a/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
+++ b/src/Npgsql.NodaTime/NpgsqlNodaTimeExtensions.cs
@@ -9,11 +9,22 @@ namespace Npgsql;
 /// </summary>
 public static class NpgsqlNodaTimeExtensions
 {
+    // Note: defined for binary compatibility and NpgsqlConnection.GlobalTypeMapper.
     /// <summary>
     /// Sets up NodaTime mappings for the PostgreSQL date/time types.
     /// </summary>
     /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
     public static INpgsqlTypeMapper UseNodaTime(this INpgsqlTypeMapper mapper)
+    {
+        mapper.AddTypeInfoResolverFactory(new NodaTimeTypeInfoResolverFactory());
+        return mapper;
+    }
+
+    /// <summary>
+    /// Sets up NodaTime mappings for the PostgreSQL date/time types.
+    /// </summary>
+    /// <param name="mapper">The type mapper to set up (global or connection-specific)</param>
+    public static TMapper UseNodaTime<TMapper>(this TMapper mapper) where TMapper : INpgsqlTypeMapper
     {
         mapper.AddTypeInfoResolverFactory(new NodaTimeTypeInfoResolverFactory());
         return mapper;

--- a/src/Npgsql.NodaTime/PublicAPI.Unshipped.txt
+++ b/src/Npgsql.NodaTime/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+static Npgsql.NpgsqlNodaTimeExtensions.UseNodaTime<TMapper>(this TMapper mapper) -> TMapper

--- a/src/Npgsql/NpgsqlDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlDataSourceBuilder.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql.Internal;
 using Npgsql.Internal.ResolverFactories;
+using Npgsql.NameTranslation;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
 
@@ -384,8 +385,27 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
     /// <inheritdoc />
     void INpgsqlTypeMapper.Reset() => ((INpgsqlTypeMapper)_internalBuilder).Reset();
 
-    /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    /// <summary>
+    /// Maps a CLR enum to a PostgreSQL enum type.
+    /// </summary>
+    /// <remarks>
+    /// CLR enum labels are mapped by name to PostgreSQL enum labels.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your enum fields to manually specify a PostgreSQL enum label.
+    /// If there is a discrepancy between the .NET and database labels while an enum is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
+    public NpgsqlDataSourceBuilder MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
     {
         _internalBuilder.MapEnum<TEnum>(pgName, nameTranslator);
@@ -397,32 +417,64 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
         where TEnum : struct, Enum
         => _internalBuilder.UnmapEnum<TEnum>(pgName, nameTranslator);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Maps a CLR enum to a PostgreSQL enum type.
+    /// </summary>
+    /// <remarks>
+    /// CLR enum labels are mapped by name to PostgreSQL enum labels.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your enum fields to manually specify a PostgreSQL enum label.
+    /// If there is a discrepancy between the .NET and database labels while an enum is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="clrType">The .NET enum type to be mapped</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
     [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
-    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public NpgsqlDataSourceBuilder MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-        => _internalBuilder.MapEnum(clrType, pgName, nameTranslator);
+    {
+        _internalBuilder.MapEnum(clrType, pgName, nameTranslator);
+        return this;
+    }
 
     /// <inheritdoc />
     public bool UnmapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _internalBuilder.UnmapEnum(clrType, pgName, nameTranslator);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Maps a CLR type to a PostgreSQL composite type.
+    /// </summary>
+    /// <remarks>
+    /// CLR fields and properties by string to PostgreSQL names.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your members to manually specify a PostgreSQL name.
+    /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding composite type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    /// <typeparam name="T">The .NET type to be mapped</typeparam>
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
-    public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+    public NpgsqlDataSourceBuilder MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
-        _internalBuilder.MapComposite<T>(pgName, nameTranslator);
-        return this;
-    }
-
-    /// <inheritdoc />
-    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
-    public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
-        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-    {
-        _internalBuilder.MapComposite(clrType, pgName, nameTranslator);
+        _internalBuilder.MapComposite(typeof(T), pgName, nameTranslator);
         return this;
     }
 
@@ -430,7 +482,34 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
     public bool UnmapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
-        => _internalBuilder.UnmapComposite<T>(pgName, nameTranslator);
+        => _internalBuilder.UnmapComposite(typeof(T), pgName, nameTranslator);
+
+    /// <summary>
+    /// Maps a CLR type to a composite type.
+    /// </summary>
+    /// <remarks>
+    /// Maps CLR fields and properties by string to PostgreSQL names.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="DefaultNameTranslator" />.
+    /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="clrType">The .NET type to be mapped.</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding composite type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
+    public NpgsqlDataSourceBuilder MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    {
+        _internalBuilder.MapComposite(clrType, pgName, nameTranslator);
+        return this;
+    }
 
     /// <inheritdoc />
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
@@ -503,4 +582,38 @@ public sealed class NpgsqlDataSourceBuilder : INpgsqlTypeMapper
         "The use of unmapped enums, ranges or multiranges requires dynamic code usage which is incompatible with NativeAOT.")]
     INpgsqlTypeMapper INpgsqlTypeMapper.EnableUnmappedTypes()
         => EnableUnmappedTypes();
+
+    /// <inheritdoc />
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _internalBuilder.MapEnum<TEnum>(pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _internalBuilder.MapEnum(clrType, pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _internalBuilder.MapComposite(typeof(T), pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _internalBuilder.MapComposite(clrType, pgName, nameTranslator);
+        return this;
+    }
 }

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql.Internal;
 using Npgsql.Internal.ResolverFactories;
+using Npgsql.NameTranslation;
 using Npgsql.Properties;
 using Npgsql.TypeMapping;
 using NpgsqlTypes;
@@ -357,8 +358,27 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         set => _userTypeMapper.DefaultNameTranslator = value;
     }
 
-    /// <inheritdoc />
-    public INpgsqlTypeMapper MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
+    /// <summary>
+    /// Maps a CLR enum to a PostgreSQL enum type.
+    /// </summary>
+    /// <remarks>
+    /// CLR enum labels are mapped by name to PostgreSQL enum labels.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your enum fields to manually specify a PostgreSQL enum label.
+    /// If there is a discrepancy between the .NET and database labels while an enum is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    /// <typeparam name="TEnum">The .NET enum type to be mapped</typeparam>
+    public NpgsqlSlimDataSourceBuilder MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         where TEnum : struct, Enum
     {
         _userTypeMapper.MapEnum<TEnum>(pgName, nameTranslator);
@@ -370,9 +390,28 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         where TEnum : struct, Enum
         => _userTypeMapper.UnmapEnum<TEnum>(pgName, nameTranslator);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Maps a CLR enum to a PostgreSQL enum type.
+    /// </summary>
+    /// <remarks>
+    /// CLR enum labels are mapped by name to PostgreSQL enum labels.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your enum fields to manually specify a PostgreSQL enum label.
+    /// If there is a discrepancy between the .NET and database labels while an enum is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="clrType">The .NET enum type to be mapped</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding enum type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
     [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
-    public INpgsqlTypeMapper MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public NpgsqlSlimDataSourceBuilder MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _userTypeMapper.MapEnum(clrType, pgName, nameTranslator);
@@ -384,9 +423,28 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapEnum(clrType, pgName, nameTranslator);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Maps a CLR type to a PostgreSQL composite type.
+    /// </summary>
+    /// <remarks>
+    /// CLR fields and properties by string to PostgreSQL names.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="NpgsqlSnakeCaseNameTranslator"/>.
+    /// You can also use the <see cref="PgNameAttribute"/> on your members to manually specify a PostgreSQL name.
+    /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding composite type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
+    /// <typeparam name="T">The .NET type to be mapped</typeparam>
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
-    public INpgsqlTypeMapper MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+    public NpgsqlSlimDataSourceBuilder MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _userTypeMapper.MapComposite(typeof(T), pgName, nameTranslator);
@@ -399,9 +457,27 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(typeof(T), pgName, nameTranslator);
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Maps a CLR type to a composite type.
+    /// </summary>
+    /// <remarks>
+    /// Maps CLR fields and properties by string to PostgreSQL names.
+    /// The translation strategy can be controlled by the <paramref name="nameTranslator"/> parameter,
+    /// which defaults to <see cref="DefaultNameTranslator" />.
+    /// If there is a discrepancy between the .NET type and database type while a composite is read or written,
+    /// an exception will be raised.
+    /// </remarks>
+    /// <param name="clrType">The .NET type to be mapped.</param>
+    /// <param name="pgName">
+    /// A PostgreSQL type name for the corresponding composite type in the database.
+    /// If null, the name translator given in <paramref name="nameTranslator"/> will be used.
+    /// </param>
+    /// <param name="nameTranslator">
+    /// A component which will be used to translate CLR names (e.g. SomeClass) into database names (e.g. some_class).
+    /// Defaults to <see cref="DefaultNameTranslator" />.
+    /// </param>
     [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
-    public INpgsqlTypeMapper MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+    public NpgsqlSlimDataSourceBuilder MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
     {
         _userTypeMapper.MapComposite(clrType, pgName, nameTranslator);
@@ -413,7 +489,6 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
     public bool UnmapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type clrType, string? pgName = null, INpgsqlNameTranslator? nameTranslator = null)
         => _userTypeMapper.UnmapComposite(clrType, pgName, nameTranslator);
-
 
     /// <inheritdoc />
     public void AddTypeInfoResolverFactory(PgTypeInfoResolverFactory factory) => _resolverChainBuilder.PrependResolverFactory(factory);
@@ -787,4 +862,38 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         "The use of unmapped enums, ranges or multiranges requires dynamic code usage which is incompatible with NativeAOT.")]
     INpgsqlTypeMapper INpgsqlTypeMapper.EnableUnmappedTypes()
         => EnableUnmappedTypes();
+
+    /// <inheritdoc />
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _userTypeMapper.MapEnum<TEnum>(pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Calling MapEnum with a Type can require creating new generic types or methods. This may not work when AOT compiling.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapEnum([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        Type clrType, string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _userTypeMapper.MapEnum(clrType, pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapComposite<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _userTypeMapper.MapComposite(typeof(T), pgName, nameTranslator);
+        return this;
+    }
+
+    /// <inheritdoc />
+    [RequiresDynamicCode("Mapping composite types involves serializing arbitrary types which can require creating new generic types or methods. This is currently unsupported with NativeAOT, vote on issue #5303 if this is important to you.")]
+    INpgsqlTypeMapper INpgsqlTypeMapper.MapComposite([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
+        Type clrType, string? pgName, INpgsqlNameTranslator? nameTranslator)
+    {
+        _userTypeMapper.MapComposite(clrType, pgName, nameTranslator);
+        return this;
+    }
 }

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -5,6 +5,10 @@ Npgsql.NpgsqlConnection.SslClientAuthenticationOptionsCallback.get -> System.Act
 Npgsql.NpgsqlConnection.SslClientAuthenticationOptionsCallback.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.SslNegotiation.get -> Npgsql.SslNegotiation
 Npgsql.NpgsqlConnectionStringBuilder.SslNegotiation.set -> void
+Npgsql.NpgsqlDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlDataSourceBuilder!
+Npgsql.NpgsqlDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlDataSourceBuilder!
+Npgsql.NpgsqlDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlDataSourceBuilder!
+Npgsql.NpgsqlDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.ConfigureTracingOptions(Npgsql.NpgsqlTracingOptions! tracingOptions) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.UseNegotiateOptionsCallback(System.Action<System.Net.Security.NegotiateAuthenticationClientOptions!>? negotiateOptionsCallback) -> Npgsql.NpgsqlDataSourceBuilder!
 Npgsql.NpgsqlDataSourceBuilder.UseSslClientAuthenticationOptionsCallback(System.Action<System.Net.Security.SslClientAuthenticationOptions!>? sslClientAuthenticationOptionsCallback) -> Npgsql.NpgsqlDataSourceBuilder!
@@ -14,6 +18,10 @@ Npgsql.NpgsqlSlimDataSourceBuilder.ConfigureTracingOptions(Npgsql.NpgsqlTracingO
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableGeometricTypes() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableJsonTypes() -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.EnableNetworkTypes() -> Npgsql.NpgsqlSlimDataSourceBuilder!
+Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlSlimDataSourceBuilder!
+Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlSlimDataSourceBuilder!
+Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlSlimDataSourceBuilder!
+Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.UseNegotiateOptionsCallback(System.Action<System.Net.Security.NegotiateAuthenticationClientOptions!>? negotiateOptionsCallback) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlSlimDataSourceBuilder.UseSslClientAuthenticationOptionsCallback(System.Action<System.Net.Security.SslClientAuthenticationOptions!>? sslClientAuthenticationOptionsCallback) -> Npgsql.NpgsqlSlimDataSourceBuilder!
 Npgsql.NpgsqlTracingOptions.EnableFirstResponseEvent.get -> bool
@@ -53,3 +61,11 @@ Npgsql.SslNegotiation
 Npgsql.SslNegotiation.Direct = 1 -> Npgsql.SslNegotiation
 Npgsql.SslNegotiation.Postgres = 0 -> Npgsql.SslNegotiation
 override Npgsql.NpgsqlMultiHostDataSource.Clear() -> void
+*REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
+*REMOVED*Npgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using Npgsql.Internal;
 using Npgsql.Internal.Postgres;
 using Npgsql.Internal.ResolverFactories;
-using NpgsqlTypes;
 
 namespace Npgsql.TypeMapping;
 

--- a/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/INpgsqlTypeMapper.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Npgsql.Internal;
-using Npgsql.Internal.ResolverFactories;
 using Npgsql.NameTranslation;
 using NpgsqlTypes;
 


### PR DESCRIPTION
First commit is strictly breaking (though I think it'll be very unlikely to cause problems), second one for the plugins is just additive. We can choose to take both or just the second commit.