### PR TITLE
Incorrect multi-threading synchronization in UpdateDatabaseState

### DIFF
--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -423,7 +423,7 @@ public abstract class NpgsqlDataSource : DbDataSource
         var databaseStateInfo = _databaseStateInfo;
 
         if (!ignoreTimeStamp && timeStamp <= databaseStateInfo.TimeStamp)
-            return _databaseStateInfo.State;
+            return databaseStateInfo.State;
 
         _databaseStateInfo = new(newState, new NpgsqlTimeout(stateExpiration), timeStamp);
 


### PR DESCRIPTION
A small fix for an apparent bug in `NpgsqlDataSource.UpdateDatabaseState`. The volatile field is being copied into a variable, but then the field is still being accessed later.