### PR TITLE
Docs: clarify NpgsqlParameterCollection.Add(object) requires NpgsqlParameter

### DIFF
--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -460,6 +460,10 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     /// Removes the specified <see cref="NpgsqlParameter"/> from the collection.
     /// </summary>
     /// <param name="value">The <see cref="NpgsqlParameter"/> to remove from the collection.</param>
+    /// <remarks>
+    /// Although this method accepts <see cref="object"/>, only instances of <see cref="NpgsqlParameter"/> are supported.
+    /// Passing any other type will result in an <see cref="InvalidCastException"/>.
+    /// </remarks>
     public override void Remove(object value)
         => Remove(Cast(value));
 


### PR DESCRIPTION
Problem: The inherited docs for Add(object) are misleading, implying callers can pass the parameter Value (a raw value) when the override requires an NpgsqlParameter and will throw otherwise.

Change: Update XML comments on Add(object) (and Insert(object) optionally) to explicitly require NpgsqlParameter and point to AddWithValue/typed overloads for convenience.

Tests: No behavior changes; existing tests for Can_only_add_NpgsqlParameter still pass.

Issue: https://github.com/npgsql/npgsql/issues/6150