### PR TITLE
Default metrics pool name to Application Name from connection string

### DIFF
--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -127,12 +127,12 @@ public abstract class NpgsqlDataSource : DbDataSource
             ConnectionString = settings.ToString();
 
             // The data source name is reported in tracing/metrics, so avoid leaking the password through there.
-            Name = name ?? settings.ToStringWithoutPassword();
+            Name = name ?? settings.ApplicationName ?? settings.ToStringWithoutPassword();
         }
         else
         {
             ConnectionString = settings.ToStringWithoutPassword();
-            Name = name ?? ConnectionString;
+            Name = name ?? settings.ApplicationName ?? ConnectionString;
         }
 
         _password = settings.Password;

--- a/test/Npgsql.Tests/MetricTests.cs
+++ b/test/Npgsql.Tests/MetricTests.cs
@@ -128,6 +128,29 @@ public class MetricTests : TestBase
     }
 
     [Test]
+    public async Task Pool_name_defaults_to_application_name()
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter("Npgsql")
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var applicationName = "MetricsDataSource" + Interlocked.Increment(ref _dataSourceCounter);
+        var dataSourceBuilder = base.CreateDataSourceBuilder();
+        dataSourceBuilder.ConnectionStringBuilder.ApplicationName = applicationName;
+        // Do not set the data source name - this makes the pool name default to the Application Name
+        await using var dataSource = dataSourceBuilder.Build();
+
+        meterProvider.ForceFlush();
+
+        var metric = exportedItems.Single(m => m.Name == "db.client.connection.max");
+        var point = GetFilteredPoints(metric.GetMetricPoints(), dataSource.Name).First();
+        var tags = ToDictionary(point.Tags);
+        Assert.That(tags["db.client.connection.pool.name"], Is.EqualTo(applicationName));
+    }
+
+    [Test]
     public async Task Password_does_not_leak_via_datasource_name([Values] bool persistSecurityInfo)
     {
         var exportedItems = new List<Metric>();
@@ -137,10 +160,9 @@ public class MetricTests : TestBase
             .Build();
 
         var dataSourceBuilder = base.CreateDataSourceBuilder();
-        dataSourceBuilder.ConnectionStringBuilder.ApplicationName = "MetricsDataSource" + Interlocked.Increment(ref _dataSourceCounter);
         dataSourceBuilder.ConnectionStringBuilder.PersistSecurityInfo = persistSecurityInfo;
-        // Do not set the data source name - this makes it default to the connection string, but without
-        // the password (even when Persist Security Info is true)
+        // Do not set the data source name or the application name - this makes the pool name default to the
+        // connection string, but without the password (even when Persist Security Info is true)
         await using var dataSource = dataSourceBuilder.Build();
 
         meterProvider.ForceFlush();


### PR DESCRIPTION
When no explicit `NpgsqlDataSourceBuilder.Name` is set, the `db.client.connection.pool.name` metric tag currently defaults to the full connection string, making metrics hard to distinguish in monitoring dashboards. This change defaults it to the `Application Name` from the connection string instead, falling back to the connection string only if `Application Name` is also unset.

The fallback priority is now:
1. Explicit `NpgsqlDataSourceBuilder.Name` (unchanged)
2. `ApplicationName` from the connection string (**new**)
3. Connection string (existing fallback)

This is done by inserting `settings.ApplicationName` in the `Name` assignment chain in `NpgsqlDataSource.cs`. No new connection string property is needed.

Tests:
- Added `Pool_name_defaults_to_application_name` verifying the new fallback behavior
- Updated `Password_does_not_leak_via_datasource_name` to test the connection-string fallback path (no `ApplicationName` set)

Closes #6531