### PR TITLE
Fix brew on mac CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,7 @@ jobs:
       - name: Start PostgreSQL ${{ matrix.pg_major }} (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
+            brew update
             brew install postgresql@${{ matrix.pg_major }}
           
             PGDATA=/opt/homebrew/var/postgresql@${{ matrix.pg_major }}


### PR DESCRIPTION
In their infinite wisdom brew/services and brew authors have decided to remove the widely referenced brew/services package. The idea being that this is now built into brew itself. In these newer versions of brew they seem to intercept requests for brew/services and return it's installed.

What they failed to realize is that CI machines won't naturally have the latest brew version installed. As a result any package that depends on brew/services fails to build on older brew versions since march 20 (when they emptied and archived https://github.com/Homebrew/homebrew-services).

The workaround until our base images are updated is to let brew update itself (which pulls in a ton of other updates too), in effect adding millions of wasteful CI minutes globally.