### PR TITLE
Add support for postgresql type names with dots

### DIFF
--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -127,12 +127,14 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
         // There is one exception and that's array syntax, which is always resolvable in both ways, while we want the canonical name.
         var schemaEndIndex = displayNameSpan.IndexOf('.');
         if (schemaEndIndex is not -1 &&
+            string.IsNullOrEmpty(schema) &&
             !displayNameSpan.Slice(schemaEndIndex).StartsWith("_".AsSpan(), StringComparison.Ordinal) &&
             !displayNameSpan.EndsWith("[]".AsSpan(), StringComparison.Ordinal))
             return new(displayName);
 
         // First we strip the schema to get the type name.
-        if (schemaEndIndex is not -1)
+        if (schemaEndIndex is not -1 &&
+            string.IsNullOrEmpty(schema))
         {
             schema = displayNameSpan.Slice(0, schemaEndIndex).ToString();
             displayNameSpan = displayNameSpan.Slice(schemaEndIndex + 1);

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -202,6 +202,28 @@ CREATE TYPE {secondSchemaName}.container AS (a int, containee {secondSchemaName}
             isDefaultForWriting: true);
     }
 
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/5972")]
+    public async Task With_schema_and_dots_in_type_name()
+    {
+        await using var adminConnection = await OpenConnectionAsync();
+        var schema = await CreateTempSchema(adminConnection);
+        var typename = "Some.Composite.with.dots";
+
+        await adminConnection.ExecuteNonQueryAsync($"CREATE TYPE {schema}.\"{typename}\" AS (x int, some_text text)");
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.MapComposite<SomeComposite>($"{schema}.{typename}");
+        await using var dataSource = dataSourceBuilder.Build();
+        await using var connection = await dataSource.OpenConnectionAsync();
+
+        await AssertType(
+            connection,
+            new SomeComposite { SomeText = "foobar", X = 10 },
+            "(10,foobar)",
+            $"{schema}.{typename}",
+            npgsqlDbType: null);
+    }
+
     [Test]
     public async Task Struct()
     {

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -220,7 +220,7 @@ CREATE TYPE {secondSchemaName}.container AS (a int, containee {secondSchemaName}
             connection,
             new SomeComposite { SomeText = "foobar", X = 10 },
             "(10,foobar)",
-            $"{schema}.{typename}",
+            $"{schema}.\"{typename}\"",
             npgsqlDbType: null);
     }
 


### PR DESCRIPTION
Fixed the problem of converting type names with dots, for example the name "public.audit.sessiontype" was parsed incorrectly and had namespace after parse "audit" and name - "sessiontype".

If the schema is not null or empty, then displayname must contain only the type name.