### PR TITLE
Fix TypeConverter test assertion and unignore test

### DIFF
--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -374,7 +374,7 @@ class RangeTests : TestBase
     public void Parse_malformed_range_throws(string input)
         => Assert.Throws<FormatException>(() => NpgsqlRange<int>.Parse(input));
 
-    [Test, Ignore("Fails only on build server, can't reproduce locally.")]
+    [Test]
     public void TypeConverter()
     {
         // Arrange
@@ -387,7 +387,7 @@ class RangeTests : TestBase
         var result = converter.ConvertFromString("empty");
 
         // Assert
-        Assert.That(result, Is.Empty);
+        Assert.That(result, Is.EqualTo(NpgsqlRange<int>.Empty));
     }
 
     #endregion


### PR DESCRIPTION
Fixed the TypeConverter test assertion to check empty range instead of using NUnit's EmptyConstraint which can't check NpgsqlRange emptiness.

It looks like this was inadvertently changed in the NUnit conversion PR https://github.com/npgsql/npgsql/pull/6183.  This PR essentially puts it back to what it was before, just with the newer assertion syntax.

I'm also attempting to unignore this test to see if it passes now on the build server.