### PR TITLE
Tighten SCRAM-SHA-256 SASL check

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -95,7 +95,7 @@ partial class NpgsqlConnector
         if (clientSupportsSha256Plus)
             DataSource.TransportSecurityHandler.AuthenticateSASLSha256Plus(this, ref mechanism, ref cbindFlag, ref cbind, ref successfulBind);
 
-        if (!successfulBind && serverSupportsSha256)
+        if (!successfulBind && clientSupportsSha256)
         {
             mechanism = "SCRAM-SHA-256";
             // We can get here if PostgreSQL supports only SCRAM-SHA-256 or there was an error while binding to SCRAM-SHA-256-PLUS

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -71,10 +71,10 @@ partial class NpgsqlConnector
     {
         // At the time of writing PostgreSQL only supports SCRAM-SHA-256 and SCRAM-SHA-256-PLUS
         var serverSupportsSha256 = mechanisms.Contains("SCRAM-SHA-256");
-        var clientSupportsSha256 = serverSupportsSha256 && Settings.ChannelBinding != ChannelBinding.Require;
+        var allowSha256 = serverSupportsSha256 && Settings.ChannelBinding != ChannelBinding.Require;
         var serverSupportsSha256Plus = mechanisms.Contains("SCRAM-SHA-256-PLUS");
-        var clientSupportsSha256Plus = serverSupportsSha256Plus && Settings.ChannelBinding != ChannelBinding.Disable;
-        if (!clientSupportsSha256 && !clientSupportsSha256Plus)
+        var allowSha256Plus = serverSupportsSha256Plus && Settings.ChannelBinding != ChannelBinding.Disable;
+        if (!allowSha256 && !allowSha256Plus)
         {
             if (serverSupportsSha256 && Settings.ChannelBinding == ChannelBinding.Require)
                 throw new NpgsqlException($"Couldn't connect because {nameof(ChannelBinding)} is set to {nameof(ChannelBinding.Require)} " +
@@ -92,10 +92,10 @@ partial class NpgsqlConnector
         var cbind = string.Empty;
         var successfulBind = false;
 
-        if (clientSupportsSha256Plus)
+        if (allowSha256Plus)
             DataSource.TransportSecurityHandler.AuthenticateSASLSha256Plus(this, ref mechanism, ref cbindFlag, ref cbind, ref successfulBind);
 
-        if (!successfulBind && clientSupportsSha256)
+        if (!successfulBind && allowSha256)
         {
             mechanism = "SCRAM-SHA-256";
             // We can get here if PostgreSQL supports only SCRAM-SHA-256 or there was an error while binding to SCRAM-SHA-256-PLUS

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1661,12 +1661,12 @@ public sealed partial class NpgsqlConnector
     internal bool IsSecure { get; private set; }
 
     /// <summary>
-    /// Returns whether SCRAM-SHA256 is being user for the connection
+    /// Returns whether SCRAM-SHA256 is being used for the connection
     /// </summary>
     internal bool IsScram { get; private set; }
 
     /// <summary>
-    /// Returns whether SCRAM-SHA256-PLUS is being user for the connection
+    /// Returns whether SCRAM-SHA256-PLUS is being used for the connection
     /// </summary>
     internal bool IsScramPlus { get; private set; }
 


### PR DESCRIPTION
Right now whenever we authenticate via SASL, we might either connect with channel binding (SCRAM-SHA-256-PLUS) or without (SCRAM-SHA-256), depending on whether the server supports it and `ChannelBinding` property in connection string. Now, in some cases (like the cert passed from the server has an unsupported hash algorithm) we might allow to downgrade from `SCRAM-SHA-256-PLUS` to `SCRAM-SHA-256`, as long as the server supports auth without channel binding. The problem is that it seems like we ignore `ChannelBinding`, so even if a user passes `ChannelBinding.Require` we can still potentially downgrade. This change makes sure that in that case we'll throw an exception instead of going through.

Shouldn't be much of a security issue as I fully expect that in case of a problematic cert we'll fail somewhere along TLS handshake.