### PR TITLE
Populate CommandText when NpgsqlBatchCommand is created

### DIFF
--- a/src/Npgsql/SqlQueryParser.cs
+++ b/src/Npgsql/SqlQueryParser.cs
@@ -506,6 +506,7 @@ sealed class SqlQueryParser
             else
             {
                 batchCommand = new NpgsqlBatchCommand { _parameters = parameters };
+                batchCommand.CommandText = sql;
                 batchCommands.Add(batchCommand);
             }
         }


### PR DESCRIPTION
Related to #4389 and #6164, which had a non-elegant solution.

After some debugging, I noticed that when the SQL parser is running in Command mode, it creates a new NpgsqlBatchCommand  passing all parameters without the SQL, and this is the root cause of the CommandText being blank in my testing.