### PR TITLE
Add missing reg* builtin type mappings

### DIFF
--- a/src/Npgsql/Internal/Postgres/DataTypeNames.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeNames.cs
@@ -79,7 +79,16 @@ static class DataTypeNames
     public static DataTypeName Varbit => ValidatedName("pg_catalog.varbit");
     public static DataTypeName TsVector => ValidatedName("pg_catalog.tsvector");
     public static DataTypeName TsQuery => ValidatedName("pg_catalog.tsquery");
+    public static DataTypeName RegClass => ValidatedName("pg_catalog.regclass");
+    public static DataTypeName RegCollation => ValidatedName("pg_catalog.regcollation");
     public static DataTypeName RegConfig => ValidatedName("pg_catalog.regconfig");
+    public static DataTypeName RegDictionary => ValidatedName("pg_catalog.regdictionary");
+    public static DataTypeName RegNamespace => ValidatedName("pg_catalog.regnamespace");
+    public static DataTypeName RegOper => ValidatedName("pg_catalog.regoper");
+    public static DataTypeName RegOperator => ValidatedName("pg_catalog.regoperator");
+    public static DataTypeName RegProc => ValidatedName("pg_catalog.regproc");
+    public static DataTypeName RegProcedure => ValidatedName("pg_catalog.regprocedure");
+    public static DataTypeName RegRole => ValidatedName("pg_catalog.regrole");
     public static DataTypeName Uuid => ValidatedName("pg_catalog.uuid");
     public static DataTypeName Xml => ValidatedName("pg_catalog.xml");
     public static DataTypeName Json => ValidatedName("pg_catalog.json");

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -280,7 +280,23 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 MatchRequirement.DataTypeName);
 
             // UInt internal types
-            foreach (var dataTypeName in new[] { DataTypeNames.Oid, DataTypeNames.Xid, DataTypeNames.Cid, DataTypeNames.RegType, DataTypeNames.RegConfig })
+            foreach (var dataTypeName in new[]
+                     {
+                         DataTypeNames.Oid,
+                         DataTypeNames.Xid,
+                         DataTypeNames.Cid,
+                         DataTypeNames.RegClass,
+                         DataTypeNames.RegCollation,
+                         DataTypeNames.RegConfig,
+                         DataTypeNames.RegDictionary,
+                         DataTypeNames.RegNamespace,
+                         DataTypeNames.RegOper,
+                         DataTypeNames.RegOperator,
+                         DataTypeNames.RegProc,
+                         DataTypeNames.RegProcedure,
+                         DataTypeNames.RegRole,
+                         DataTypeNames.RegType
+                     })
             {
                 mappings.AddStructType<uint>(dataTypeName,
                     static (options, mapping, _) => mapping.CreateInfo(options, new UInt32Converter()),
@@ -470,7 +486,23 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             mappings.AddArrayType<IDictionary<string, string?>>("hstore");
 
             // UInt internal types
-            foreach (var dataTypeName in new[] { DataTypeNames.Oid, DataTypeNames.Xid, DataTypeNames.Cid, DataTypeNames.RegType, (string)DataTypeNames.RegConfig })
+            foreach (var dataTypeName in new[]
+                     {
+                         DataTypeNames.Oid,
+                         DataTypeNames.Xid,
+                         DataTypeNames.Cid,
+                         DataTypeNames.RegClass,
+                         DataTypeNames.RegCollation,
+                         DataTypeNames.RegConfig,
+                         DataTypeNames.RegDictionary,
+                         DataTypeNames.RegNamespace,
+                         DataTypeNames.RegOper,
+                         DataTypeNames.RegOperator,
+                         DataTypeNames.RegProc,
+                         DataTypeNames.RegProcedure,
+                         DataTypeNames.RegRole,
+                         DataTypeNames.RegType
+                     })
             {
                 mappings.AddStructArrayType<uint>(dataTypeName);
             }

--- a/src/Npgsql/PostgresMinimalDatabaseInfo.cs
+++ b/src/Npgsql/PostgresMinimalDatabaseInfo.cs
@@ -65,7 +65,16 @@ sealed class PostgresMinimalDatabaseInfo : PostgresDatabaseInfo
         Add(DataTypeNames.Varbit, oid: 1562, arrayOid: 1563);
         Add(DataTypeNames.TsVector, oid: 3614, arrayOid: 3643);
         Add(DataTypeNames.TsQuery, oid: 3615, arrayOid: 3645);
+        Add(DataTypeNames.RegClass, oid: 2205, arrayOid: 2210);
+        Add(DataTypeNames.RegCollation, oid: 4191, arrayOid: 4192);
         Add(DataTypeNames.RegConfig, oid: 3734, arrayOid: 3735);
+        Add(DataTypeNames.RegDictionary, oid: 3769, arrayOid: 3770);
+        Add(DataTypeNames.RegNamespace, oid: 4089, arrayOid: 4090);
+        Add(DataTypeNames.RegOper, oid: 2203, arrayOid: 2208);
+        Add(DataTypeNames.RegOperator, oid: 2204, arrayOid: 2209);
+        Add(DataTypeNames.RegProc, oid: 24, arrayOid: 1008);
+        Add(DataTypeNames.RegProcedure, oid: 2202, arrayOid: 2207);
+        Add(DataTypeNames.RegRole, oid: 4096, arrayOid: 4097);
         Add(DataTypeNames.Uuid, oid: 2950, arrayOid: 2951);
         Add(DataTypeNames.Xml, oid: 142, arrayOid: 143);
         Add(DataTypeNames.Json, oid: 114, arrayOid: 199);

--- a/test/Npgsql.Tests/Types/InternalTypeTests.cs
+++ b/test/Npgsql.Tests/Types/InternalTypeTests.cs
@@ -20,26 +20,21 @@ public class InternalTypeTests : TestBase
     }
 
     [Test]
-    [TestCase(NpgsqlDbType.Oid)]
-    [TestCase(NpgsqlDbType.Regtype)]
-    [TestCase(NpgsqlDbType.Regconfig)]
-    public async Task Internal_uint_types(NpgsqlDbType npgsqlDbType)
+    [TestCase("oid")]
+    [TestCase("regtype")]
+    [TestCase("regconfig")]
+    [TestCase("regclass")]
+    [TestCase("regcollation")]
+    [TestCase("regdictionary")]
+    [TestCase("regnamespace")]
+    [TestCase("regoper")]
+    [TestCase("regoperator")]
+    [TestCase("regproc")]
+    [TestCase("regprocedure")]
+    [TestCase("regrole")]
+    public async Task Internal_uint_types(string postgresType)
     {
-        var postgresType = npgsqlDbType.ToString().ToLowerInvariant();
-        using var conn = await OpenConnectionAsync();
-        using var cmd = new NpgsqlCommand($"SELECT @max, 4294967295::{postgresType}, @eight, 8::{postgresType}", conn);
-        cmd.Parameters.AddWithValue("max", npgsqlDbType, uint.MaxValue);
-        cmd.Parameters.AddWithValue("eight", npgsqlDbType, 8u);
-        using var reader = await cmd.ExecuteReaderAsync();
-        reader.Read();
-
-        for (var i = 0; i < reader.FieldCount; i++)
-            Assert.That(reader.GetFieldType(i), Is.EqualTo(typeof(uint)));
-
-        Assert.That(reader.GetValue(0), Is.EqualTo(uint.MaxValue));
-        Assert.That(reader.GetValue(1), Is.EqualTo(uint.MaxValue));
-        Assert.That(reader.GetValue(2), Is.EqualTo(8u));
-        Assert.That(reader.GetValue(3), Is.EqualTo(8u));
+        await AssertType(uint.MaxValue, "4294967295", postgresType, dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test]


### PR DESCRIPTION
Completes the set of builtin `reg*` type mappings by adding `regclass`, `regcollation`, `regdictionary`, `regnamespace`, `regoper`, `regoperator`, `regproc`, `regprocedure`, and `regrole` — all reading/writing as `uint` via the existing `UInt32Converter`.

Closes #5896

### Changes
- `DataTypeNames`: add 9 new `reg*` name constants
- `PostgresMinimalDatabaseInfo`: register OIDs for all 9 new types (scalar + array)
- `AdoTypeInfoResolverFactory`: include all 9 types in both the scalar and array uint mapping loops
- `InternalTypeTests`: merge into a single `AssertType`-based parameterized test covering all 12 builtin uint types