### PR TITLE
Fix a few issues with type mappings for schema generator

### DIFF
--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -259,8 +259,11 @@ ORDER BY attnum";
     {
         var serializerOptions = _connection.Connector!.SerializerOptions;
 
-        column.NpgsqlDbType = column.PostgresType.DataTypeName.ToNpgsqlDbType();
-        if (serializerOptions.GetDefaultTypeInfo(serializerOptions.ToCanonicalTypeId(column.PostgresType)) is { } typeInfo)
+        // Call GetRepresentationalType to also handle domain types
+        // Because NpgsqlCommandBuilder relies on NpgsqlDbType for correct type mapping
+        // And otherwise we'll get NpgsqlDbType.Unknown
+        column.NpgsqlDbType = column.PostgresType.GetRepresentationalType().DataTypeName.ToNpgsqlDbType();
+        if (serializerOptions.GetTypeInfo(typeof(object), serializerOptions.ToCanonicalTypeId(column.PostgresType)) is { } typeInfo)
         {
             column.DataType = typeInfo.Type;
             column.IsLong = column.PostgresType.DataTypeName == DataTypeNames.Bytea;

--- a/test/Npgsql.Tests/CommandBuilderTests.cs
+++ b/test/Npgsql.Tests/CommandBuilderTests.cs
@@ -387,4 +387,60 @@ INSERT INTO {table} VALUES('key1', 'description', '2018-07-03', '2018-07-03 07:0
 
         daDataAdapter.Update(dtTable);
     }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/6240")]
+    public async Task Get_update_command_with_domain_column_type()
+    {
+        await using var adminConnection = await OpenConnectionAsync();
+        var domainTypeName = await GetTempTypeName(adminConnection);
+
+        await adminConnection.ExecuteNonQueryAsync($"CREATE DOMAIN {domainTypeName} AS smallint");
+
+        var tableName = await CreateTempTable(adminConnection, $"id serial PRIMARY KEY, domtest {domainTypeName}");
+
+        await using var dataSource = CreateDataSource();
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        using var adapter = new NpgsqlDataAdapter($"select * from {tableName}", conn);
+
+        var builder = new NpgsqlCommandBuilder(adapter)
+        {
+            ConflictOption = ConflictOption.CompareAllSearchableValues,
+            SetAllValues = true
+        };
+
+        adapter.InsertCommand = builder.GetInsertCommand();
+        adapter.UpdateCommand = builder.GetUpdateCommand();
+        adapter.DeleteCommand = builder.GetDeleteCommand();
+
+        using var dataTable = new DataTable();
+
+        adapter.Fill(dataTable);
+
+        const short sval = 5;
+
+        var newRow = dataTable.NewRow();
+        newRow[1] = sval;
+        dataTable.Rows.Add(newRow);
+
+        adapter.Update(dataTable);
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/6240")]
+    public async Task Fill_datatable_with_array_column_type()
+    {
+        await using var connection = await OpenConnectionAsync();
+
+        var tableName = await CreateTempTable(connection, "id serial PRIMARY KEY, textarr text[] COLLATE pg_catalog.\"default\"");
+
+        using var adapter = new NpgsqlDataAdapter($"select * from {tableName}", connection);
+
+        using var dataTable = new DataTable();
+
+        adapter.FillSchema(dataTable, SchemaType.Source);
+
+        adapter.MissingSchemaAction = MissingSchemaAction.Ignore;
+
+        adapter.Fill(dataTable);
+    }
 }

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -451,6 +452,19 @@ CREATE UNIQUE INDEX idx_{table} ON {table} (non_id_second, non_id_third)");
     }
 
     [Test]
+    public async Task DataType_with_array()
+    {
+        using var conn = await OpenConnectionAsync();
+        var table = await CreateTempTable(conn, "foo INTEGER[]");
+
+        using var cmd = new NpgsqlCommand($"SELECT foo, ARRAY[1::INTEGER, 2::INTEGER] FROM {table}", conn);
+        using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly);
+        var columns = await GetColumnSchema(reader);
+        Assert.That(columns[0].DataType, Is.SameAs(typeof(Array)));
+        Assert.That(columns[1].DataType, Is.SameAs(typeof(Array)));
+    }
+
+    [Test]
     public async Task UdtAssemblyQualifiedName()
     {
         // Also see DataTypeWithComposite
@@ -673,6 +687,8 @@ CREATE TABLE {table2} (foo INTEGER)");
         var pgType = domainSchema.PostgresType;
         Assert.That(pgType, Is.InstanceOf<PostgresDomainType>());
         Assert.That(((PostgresDomainType)pgType).BaseType.Name, Is.EqualTo("character varying"));
+        // For domains we should return the underlying type
+        Assert.That(domainSchema.NpgsqlDbType, Is.EqualTo(NpgsqlTypes.NpgsqlDbType.Varchar));
     }
 
     [Test]

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -304,7 +304,7 @@ INSERT INTO {table} (name) VALUES ('Text with '' single quote');");
     {
         await using var conn = await OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand(@"SELECT 1::INT4 AS some_column", conn);
-        await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly);
+        await using var reader = await cmd.ExecuteReaderAsync(Behavior | CommandBehavior.SchemaOnly);
         reader.Read();
         Assert.That(reader.GetFieldType(0), Is.SameAs(typeof(int)));
     }


### PR DESCRIPTION
Fixes #6240

So, there are two issues that are fixed.

The first one started to reproduce after #5123 and the gist of it is that while before we were consulting type mapping to deduce which actual type we're retrieving for schema, afterwards we stopped doing that. The fix seems to be quite easy, an additional `GetRepresentationalType` call will unwrap all possible domains so we'll retrieve the original type.

As for the second, this one is a bit weird. After #5559 `NpgsqlDataReader.GetColumnSchema` started to return the actual types for arrays (say, `int[]` or something similar) while `NpgsqlDataReader.GetFieldType` is still returning `Array` (no idea why is that) and this mismatch resulted in `NpgsqlDataAdapter` being a bit confused because it can't map `Array` to `int[]` (and that is because `typeof(Array).IsArray` returns `false`, funny enough). As a fix I changed the way we retrieve the type by passing `typeof(object)` (similar to how is done for `GetFieldType`).

@NinoFloris you probably should also take a look.