### PR TITLE
Devcontainer update

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres
+FROM postgres:17
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends openssl postgresql-16-postgis-3
+    apt-get install -y --no-install-recommends openssl postgresql-17-postgis-3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,25 +5,29 @@
 
   "workspaceFolder": "/workspace",
 
-  "settings": {
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-          "path": "/bin/bash"
-      }
-    },
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "remote.extensionKind": {
-      "ms-azuretools.vscode-docker": "workspace"
+  "customizations": {
+    "vscode": {
+      "settings": {
+          "terminal.integrated.profiles.linux": {
+            "bash": {
+              "path": "/bin/bash"
+            }
+          },
+          "terminal.integrated.defaultProfile.linux": "bash",
+          "remote.extensionKind": {
+            "ms-azuretools.vscode-docker": "workspace"
+          }
+        },
+
+        "extensions": [
+          "ms-dotnettools.csharp",
+          "formulahendry.dotnet-test-explorer",
+          "ms-azuretools.vscode-docker",
+          "mutantdino.resourcemonitor"
+        ]
     }
   },
-
-  "extensions": [
-    "ms-dotnettools.csharp",
-    "formulahendry.dotnet-test-explorer",
-    "ms-azuretools.vscode-docker",
-    "mutantdino.resourcemonitor"
-  ],
-
+  
   "forwardPorts": [5432, 5050],
 
   "remoteEnv": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   npgsql-dev:
     # Source for tags: https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-    image: mcr.microsoft.com/dotnet/sdk:8.0.100
+    image: mcr.microsoft.com/dotnet/sdk:9.0
     volumes:
       - ..:/workspace:cached
     tty: true

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3'
 
 services:
   npgsql-dev:
-    # Source for tags: https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-    image: mcr.microsoft.com/dotnet/sdk:9.0
+    build: ./dotnet
     volumes:
       - ..:/workspace:cached
     tty: true

--- a/.devcontainer/dotnet/Dockerfile
+++ b/.devcontainer/dotnet/Dockerfile
@@ -1,0 +1,5 @@
+# Source for tags: https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
+FROM mcr.microsoft.com/dotnet/sdk:9.0
+
+# "install" the .NET 8 runtime
+COPY --from=mcr.microsoft.com/dotnet/sdk:8.0 /usr/share/dotnet/shared /usr/share/dotnet/shared

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "omnisharp.defaultLaunchSolution": "Npgsql.sln",
-  "dotnet-test-explorer.testProjectPath": "**/*.Tests.csproj"
+  "dotnet-test-explorer.testProjectPath": "**/*.Tests.csproj",
+  "dotnet.defaultSolution": "Npgsql.sln"
 }


### PR DESCRIPTION
- Use .NET 9 SDK + .NET 8 runtime
- Use Postgres 17
- Fix obsolete warnings in devcontainer and vscode settings configuration files