### PR TITLE
Avoid loading certificates from system store for every connection

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -1845,7 +1846,7 @@ public sealed partial class NpgsqlConnector
         (sender, certificate, chain, sslPolicyErrors)
             => true;
 
-    static RemoteCertificateValidationCallback SslRootValidation(bool verifyFull, string? certRootPath, X509Certificate2Collection? caCertificates)
+    RemoteCertificateValidationCallback SslRootValidation(bool verifyFull, string? certRootPath, X509Certificate2Collection? caCertificates)
         => (_, certificate, chain, sslPolicyErrors) =>
         {
             if (certificate is null || chain is null)
@@ -1868,7 +1869,7 @@ public sealed partial class NpgsqlConnector
             return chain.Build(certificate as X509Certificate2 ?? new X509Certificate2(certificate));
         };
 
-    private static X509Certificate2Collection GetCustomRootCertificates(string? certRootPath, X509Certificate2Collection? caCertificates)
+    private X509Certificate2Collection GetCustomRootCertificates(string? certRootPath, X509Certificate2Collection? caCertificates)
     {
         if (certRootPath is null)
         {
@@ -1879,18 +1880,52 @@ public sealed partial class NpgsqlConnector
         {
             Debug.Assert(caCertificates is null or { Count: 0 });
 
-            var certs = new X509Certificate2Collection();
+            // Add the file timestamp to the cache key, in case the certificate file is modified while
+            // the application is running.
+            // If this happens, a useless old entry will remain in the cache, but we don't really
+            // expect the file to change in the first place.
+            var certRootTimeStamp = TryGetFileTimeStamp(certRootPath);
 
-            if (Path.GetExtension(certRootPath).ToUpperInvariant() != ".PFX")
-                certs.ImportFromPemFile(certRootPath);
-
-            if (certs.Count == 0)
+            if (certRootTimeStamp.HasValue)
             {
-                // This is not a PEM certificate, probably PFX
-                certs.Add(X509CertificateLoader.LoadPkcs12FromFile(certRootPath, null));
+                return DataSource.CustomRootCertificateCache.GetOrAdd((certRootPath, certRootTimeStamp.Value), certRoot =>
+                    LoadRootCertificatesFromFile(certRoot.Item1));
             }
+            else
+            {
+                // For security reasons, don't cache the certificates if we can't invalidate the cache.
+                return LoadRootCertificatesFromFile(certRootPath);
+            }
+        }
+    }
 
-            return certs;
+    private static X509Certificate2Collection LoadRootCertificatesFromFile(string certRootPath)
+    {
+        var certs = new X509Certificate2Collection();
+
+        if (Path.GetExtension(certRootPath).ToUpperInvariant() != ".PFX")
+            certs.ImportFromPemFile(certRootPath);
+
+        if (certs.Count == 0)
+        {
+            // This is not a PEM certificate, probably PFX
+            certs.Add(X509CertificateLoader.LoadPkcs12FromFile(certRootPath, null));
+        }
+
+        return certs;
+    }
+
+    private static DateTime? TryGetFileTimeStamp(string path)
+    {
+        try
+        {
+            return File.GetLastWriteTimeUtc(path);
+        }
+        catch
+        {
+            // Ignore errors at this point. If the file is loaded afterwards, the code that
+            // does that will hopefully throw a more meaningful exception.
+            return null;
         }
     }
 

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1858,25 +1858,7 @@ public sealed partial class NpgsqlConnector
             if (verifyFull && sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
                 return false;
 
-            var certs = new X509Certificate2Collection();
-
-            if (certRootPath is null)
-            {
-                Debug.Assert(caCertificates is { Count: > 0 });
-                certs.AddRange(caCertificates);
-            }
-            else
-            {
-                Debug.Assert(caCertificates is null or { Count: 0 });
-                if (Path.GetExtension(certRootPath).ToUpperInvariant() != ".PFX")
-                    certs.ImportFromPemFile(certRootPath);
-
-                if (certs.Count == 0)
-                {
-                    // This is not a PEM certificate, probably PFX
-                    certs.Add(X509CertificateLoader.LoadPkcs12FromFile(certRootPath, null));
-                }
-            }
+            var certs = GetCustomRootCertificates(certRootPath, caCertificates);
 
             chain.ChainPolicy.CustomTrustStore.AddRange(certs);
             chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -1885,6 +1867,32 @@ public sealed partial class NpgsqlConnector
 
             return chain.Build(certificate as X509Certificate2 ?? new X509Certificate2(certificate));
         };
+
+    private static X509Certificate2Collection GetCustomRootCertificates(string? certRootPath, X509Certificate2Collection? caCertificates)
+    {
+        if (certRootPath is null)
+        {
+            Debug.Assert(caCertificates is { Count: > 0 });
+            return caCertificates;
+        }
+        else
+        {
+            Debug.Assert(caCertificates is null or { Count: 0 });
+
+            var certs = new X509Certificate2Collection();
+
+            if (Path.GetExtension(certRootPath).ToUpperInvariant() != ".PFX")
+                certs.ImportFromPemFile(certRootPath);
+
+            if (certs.Count == 0)
+            {
+                // This is not a PEM certificate, probably PFX
+                certs.Add(X509CertificateLoader.LoadPkcs12FromFile(certRootPath, null));
+            }
+
+            return certs;
+        }
+    }
 
     #endregion SSL
 

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -1867,7 +1867,7 @@ public sealed partial class NpgsqlConnector
             }
             else
             {
-                Debug.Assert(caCertificates is null or { Count: > 0 });
+                Debug.Assert(caCertificates is null or { Count: 0 });
                 if (Path.GetExtension(certRootPath).ToUpperInvariant() != ".PFX")
                     certs.ImportFromPemFile(certRootPath);
 

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -92,6 +94,13 @@ public abstract class NpgsqlDataSource : DbDataSource
 
     readonly INpgsqlNameTranslator _defaultNameTranslator;
     readonly IDisposable? _eventSourceEvents;
+
+    /// <summary>
+    /// A cache of loaded certificates that is used in case e.g. the "PGSSLROOTCERT" environment variable is set.
+    /// Although we don't expect the value of that variable to differ between data sources, we want to make sure
+    /// that data sources don't inherit cached data from other data sources.
+    /// </summary>
+    internal ConcurrentDictionary<(string, DateTime), X509Certificate2Collection> CustomRootCertificateCache { get; } = new();
 
     internal NpgsqlDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig, bool reportMetrics)
     {


### PR DESCRIPTION
Cache loaded custom root certificates, in particular if the `PGSSLROOTCERT` environment variable is set. This fixes #6417.

Original text:
> This PR contains two changes:
> * An improvement for commit 73202604c3d66d4b55c81d3d532bf0e78cc5c2ee: After that commit, it should no longer be necessary to validate against two different certificate stores.
> * An attempt to fix #6417, by guessing whether the value of `PGSSLROOTCERT` matches the system store.
>
> I hope the changes are OK; unfortunately I can only test them in limited ways.