### PR TITLE
Reduce temporary string creation during types load

### DIFF
--- a/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
+++ b/src/Npgsql/Internal/NpgsqlDatabaseInfo.cs
@@ -241,9 +241,9 @@ public abstract class NpgsqlDatabaseInfo
             ByFullName[type.DataTypeName.Value] = type;
             // If more than one type exists with the same partial name, we place a null value.
             // This allows us to detect this case later and force the user to use full names only.
-            ByName[type.InternalName] = ByName.ContainsKey(type.InternalName)
-                ? null
-                : type;
+            var typeInternalName = type.InternalName;
+            if (!ByName.TryAdd(typeInternalName, type))
+                ByName[typeInternalName] = null;
 
             switch (type)
             {

--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -86,11 +86,10 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
         if (unqualifiedNameSpan.StartsWith("_".AsSpan(), StringComparison.Ordinal))
             return this;
 
-        var unqualifiedName = unqualifiedNameSpan.ToString();
-        if (unqualifiedName.Length + "_".Length > NAMEDATALEN)
-            unqualifiedName = unqualifiedName.Substring(0, NAMEDATALEN - "_".Length);
+        if (unqualifiedNameSpan.Length + "_".Length > NAMEDATALEN)
+            unqualifiedNameSpan = unqualifiedNameSpan.Slice(0, NAMEDATALEN - "_".Length);
 
-        return new(Schema + "._" + unqualifiedName);
+        return new(string.Concat(Schema, "._", unqualifiedNameSpan));
     }
 
     // Static transform as defined by https://www.postgresql.org/docs/current/sql-createtype.html#SQL-CREATETYPE-RANGE
@@ -101,20 +100,25 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
         if (UnqualifiedNameSpan.IndexOf("multirange".AsSpan(), StringComparison.Ordinal) != -1)
             return this;
 
-        var unqualifiedName = unqualifiedNameSpan.ToString();
-        var rangeIndex = unqualifiedName.IndexOf("range", StringComparison.Ordinal);
+        var rangeIndex = unqualifiedNameSpan.IndexOf("range", StringComparison.Ordinal);
         if (rangeIndex != -1)
         {
-            var str = unqualifiedName.Substring(0, rangeIndex) + "multirange" + unqualifiedName.Substring(rangeIndex + "range".Length);
+            ReadOnlySpan<char> str = string.Concat(unqualifiedNameSpan.Slice(0, rangeIndex), "multirange", unqualifiedNameSpan.Slice(rangeIndex + "range".Length));
 
-            return new($"{Schema}." + (unqualifiedName.Length + "multi".Length > NAMEDATALEN
-                ? str.Substring(0, NAMEDATALEN - "multi".Length)
-                : str));
+            if (unqualifiedNameSpan.Length + "multi".Length > NAMEDATALEN)
+                str = str.Slice(0, NAMEDATALEN - "multi".Length);
+
+            return new(string.Concat(Schema, ".", str));
         }
+        else
+        {
+            var str = unqualifiedNameSpan;
 
-        return new($"{Schema}." + (unqualifiedName.Length + "multi".Length > NAMEDATALEN
-            ? unqualifiedName.Substring(0, NAMEDATALEN - "_multirange".Length) + "_multirange"
-            : unqualifiedName + "_multirange"));
+            if (str.Length + "multi".Length > NAMEDATALEN)
+                str = str.Slice(0, NAMEDATALEN - "_multirange".Length);
+
+            return new(string.Concat(Schema, ".", str, "_multirange"));
+        }
     }
 
     // Create a DataTypeName from a broader range of valid names.
@@ -151,7 +155,7 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
             displayNameSpan = displayNameSpan.Slice(0, displayNameSpan.Length - 2);
         }
 
-        string mapped;
+        ReadOnlySpan<char> mapped;
         if (schemaEndIndex is -1)
         {
             // Finally we strip the facet info.
@@ -160,7 +164,7 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
                 displayNameSpan = displayNameSpan.Slice(0, parenIndex);
 
             // Map any aliases to the internal type name.
-            mapped = displayNameSpan.ToString() switch
+            mapped = displayNameSpan switch
             {
                 "boolean" => "bool",
                 "character" => "bpchar",
@@ -182,10 +186,10 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
         else
         {
             // If we had a schema originally we stop here, see comment at schemaEndIndex.
-            mapped = displayNameSpan.ToString();
+            mapped = displayNameSpan;
         }
 
-        return new((schema ?? "pg_catalog") + "." + (isArray ? "_" : "") + mapped);
+        return new(string.Concat(schema ?? "pg_catalog", ".", isArray ? "_" : "", mapped));
     }
 
     // The type names stored in a DataTypeName are usually the actual typname from the pg_type column.
@@ -196,7 +200,7 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
     static string ToDisplayName(ReadOnlySpan<char> unqualifiedName)
     {
         var isArray = unqualifiedName.IndexOf('_') == 0;
-        var baseTypeName = isArray ? unqualifiedName.Slice(1).ToString() : unqualifiedName.ToString();
+        var baseTypeName = isArray ? unqualifiedName.Slice(1) : unqualifiedName;
 
         var mappedBaseType = baseTypeName switch
         {
@@ -214,7 +218,7 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
             "timestamptz" => "timestamp with time zone",
             "varbit" => "bit varying",
             "varchar" => "character varying",
-            _ => baseTypeName
+            _ => baseTypeName.ToString()
         };
 
         if (isArray)


### PR DESCRIPTION
Reduce string creation by using the span overloads of `string.Concat`.

NpgsqlDatabaseInfo.cs - InternalName returns a new string every time. Store it in a variable and only do the Dictionary key lookup once in the common case.

ToDefaultMultirangeName does not look to be correct in both existing cases where the final string will be too long. In the first case (range -> multirange) the original name + "multi" is checked against NAMEDATALEN then the final name is trimmed to 58 characters.
It looks like it should be
```
            if (str.Length > NAMEDATALEN)
                str = str.Slice(0, NAMEDATALEN);
```
In the second case the original name + "multi" is checked against NAMEDATALEN but "_multirange" is being appended later.
It looks like it should be
```
            if (str.Length + "_multirange".Length > NAMEDATALEN)
```

I can change that as part of this PR if they are incorrect.