### PR TITLE
Bypass CompositeBuilder for parameterless composite types

### DIFF
--- a/test/Npgsql.Tests/Types/CompositeHandlerTests.Read.cs
+++ b/test/Npgsql.Tests/Types/CompositeHandlerTests.Read.cs
@@ -118,6 +118,15 @@ public partial class CompositeHandlerTests
             Assert.That(() => execute(), Throws.Exception.TypeOf<InvalidCastException>().With.Property("InnerException").TypeOf<InvalidOperationException>()));
 
     [Test]
+    public Task Read_type_with_nullable_property_set_to_null() =>
+        Read(new TypeWithNullableProperty { IntValue = TheAnswer }, (execute, expected) =>
+        {
+            var actual = execute();
+            Assert.That(actual.IntValue, Is.EqualTo(expected.IntValue));
+            Assert.That(actual.StringValue, Is.Null);
+        });
+
+    [Test]
     public Task Read_type_with_one_parameter() =>
         Read(new TypeWithOneParameter(1), (execute, expected) => Assert.That(execute().Value1, Is.EqualTo(expected.Value1)));
 

--- a/test/Npgsql.Tests/Types/CompositeHandlerTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeHandlerTests.cs
@@ -220,6 +220,15 @@ public partial class CompositeHandlerTests : TestBase
         public string? StringValue { get; } = stringValue;
     }
 
+    public class TypeWithNullableProperty : IComposite
+    {
+        public int IntValue { get; set; }
+        public string? StringValue { get; set; }
+
+        public string GetAttributes() => "int_value integer, string_value text";
+        public string GetValues() => $"{IntValue}, NULL";
+    }
+
     public class TypeWithNineParameters(
         int value1,
         int value2,


### PR DESCRIPTION
Fixes #6452

When `ConstructorParameters == 0`, `CompositeBuilder` is unnecessary — it just creates the instance, boxes it, and calls `field.Set()` for each field. This adds a fast path that skips the builder entirely, avoiding per-read allocations.

### Changes
- Add `ReadAndSet` / `SetDbNull` methods to `CompositeFieldInfo` for direct field setting
- Split `CompositeConverter.Read()` into `ReadDirect` (fast path) and `ReadWithBuilder` (existing path)
- Extract `ValidateOid` as a shared static method
- Add test for nullable property through the fast path