### PR TITLE
Add back parameterless overload of ReloadTypesAsync

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1752,7 +1752,14 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// Flushes the type cache for this connection's connection string and reloads the types for this connection only.
     /// Type changes will appear for other connections only after they are re-opened from the pool.
     /// </summary>
-    public async Task ReloadTypesAsync(CancellationToken cancellationToken = default)
+    public Task ReloadTypesAsync()
+        => ReloadTypesAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Flushes the type cache for this connection's connection string and reloads the types for this connection only.
+    /// Type changes will appear for other connections only after they are re-opened from the pool.
+    /// </summary>
+    public async Task ReloadTypesAsync(CancellationToken cancellationToken)
     {
         CheckReady();
 

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -402,6 +402,7 @@ Npgsql.NpgsqlConnection.ProvidePasswordCallback.get -> Npgsql.ProvidePasswordCal
 Npgsql.NpgsqlConnection.ProvidePasswordCallback.set -> void
 Npgsql.NpgsqlConnection.ReloadTypes() -> void
 Npgsql.NpgsqlConnection.ReloadTypesAsync() -> System.Threading.Tasks.Task!
+Npgsql.NpgsqlConnection.ReloadTypesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Npgsql.NpgsqlConnection.Timezone.get -> string!
 Npgsql.NpgsqlConnection.TypeMapper.get -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 Npgsql.NpgsqlConnection.UnprepareAll() -> void

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -98,7 +98,6 @@ override Npgsql.NpgsqlDataReader.GetColumnSchemaAsync(System.Threading.Cancellat
 override Npgsql.NpgsqlMultiHostDataSource.Clear() -> void
 Npgsql.NpgsqlDataSource.ReloadTypes() -> void
 Npgsql.NpgsqlDataSource.ReloadTypesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Npgsql.NpgsqlConnection.ReloadTypesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*Npgsql.NpgsqlLargeObjectManager
 *REMOVED*Npgsql.NpgsqlLargeObjectManager.Create(uint preferredOid = 0) -> uint
 *REMOVED*Npgsql.NpgsqlLargeObjectManager.CreateAsync(uint preferredOid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<uint>!
@@ -121,7 +120,6 @@ Npgsql.NpgsqlConnection.ReloadTypesAsync(System.Threading.CancellationToken canc
 *REMOVED*Npgsql.NpgsqlLargeObjectStream.Has64BitSupport.get -> bool
 *REMOVED*Npgsql.NpgsqlLargeObjectStream.SeekAsync(long offset, System.IO.SeekOrigin origin, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>!
 *REMOVED*Npgsql.NpgsqlLargeObjectStream.SetLength(long value, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-*REMOVED*Npgsql.NpgsqlConnection.ReloadTypesAsync() -> System.Threading.Tasks.Task!
 *REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapComposite(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapComposite<T>(string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*Npgsql.NpgsqlDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, Npgsql.INpgsqlNameTranslator? nameTranslator = null) -> Npgsql.TypeMapping.INpgsqlTypeMapper!


### PR DESCRIPTION
#5919 caused a binary break by replaceing `NpgsqlConnection.ReloadTypesAsync()` with `ReloadTypesAsync(CancellationToken)`; this notably blocks people from using the PostgreSQL MEVD provider - which is compiled against Npgsql 8.0 (to be netfx-compatible) - with Npgsql 10.0.