### PR TITLE
feat: add support for PGAPPNAME to set application name

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -833,8 +833,9 @@ public sealed partial class NpgsqlConnector
         if (Settings.Database is not null)
             startupParams["database"] = Settings.Database;
 
-        if (Settings.ApplicationName?.Length > 0)
-            startupParams["application_name"] = Settings.ApplicationName;
+        var applicationName = Settings.ApplicationName ?? PostgresEnvironment.AppName;
+        if (applicationName?.Length > 0)
+            startupParams["application_name"] = applicationName;
 
         if (Settings.SearchPath?.Length > 0)
             startupParams["search_path"] = Settings.SearchPath;

--- a/src/Npgsql/PostgresEnvironment.cs
+++ b/src/Npgsql/PostgresEnvironment.cs
@@ -54,6 +54,8 @@ static class PostgresEnvironment
 
     internal static string? RequireAuth => Environment.GetEnvironmentVariable("PGREQUIREAUTH");
 
+    internal static string? AppName => Environment.GetEnvironmentVariable("PGAPPNAME");
+
     static string? GetHomeDir()
         => Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "APPDATA" : "HOME");
 


### PR DESCRIPTION
This PR solves #6133

This is especially useful to automatically set the application name. For example, we'll use it in Kubernetes to push the pod name:
```yaml
spec:
  template:
    spec:
      containers:
      - name: my-app
        env:
        - name: PGAPPNAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
```

Related doc is at https://github.com/npgsql/doc/pull/409