### PR TITLE
If no suitable host is found, try rechecking the database state.

### DIFF
--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -163,7 +163,8 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
         TargetSessionAttributes preferredType, Func<DatabaseState, TargetSessionAttributes, bool> stateValidator,
         int poolIndex,
         IList<Exception> exceptions,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool ignoreExpiration = false)
     {
         var pools = _pools;
         for (var i = 0; i < pools.Length; i++)
@@ -173,7 +174,7 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
             if (poolIndex == pools.Length)
                 poolIndex = 0;
 
-            var databaseState = pool.GetDatabaseState();
+            var databaseState = pool.GetDatabaseState(ignoreExpiration);
             if (!stateValidator(databaseState, preferredType))
                 continue;
 
@@ -238,7 +239,8 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
         Func<DatabaseState, TargetSessionAttributes, bool> stateValidator,
         int poolIndex,
         IList<Exception> exceptions,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool ignoreExpiration = false)
     {
         var pools = _pools;
         for (var i = 0; i < pools.Length; i++)
@@ -248,7 +250,7 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
             if (poolIndex == pools.Length)
                 poolIndex = 0;
 
-            var databaseState = pool.GetDatabaseState();
+            var databaseState = pool.GetDatabaseState(ignoreExpiration);
             if (!stateValidator(databaseState, preferredType))
                 continue;
 
@@ -309,6 +311,19 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
                         (checkUnpreferred ?
                             await TryGet(conn, timeoutPerHost, async, preferredType, IsOnline, poolIndex, exceptions, cancellationToken).ConfigureAwait(false)
                             : null);
+
+        //Not suitable host found, try a round verifying database state
+        if (connector == null && exceptions.Count == 0)
+        {
+             var connector = await TryGetIdleOrNew(conn, timeoutPerHost, async, preferredType, IsPreferred, poolIndex, exceptions, cancellationToken, true).ConfigureAwait(false) ??
+                        (checkUnpreferred ?
+                            await TryGetIdleOrNew(conn, timeoutPerHost, async, preferredType, IsOnline, poolIndex, exceptions, cancellationToken, true).ConfigureAwait(false)
+                            : null) ??
+                        await TryGet(conn, timeoutPerHost, async, preferredType, IsPreferred, poolIndex, exceptions, cancellationToken, true).ConfigureAwait(false) ??
+                        (checkUnpreferred ?
+                            await TryGet(conn, timeoutPerHost, async, preferredType, IsOnline, poolIndex, exceptions, cancellationToken, true).ConfigureAwait(false)
+                            : null);
+        }
 
         return connector ?? throw NoSuitableHostsException(exceptions);
     }


### PR DESCRIPTION
When all hosts does not meet the requirements, try force check database state.

The state of the database connections seems to be put as invalid driven by 
message errors/exceptions.

We have a situation where all hosts are invalidated but the databases and pgbouncers 
are alive an reachable.

We know that because setting Host Recheck Seconds to zero fixes the issue.

This proposal add a pass to the NpgsqlMultiHostDataSource.Get forcing a database check in case of 
none suitable host.

This is a proposal, i can not compile the code ( requires .net 9, requires also some sort of signing procedure)

