### PR TITLE
Check pgTypeId for default resolution call in ObjectConverter

### DIFF
--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
@@ -37,6 +38,7 @@ sealed class ObjectConverter(PgSerializerOptions options, PgTypeId pgTypeId) : P
 
         // We can call GetDefaultResolution here as validation has already happened in IsDbNullValue.
         // And we know it was called due to the writeState being filled.
+        Debug.Assert(typeInfo.PgTypeId is not null);
         var converter = typeInfo is PgResolverTypeInfo resolverTypeInfo
             ? resolverTypeInfo.GetDefaultResolution(null).Converter
             : typeInfo.GetResolution().Converter;
@@ -79,6 +81,7 @@ sealed class ObjectConverter(PgSerializerOptions options, PgTypeId pgTypeId) : P
 
         // We can call GetDefaultResolution here as validation has already happened in IsDbNullValue.
         // And we know it was called due to the writeState being filled.
+        Debug.Assert(typeInfo.PgTypeId is not null);
         var converter = typeInfo is PgResolverTypeInfo resolverTypeInfo
             ? resolverTypeInfo.GetDefaultResolution(null).Converter
             : typeInfo.GetResolution().Converter;


### PR DESCRIPTION
Small thing I noticed, would generally not cause any issues but good to get it asserted.