### PR TITLE
Devirtualize UTF8 with a specialized text converter

### DIFF
--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -20,8 +20,8 @@ sealed class NpgsqlWriteBuffer : IDisposable
 {
     #region Fields and Properties
 
-    internal static readonly UTF8Encoding UTF8Encoding = new(false, true);
-    internal static readonly UTF8Encoding RelaxedUTF8Encoding = new(false, false);
+    internal static readonly UTF8EncodingNoBom UTF8Encoding = new(true);
+    internal static readonly UTF8EncodingNoBom RelaxedUTF8Encoding = new(false);
 
     internal readonly NpgsqlConnector Connector;
 

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -48,7 +48,7 @@ public sealed class PgSerializerOptions
     internal NpgsqlDatabaseInfo DatabaseInfo { get; }
 
     public string TimeZone => _timeZoneProvider?.Invoke() ?? throw new NotSupportedException("TimeZone was not configured.");
-    public Encoding TextEncoding { get; init; } = Encoding.UTF8;
+    public Encoding TextEncoding { get; init; } = NpgsqlWriteBuffer.RelaxedUTF8Encoding;
     public IPgTypeInfoResolver TypeInfoResolver
     {
         get => _typeInfoResolver ??= new ChainTypeInfoResolver(_resolverChain);

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -42,7 +42,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 || options.DatabaseInfo.GetPostgresType(dataTypeName) is not PostgresEnumType)
                 return null;
 
-            return new PgTypeInfo(options, new StringTextConverter(options.TextEncoding), dataTypeName,
+            return new PgTypeInfo(options, StringTextConverter.Create(options.TextEncoding), dataTypeName,
                 unboxedType: type == typeof(object) ? typeof(string) : null);
         }
 
@@ -76,7 +76,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Text
             // Update PgSerializerOptions.IsWellKnownTextType(Type) after any changes to this list.
             mappings.AddType<string>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
+                static (options, mapping, _) => mapping.CreateInfo(options, StringTextConverter.Create(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
             mappings.AddStructType<char>(DataTypeNames.Text,
                 static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
             // Uses the bytea converters, as neither type has a header.
@@ -103,7 +103,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                         DataTypeNames.Xml, DataTypeNames.Name, DataTypeNames.RefCursor })
             {
                 mappings.AddType<string>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
+                    static (options, mapping, _) => mapping.CreateInfo(options, StringTextConverter.Create(options.TextEncoding), preferredFormat: DataFormat.Text), isDefault: true);
                 mappings.AddStructType<char>(dataTypeName,
                     static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
                 // Uses the bytea converters, as neither type has a header.
@@ -128,7 +128,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Jsonb
             const byte jsonbVersion = 1;
             mappings.AddType<string>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<string>(jsonbVersion, new StringTextConverter(options.TextEncoding))), isDefault: true);
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<string>(jsonbVersion, StringTextConverter.Create(options.TextEncoding))), isDefault: true);
             mappings.AddStructType<char>(DataTypeNames.Jsonb,
                 static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<char>(jsonbVersion, new CharTextConverter(options.TextEncoding))));
             mappings.AddType<byte[]>(DataTypeNames.Jsonb,
@@ -151,7 +151,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Jsonpath
             const byte jsonpathVersion = 1;
             mappings.AddType<string>(DataTypeNames.Jsonpath,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<string>(jsonpathVersion, new StringTextConverter(options.TextEncoding))), isDefault: true);
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<string>(jsonpathVersion, StringTextConverter.Create(options.TextEncoding))), isDefault: true);
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Jsonpath,
                 static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<TextReader>(jsonpathVersion, new TextReaderTextConverter(options.TextEncoding)), supportsWriting: false, preferredFormat: DataFormat.Text),
@@ -271,7 +271,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             // Unknown
             mappings.AddType<string>(DataTypeNames.Unknown,
-                static (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text),
+                static (options, mapping, _) => mapping.CreateInfo(options, StringTextConverter.Create(options.TextEncoding), preferredFormat: DataFormat.Text),
                 MatchRequirement.DataTypeName);
 
             // Void
@@ -517,7 +517,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             var mappings = new TypeInfoMappingCollection();
             mappings.AddType<string>(enumType.DataTypeName,
-                (options, mapping, _) => mapping.CreateInfo(options, new StringTextConverter(options.TextEncoding)), MatchRequirement.DataTypeName);
+                (options, mapping, _) => mapping.CreateInfo(options, StringTextConverter.Create(options.TextEncoding)), MatchRequirement.DataTypeName);
             mappings.AddArrayType<string>(enumType.DataTypeName);
             return mappings.Find(type, dataTypeName, options);
         }

--- a/src/Npgsql/Internal/ResolverFactories/LTreeTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/LTreeTypeInfoResolverFactory.cs
@@ -31,15 +31,15 @@ sealed class LTreeTypeInfoResolverFactory : PgTypeInfoResolverFactory
         {
             mappings.AddType<string>("ltree",
                 static (options, mapping, _) => mapping.CreateInfo(options,
-                    new VersionPrefixedTextConverter<string>(LTreeVersion, new StringTextConverter(options.TextEncoding))),
+                    new VersionPrefixedTextConverter<string>(LTreeVersion, StringTextConverter.Create(options.TextEncoding))),
                 MatchRequirement.DataTypeName);
             mappings.AddType<string>("lquery",
                 static (options, mapping, _) => mapping.CreateInfo(options,
-                    new VersionPrefixedTextConverter<string>(LTreeVersion, new StringTextConverter(options.TextEncoding))),
+                    new VersionPrefixedTextConverter<string>(LTreeVersion, StringTextConverter.Create(options.TextEncoding))),
                 MatchRequirement.DataTypeName);
             mappings.AddType<string>("ltxtquery",
                 static (options, mapping, _) => mapping.CreateInfo(options,
-                    new VersionPrefixedTextConverter<string>(LTreeVersion, new StringTextConverter(options.TextEncoding))),
+                    new VersionPrefixedTextConverter<string>(LTreeVersion, StringTextConverter.Create(options.TextEncoding))),
                 MatchRequirement.DataTypeName);
 
             return mappings;

--- a/src/Npgsql/Internal/UTF8EncodingNoBom.cs
+++ b/src/Npgsql/Internal/UTF8EncodingNoBom.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Text;
+
+namespace Npgsql.Internal;
+
+/// <summary>
+/// A special instance of <see cref="UTF8Encoding"/>. This type allows for devirtualization
+/// when the type is known.
+/// </summary>
+internal sealed class UTF8EncodingNoBom : UTF8Encoding
+{
+    public UTF8EncodingNoBom() : base(false) { }
+    public UTF8EncodingNoBom(bool throwOnInvalidBytes) : base(false, throwOnInvalidBytes) { }
+
+    public override ReadOnlySpan<byte> Preamble => default;
+
+    public override int GetMaxByteCount(int charCount)
+    {
+        // This is a specialization of UTF8Encoding.GetMaxByteCount
+        // with the assumption that the default replacement fallback
+        // emits 3 fallback bytes ([ EF BF BD ] = '\uFFFD') per
+        // malformed input char in the worst case.
+        const int MaxUtf8BytesPerChar = 3;
+
+        if ((uint)charCount > (int.MaxValue / MaxUtf8BytesPerChar) - 1)
+            ThrowHelper.ThrowArgumentOutOfRangeException();
+
+        return (charCount * MaxUtf8BytesPerChar) + MaxUtf8BytesPerChar;
+    }
+}

--- a/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/Text.cs
@@ -1,12 +1,12 @@
 ﻿using BenchmarkDotNet.Attributes;
-using System.Collections.Generic;
-using System.Text;
+using Npgsql.Internal;
 using Npgsql.Internal.Converters;
+using System.Collections.Generic;
 
 namespace Npgsql.Benchmarks.TypeHandlers;
 
 [Config(typeof(Config))]
-public class Text() : TypeHandlerBenchmarks<string>(new StringTextConverter(Encoding.UTF8))
+public class Text() : TypeHandlerBenchmarks<string>(StringTextConverter.Create(NpgsqlWriteBuffer.UTF8Encoding))
 {
     protected override IEnumerable<string> ValuesOverride()
     {


### PR DESCRIPTION
`Encoding.UTF8` actually returns a UTF8EncodingSealed object (https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.Sealed.cs) that allows for the functions to be devirtualized if accessed via that static.

Npgsql is creating its own UTF8Encoding objects that don't allow for this specialization.

Using a custom UTF8Encoding and a specific TextConverter when that encoding is in use allows greater performance. I did not see much performance differences with the rest of the stack allocations in UTF8EncodingSealed.

Before
| Method | Value                | Mean      | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    |  24.72 ns | 0.098 ns | 0.087 ns | 40,449,395.2 | 0.0023 |      24 B |
| Write  | x                    |        NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           |  26.19 ns | 0.078 ns | 0.069 ns | 38,187,844.1 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           |  18.96 ns | 0.027 ns | 0.024 ns | 52,748,503.0 | 0.0000 |         - |
| Read   | xxxx(...)xxxx [100]  |  35.01 ns | 0.649 ns | 0.575 ns | 28,564,979.3 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  |  24.38 ns | 0.071 ns | 0.059 ns | 41,019,998.9 | 0.0005 |       5 B |
| Read   | xxxx(...)xxxx [1000] | 107.83 ns | 0.627 ns | 0.556 ns |  9,273,447.3 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] |  71.47 ns | 0.165 ns | 0.147 ns | 13,992,508.8 | 0.0051 |      54 B |

After
| Method | Value                | Mean     | Error    | StdDev   | Op/s         | Gen0   | Allocated |
|------- |--------------------- |---------:|---------:|---------:|-------------:|-------:|----------:|
| Read   | x                    | 18.88 ns | 0.161 ns | 0.135 ns | 52,956,082.8 | 0.0023 |      24 B |
| Write  | x                    |       NA |       NA |       NA |           NA |     NA |        NA |
| Read   | xxxxxxxxxx           | 20.33 ns | 0.093 ns | 0.078 ns | 49,191,801.5 | 0.0046 |      48 B |
| Write  | xxxxxxxxxx           | 18.83 ns | 0.019 ns | 0.015 ns | 53,103,167.5 | 0.0000 |         - |
| Read   | xxxx(...)xxxx [100]  | 27.33 ns | 0.091 ns | 0.085 ns | 36,587,970.4 | 0.0214 |     224 B |
| Write  | xxxx(...)xxxx [100]  | 21.84 ns | 0.028 ns | 0.023 ns | 45,783,841.6 | 0.0005 |       5 B |
| Read   | xxxx(...)xxxx [1000] | 98.62 ns | 0.773 ns | 0.723 ns | 10,139,873.0 | 0.1935 |    2024 B |
| Write  | xxxx(...)xxxx [1000] | 67.47 ns | 0.227 ns | 0.201 ns | 14,822,340.7 | 0.0051 |      54 B |