### PR TITLE
Use connection search path when attempting to lookup ambiguous type

### DIFF
--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -79,7 +79,7 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
     public virtual bool HasTypeCategory => Version.IsGreaterOrEqual(8, 4);
 
     internal PostgresDatabaseInfo(NpgsqlConnector conn)
-        : base(conn.Host!, conn.Port, conn.Database!, conn.PostgresParameters["server_version"])
+        : base(conn.Host!, conn.Port, conn.Database!, conn.PostgresParameters["server_version"], conn.Settings.SearchPath?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries ))
         => _connectionLogger = conn.LoggingConfiguration.ConnectionLogger;
 
     private protected PostgresDatabaseInfo(string host, int port, string databaseName, string serverVersion)


### PR DESCRIPTION
If an duplicate name for a type exists in multiple schemas and there is an attempt to use that name without schema-qualification then currently npgsql just throws an `ArgumentException`. 

postgresql doesn't behave this way, instead it resolves unqualified type names based on some "search path" for the current session/user/database/connection, using the first matching type it finds in that search path.

This PR attempts to more closely align npgsql with postgresql's behaviour in this regard.

Future enhancement would be to retrieve the current search path for a connection (if not explicitly set in connection string) during initialisation instead of using hardcoded defaults as is done in this PR.