### PR TITLE
Move type loading to use the data type name constructors

### DIFF
--- a/src/Npgsql/Internal/Postgres/DataTypeName.cs
+++ b/src/Npgsql/Internal/Postgres/DataTypeName.cs
@@ -52,13 +52,15 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
     internal static DataTypeName ValidatedName(string fullyQualifiedDataTypeName)
         => new(fullyQualifiedDataTypeName, validated: true);
 
+    bool IsUnqualifiedDisplayName => SchemaSpan is "pg_catalog" || IsUnqualified;
+
     // Includes schema unless it's pg_catalog or the schema is an invalid character used to represent an unspecified schema.
     public string DisplayName =>
-        Value.StartsWith("pg_catalog", StringComparison.Ordinal) || IsUnqualified
+        IsUnqualifiedDisplayName
             ? UnqualifiedDisplayName
             : Schema + "." + UnqualifiedDisplayName;
 
-    public string UnqualifiedDisplayName => ToDisplayName(UnqualifiedNameSpan);
+    public string UnqualifiedDisplayName => ToDisplayName(UnqualifiedNameSpan, mapAliases: IsUnqualifiedDisplayName);
 
     internal ReadOnlySpan<char> SchemaSpan => Value.AsSpan(0, _value.IndexOf('.'));
     public string Schema => Value.Substring(0, _value.IndexOf('.'));
@@ -124,27 +126,20 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
 
     // Create a DataTypeName from a broader range of valid names.
     // including SQL aliases like 'timestamp without time zone', trailing facet info etc.
-    public static DataTypeName FromDisplayName(string displayName, string? schema = null)
-        => FromDisplayName(displayName, schema, assumeUnqualified: false); // user strings may come fully qualified.
-
-    // This method is used during type loading, it allows us to accept friendly names in constructors, without having to preconcatenate the schema.
-    internal static DataTypeName FromDisplayName(string displayName, string? schema, bool assumeUnqualified)
+    public static DataTypeName FromDisplayName(string displayName)
     {
         var displayNameSpan = displayName.AsSpan().Trim();
 
         var schemaEndIndex = displayNameSpan.IndexOf('.');
         ReadOnlySpan<char> schemaSpan;
-        if (schemaEndIndex is not -1 && !assumeUnqualified)
+        if (schemaEndIndex is not -1)
         {
-            if (schema is not null)
-                throw new ArgumentException("Schema provided for a fully qualified name.");
-
             schemaSpan = displayNameSpan.Slice(0, schemaEndIndex);
             displayNameSpan = displayNameSpan.Slice(schemaEndIndex + 1);
         }
         else
         {
-            schemaSpan = schema is null ? $"{InvalidIdentifier}" : schema.AsSpan();
+            schemaSpan = $"{InvalidIdentifier}";
         }
 
         // Then we strip either of the two valid array representations to get the base type name (with or without facets).
@@ -196,7 +191,7 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
             var value => value
         };
 
-        if (schema is null && DataTypeNames.IsWellKnownUnqualifiedName(mapped))
+        if (DataTypeNames.IsWellKnownUnqualifiedName(mapped))
             schemaSpan = "pg_catalog".AsSpan();
 
         return new(string.Concat(schemaSpan, ".", isArray ? "_" : "", mapped));
@@ -207,29 +202,33 @@ public readonly struct DataTypeName : IEquatable<DataTypeName>
     // Additionally array types have a '_' prefix while for readability their element type should be postfixed with '[]'.
     // See the table for all the aliases https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE
     // Alternatively some of the source lives at https://github.com/postgres/postgres/blob/c8e1ba736b2b9e8c98d37a5b77c4ed31baf94147/src/backend/utils/adt/format_type.c#L186
-    static string ToDisplayName(ReadOnlySpan<char> unqualifiedName)
+    static string ToDisplayName(ReadOnlySpan<char> unqualifiedName, bool mapAliases)
     {
         var isArray = unqualifiedName.IndexOf('_') is 0;
         var baseTypeName = isArray ? unqualifiedName.Slice(1) : unqualifiedName;
 
-        var mappedBaseType = baseTypeName switch
+        string? mappedBaseType = null;
+        if (mapAliases)
         {
-            "bool" => "boolean",
-            "bpchar" => "character",
-            "decimal" => "numeric",
-            "float4" => "real",
-            "float8" => "double precision",
-            "int2" => "smallint",
-            "int4" => "integer",
-            "int8" => "bigint",
-            "time" => "time without time zone",
-            "timestamp" => "timestamp without time zone",
-            "timetz" => "time with time zone",
-            "timestamptz" => "timestamp with time zone",
-            "varbit" => "bit varying",
-            "varchar" => "character varying",
-            _ => null
-        };
+            mappedBaseType = baseTypeName switch
+            {
+                "bool" => "boolean",
+                "bpchar" => "character",
+                "decimal" => "numeric",
+                "float4" => "real",
+                "float8" => "double precision",
+                "int2" => "smallint",
+                "int4" => "integer",
+                "int8" => "bigint",
+                "time" => "time without time zone",
+                "timestamp" => "timestamp without time zone",
+                "timetz" => "time with time zone",
+                "timestamptz" => "timestamp with time zone",
+                "varbit" => "bit varying",
+                "varchar" => "character varying",
+                _ => null
+            };
+        }
 
         return isArray
             ? string.Concat(mappedBaseType ?? baseTypeName, "[]")

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql.BackendMessages;
 using Npgsql.Internal;
+using Npgsql.Internal.Postgres;
 using Npgsql.PostgresTypes;
 using Npgsql.Util;
 using static Npgsql.Util.Statics;
@@ -523,7 +524,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
             switch (postgresTypeDefinition.Type)
             {
             case 'b': // Normal base type
-                var baseType = new PostgresBaseType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID);
+                var baseType = new PostgresBaseType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID);
                 byOID[baseType.OID] = baseType;
                 return true;
 
@@ -537,7 +538,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                     return false;
                 }
 
-                var arrayType = new PostgresArrayType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID, elementPostgresType);
+                var arrayType = new PostgresArrayType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID, elementPostgresType);
                 byOID[arrayType.OID] = arrayType;
                 return true;
             }
@@ -552,7 +553,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                     return false;
                 }
 
-                var rangeType = new PostgresRangeType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID, subtypePostgresType);
+                var rangeType = new PostgresRangeType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID, subtypePostgresType);
                 byOID[rangeType.OID] = rangeType;
                 return true;
             }
@@ -573,17 +574,17 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                     return false;
                 }
 
-                var multirangeType = new PostgresMultirangeType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID, rangePostgresType);
+                var multirangeType = new PostgresMultirangeType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID, rangePostgresType);
                 byOID[multirangeType.OID] = multirangeType;
                 return true;
 
             case 'e': // Enum
-                var enumType = new PostgresEnumType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID);
+                var enumType = new PostgresEnumType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID);
                 byOID[enumType.OID] = enumType;
                 return true;
 
             case 'c': // Composite
-                var compositeType = new PostgresCompositeType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID);
+                var compositeType = new PostgresCompositeType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID);
                 byOID[compositeType.OID] = compositeType;
                 return true;
 
@@ -596,7 +597,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
                     return false;
                 }
 
-                var domainType = new PostgresDomainType(postgresTypeDefinition.Namespace, postgresTypeDefinition.Name, postgresTypeDefinition.OID, basePostgresType, postgresTypeDefinition.NotNull);
+                var domainType = new PostgresDomainType(postgresTypeDefinition.DataTypeName, postgresTypeDefinition.OID, basePostgresType, postgresTypeDefinition.NotNull);
                 byOID[domainType.OID] = domainType;
                 return true;
 
@@ -610,4 +611,7 @@ ORDER BY oid{(withEnumSortOrder ? ", enumsortorder" : "")};";
     }
 }
 
-readonly record struct PostgresTypeDefinition(string Namespace, uint OID, string Name, char Type, bool NotNull, uint ElemTypeOID);
+readonly record struct PostgresTypeDefinition(string Namespace, uint OID, string Name, char Type, bool NotNull, uint ElemTypeOID)
+{
+    public DataTypeName DataTypeName => DataTypeName.CreateFullyQualifiedName(Namespace + "." + Name);
+}

--- a/src/Npgsql/PostgresTypes/PostgresType.cs
+++ b/src/Npgsql/PostgresTypes/PostgresType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.PostgresTypes;
@@ -20,13 +21,12 @@ public abstract class PostgresType
     /// Constructs a representation of a PostgreSQL data type.
     /// </summary>
     /// <param name="ns">The data type's namespace (or schema).</param>
-    /// <param name="name">The data type's name.</param>
+    /// <param name="name">The data type's display name.</param>
     /// <param name="oid">The data type's OID.</param>
     private protected PostgresType(string ns, string name, uint oid)
     {
-        DataTypeName = DataTypeName.FromDisplayName(name, ns, assumeUnqualified: true);
+        DataTypeName = DataTypeName.FromDisplayName(ns is null or "pg_catalog" ? name : ns + "." + name);
         OID = oid;
-        FullName = Namespace + "." + Name;
     }
 
     /// <summary>
@@ -38,7 +38,6 @@ public abstract class PostgresType
     {
         DataTypeName = dataTypeName;
         OID = oid.Value;
-        FullName = Namespace + "." + Name;
     }
 
     #endregion
@@ -67,7 +66,8 @@ public abstract class PostgresType
     /// <summary>
     /// The full name of the backend type, including its namespace.
     /// </summary>
-    public string FullName { get; }
+    [field: MaybeNull]
+    public string FullName => field ??= Namespace + "." + Name;
 
     internal DataTypeName DataTypeName { get; }
 

--- a/test/Npgsql.Tests/DataTypeNameTests.cs
+++ b/test/Npgsql.Tests/DataTypeNameTests.cs
@@ -81,6 +81,6 @@ public class DataTypeNameTests
     [TestCase("public._numeric", ExpectedResult = "numeric[]")]
     [TestCase("public.decimal", ExpectedResult = "decimal")]
     [TestCase("public._decimal", ExpectedResult = "decimal[]")]
-    public string UnqualifiedDisplayName(string fullyQuallifiedName)
-        => new DataTypeName(fullyQuallifiedName).UnqualifiedDisplayName;
+    public string UnqualifiedDisplayName(string fullyQualifiedName)
+        => new DataTypeName(fullyQualifiedName).UnqualifiedDisplayName;
 }

--- a/test/Npgsql.Tests/DataTypeNameTests.cs
+++ b/test/Npgsql.Tests/DataTypeNameTests.cs
@@ -60,9 +60,27 @@ public class DataTypeNameTests
     [TestCase("name ", "public", ExpectedResult = "public.name")]
     [TestCase("_name", "public", ExpectedResult = "public._name")]
     [TestCase("name[]", "public", ExpectedResult = "public._name")]
-    [TestCase("timestamp with time zone", "public", ExpectedResult = "public.timestamptz")]
-    [TestCase("boolean(facet_name)", "public", ExpectedResult = "public.bool")]
+    [TestCase("timestamp with time zone", "public", ExpectedResult = "public.timestamp with time zone")]
+    [TestCase("timestamp with time zone", "pg_catalog", ExpectedResult = "pg_catalog.timestamptz")]
+    [TestCase("timestamp with time zone", null, ExpectedResult = "pg_catalog.timestamptz")]
+    [TestCase("boolean(facet_name)", "public", ExpectedResult = "public.boolean(facet_name)")]
+    [TestCase("boolean(facet_name)", "pg_catalog", ExpectedResult = "pg_catalog.bool")]
+    [TestCase("boolean(facet_name)", null, ExpectedResult = "pg_catalog.bool")]
     [TestCase(" public.name ", null, ExpectedResult = "public.name")]
+    [TestCase("decimal", "public", ExpectedResult = "public.decimal")]
+    [TestCase("numeric", "public", ExpectedResult = "public.numeric")]
     public string FromDisplayName(string name, string? schema)
-    => DataTypeName.FromDisplayName(name, schema).Value;
+        => DataTypeName.FromDisplayName(schema is null or "pg_catalog" ? name : schema + "." + name).Value;
+
+    [TestCase("pg_catalog.bool", ExpectedResult = "boolean")]
+    [TestCase("public.bool", ExpectedResult = "bool")]
+    [TestCase("pg_catalog.numeric", ExpectedResult = "numeric")]
+    [TestCase("pg_catalog._numeric", ExpectedResult = "numeric[]")]
+    [TestCase("pg_catalog.decimal", ExpectedResult = "numeric")]
+    [TestCase("public.numeric", ExpectedResult = "numeric")]
+    [TestCase("public._numeric", ExpectedResult = "numeric[]")]
+    [TestCase("public.decimal", ExpectedResult = "decimal")]
+    [TestCase("public._decimal", ExpectedResult = "decimal[]")]
+    public string UnqualifiedDisplayName(string fullyQuallifiedName)
+        => new DataTypeName(fullyQuallifiedName).UnqualifiedDisplayName;
 }


### PR DESCRIPTION
Move type loading to use the data type name constructors, just like we already do in PostgresMinimalDatabaseInfo.

Closes #6367