### PR TITLE
Fix range test assertion to check for NpgsqlRange<int>.Empty

### DIFF
--- a/test/Npgsql.Tests/Types/RangeTests.cs
+++ b/test/Npgsql.Tests/Types/RangeTests.cs
@@ -387,7 +387,7 @@ class RangeTests : TestBase
         var result = converter.ConvertFromString("empty");
 
         // Assert
-        Assert.That(result, Is.Empty);
+        Assert.That(result, Is.EqualTo(NpgsqlRange<int>.Empty));
     }
 
     #endregion


### PR DESCRIPTION
Fixed the TypeConverter test assertion to check empty range instead of using NUnit's EmptyConstraint which can't check NpgsqlRange emptiness.

It looks like this was inadvertently changed in the NUnit conversion PR https://github.com/npgsql/npgsql/pull/6183.  This PR essentially puts it back to what it was before, just with the newer assertion syntax.

The test remains ignored, but now passes when run locally.