### PR TITLE
Do not throw open data reader exception for CommandState.Disposed

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -183,7 +183,7 @@ public class NpgsqlCommand : DbCommand, ICloneable, IComponent
         {
             Debug.Assert(WrappingBatch is null);
 
-            if (State != CommandState.Idle)
+            if (State == CommandState.InProgress)
                 ThrowHelper.ThrowInvalidOperationException("An open data reader exists for this command.");
 
             _commandText = value ?? string.Empty;
@@ -252,7 +252,7 @@ public class NpgsqlCommand : DbCommand, ICloneable, IComponent
             if (InternalConnection == value)
                 return;
 
-            InternalConnection = State == CommandState.Idle
+            InternalConnection = State != CommandState.InProgress
                 ? (NpgsqlConnection?)value
                 : throw new InvalidOperationException("An open data reader exists for this command.");
 

--- a/test/Npgsql.Tests/CommandTests.cs
+++ b/test/Npgsql.Tests/CommandTests.cs
@@ -1639,4 +1639,18 @@ FROM
 
         Assert.That(connection.PostgresParameters, Contains.Key("SomeKey").WithValue("SomeValue"));
     }
+
+    [Test, Description("Writing to properties of a disposed command does not raise exceptions. This is the SqlClient behavior.")]
+    public async Task Command_Dispose_allows_assignment()
+    {
+        await using var conn = await OpenConnectionAsync();
+        var command = new NpgsqlCommand("SELECT 1");
+        command.Dispose();
+
+        command.Connection = conn;
+        command.CommandText = "SELECT 2";
+
+        Assert.AreSame(conn, command.Connection);
+        Assert.AreSame("SELECT 2", command.CommandText);
+    }
 }


### PR DESCRIPTION
Checks for InProgress command state instead of just Idle when assigning Connection and CommandText to not throw a misleading open data reader exception when a command is disposed. An ObjectDisposedException is still thrown when invoking actual query methods.

No exception is thrown matching the behavior of the behavior of multiple other libraries, shown below.
| Library | Behavior |
|--------|--------|
| Microsoft.Data.SqlClient | Assigned, no exception |
| Microsoft.Data.Sqlite | Assigned, no exception |
| System.Data.SQLite | ObjectDisposedException: Cannot access a disposed object. | 
| MySql.Data.MySqlClient | Assigned, no exception |
| MySqlConnector | Assigned, no exception |
| FirebirdSql.Data.FirebirdClient | Assigned, no exception | 
| Npgsql | InvalidOperationException: An open data reader exists for this command. | 