### PR TITLE
Support async connection close during NpgsqlDataReader cleanup and NpgsqlCommand exception handling

### DIFF
--- a/src/Npgsql/NpgsqlCommand.cs
+++ b/src/Npgsql/NpgsqlCommand.cs
@@ -1567,7 +1567,7 @@ GROUP BY pg_proc.proargnames, pg_proc.proargtypes, pg_proc.proallargtypes, pg_pr
             if ((behavior & CommandBehavior.CloseConnection) == CommandBehavior.CloseConnection)
             {
                 Debug.Assert(_connector is null && conn is not null);
-                conn.Close();
+                await conn.Close(async).ConfigureAwait(false);
             }
 
             throw;

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -70,7 +70,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     int _columnsStartPos;
 
     /// <summary>
-    /// The index of the column that we're on, i.e. that has already been parsed, is
+    /// The index of the column that we're on, i.e. that has already been parsed,
     /// is memory and can be retrieved. Initialized to -1, which means we're on the column
     /// count (which comes before the first column).
     /// </summary>
@@ -1192,7 +1192,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (_behavior.HasFlag(CommandBehavior.CloseConnection) && !connectionClosing)
         {
             Debug.Assert(_connection is not null);
-            _connection.Close();
+            await _connection.Close(async).ConfigureAwait(false);
         }
 
         if (ReaderClosed != null)
@@ -1321,7 +1321,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// Gets the value of the specified column as a TimeSpan,
     /// </summary>
     /// <remarks>
-    /// PostgreSQL's interval type has has a resolution of 1 microsecond and ranges from
+    /// PostgreSQL's interval type has a resolution of 1 microsecond and ranges from
     /// -178000000 to 178000000 years, while .NET's TimeSpan has a resolution of 100 nanoseconds
     /// and ranges from roughly -29247 to 29247 years.
     /// See https://www.postgresql.org/docs/current/static/datatype-datetime.html
@@ -1335,7 +1335,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
     /// <summary>
     /// Returns a nested data reader for the requested column.
-    /// The column type must be a record or a to Npgsql known composite type, or an array thereof.
+    /// The column type must be a record or a Npgsql known composite type, or an array thereof.
     /// Currently only supported in non-sequential mode.
     /// </summary>
     /// <param name="ordinal">The zero-based column ordinal.</param>
@@ -2101,7 +2101,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
     /// <summary>
     /// Checks that we have a RowDescription, but not necessary an actual resultset
-    /// (for operations which work in SchemaOnly mode.
+    /// (for operations which work in SchemaOnly mode).
     /// </summary>
     FieldDescription GetField(int ordinal)
     {


### PR DESCRIPTION
Call `await _connection.Close(async).ConfigureAwait(false)` instead of `_connection.Close()` to support async behavior.