### PR TITLE
Change FinalCommandText to public in NpgsqlBatchCommand

### DIFF
--- a/src/Npgsql/NpgsqlBatchCommand.cs
+++ b/src/Npgsql/NpgsqlBatchCommand.cs
@@ -120,7 +120,7 @@ public sealed class NpgsqlBatchCommand : DbBatchCommand
     /// The SQL as it will be sent to PostgreSQL, after any rewriting performed by Npgsql (e.g. named to positional parameter
     /// placeholders).
     /// </summary>
-    internal string? FinalCommandText { get; set; }
+    public string? FinalCommandText { get; internal set; }
 
     /// <summary>
     /// The list of parameters, ordered positionally, as it will be sent to PostgreSQL.


### PR DESCRIPTION
Related to #4389
Change the FinalCommandText to be publicly accessible but only internally changed.

This change enable to get the final query when the CommandText is not populated.

