### PR TITLE
Fix db.client.connections.create_time metric with .NET 6

### DIFF
--- a/src/Npgsql/MetricsReporter.cs
+++ b/src/Npgsql/MetricsReporter.cs
@@ -164,8 +164,15 @@ sealed class MetricsReporter : IDisposable
     internal void ReportPendingConnectionRequestStop()
         => PendingConnectionRequests.Add(-1, _poolNameTag);
 
-    internal void ReportConnectionCreateTime(TimeSpan duration)
-        => ConnectionCreateTime.Record(duration.TotalSeconds, _poolNameTag);
+    internal void ReportConnectionCreateTime(long startTimestamp)
+    {
+#if NET7_0_OR_GREATER
+        var duration = Stopwatch.GetElapsedTime(startTimestamp);
+#else
+        var duration = new TimeSpan((long)((Stopwatch.GetTimestamp() - startTimestamp) * StopWatchTickFrequency));
+#endif
+        ConnectionCreateTime.Record(duration.TotalSeconds, _poolNameTag);
+    }
 
     static IEnumerable<Measurement<int>> GetConnectionUsage()
     {

--- a/src/Npgsql/PoolingDataSource.cs
+++ b/src/Npgsql/PoolingDataSource.cs
@@ -268,14 +268,10 @@ class PoolingDataSource : NpgsqlDataSource
             try
             {
                 // We've managed to increase the open counter, open a physical connections.
-#if NET7_0_OR_GREATER
                 var startTime = Stopwatch.GetTimestamp();
-#endif
                 var connector = new NpgsqlConnector(this, conn) { ClearCounter = _clearCounter };
                 await connector.Open(timeout, async, cancellationToken).ConfigureAwait(false);
-#if NET7_0_OR_GREATER
-                MetricsReporter.ReportConnectionCreateTime(Stopwatch.GetElapsedTime(startTime));
-#endif
+                MetricsReporter.ReportConnectionCreateTime(startTime);
 
                 var i = 0;
                 for (; i < MaxConnections; i++)


### PR DESCRIPTION
Fixes #6247