### PR TITLE
Override GetColumnSchemaAsync

### DIFF
--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -87,6 +87,7 @@ Npgsql.Replication.PgOutput.PgOutputStreamingMode.Parallel = 2 -> Npgsql.Replica
 Npgsql.SslNegotiation
 Npgsql.SslNegotiation.Direct = 1 -> Npgsql.SslNegotiation
 Npgsql.SslNegotiation.Postgres = 0 -> Npgsql.SslNegotiation
+override Npgsql.NpgsqlDataReader.GetColumnSchemaAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.ObjectModel.ReadOnlyCollection<System.Data.Common.DbColumn!>!>!
 override Npgsql.NpgsqlMultiHostDataSource.Clear() -> void
 Npgsql.NpgsqlDataSource.ReloadTypes() -> void
 Npgsql.NpgsqlDataSource.ReloadTypesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
@@ -135,3 +136,4 @@ NpgsqlTypes.NpgsqlTid.Deconstruct(out uint blockNumber, out ushort offsetNumber)
 *REMOVED*Npgsql.NpgsqlConnection.BeginTextExportAsync(string! copyToCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextReader!>!
 *REMOVED*Npgsql.NpgsqlConnection.BeginTextImport(string! copyFromCommand) -> System.IO.TextWriter!
 *REMOVED*Npgsql.NpgsqlConnection.BeginTextImportAsync(string! copyFromCommand, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.TextWriter!>!
+*REMOVED*Npgsql.NpgsqlDataReader.GetColumnSchemaAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.ObjectModel.ReadOnlyCollection<Npgsql.Schema.NpgsqlDbColumn!>!>!

--- a/test/Npgsql.Tests/ReaderNewSchemaTests.cs
+++ b/test/Npgsql.Tests/ReaderNewSchemaTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 using NUnit.Framework;
@@ -809,6 +811,6 @@ CREATE TABLE {table2} (foo INTEGER)");
         public int Foo { get; set; }
     }
 
-    async Task<ReadOnlyCollection<Schema.NpgsqlDbColumn>> GetColumnSchema(NpgsqlDataReader reader)
-        => IsAsync ? await reader.GetColumnSchemaAsync() : reader.GetColumnSchema();
+    async Task<IReadOnlyList<Schema.NpgsqlDbColumn>> GetColumnSchema(NpgsqlDataReader reader)
+        => IsAsync ? (await reader.GetColumnSchemaAsync(CancellationToken.None)).Cast<Schema.NpgsqlDbColumn>().ToArray() : reader.GetColumnSchema();
 }


### PR DESCRIPTION
Fixes #6017

Due to the ADO pattern not being followed we cannot provide a strongly typed version as well as the virtual implementation.
(technically it's possible in IL to implement a virtual from another method name, such that we could also expose our existing method, but this is not supported in C#)