### PR TITLE
Fix multi host data source type reloading

### DIFF
--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -248,7 +248,7 @@ public abstract class NpgsqlDataSource : DbDataSource
         }
     }
 
-    internal async Task Bootstrap(
+    internal virtual async Task Bootstrap(
         NpgsqlConnector connector,
         NpgsqlTimeout timeout,
         bool forceReload,

--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -64,6 +64,14 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
             _wrappers[(int)targetSessionAttribute] = new(this, targetSessionAttribute);
     }
 
+    internal override async Task Bootstrap(NpgsqlConnector connector, NpgsqlTimeout timeout, bool forceReload, bool async, CancellationToken cancellationToken)
+    {
+        foreach (var pool in _pools)
+        {
+            await pool.Bootstrap(connector, timeout, forceReload, async, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     /// <summary>
     /// Returns a new, unopened connection from this data source.
     /// </summary>


### PR DESCRIPTION
Closes #6237

We were not actually bootstrapping the individual data sources, so no types for the concrete connections would get reloaded by doing multihostdatasource.ReloadTypes().