### PR TITLE
Change bad hostname tests to use .invalid reserved TLD.

### DIFF
--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -307,7 +307,7 @@ public class ConnectionTests : TestBase
     [Test]
     public void Bad_hostname()
     {
-        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.that.does.not.exist");
+        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.invalid");
         using var conn = dataSource.CreateConnection();
 
         Assert.That(
@@ -323,7 +323,7 @@ public class ConnectionTests : TestBase
     [Test]
     public void Bad_hostname_async()
     {
-        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.that.does.not.exist");
+        using var dataSource = CreateDataSource(csb => csb.Host = "hostname.invalid");
         using var conn = dataSource.CreateConnection();
 
         Assert.That(


### PR DESCRIPTION
This is sort of a strange one, but these two tests fail when running locally because my DNS [resolves some potentially malicious domain names to 0.0.0.0](https://developers.cloudflare.com/1.1.1.1/setup/#1111-for-families). The domain name `hostname.that.does.not.exist` resolves to `0.0.0.0` and I have postgres running locally so the tests connect unexpectedly to my locally running postgres instance.

A more robust approach is to use the [`.invalid` reserved TLD](https://en.wikipedia.org/wiki/.invalid), which guarantees that the name will not resolve to something accidentally.

This change allows these two tests to pass when running on my local machine.

