### PR TITLE
Fix for retrieving column metadata for Postgres < 10

### DIFF
--- a/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
+++ b/src/Npgsql/Schema/DbColumnSchemaGenerator.cs
@@ -39,7 +39,7 @@ sealed class DbColumnSchemaGenerator
      CASE WHEN ((cls.relkind = ANY (ARRAY['r'::""char"", 'p'::""char""]))
                OR ((cls.relkind = ANY (ARRAY['v'::""char"", 'f'::""char""]))
                AND pg_column_is_updatable((cls.oid)::regclass, attr.attnum, false)))
-  	           AND attr.attidentity NOT IN ('a') THEN 'true'::boolean
+  	           {(pgVersion.IsGreaterOrEqual(10) ? "AND attr.attidentity NOT IN ('a')" : "")} THEN 'true'::boolean
                ELSE 'false'::boolean
                END AS is_updatable,
      EXISTS (


### PR DESCRIPTION
I maintain a system that runs Greenplum 6 (PG 9).

After changing https://github.com/npgsql/npgsql/commit/450f9002bacce6b388b4735cb0354543001b912a , retrieving metadata returns the following error:
<img width="1448" height="945" alt="Снимок экрана 2026-02-06 в 19 28 57" src="https://github.com/user-attachments/assets/aeb0d982-a6a8-47b9-8c0f-b93a00e9d951" />

In this case the following SQL is generated:
<img width="1193" height="695" alt="Снимок экрана 2026-02-06 в 19 30 48" src="https://github.com/user-attachments/assets/d2cdba41-9c5e-436e-9eb3-b53fdd55cc81" />

I checked that the information_schema.columns attribute in postgres 9 can be updated without the attribute identity.
After the change, retrieving metadata works correctly.

This error is repeated in versions 9 and 10.