### PR TITLE
Implement dispose method for PoolingDataSource resource cleanup

### DIFF
--- a/src/Npgsql/PoolingDataSource.cs
+++ b/src/Npgsql/PoolingDataSource.cs
@@ -151,7 +151,7 @@ class PoolingDataSource : NpgsqlDataSource
                             try
                             {
                                 var awaiter = _idleConnectorReader.ReadAsync(finalToken).ConfigureAwait(false).GetAwaiter();
-                                var mres = new ManualResetEventSlim(false, 0);
+                                using var mres = new ManualResetEventSlim(false, 0);
 
                                 // Cancellation happens through the ReadAsync call, which will complete the task.
                                 awaiter.UnsafeOnCompleted(() => mres.Set());
@@ -445,4 +445,24 @@ class PoolingDataSource : NpgsqlDataSource
     static int DivideRoundingUp(int value, int divisor) => 1 + (value - 1) / divisor;
 
     #endregion
+
+    /// <inheritdoc />
+    protected override void DisposeBase()
+    {
+        base.DisposeBase();
+
+        // Mark the idle connector channel as complete, which will release all waiting attempts on it with an exception,
+        // and prevent any further attempts to return connectors to it.
+        IdleConnectorWriter.TryComplete();
+    }
+
+    /// <inheritdoc />
+    protected override async ValueTask DisposeAsyncBase()
+    {
+        await base.DisposeAsyncBase().ConfigureAwait(false);
+
+        // Mark the idle connector channel as complete, which will release all waiting attempts on it with an exception,
+        // and prevent any further attempts to return connectors to it.
+        IdleConnectorWriter.TryComplete();
+    }
 }

--- a/test/Npgsql.Tests/PoolTests.cs
+++ b/test/Npgsql.Tests/PoolTests.cs
@@ -69,6 +69,37 @@ class PoolTests : TestBase
     }
 
     [Test]
+    public async Task Dispose_releases_waiter_from_exhausted_pool([Values(true, false)] bool async)
+    {
+        await using var dataSource = CreateDataSource(csb =>
+        {
+            csb.MaxPoolSize = 1;
+            csb.Timeout = 5;
+        });
+
+        await using var conn1 = await dataSource.OpenConnectionAsync();
+
+        // Pool is exhausted
+        await using var conn2 = dataSource.CreateConnection();
+        var openTask = async
+            ? conn2.OpenAsync()
+            : Task.Run(() => conn2.Open());
+
+        // Make sure that the openTask is blocked
+        Assert.That(await Task.WhenAny(openTask, Task.Delay(100)), Is.Not.SameAs(openTask));
+
+        // Dispose the pool while the openTask is waiting for a connection. This should cause the openTask to complete with an exception.
+        if (async)
+            await dataSource.DisposeAsync();
+        else
+            dataSource.Dispose();
+
+        // Now openTask should complete with an exception
+        Assert.That(await Task.WhenAny(openTask, Task.Delay(TimeSpan.FromSeconds(1))), Is.SameAs(openTask));
+        Assert.That(async () => await openTask, Throws.Exception.TypeOf<NpgsqlException>().With.Message.EqualTo("The connection pool has been shut down."));
+    }
+
+    [Test]
     public async Task Timeout_getting_connector_from_exhausted_pool([Values(true, false)] bool async)
     {
         await using var dataSource = CreateDataSource(csb =>


### PR DESCRIPTION
This pull request introduces improvements to the connection pool disposal logic in `PoolingDataSource`, ensuring that pending connection requests are properly released when the pool is disposed. Additionally, a new test verifies this behavior. The most important changes are grouped below:

Connection pool disposal improvements:

* Added `DisposeBase` and `DisposeAsyncBase` overrides in `PoolingDataSource` to mark the idle connector channel as complete, ensuring all waiting connection attempts are released with an exception when the pool is disposed.
* Updated the use of `ManualResetEventSlim` in `RentAsync` to ensure proper disposal by using a `using` statement.

Testing enhancements:

* Added the `Dispose_releases_waiter_from_exhausted_pool` test in `PoolTests.cs` to verify that disposing the pool releases blocked connection requests with an exception, covering both synchronous and asynchronous disposal scenarios.

Fixes #6514 