### PR TITLE
Fix getting wrong schema with CommandBehavior.SchemaOnly and autoprepare

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1118,11 +1118,24 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
                     await new TaskSchedulerAwaitable(ConstrainedConcurrencyScheduler);
 
                 var batchCommand = InternalBatchCommands[i];
+                var pStatement = batchCommand.PreparedStatement;
 
-                if (batchCommand.PreparedStatement?.State == PreparedState.Prepared)
-                    continue; // Prepared, we already have the RowDescription
+                pStatement?.RefreshLastUsed();
 
-                await connector.WriteParse(batchCommand.FinalCommandText!, batchCommand.StatementName,
+                Debug.Assert(batchCommand.FinalCommandText is not null);
+
+                if (pStatement != null && !batchCommand.IsPreparing)
+                {
+                    // Prepared, we already have the RowDescription
+                    Debug.Assert(pStatement.IsPrepared);
+                    continue;
+                }
+
+                // We may have a prepared statement that replaces an existing statement - close the latter first.
+                if (pStatement?.StatementBeingReplaced != null)
+                    await connector.WriteClose(StatementOrPortal.Statement, pStatement.StatementBeingReplaced.Name!, async, cancellationToken).ConfigureAwait(false);
+
+                await connector.WriteParse(batchCommand.FinalCommandText, batchCommand.StatementName,
                     batchCommand.CurrentParametersReadOnly,
                     async, cancellationToken).ConfigureAwait(false);
                 await connector.WriteDescribe(StatementOrPortal.Statement, batchCommand.StatementName, async, cancellationToken).ConfigureAwait(false);

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -713,6 +713,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                         break;
                     case BackendMessageCode.RowDescription:
                         // We have a resultset
+                        // RowDescription messages are cached on the connector, but if we're auto-preparing, we need to
+                        // clone our own copy which will last beyond the lifetime of this invocation.
                         RowDescription = _statements[StatementIndex].Description = preparedStatement == null
                             ? (RowDescriptionMessage)msg
                             : ((RowDescriptionMessage)msg).Clone();

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -713,7 +713,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                         break;
                     case BackendMessageCode.RowDescription:
                         // We have a resultset
-                        RowDescription = _statements[StatementIndex].Description = (RowDescriptionMessage)msg;
+                        RowDescription = _statements[StatementIndex].Description = preparedStatement == null
+                            ? (RowDescriptionMessage)msg
+                            : ((RowDescriptionMessage)msg).Clone();
                         Command.FixupRowDescription(RowDescription, StatementIndex == 0);
                         break;
                     default:
@@ -734,17 +736,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
                 // Found a resultset
                 if (RowDescription is not null)
-                {
-                    if (ColumnInfoCache?.Length >= ColumnCount)
-                        Array.Clear(ColumnInfoCache, 0, ColumnCount);
-                    else
-                    {
-                        if (ColumnInfoCache is { } cache)
-                            ArrayPool<ColumnInfo>.Shared.Return(cache, clearArray: true);
-                        ColumnInfoCache = ArrayPool<ColumnInfo>.Shared.Rent(ColumnCount);
-                    }
                     return true;
-                }
             }
 
             State = ReaderState.Consumed;


### PR DESCRIPTION
Fixes #6038

This one was annoying. For some reason we've been missing quite a big chunk of AutoPrepare logic around `CommandBehavior.SchemaOnly`. @roji would be great if you can also take a look in case I missed something.