### PR TITLE
Improve performance of buffered string write

### DIFF
--- a/src/Npgsql/Internal/Converters/FullTextSearch/TsQueryConverter.cs
+++ b/src/Npgsql/Internal/Converters/FullTextSearch/TsQueryConverter.cs
@@ -180,7 +180,7 @@ sealed class TsQueryConverter<T>(Encoding encoding) : PgStreamingConverter<T>
                 writer.WriteByte(lexemeNode.IsPrefixSearch ? (byte)1 : (byte)0);
 
                 if (async)
-                    await writer.WriteCharsAsync(lexemeNode.Text.AsMemory(), encoding, cancellationToken).ConfigureAwait(false);
+                    await writer.WriteCharsAsync(lexemeNode.Text.AsMemory(), encoding, cancellationToken: cancellationToken).ConfigureAwait(false);
                 else
                     writer.WriteChars(lexemeNode.Text.AsMemory().Span, encoding);
 

--- a/src/Npgsql/Internal/Converters/FullTextSearch/TsVectorConverter.cs
+++ b/src/Npgsql/Internal/Converters/FullTextSearch/TsVectorConverter.cs
@@ -85,7 +85,7 @@ sealed class TsVectorConverter(Encoding encoding) : PgStreamingConverter<NpgsqlT
         foreach (var lexeme in value)
         {
             if (async)
-                await writer.WriteCharsAsync(lexeme.Text.AsMemory(), encoding, cancellationToken).ConfigureAwait(false);
+                await writer.WriteCharsAsync(lexeme.Text.AsMemory(), encoding, cancellationToken: cancellationToken).ConfigureAwait(false);
             else
                 writer.WriteChars(lexeme.Text.AsMemory().Span, encoding);
 

--- a/src/Npgsql/Internal/Converters/HstoreConverter.cs
+++ b/src/Npgsql/Internal/Converters/HstoreConverter.cs
@@ -122,7 +122,7 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
             var length = size.Value;
             writer.WriteInt32(length);
             if (async)
-                await writer.WriteCharsAsync(kv.Key.AsMemory(), encoding, cancellationToken).ConfigureAwait(false);
+                await writer.WriteCharsAsync(kv.Key.AsMemory(), encoding, cancellationToken: cancellationToken).ConfigureAwait(false);
             else
                 writer.WriteChars(kv.Key.AsSpan(), encoding);
 
@@ -138,7 +138,7 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
             if (valueLength is not -1)
             {
                 if (async)
-                    await writer.WriteCharsAsync(kv.Value.AsMemory(), encoding, cancellationToken).ConfigureAwait(false);
+                    await writer.WriteCharsAsync(kv.Value.AsMemory(), encoding, cancellationToken: cancellationToken).ConfigureAwait(false);
                 else
                     writer.WriteChars(kv.Value.AsSpan(), encoding);
             }

--- a/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
@@ -23,10 +23,10 @@ abstract class StringBasedTextConverter<T>(Encoding encoding) : PgStreamingConve
         => TextConverter.GetSize(ref context, ConvertTo(value), encoding);
 
     public override void Write(PgWriter writer, T value)
-        => writer.WriteChars(ConvertTo(value).Span, encoding);
+        => writer.WriteChars(ConvertTo(value).Span, encoding, writer.Current.Size.Kind == SizeKind.Exact ? writer.Current.Size.Value : null);
 
     public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
-        => writer.WriteCharsAsync(ConvertTo(value), encoding, cancellationToken);
+        => writer.WriteCharsAsync(ConvertTo(value), encoding, writer.Current.Size.Kind == SizeKind.Exact ? writer.Current.Size.Value : null, cancellationToken : cancellationToken);
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
     {
@@ -75,7 +75,7 @@ abstract class ArrayBasedTextConverter<T>(Encoding encoding) : PgStreamingConver
         => writer.WriteChars(ConvertTo(value).AsSpan(), encoding);
 
     public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
-        => writer.WriteCharsAsync(ConvertTo(value), encoding, cancellationToken);
+        => writer.WriteCharsAsync(ConvertTo(value), encoding, cancellationToken: cancellationToken);
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
     {
@@ -149,14 +149,14 @@ sealed class CharTextConverter(Encoding encoding) : PgBufferedConverter<char>
 
     public override Size GetSize(SizeContext context, char value, ref object? writeState)
     {
-        Span<char> spanValue = [value];
+        ReadOnlySpan<char> spanValue = [value];
         return encoding.GetByteCount(spanValue);
     }
 
     protected override void WriteCore(PgWriter writer, char value)
     {
-        Span<char> spanValue = [value];
-        writer.WriteChars(spanValue, encoding);
+        ReadOnlySpan<char> spanValue = [value];
+        writer.WriteChars(spanValue, encoding, writer.Current.Size.Kind == SizeKind.Exact ? writer.Current.Size.Value : null);
     }
 }
 

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -744,10 +744,10 @@ public class PgReader
         => ShouldBuffer(GetBufferRequirementByteCount(bufferRequirement));
     public bool ShouldBuffer(int byteCount)
     {
-        return _buffer.ReadBytesLeft < byteCount && ShouldBufferSlow();
+        return _buffer.ReadBytesLeft < byteCount && ShouldBufferSlow(byteCount);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        bool ShouldBufferSlow()
+        bool ShouldBufferSlow(int byteCount)
         {
             if (byteCount > _buffer.Size)
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(byteCount),

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -76,9 +76,9 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Text
             // Update PgSerializerOptions.IsWellKnownTextType(Type) after any changes to this list.
             mappings.AddType<string>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
+                static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding, nested: false), preferredFormat: DataFormat.Text), isDefault: true);
             mappings.AddStructType<char>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
+                static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding, nested: false), preferredFormat: DataFormat.Text));
             // Uses the bytea converters, as neither type has a header.
             mappings.AddType<byte[]>(DataTypeNames.Text,
                 static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter()),
@@ -103,9 +103,9 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                         DataTypeNames.Xml, DataTypeNames.Name, DataTypeNames.RefCursor })
             {
                 mappings.AddType<string>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
+                    static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding, nested: false), preferredFormat: DataFormat.Text), isDefault: true);
                 mappings.AddStructType<char>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
+                    static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding, nested: false), preferredFormat: DataFormat.Text));
                 // Uses the bytea converters, as neither type has a header.
                 mappings.AddType<byte[]>(dataTypeName,
                     static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter()),

--- a/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
@@ -108,7 +108,7 @@ sealed class ExtraConversionResolverFactory : PgTypeInfoResolverFactory
             mappings.AddType<char[]>(DataTypeNames.Text,
                 static (options, mapping, _) => mapping.CreateInfo(options, new CharArrayTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
             mappings.AddStructType<ReadOnlyMemory<char>>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
+                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryTextConverter(options.TextEncoding, nested: false), preferredFormat: DataFormat.Text));
             mappings.AddStructType<ArraySegment<char>>(DataTypeNames.Text,
                 static (options, mapping, _) => mapping.CreateInfo(options, new CharArraySegmentTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
 
@@ -121,7 +121,7 @@ sealed class ExtraConversionResolverFactory : PgTypeInfoResolverFactory
                     static (options, mapping, _) => mapping.CreateInfo(options, new CharArrayTextConverter(options.TextEncoding),
                         preferredFormat: DataFormat.Text));
                 mappings.AddStructType<ReadOnlyMemory<char>>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryTextConverter(options.TextEncoding),
+                    static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryTextConverter(options.TextEncoding, nested: false),
                         preferredFormat: DataFormat.Text));
                 mappings.AddStructType<ArraySegment<char>>(dataTypeName,
                     static (options, mapping, _) => mapping.CreateInfo(options, new CharArraySegmentTextConverter(options.TextEncoding),

--- a/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
@@ -1,16 +1,16 @@
 ﻿using BenchmarkDotNet.Attributes;
-using System.Collections.Generic;
-using System.Text;
+using Npgsql.Internal;
 using Npgsql.Internal.Converters;
+using System.Collections.Generic;
 
 namespace Npgsql.Benchmarks.TypeHandlers;
 
 [Config(typeof(Config))]
-public class Text() : TypeHandlerBenchmarks<string>(new StringTextConverter(Encoding.UTF8))
+public class Text() : TypeHandlerBenchmarks<string>(new StringTextConverter(NpgsqlWriteBuffer.UTF8Encoding))
 {
     protected override IEnumerable<string> ValuesOverride()
     {
-        for (var i = 1; i <= 10000; i *= 10)
+        for (var i = 1; i <= 1000; i *= 10)
             yield return new string('x', i);
     }
 }

--- a/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Npgsql.Benchmarks.TypeHandlers;
 
 [Config(typeof(Config))]
-public class Text() : TypeHandlerBenchmarks<string>(new StringTextConverter(NpgsqlWriteBuffer.UTF8Encoding))
+public class Text() : TypeHandlerBenchmarks<string>(new StringTextConverter(NpgsqlWriteBuffer.UTF8Encoding, nested: false))
 {
     protected override IEnumerable<string> ValuesOverride()
     {

--- a/test/Npgsql.Tests/TypeMapperTests.cs
+++ b/test/Npgsql.Tests/TypeMapperTests.cs
@@ -101,7 +101,7 @@ CREATE EXTENSION citext SCHEMA ""{schemaName}""");
             {
                 if (type == typeof(string) || dataTypeName?.UnqualifiedName == "citext")
                     if (options.DatabaseInfo.TryGetPostgresTypeByName("citext", out var pgType))
-                        return new(options, new StringTextConverter(options.TextEncoding), options.ToCanonicalTypeId(pgType));
+                        return new(options, new StringTextConverter(options.TextEncoding, nested: false), options.ToCanonicalTypeId(pgType));
 
                 return null;
             }


### PR DESCRIPTION
When the string to be written can potentially be fully buffered there is a second call to `GetByteCount` (first one is GetSize). If the converter is not nested inside another converter, the size has already been calculated.
Basing this off BitArrayBitStringConverter that its safe to do.

PgReader.cs change is just to remove the DisplayClass struct creation.

Text.cs test string of 10_000 doesn't fit in the test buffer.

**Before**
| Method | Value                | Mean      | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    |  25.41 ns | 0.203 ns | 0.190 ns | 39,359,074.1 | 0.0023 |      24 B |
| Write  | x                    |        NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           |  27.39 ns | 0.370 ns | 0.346 ns | 36,512,150.3 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           |  20.93 ns | 0.230 ns | 0.204 ns | 47,775,325.5 | 0.0000 |       1 B |
| Read   | xxxx(...)xxxx [100]  |  30.99 ns | 0.196 ns | 0.184 ns | 32,267,999.8 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  |  24.14 ns | 0.064 ns | 0.057 ns | 41,425,834.0 | 0.0007 |       8 B |
| Read   | xxxx(...)xxxx [1000] | 107.35 ns | 0.816 ns | 0.637 ns |  9,315,283.3 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] |  74.81 ns | 0.312 ns | 0.261 ns | 13,367,517.5 | 0.0074 |      78 B |

**After**
| Method | Value                | Mean      | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    |  23.42 ns | 0.095 ns | 0.089 ns | 42,704,740.3 | 0.0023 |      24 B |
| Write  | x                    |        NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           |  25.19 ns | 0.075 ns | 0.070 ns | 39,701,387.8 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           |  15.57 ns | 0.039 ns | 0.037 ns | 64,237,944.4 | 0.0000 |         - |
| Read   | xxxx(...)xxxx [100]  |  31.36 ns | 0.174 ns | 0.145 ns | 31,890,144.5 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  |  20.31 ns | 0.058 ns | 0.052 ns | 49,229,262.7 | 0.0005 |       5 B |
| Read   | xxxx(...)xxxx [1000] | 107.48 ns | 0.698 ns | 0.653 ns |  9,304,087.4 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] |  57.45 ns | 0.100 ns | 0.094 ns | 17,405,246.9 | 0.0052 |      54 B |