### PR TITLE
Use exception convenience methods

### DIFF
--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -313,8 +313,7 @@ public abstract class NpgsqlDatabaseInfo
     /// </summary>
     public static void RegisterFactory(INpgsqlDatabaseInfoFactory factory)
     {
-        if (factory == null)
-            throw new ArgumentNullException(nameof(factory));
+        ArgumentNullException.ThrowIfNull(factory);
 
         var factories = new INpgsqlDatabaseInfoFactory[Factories.Length + 1];
         factories[0] = factory;

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -73,8 +73,7 @@ sealed partial class NpgsqlReadBuffer
             }
             set
             {
-                if (value < 0)
-                    throw new ArgumentOutOfRangeException(nameof(value), "Non - negative number required.");
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
                 Seek(value, SeekOrigin.Begin);
             }
         }
@@ -85,8 +84,7 @@ sealed partial class NpgsqlReadBuffer
 
             if (!_canSeek)
                 throw new NotSupportedException();
-            if (offset > int.MaxValue)
-                throw new ArgumentOutOfRangeException(nameof(offset), "Stream length must be non-negative and less than 2^31 - 1 - origin.");
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, int.MaxValue);
 
             const string seekBeforeBegin = "An attempt was made to move the position before the beginning of the stream.";
 
@@ -222,12 +220,9 @@ sealed partial class NpgsqlReadBuffer
     static void ValidateArguments(byte[] buffer, int offset, int count)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-            throw new ArgumentNullException(nameof(buffer));
-        if (offset < 0)
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        if (count < 0)
-            throw new ArgumentOutOfRangeException(nameof(count));
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (buffer.Length - offset < count)
-            throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+            ThrowHelper.ThrowArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
     }
 }

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -224,7 +224,7 @@ sealed partial class NpgsqlReadBuffer
 
     static void ValidateArguments(byte[] buffer, int offset, int count)
     {
-        if (buffer == null)
+        ArgumentNullException.ThrowIfNull(buffer);
             throw new ArgumentNullException(nameof(buffer));
         if (offset < 0)
             throw new ArgumentOutOfRangeException(nameof(offset));

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.Stream.cs
@@ -191,10 +191,7 @@ sealed partial class NpgsqlReadBuffer
             => throw new NotSupportedException();
 
         void CheckDisposed()
-        {
-            if (IsDisposed)
-                ThrowHelper.ThrowObjectDisposedException(nameof(ColumnStream));
-        }
+            => ObjectDisposedException.ThrowIf(IsDisposed, this);
 
         protected override void Dispose(bool disposing)
         {

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -113,10 +113,7 @@ sealed partial class NpgsqlReadBuffer : IDisposable
         Encoding relaxedTextEncoding,
         bool usePool = false)
     {
-        if (size < MinimumSize)
-        {
-            throw new ArgumentOutOfRangeException(nameof(size), size, "Buffer size must be at least " + MinimumSize);
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, MinimumSize);
 
         Connector = connector!; // TODO: Clean this up
         Underlying = stream;

--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -101,8 +101,7 @@ sealed class NpgsqlWriteBuffer : IDisposable
         int size,
         Encoding textEncoding)
     {
-        if (size < MinimumSize)
-            throw new ArgumentOutOfRangeException(nameof(size), size, "Buffer size must be at least " + MinimumSize);
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, MinimumSize);
 
         Connector = connector!; // TODO: Clean this up; only null when used from PregeneratedMessages, where we don't care.
         Underlying = stream;
@@ -579,8 +578,7 @@ sealed class NpgsqlWriteBuffer : IDisposable
 
         void Throw()
         {
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), "Can't advance by a negative count");
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
 
             if (_messageLength is null)
                 throw Connector.Break(new InvalidOperationException("No message was started"));

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -495,7 +495,7 @@ public sealed class PgWriter
 
         Task Write(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (buffer is null)
+            ArgumentNullException.ThrowIfNull(buffer);
                 throw new ArgumentNullException(nameof(buffer));
             if (offset < 0)
                 throw new ArgumentNullException(nameof(offset));

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -496,13 +496,10 @@ public sealed class PgWriter
         Task Write(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(buffer);
-                throw new ArgumentNullException(nameof(buffer));
-            if (offset < 0)
-                throw new ArgumentNullException(nameof(offset));
-            if (count < 0)
-                throw new ArgumentNullException(nameof(count));
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
             if (buffer.Length - offset < count)
-                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+                ThrowHelper.ThrowArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
 
             if (async)
             {

--- a/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
+++ b/src/Npgsql/NameTranslation/NpgsqlSnakeCaseNameTranslator.cs
@@ -55,8 +55,7 @@ public sealed class NpgsqlSnakeCaseNameTranslator : INpgsqlNameTranslator
     /// </summary>
     public string TranslateMemberName(string clrName)
     {
-        if (clrName == null)
-            throw new ArgumentNullException(nameof(clrName));
+        ArgumentNullException.ThrowIfNull(clrName);
 
         return LegacyMode
             ? string.Concat(LegacyModeMap(clrName)).ToLower(_culture)

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1955,8 +1955,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
 
     NpgsqlConnection? CheckAndGetConnection()
     {
-        if (State is CommandState.Disposed)
-            ThrowHelper.ThrowObjectDisposedException(GetType().FullName);
+        ObjectDisposedException.ThrowIf(State is CommandState.Disposed, this);
 
         var conn = InternalConnection;
         if (conn is null)

--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -223,9 +223,7 @@ public class NpgsqlCommand : DbCommand, ICloneable, IComponent
         get => _timeout ?? (InternalConnection?.CommandTimeout ?? DefaultTimeout);
         set
         {
-            if (value < 0) {
-                throw new ArgumentOutOfRangeException(nameof(value), value, "CommandTimeout can't be less than zero.");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _timeout = value;
         }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1529,10 +1529,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     }
 
     void CheckDisposed()
-    {
-        if (_disposed)
-            ThrowHelper.ThrowObjectDisposedException(nameof(NpgsqlConnection));
-    }
+        => ObjectDisposedException.ThrowIf(_disposed, this);
 
     internal void CheckReady()
     {

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1145,8 +1145,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
     async Task<NpgsqlBinaryImporter> BeginBinaryImport(bool async, string copyFromCommand, CancellationToken cancellationToken = default)
     {
-        if (copyFromCommand == null)
-            throw new ArgumentNullException(nameof(copyFromCommand));
+        ArgumentNullException.ThrowIfNull(copyFromCommand);
         if (!IsValidCopyCommand(copyFromCommand))
             throw new ArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
 
@@ -1196,8 +1195,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
     async Task<NpgsqlBinaryExporter> BeginBinaryExport(bool async, string copyToCommand, CancellationToken cancellationToken = default)
     {
-        if (copyToCommand == null)
-            throw new ArgumentNullException(nameof(copyToCommand));
+        ArgumentNullException.ThrowIfNull(copyToCommand);
         if (!IsValidCopyCommand(copyToCommand))
             throw new ArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
 
@@ -1253,8 +1251,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
     async Task<TextWriter> BeginTextImport(bool async, string copyFromCommand, CancellationToken cancellationToken = default)
     {
-        if (copyFromCommand == null)
-            throw new ArgumentNullException(nameof(copyFromCommand));
+        ArgumentNullException.ThrowIfNull(copyFromCommand);
         if (!IsValidCopyCommand(copyFromCommand))
             throw new ArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
 
@@ -1311,8 +1308,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
     async Task<TextReader> BeginTextExport(bool async, string copyToCommand, CancellationToken cancellationToken = default)
     {
-        if (copyToCommand == null)
-            throw new ArgumentNullException(nameof(copyToCommand));
+        ArgumentNullException.ThrowIfNull(copyToCommand);
         if (!IsValidCopyCommand(copyToCommand))
             throw new ArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
 
@@ -1369,8 +1365,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
     async Task<NpgsqlRawCopyStream> BeginRawBinaryCopy(bool async, string copyCommand, CancellationToken cancellationToken = default)
     {
-        if (copyCommand == null)
-            throw new ArgumentNullException(nameof(copyCommand));
+        ArgumentNullException.ThrowIfNull(copyCommand);
         if (!IsValidCopyCommand(copyCommand))
             throw new ArgumentException("Must contain a COPY TO STDOUT OR COPY FROM STDIN command!", nameof(copyCommand));
 
@@ -1825,8 +1820,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <param name="dbName">The name of the database to use in place of the current database.</param>
     public override void ChangeDatabase(string dbName)
     {
-        if (dbName == null)
-            throw new ArgumentNullException(nameof(dbName));
+        ArgumentNullException.ThrowIfNull(dbName);
         if (string.IsNullOrEmpty(dbName))
             throw new ArgumentOutOfRangeException(nameof(dbName), dbName, $"Invalid database name: {dbName}");
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -244,8 +244,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _port;
         set
         {
-            if (value <= 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid port: " + value);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
 
             _port = value;
             SetValue(nameof(Port), value);
@@ -720,8 +719,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _minPoolSize;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "MinPoolSize can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _minPoolSize = value;
             SetValue(nameof(MinPoolSize), value);
@@ -742,8 +740,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _maxPoolSize;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "MaxPoolSize can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _maxPoolSize = value;
             SetValue(nameof(MaxPoolSize), value);
@@ -836,8 +833,8 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _timeout;
         set
         {
-            if (value < 0 || value > NpgsqlConnection.TimeoutLimit)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Timeout must be between 0 and " + NpgsqlConnection.TimeoutLimit);
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, NpgsqlConnection.TimeoutLimit);
 
             _timeout = value;
             SetValue(nameof(Timeout), value);
@@ -861,8 +858,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _commandTimeout;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "CommandTimeout can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _commandTimeout = value;
             SetValue(nameof(CommandTimeout), value);
@@ -885,8 +881,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _cancellationTimeout;
         set
         {
-            if (value < -1)
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(CancellationTimeout)} can't less than -1");
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, -1);
 
             _cancellationTimeout = value;
             SetValue(nameof(CancellationTimeout), value);
@@ -975,8 +970,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _hostRecheckSeconds;
         set
         {
-            if (value < 0)
-                throw new ArgumentException($"{HostRecheckSeconds} cannot be negative", nameof(HostRecheckSeconds));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             _hostRecheckSeconds = value;
             SetValue(nameof(HostRecheckSeconds), value);
         }
@@ -1000,8 +994,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _keepAlive;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "KeepAlive can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _keepAlive = value;
             SetValue(nameof(KeepAlive), value);
@@ -1041,8 +1034,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _tcpKeepAliveTime;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "TcpKeepAliveTime can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _tcpKeepAliveTime = value;
             SetValue(nameof(TcpKeepAliveTime), value);
@@ -1063,8 +1055,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _tcpKeepAliveInterval;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, "TcpKeepAliveInterval can't be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _tcpKeepAliveInterval = value;
             SetValue(nameof(TcpKeepAliveInterval), value);
@@ -1160,8 +1151,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _maxAutoPrepare;
         set
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(MaxAutoPrepare)} cannot be negative");
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _maxAutoPrepare = value;
             SetValue(nameof(MaxAutoPrepare), value);
@@ -1183,8 +1173,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
         get => _autoPrepareMinUsages;
         set
         {
-            if (value < 1)
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(AutoPrepareMinUsages)} must be 1 or greater");
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
 
             _autoPrepareMinUsages = value;
             SetValue(nameof(AutoPrepareMinUsages), value);
@@ -1408,8 +1397,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
 
     internal void PostProcessAndValidate()
     {
-        if (string.IsNullOrWhiteSpace(Host))
-            throw new ArgumentException("Host can't be null");
+        ArgumentException.ThrowIfNullOrWhiteSpace(Host);
         if (Multiplexing && !Pooling)
             throw new ArgumentException("Pooling must be on to use multiplexing");
         if (SslNegotiation == SslNegotiation.Direct && SslMode is not SslMode.Require and not SslMode.VerifyCA and not SslMode.VerifyFull)

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -533,10 +533,7 @@ public abstract class NpgsqlDataSource : DbDataSource
     }
 
     private protected void CheckDisposed()
-    {
-        if (_isDisposed == 1)
-            ThrowHelper.ThrowObjectDisposedException(GetType().FullName);
-    }
+        => ObjectDisposedException.ThrowIf(_isDisposed == 1, this);
 
     #endregion
 

--- a/src/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/src/Npgsql/NpgsqlLargeObjectStream.cs
@@ -64,7 +64,7 @@ public sealed class NpgsqlLargeObjectStream : Stream
 
     async Task<int> Read(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
-        if (buffer == null)
+        ArgumentNullException.ThrowIfNull(buffer);
             throw new ArgumentNullException(nameof(buffer));
         if (offset < 0)
             throw new ArgumentOutOfRangeException(nameof(offset));
@@ -115,7 +115,7 @@ public sealed class NpgsqlLargeObjectStream : Stream
 
     async Task Write(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
-        if (buffer == null)
+        ArgumentNullException.ThrowIfNull(buffer);
             throw new ArgumentNullException(nameof(buffer));
         if (offset < 0)
             throw new ArgumentOutOfRangeException(nameof(offset));

--- a/src/Npgsql/NpgsqlLargeObjectStream.cs
+++ b/src/Npgsql/NpgsqlLargeObjectStream.cs
@@ -65,13 +65,10 @@ public sealed class NpgsqlLargeObjectStream : Stream
     async Task<int> Read(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-            throw new ArgumentNullException(nameof(buffer));
-        if (offset < 0)
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        if (count < 0)
-            throw new ArgumentOutOfRangeException(nameof(count));
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (buffer.Length - offset < count)
-            throw new ArgumentException("Invalid offset or count for this buffer");
+            ThrowHelper.ThrowArgumentException("Invalid offset or count for this buffer");
 
         CheckDisposed();
 
@@ -116,13 +113,10 @@ public sealed class NpgsqlLargeObjectStream : Stream
     async Task Write(bool async, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-            throw new ArgumentNullException(nameof(buffer));
-        if (offset < 0)
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        if (count < 0)
-            throw new ArgumentOutOfRangeException(nameof(count));
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (buffer.Length - offset < count)
-            throw new ArgumentException("Invalid offset or count for this buffer");
+            ThrowHelper.ThrowArgumentException("Invalid offset or count for this buffer");
 
         CheckDisposed();
 
@@ -262,8 +256,7 @@ public sealed class NpgsqlLargeObjectStream : Stream
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (value < 0)
-            throw new ArgumentOutOfRangeException(nameof(value));
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
         if (!Has64BitSupport && value != (int)value)
             throw new ArgumentOutOfRangeException(nameof(value), "offset must fit in 32 bits for PostgreSQL versions older than 9.3");
 

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -174,8 +174,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     /// <inheritdoc />
     public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
     {
-        if (dataOffset is < 0 or > int.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(dataOffset), dataOffset, $"dataOffset must be between 0 and {int.MaxValue}");
+        ArgumentOutOfRangeException.ThrowIfNegative(dataOffset);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(dataOffset, int.MaxValue);
         if (buffer != null && (bufferOffset < 0 || bufferOffset >= buffer.Length + 1))
             throw new IndexOutOfRangeException($"bufferOffset must be between 0 and {buffer.Length}");
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -303,8 +303,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     /// <inheritdoc />
     public override int GetValues(object[] values)
     {
-        if (values == null)
-            throw new ArgumentNullException(nameof(values));
+        ArgumentNullException.ThrowIfNull(values);
         CheckOnRow();
 
         var count = Math.Min(FieldCount, values.Length);

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -365,9 +365,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         set
         {
             if (value == NpgsqlDbType.Array)
-                throw new ArgumentOutOfRangeException(nameof(value), "Cannot set NpgsqlDbType to just Array, Binary-Or with the element type (e.g. Array of Box is NpgsqlDbType.Array | NpgsqlDbType.Box).");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(value), "Cannot set NpgsqlDbType to just Array, Binary-Or with the element type (e.g. Array of Box is NpgsqlDbType.Array | NpgsqlDbType.Box).");
             if (value == NpgsqlDbType.Range)
-                throw new ArgumentOutOfRangeException(nameof(value), "Cannot set NpgsqlDbType to just Range, Binary-Or with the element type (e.g. Range of integer is NpgsqlDbType.Range | NpgsqlDbType.Integer)");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(value), "Cannot set NpgsqlDbType to just Range, Binary-Or with the element type (e.g. Range of integer is NpgsqlDbType.Range | NpgsqlDbType.Integer)");
 
             ResetTypeInfo();
             _npgsqlDbType = value;
@@ -453,7 +453,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         set
         {
             if (value < -1)
-                throw new ArgumentException($"Invalid parameter Size value '{value}'. The value must be greater than or equal to 0.");
+                ThrowHelper.ThrowArgumentException($"Invalid parameter Size value '{value}'. The value must be greater than or equal to 0.");
 
             ResetBindingInfo();
             _size = value;
@@ -599,7 +599,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
         void ThrowNotSupported(string dataTypeName)
         {
-            throw new NotSupportedException(_npgsqlDbType is not null
+            ThrowHelper.ThrowNotSupportedException(_npgsqlDbType is not null
                 ? $"The NpgsqlDbType '{_npgsqlDbType}' isn't present in your database. You may need to install an extension or upgrade to a newer version."
                 : $"The data type name '{dataTypeName}' isn't present in your database. You may need to install an extension or upgrade to a newer version.");
         }

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -170,7 +170,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
             var index = IndexOf(parameterName);
             if (index == -1)
-                throw new ArgumentException("Parameter not found");
+                ThrowHelper.ThrowArgumentException("Parameter not found");
 
             return InternalList[index];
         }
@@ -181,10 +181,10 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
 
             var index = IndexOf(parameterName);
             if (index == -1)
-                throw new ArgumentException("Parameter not found");
+                ThrowHelper.ThrowArgumentException("Parameter not found");
 
             if (!string.Equals(parameterName, value.TrimmedName, StringComparison.OrdinalIgnoreCase))
-                throw new ArgumentException("Parameter name must be a case-insensitive match with the property 'ParameterName' on the given NpgsqlParameter", nameof(parameterName));
+                ThrowHelper.ThrowArgumentException("Parameter name must be a case-insensitive match with the property 'ParameterName' on the given NpgsqlParameter", nameof(parameterName));
 
             var oldValue = InternalList[index];
             LookupChangeName(value, oldValue.ParameterName, oldValue.TrimmedName, index);
@@ -425,8 +425,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <param name="index">The zero-based index of the parameter.</param>
     public override void RemoveAt(int index)
     {
-        if (InternalList.Count - 1 < index)
-            throw new ArgumentOutOfRangeException(nameof(index));
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InternalList.Count);
 
         Remove(InternalList[index]);
     }

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -166,8 +166,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     {
         get
         {
-            if (parameterName is null)
-                throw new ArgumentNullException(nameof(parameterName));
+            ArgumentNullException.ThrowIfNull(parameterName);
 
             var index = IndexOf(parameterName);
             if (index == -1)
@@ -177,10 +176,8 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
         }
         set
         {
-            if (parameterName is null)
-                throw new ArgumentNullException(nameof(parameterName));
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(parameterName);
+            ArgumentNullException.ThrowIfNull(value);
 
             var index = IndexOf(parameterName);
             if (index == -1)
@@ -206,8 +203,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
         get => InternalList[index];
         set
         {
-            if (value is null)
-                ThrowHelper.ThrowArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
             if (value.Collection is not null)
                 ThrowHelper.ThrowInvalidOperationException("The parameter already belongs to a collection");
 
@@ -231,8 +227,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <returns>The parameter that was added.</returns>
     public NpgsqlParameter Add(NpgsqlParameter value)
     {
-        if (value is null)
-            ThrowHelper.ThrowArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(value);
         if (value.Collection is not null)
             ThrowHelper.ThrowInvalidOperationException("The parameter already belongs to a collection");
 
@@ -446,8 +441,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <param name="parameterName">The name of the <see cref="NpgsqlParameter"/> to remove from the collection.</param>
     public void Remove(string parameterName)
     {
-        if (parameterName is null)
-            ThrowHelper.ThrowArgumentNullException(nameof(parameterName));
+        ArgumentNullException.ThrowIfNull(parameterName);
 
         var index = IndexOf(parameterName);
         if (index < 0)
@@ -481,8 +475,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// </returns>
     public bool TryGetValue(string parameterName, [NotNullWhen(true)] out NpgsqlParameter? parameter)
     {
-        if (parameterName is null)
-            throw new ArgumentNullException(nameof(parameterName));
+        ArgumentNullException.ThrowIfNull(parameterName);
 
         var index = IndexOf(parameterName);
 
@@ -561,8 +554,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <inheritdoc />
     public override void AddRange(Array values)
     {
-        if (values is null)
-            throw new ArgumentNullException(nameof(values));
+        ArgumentNullException.ThrowIfNull(values);
 
         foreach (var parameter in values)
             Add(Cast(parameter));
@@ -599,8 +591,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <param name="item">Parameter to insert.</param>
     public void Insert(int index, NpgsqlParameter item)
     {
-        if (item is null)
-            throw new ArgumentNullException(nameof(item));
+        ArgumentNullException.ThrowIfNull(item);
         if (item.Collection != null)
             throw new Exception("The parameter already belongs to a collection");
 
@@ -624,8 +615,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// <returns>True if the parameter was found and removed, otherwise false.</returns>
     public bool Remove(NpgsqlParameter item)
     {
-        if (item == null)
-            ThrowHelper.ThrowArgumentNullException(nameof(item));
+        ArgumentNullException.ThrowIfNull(item);
         if (item.Collection != this)
             ThrowHelper.ThrowInvalidOperationException("The item does not belong to this collection");
 

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -446,13 +446,10 @@ public sealed class NpgsqlRawCopyStream : Stream, ICancelable
     static void ValidateArguments(byte[] buffer, int offset, int count)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-            throw new ArgumentNullException(nameof(buffer));
-        if (offset < 0)
-            throw new ArgumentNullException(nameof(offset));
-        if (count < 0)
-            throw new ArgumentNullException(nameof(count));
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (buffer.Length - offset < count)
-            throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+            ThrowHelper.ThrowArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
     }
     #endregion
 }

--- a/src/Npgsql/NpgsqlRawCopyStream.cs
+++ b/src/Npgsql/NpgsqlRawCopyStream.cs
@@ -445,7 +445,7 @@ public sealed class NpgsqlRawCopyStream : Stream, ICancelable
     #region Input validation
     static void ValidateArguments(byte[] buffer, int offset, int count)
     {
-        if (buffer == null)
+        ArgumentNullException.ThrowIfNull(buffer);
             throw new ArgumentNullException(nameof(buffer));
         if (offset < 0)
             throw new ArgumentNullException(nameof(offset));

--- a/src/Npgsql/NpgsqlSchema.cs
+++ b/src/Npgsql/NpgsqlSchema.cs
@@ -19,8 +19,7 @@ static class NpgsqlSchema
 {
     public static Task<DataTable> GetSchema(bool async, NpgsqlConnection conn, string? collectionName, string?[]? restrictions, CancellationToken cancellationToken = default)
     {
-        if (collectionName is null)
-            throw new ArgumentNullException(nameof(collectionName));
+        ArgumentNullException.ThrowIfNull(collectionName);
         if (collectionName.Length == 0)
             throw new ArgumentException("Collection name cannot be empty.", nameof(collectionName));
 

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -193,9 +193,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     public override void Save(string name)
     {
         ArgumentNullException.ThrowIfNull(name);
-            throw new ArgumentNullException(nameof(name));
-        if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException("name can't be empty", nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();
         if (!_connector.DatabaseInfo.SupportsTransactions)
@@ -237,9 +235,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     async Task Rollback(bool async, string name, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(name);
-            throw new ArgumentNullException(nameof(name));
-        if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException("name can't be empty", nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();
         if (!_connector.DatabaseInfo.SupportsTransactions)
@@ -272,9 +268,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     async Task Release(bool async, string name, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(name);
-            throw new ArgumentNullException(nameof(name));
-        if (string.IsNullOrWhiteSpace(name))
-            throw new ArgumentException("name can't be empty", nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();
         if (!_connector.DatabaseInfo.SupportsTransactions)

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -192,7 +192,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     /// </remarks>
     public override void Save(string name)
     {
-        if (name == null)
+        ArgumentNullException.ThrowIfNull(name);
             throw new ArgumentNullException(nameof(name));
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("name can't be empty", nameof(name));
@@ -236,7 +236,7 @@ public sealed class NpgsqlTransaction : DbTransaction
 
     async Task Rollback(bool async, string name, CancellationToken cancellationToken = default)
     {
-        if (name == null)
+        ArgumentNullException.ThrowIfNull(name);
             throw new ArgumentNullException(nameof(name));
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("name can't be empty", nameof(name));
@@ -271,7 +271,7 @@ public sealed class NpgsqlTransaction : DbTransaction
 
     async Task Release(bool async, string name, CancellationToken cancellationToken = default)
     {
-        if (name == null)
+        ArgumentNullException.ThrowIfNull(name);
             throw new ArgumentNullException(nameof(name));
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("name can't be empty", nameof(name));

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -192,7 +192,6 @@ public sealed class NpgsqlTransaction : DbTransaction
     /// </remarks>
     public override void Save(string name)
     {
-        ArgumentNullException.ThrowIfNull(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();
@@ -234,7 +233,6 @@ public sealed class NpgsqlTransaction : DbTransaction
 
     async Task Rollback(bool async, string name, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();
@@ -267,7 +265,6 @@ public sealed class NpgsqlTransaction : DbTransaction
 
     async Task Release(bool async, string name, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         CheckReady();

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -378,8 +378,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     [RequiresUnreferencedCode("Parse implementations for certain types of T may require members that have been trimmed.")]
     public static NpgsqlRange<T> Parse(string value)
     {
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(value);
 
         value = value.Trim();
 

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
@@ -403,8 +403,7 @@ public sealed class NpgsqlTsQueryLexeme : NpgsqlTsQuery
         get => _text;
         set
         {
-            if (string.IsNullOrEmpty(value))
-                throw new ArgumentException("Text is null or empty string", nameof(value));
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             _text = value;
         }
@@ -674,8 +673,7 @@ public sealed class NpgsqlTsQueryFollowedBy : NpgsqlTsQueryBinOp
         NpgsqlTsQuery right)
         : base(NodeKind.Phrase, left, right)
     {
-        if (distance < 0)
-            throw new ArgumentOutOfRangeException(nameof(distance));
+        ArgumentOutOfRangeException.ThrowIfNegative(distance);
 
         Distance = distance;
     }

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTsQuery.cs
@@ -79,8 +79,7 @@ public abstract class NpgsqlTsQuery : IEquatable<NpgsqlTsQuery>
     [Obsolete("Client-side parsing of NpgsqlTsQuery is unreliable and cannot fully duplicate the PostgreSQL logic. Use PG functions instead (e.g. to_tsquery)")]
     public static NpgsqlTsQuery Parse(string value)
     {
-        if (value == null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(value);
 
         var valStack = new Stack<NpgsqlTsQuery>();
         var opStack = new Stack<NpgsqlTsQueryOperator>();

--- a/src/Npgsql/NpgsqlTypes/NpgsqlTsVector.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlTsVector.cs
@@ -76,8 +76,7 @@ public sealed class NpgsqlTsVector : IEnumerable<NpgsqlTsVector.Lexeme>, IEquata
     [Obsolete("Client-side parsing of NpgsqlTsVector is unreliable and cannot fully duplicate the PostgreSQL logic. Use PG functions instead (e.g. to_tsvector)")]
     public static NpgsqlTsVector Parse(string value)
     {
-        if (value == null)
-            throw new ArgumentNullException(nameof(value));
+        ArgumentNullException.ThrowIfNull(value);
 
         var lexemes = new List<Lexeme>();
         var pos = 0;

--- a/src/Npgsql/PreparedTextReader.cs
+++ b/src/Npgsql/PreparedTextReader.cs
@@ -58,16 +58,11 @@ sealed class PreparedTextReader : TextReader
     public override int Read(char[] buffer, int index, int count)
     {
         ArgumentNullException.ThrowIfNull(buffer);
-        {
-            throw new ArgumentNullException(nameof(buffer));
-        }
-        if (index < 0 || count < 0)
-        {
-            throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (buffer.Length - index < count)
         {
-            throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+            ThrowHelper.ThrowArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
         }
 
         return Read(buffer.AsSpan(index, count));

--- a/src/Npgsql/PreparedTextReader.cs
+++ b/src/Npgsql/PreparedTextReader.cs
@@ -95,10 +95,7 @@ sealed class PreparedTextReader : TextReader
     public override Task<string> ReadToEndAsync() => Task.FromResult(ReadToEnd());
 
     void CheckDisposed()
-    {
-        if (_disposed || _stream.IsDisposed)
-            ThrowHelper.ThrowObjectDisposedException(nameof(PreparedTextReader));
-    }
+        => ObjectDisposedException.ThrowIf(_disposed || _stream.IsDisposed, this);
 
     public void Restart()
     {

--- a/src/Npgsql/PreparedTextReader.cs
+++ b/src/Npgsql/PreparedTextReader.cs
@@ -57,7 +57,7 @@ sealed class PreparedTextReader : TextReader
 
     public override int Read(char[] buffer, int index, int count)
     {
-        if (buffer == null)
+        ArgumentNullException.ThrowIfNull(buffer);
         {
             throw new ArgumentNullException(nameof(buffer));
         }

--- a/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
+++ b/src/Npgsql/Replication/Internal/LogicalReplicationConnectionExtensions.cs
@@ -61,10 +61,8 @@ public static class LogicalReplicationConnectionExtensions
         CancellationToken cancellationToken = default)
     {
         connection.CheckDisposed();
-        if (slotName is null)
-            throw new ArgumentNullException(nameof(slotName));
-        if (outputPlugin is null)
-            throw new ArgumentNullException(nameof(outputPlugin));
+        ArgumentNullException.ThrowIfNull(slotName);
+        ArgumentNullException.ThrowIfNull(outputPlugin);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -322,8 +322,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
     /// <returns>The current setting of the run-time parameter specified in <paramref name="parameterName"/> as <see cref="string"/>.</returns>
     public Task<string> Show(string parameterName, CancellationToken cancellationToken = default)
     {
-        if (parameterName is null)
-            throw new ArgumentNullException(nameof(parameterName));
+        ArgumentNullException.ThrowIfNull(parameterName);
 
         return ShowInternal(parameterName, cancellationToken);
 
@@ -710,8 +709,7 @@ public abstract class ReplicationConnection : IAsyncDisposable
     /// <returns>A task representing the asynchronous drop operation.</returns>
     public Task DropReplicationSlot(string slotName, bool wait = false, CancellationToken cancellationToken = default)
     {
-        if (slotName is null)
-            throw new ArgumentNullException(nameof(slotName));
+        ArgumentNullException.ThrowIfNull(slotName);
 
         CheckDisposed();
 

--- a/src/Npgsql/ThrowHelper.cs
+++ b/src/Npgsql/ThrowHelper.cs
@@ -89,10 +89,6 @@ static class ThrowHelper
         => throw new ArgumentException(message, paramName);
 
     [DoesNotReturn]
-    internal static void ThrowArgumentNullException(string paramName)
-        => throw new ArgumentNullException(paramName);
-
-    [DoesNotReturn]
     internal static void ThrowArgumentNullException(string message, string paramName)
         => throw new ArgumentNullException(paramName, message);
 

--- a/src/Npgsql/Util/SubReadStream.cs
+++ b/src/Npgsql/Util/SubReadStream.cs
@@ -75,10 +75,7 @@ sealed class SubReadStream : Stream
     public override bool CanWrite => false;
 
     void ThrowIfDisposed()
-    {
-        if (_isDisposed)
-            throw new ObjectDisposedException(GetType().ToString());
-    }
+        => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
     void ThrowIfCantRead()
     {

--- a/src/Npgsql/VolatileResourceManager.cs
+++ b/src/Npgsql/VolatileResourceManager.cs
@@ -293,10 +293,7 @@ sealed class VolatileResourceManager : ISinglePhaseNotification
 #pragma warning restore CS8625
 
     void CheckDisposed()
-    {
-        if (_isDisposed)
-            throw new ObjectDisposedException(nameof(VolatileResourceManager));
-    }
+        => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
     #endregion
 

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -217,7 +217,7 @@ public class ConnectionTests(MultiplexingMode multiplexingMode) : MultiplexingTe
 
     [Test, Description("Tests that mandatory connection string parameters are indeed mandatory")]
     public void Mandatory_connection_string_params()
-        => Assert.Throws<ArgumentException>(() =>
+        => Assert.Throws<ArgumentNullException>(() =>
             new NpgsqlConnection("User ID=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests"));
 
     [Test, Description("Reuses the same connection instance for a failed connection, then a successful one")]

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -323,7 +323,7 @@ public class MultipleHostsTests : TestBase
 
     [Test]
     public void HostRecheckSeconds_invalid_throws()
-        => Assert.Throws<ArgumentException>(() =>
+        => Assert.Throws<ArgumentOutOfRangeException>(() =>
             new NpgsqlConnectionStringBuilder
             {
                 HostRecheckSeconds = -1


### PR DESCRIPTION
Use the built-in .net exception convenience methods where they make sense. Contributes to #2237
Converted most of the Parameter exceptions to convenience methods or the helper class.

Some observable changes:
NpgsqlRawCopyStream.ValidateArguments can throw ArgumentOutOfRangeException.
PgWriter.Write can throw ArgumentOutOfRangeException.
NpgsqlConnectionStringBuilder.HostRecheckSeconds now throws ArgumentOutOfRangeException.
ObjectDisposedException will use the type's FullName instead of a mix of class name and full name.
ArgumentException.ThrowIfNullOrEmpty/ThrowIfNullOrWhiteSpace will throw a ArgumentNullException if the value is null or just the ArgumentException base class if the value is empty.
Some exception messages are now just using the defaults. Left anything that looked meaningful or provided extra context.