### PR TITLE
Remove LongRunningConnection field from NpgsqlConnector

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -182,9 +182,6 @@ public sealed partial class NpgsqlConnector
     /// </summary>
     volatile Exception? _breakReason;
 
-    // Used by replication to change our cancellation behaviour on ColumnStreams.
-    internal bool LongRunningConnection { get; set; }
-
     /// <summary>
     /// <para>
     /// Used by the pool to indicate that I/O is currently in progress on this connector, so that another write
@@ -2399,7 +2396,6 @@ public sealed partial class NpgsqlConnector
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     void ResetReadBuffer()
     {
-        LongRunningConnection = false;
         if (_origReadBuffer != null)
         {
             Debug.Assert(_origReadBuffer.ReadBytesLeft == 0);

--- a/src/Npgsql/Internal/NpgsqlReadBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlReadBuffer.cs
@@ -678,7 +678,7 @@ sealed partial class NpgsqlReadBuffer : IDisposable
     {
         if (_lastStream is not { IsDisposed: true })
             _lastStream = new ColumnStream(Connector);
-        _lastStream.Init(len, canSeek, !Connector.LongRunningConnection, consumeOnDispose);
+        _lastStream.Init(len, canSeek, Connector.Settings.ReplicationMode == ReplicationMode.Off, consumeOnDispose);
         return _lastStream;
     }
 

--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -237,8 +237,6 @@ public abstract class ReplicationConnection : IAsyncDisposable
 
         SetTimeouts(CommandTimeout, CommandTimeout);
 
-        _npgsqlConnection.Connector!.LongRunningConnection = true;
-
         ReplicationLogger = _npgsqlConnection.Connector!.LoggingConfiguration.ReplicationLogger;
     }
 


### PR DESCRIPTION
This field is only set while instantiating `ReplicationConnection`, which also sets `ReplicationMode` in connection string, so we should be able to piggyback from that.

cc @Brar @NinoFloris 