### PR TITLE
Additional GetBytes/GetStream tests

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1463,7 +1463,39 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// Retrieves data as a <see cref="Stream"/>.
     /// </summary>
     /// <param name="ordinal">The zero-based column ordinal.</param>
-    /// <returns>The returned object.</returns>
+    /// <returns>A stream object.</returns>
+    /// <remarks>
+    /// <para>The following <see cref="T:System.IO.Stream" /> members are not available for objects returned by <b>GetStream</b>:</para>
+    /// <list type="bullet">
+    /// <item>BeginWrite</item>
+    /// <item>EndWrite</item>
+    /// <item>ReadTimeout</item>
+    /// <item>SetLength</item>
+    /// <item>Write</item>
+    /// <item>WriteAsync</item>
+    /// <item>WriteByte</item>
+    /// <item>WriteTimeout</item>
+    /// </list>
+    /// </remarks>
+    /// <exception cref="T:System.InvalidOperationException">
+    /// <list type="bullet">
+    /// <item>The connection drops or is closed during the data retrieval.</item>
+    /// <item>The reader is closed during the data retrieval.</item>
+    /// <item>Tried to read a previously-read column in sequential mode.</item>
+    /// <item>There is no data ready to be read (for example, the first <see cref="M:Npgsql.NpgsqlDataReader.Read" /> hasn't been called, or returned false).</item>
+    /// <item>A stream is already open for this reader</item>
+    /// </list>
+    /// </exception>
+    /// <exception cref="T:System.IndexOutOfRangeException">
+    /// Trying to read a column that does not exist.
+    /// </exception>
+    /// <exception cref="T:System.InvalidCastException">
+    /// <list type="bullet">
+    /// <item>Column value is null</item>
+    /// </list>
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">
+    /// </exception>
     public override Stream GetStream(int ordinal)
         => GetFieldValueCore<Stream>(ordinal);
 
@@ -1474,7 +1506,39 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// <param name="cancellationToken">
     /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
     /// </param>
-    /// <returns>The returned object.</returns>
+    /// <returns>A stream object.</returns>
+    /// <remarks>
+    /// <para>The following <see cref="T:System.IO.Stream" /> members are not available for objects returned by <b>GetStreamAsync</b>:</para>
+    /// <list type="bullet">
+    /// <item>BeginWrite</item>
+    /// <item>EndWrite</item>
+    /// <item>ReadTimeout</item>
+    /// <item>SetLength</item>
+    /// <item>Write</item>
+    /// <item>WriteAsync</item>
+    /// <item>WriteByte</item>
+    /// <item>WriteTimeout</item>
+    /// </list>
+    /// </remarks>
+    /// <exception cref="T:System.InvalidOperationException">
+    /// <list type="bullet">
+    /// <item>The connection drops or is closed during the data retrieval.</item>
+    /// <item>The reader is closed during the data retrieval.</item>
+    /// <item>Tried to read a previously-read column in sequential mode.</item>
+    /// <item>There is no data ready to be read (for example, the first <see cref="M:Npgsql.NpgsqlDataReader.Read" /> hasn't been called, or returned false).</item>
+    /// <item>A stream is already open for this reader</item>
+    /// </list>
+    /// </exception>
+    /// <exception cref="T:System.IndexOutOfRangeException">
+    /// Trying to read a column that does not exist.
+    /// </exception>
+    /// <exception cref="T:System.InvalidCastException">
+    /// <list type="bullet">
+    /// <item>Column value is null</item>
+    /// </list>
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">
+    /// </exception>
     public Task<Stream> GetStreamAsync(int ordinal, CancellationToken cancellationToken = default)
         => GetFieldValueAsync<Stream>(ordinal, cancellationToken);
 

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -809,6 +809,7 @@ LANGUAGE 'plpgsql'");
             Assert.That(reader.GetFieldValue<object>(i), Is.EqualTo(DBNull.Value));
             Assert.That(reader.GetProviderSpecificValue(i), Is.EqualTo(DBNull.Value));
             Assert.That(() => reader.GetString(i), Throws.Exception.TypeOf<InvalidCastException>());
+            Assert.That(() => reader.GetStream(i), Throws.Exception.TypeOf<InvalidCastException>());
         }
     }
 
@@ -1426,6 +1427,25 @@ LANGUAGE plpgsql VOLATILE";
 
         Assert.That(async () => await streamGetter(reader, 0),
             Throws.Exception.TypeOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public async Task GetBytes_before_getstream([Values(true, false)] bool isAsync)
+    {
+        var expected = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var streamGetter = BuildStreamGetter(isAsync);
+
+        using var conn = await OpenConnectionAsync();
+        using var cmd = new NpgsqlCommand($"SELECT {EncodeByteaHex(expected)}::bytea", conn);
+        using var reader = await cmd.ExecuteReaderAsync(Behavior);
+
+        await reader.ReadAsync();
+
+        // GetBytes with null buffer won't consume column in any way
+        Assert.That(reader.GetBytes(0, 0, null, 0, 0), Is.EqualTo(expected.Length), "Bad column length");
+
+        using var stream = await streamGetter(reader, 0);
+        Assert.That(stream.Length, Is.EqualTo(expected.Length));
     }
 
     public static IEnumerable GetStreamCases()


### PR DESCRIPTION
Adding a couple of differences from SqlClient into the tests.

1) `GetStream` after `GetBytes` throws on SqlClient with sequentially access. Npgsql doesn't which is good. Should be able to get the length first with a null buffer even though the Npgsql stream implements the length property.
2) `GetStream` on null column returns an empty stream on SqlClient, throws on Npgsql. I think the no throw is better in this situation but added it to the tests.

Filled in the doco on what is supported in `GetStream` using SqlClient as a template.