### PR TITLE
Move to Microsoft.Data.SqlClient v6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
 
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
 
     <!-- NativeAOT -->


### PR DESCRIPTION
Only used in Npgsql.Benchmarks project
New major version 6.0 has removed the support of netstandard2.x and net6.0 TFMs
