### PR TITLE
Fix infinite loop when a connector is closed while concurrently consuming result set

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -467,7 +467,7 @@ public sealed partial class NpgsqlConnector
     /// <summary>
     /// Returns whether the connector is open, regardless of any task it is currently performing
     /// </summary>
-    bool IsConnected => State is not (ConnectorState.Closed or ConnectorState.Connecting or ConnectorState.Broken);
+    internal bool IsConnected => State is not (ConnectorState.Closed or ConnectorState.Connecting or ConnectorState.Broken);
 
     internal bool IsReady => State == ConnectorState.Ready;
     internal bool IsClosed => State == ConnectorState.Closed;

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -984,11 +984,14 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         // state for auto-prepared statements
         //
         // The only exception is when the connector is broken (which can happen in the middle of consuming)
-        // As then there is no point in going forward
+        // As then there is no point in going forward.
+        // An exception to the exception above is when connector is concurrently closed while
+        // the reader is still going over the result set.
+        // While this is undefined behavior and user error, we should try to at least do our best to not loop indefinitely.
         //
         // While we can also check our local state (State == Closed)
         // It's probably better to rely on connector since it's private and its state can't be changed
-        while (!Connector.IsBroken)
+        while (Connector.IsConnected)
         {
             try
             {


### PR DESCRIPTION
Fixes #6264

While this is a user error, the change is very minimal, so why not 🤷 