### PR TITLE
Limit number of authentication attempts

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -23,6 +23,7 @@ partial class NpgsqlConnector
     {
         // Connecting to PG through an intermediatary, such as PgPool-II, can sometimes cause the connection to require multiple nested authentications.
         // Since we do not know how many times we need to authenticate, we do it in a loop until its no longer expected.
+        // See https://github.com/npgsql/npgsql/pull/5006 + https://github.com/npgsql/npgsql/issues/6029 for details
 
         var attempt = 0;
         while (!timeout.HasExpired && !cancellationToken.IsCancellationRequested && attempt <= MAX_AUTH_ATTEMPTS)

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -21,7 +21,7 @@ partial class NpgsqlConnector
 
     async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
     {
-        // Connecting to PG through an intermediatary, such as PG bouncer, can sometimes cause the connection to require multiple nested authentications.
+        // Connecting to PG through an intermediatary, such as PgPool-II, can sometimes cause the connection to require multiple nested authentications.
         // Since we do not know how many times we need to authenticate, we do it in a loop until its no longer expected.
 
         var attempt = 0;

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -67,7 +67,7 @@ partial class NpgsqlConnector
         }
 
         // If we made it this far, authentication failed to occur within the specified timeout, or attempt limit.
-        throw new NpgsqlException($"Authentication cycle timed out after {attempt} attempts.");
+        throw new NpgsqlException($"Authentication cycle failed to complete successfully after {attempt} attempts.");
     }
 
     async Task AuthenticateCleartext(string username, bool async, CancellationToken cancellationToken = default)

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -66,6 +66,7 @@ partial class NpgsqlConnector
             }
         }
 
+        // If we made it this far, authentication failed to occur within the specified timeout, or attempt limit.
         throw new NpgsqlException($"Authentication cycle timed out after {attempt} attempts.");
     }
 

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -17,7 +17,7 @@ namespace Npgsql.Internal;
 partial class NpgsqlConnector
 {
 
-    private const int MAX_AUTH_ATTEMPTS = 100;
+    private const int MAX_AUTH_ATTEMPTS = 10;
 
     async Task Authenticate(string username, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
     {

--- a/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.Auth.cs
@@ -23,7 +23,10 @@ partial class NpgsqlConnector
     {
         // Connecting to PG through an intermediatary, such as PgPool-II, can sometimes cause the connection to require multiple nested authentications.
         // Since we do not know how many times we need to authenticate, we do it in a loop until its no longer expected.
-        // See https://github.com/npgsql/npgsql/pull/5006 + https://github.com/npgsql/npgsql/issues/6029 for details
+        // See the following issues for details
+        // https://github.com/npgsql/npgsql/pull/5006
+        // https://github.com/npgsql/npgsql/issues/6029
+        // https://github.com/dotnet/runtime/issues/112898
 
         var attempt = 0;
         while (!timeout.HasExpired && !cancellationToken.IsCancellationRequested && attempt <= MAX_AUTH_ATTEMPTS)


### PR DESCRIPTION
This removes the `while(true)` loop in authentication process.
Replacing it with a maximum number of attempts read from `MAX_AUTH_ATTEMPTS`.

Ideally, we would want to know why authentication is not progressing or changing its state during the process, so this is kind of a stop gap to try and prevent holding up threads.