### PR TITLE
Remove ReadOnlySequence from PgReader that only ever had one segment

### DIFF
--- a/src/Npgsql/Internal/Converters/HstoreConverter.cs
+++ b/src/Npgsql/Internal/Converters/HstoreConverter.cs
@@ -72,7 +72,7 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
                 await reader.Buffer(async, sizeof(int), cancellationToken).ConfigureAwait(false);
             var keySize = reader.ReadInt32();
             var key = encoding.GetString(async
-                ? await reader.ReadBytesAsync(keySize, cancellationToken).ConfigureAwait(false)
+                ? (await reader.ReadBytesAsync(keySize, cancellationToken).ConfigureAwait(false)).Span
                 : reader.ReadBytes(keySize)
             );
 
@@ -82,7 +82,7 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
             string? value = null;
             if (valueSize is not -1)
                 value = encoding.GetString(async
-                    ? await reader.ReadBytesAsync(valueSize, cancellationToken).ConfigureAwait(false)
+                    ? (await reader.ReadBytesAsync(valueSize, cancellationToken).ConfigureAwait(false)).Span
                     : reader.ReadBytes(valueSize)
                 );
 

--- a/src/Npgsql/Internal/Converters/Primitive/GuidUuidConverter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/GuidUuidConverter.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Buffers.Binary;
-using System.Runtime.InteropServices;
 
 namespace Npgsql.Internal.Converters;
 
@@ -13,7 +11,7 @@ sealed class GuidUuidConverter : PgBufferedConverter<Guid>
     }
 
     protected override Guid ReadCore(PgReader reader)
-        => new(reader.ReadBytes(16).FirstSpan, bigEndian: true);
+        => new(reader.ReadBytes(16), bigEndian: true);
 
     protected override void WriteCore(PgWriter writer, Guid value)
     {


### PR DESCRIPTION
`PgReader` only ever created a sequence with one array segment in it. If there are no future plans for this it can use a simpler structure.
This was the only reference to `ReadOnlySequence` in the codebase.

Just to confirm no regressions:
**Text Benchmark Before**
| Method | Value                | Mean      | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    |  26.65 ns | 0.201 ns | 0.188 ns | 37,517,756.2 | 0.0023 |      24 B |
| Write  | x                    |        NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           |  28.97 ns | 0.244 ns | 0.229 ns | 34,516,841.6 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           |  21.65 ns | 0.060 ns | 0.054 ns | 46,184,982.6 | 0.0000 |       1 B |
| Read   | xxxx(...)xxxx [100]  |  34.40 ns | 0.296 ns | 0.262 ns | 29,071,355.0 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  |  26.09 ns | 0.057 ns | 0.054 ns | 38,334,456.6 | 0.0007 |       8 B |
| Read   | xxxx(...)xxxx [1000] | 109.88 ns | 0.514 ns | 0.455 ns |  9,100,657.8 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] |  76.42 ns | 0.462 ns | 0.386 ns | 13,086,061.3 | 0.0074 |      78 B |

**After**
| Method | Value                | Mean      | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    |  20.24 ns | 0.093 ns | 0.082 ns | 49,397,547.1 | 0.0023 |      24 B |
| Write  | x                    |        NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           |  21.79 ns | 0.105 ns | 0.093 ns | 45,887,590.1 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           |  21.43 ns | 0.046 ns | 0.041 ns | 46,671,848.8 | 0.0000 |       1 B |
| Read   | xxxx(...)xxxx [100]  |  28.71 ns | 0.100 ns | 0.078 ns | 34,835,393.3 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  |  25.96 ns | 0.030 ns | 0.023 ns | 38,526,919.5 | 0.0007 |       8 B |
| Read   | xxxx(...)xxxx [1000] | 105.95 ns | 0.575 ns | 0.538 ns |  9,438,815.4 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] |  76.59 ns | 0.187 ns | 0.166 ns | 13,056,234.6 | 0.0074 |      78 B |

(Had to make some test changes to get the benchmark to run at all)