### PR TITLE
Add explicit release notes URL when they are mentioned in error messages

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -78,13 +78,13 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// The global type mapper, which contains defaults used by all new connections.
     /// Modify mappings on this mapper to affect your entire application.
     /// </summary>
-    [Obsolete("Global-level type mapping has been replaced with data source mapping, see the 7.0 release notes.")]
+    [Obsolete("Global-level type mapping has been replaced with data source mapping, see the 7.0 release notes at https://www.npgsql.org/doc/release-notes/7.0.html#managing-type-mappings-at-the-connection-level-is-no-longer-supported for more information.")]
     public static INpgsqlTypeMapper GlobalTypeMapper => TypeMapping.GlobalTypeMapper.Instance;
 
     /// <summary>
-    /// Connection-level type mapping is no longer supported. See the 7.0 release notes for configuring type mapping on NpgsqlDataSource.
+    /// Connection-level type mapping is no longer supported. See the 7.0 release notes at https://www.npgsql.org/doc/release-notes/7.0.html#managing-type-mappings-at-the-connection-level-is-no-longer-supported for configuring type mapping on NpgsqlDataSource.
     /// </summary>
-    [Obsolete("Connection-level type mapping is no longer supported. See the 7.0 release notes for configuring type mapping on NpgsqlDataSource.", true)]
+    [Obsolete("Connection-level type mapping is no longer supported. See the 7.0 release notes at https://www.npgsql.org/doc/release-notes/7.0.html#managing-type-mappings-at-the-connection-level-is-no-longer-supported for configuring type mapping on NpgsqlDataSource.", true)]
     public INpgsqlTypeMapper TypeMapper
         => throw new NotSupportedException();
 

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1374,7 +1374,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     [Description("Load table composite type definitions, and not just free-standing composite types.")]
     [DisplayName("Load Table Composites")]
     [NpgsqlConnectionStringProperty]
-    [Obsolete("Specifying type loading options through the connection string is obsolete, use the DataSource builder instead. See the 9.0 release notes for more information.")]
+    [Obsolete("Specifying type loading options through the connection string is obsolete, use the DataSource builder instead. See the 9.0 release notes at https://www.npgsql.org/doc/release-notes/9.0.html#obsoleted-the-server-compatibility-mode-and-load-table-composites-connection-string-parameters for more information.")]
     public bool LoadTableComposites
     {
         get => _loadTableComposites;
@@ -1393,7 +1393,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     [Description("A compatibility mode for special PostgreSQL server types.")]
     [DisplayName("Server Compatibility Mode")]
     [NpgsqlConnectionStringProperty]
-    [Obsolete("Specifying type loading options through the connection string is obsolete, use the DataSource builder instead. See the 9.0 release notes for more information.")]
+    [Obsolete("Specifying type loading options through the connection string is obsolete, use the DataSource builder instead. See the 9.0 release notes at https://www.npgsql.org/doc/release-notes/9.0.html#obsoleted-the-server-compatibility-mode-and-load-table-composites-connection-string-parameters for more information.")]
     public ServerCompatibilityMode ServerCompatibilityMode
     {
         // Physical replication connections don't allow regular queries, so we can't load types from PG

--- a/src/Npgsql/Properties/NpgsqlStrings.resx
+++ b/src/Npgsql/Properties/NpgsqlStrings.resx
@@ -70,7 +70,7 @@
         <value>ValidationRootCertificateCallback cannot be used in conjunction with SslClientAuthenticationOptionsCallback overwriting RemoteCertificateValidationCallback; when registering a validation callback, perform whatever validation you require in that callback.</value>
     </data>
     <data name="RecordsNotEnabled" xml:space="preserve">
-        <value>Could not read a PostgreSQL record. If you're attempting to read a record as a .NET tuple, call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/basic.html and the 8.0 release notes for more details). If you're reading a record as a .NET object array using NpgsqlSlimDataSourceBuilder, call '{2}'.
+        <value>Could not read a PostgreSQL record. If you're attempting to read a record as a .NET tuple, call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/basic.html and the 8.0 release notes at https://www.npgsql.org/doc/release-notes/8.0.html for more details). If you're reading a record as a .NET object array using NpgsqlSlimDataSourceBuilder, call '{2}'.
 </value>
     </data>
     <data name="FullTextSearchNotEnabled" xml:space="preserve">
@@ -98,14 +98,14 @@
         <value>Cannot write DateTime with Kind=UTC. Consider using timestamptz instead. Note that it's not possible to mix DateTimes with different Kinds in an array, range, or multirange.</value>
     </data>
     <data name="DynamicJsonNotEnabled" xml:space="preserve">
-        <value>Type '{0}' required dynamic JSON serialization, which requires an explicit opt-in; call '{1}' on '{2}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/json.html and the 8.0 release notes for more details). Alternatively, if you meant to use Newtonsoft JSON.NET instead of System.Text.Json, call UseJsonNet() instead.
+        <value>Type '{0}' required dynamic JSON serialization, which requires an explicit opt-in; call '{1}' on '{2}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/json.html and the 8.0 release notes at https://www.npgsql.org/doc/release-notes/8.0.html for more details). Alternatively, if you meant to use Newtonsoft JSON.NET instead of System.Text.Json, call UseJsonNet() instead.
 </value>
     </data>
     <data name="UnmappedEnumsNotEnabled" xml:space="preserve">
-        <value>Reading and writing unmapped enums requires an explicit opt-in; call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/enums_and_composites.html and the 8.0 release notes for more details).</value>
+        <value>Reading and writing unmapped enums requires an explicit opt-in; call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/enums_and_composites.html and the 8.0 release notes at https://www.npgsql.org/doc/release-notes/8.0.html for more details).</value>
     </data>
     <data name="UnmappedRangesNotEnabled" xml:space="preserve">
-        <value>Reading and writing unmapped ranges and multiranges requires an explicit opt-in; call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/ranges.html and the 8.0 release notes for more details).</value>
+        <value>Reading and writing unmapped ranges and multiranges requires an explicit opt-in; call '{0}' on '{1}' or NpgsqlConnection.GlobalTypeMapper (see https://www.npgsql.org/doc/types/ranges.html and the 8.0 release notes at https://www.npgsql.org/doc/release-notes/8.0.html for more details).</value>
     </data>
     <data name="SslClientAuthenticationOptionsCallbackWithOtherCallbacksNotSupported" xml:space="preserve">
         <value>SslClientAuthenticationOptionsCallback is not supported together with UserCertificateValidationCallback and ClientCertificatesCallback</value>


### PR DESCRIPTION
It's not hard to find the Npgsql release notes but it's even better if the exact URL is just one click away because it's included in the error messages.