### PR TITLE
Modernize NRT annotations on NpgsqlRange<T>

### DIFF
--- a/src/Npgsql.NodaTime/Internal/DateIntervalConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/DateIntervalConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NodaTime;
@@ -21,6 +22,9 @@ public class DateIntervalConverter(PgConverter<NpgsqlRange<LocalDate>> rangeConv
             ? await rangeConverter.ReadAsync(reader, cancellationToken).ConfigureAwait(false)
             // ReSharper disable once MethodHasAsyncOverloadWithCancellation
             : rangeConverter.Read(reader);
+
+        if (range.IsEmpty)
+            throw new InvalidCastException("Cannot read an empty range as a NodaTime DateInterval.");
 
         var upperBound = range.UpperBound;
 

--- a/src/Npgsql.NodaTime/Internal/IntervalConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/IntervalConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NodaTime;
@@ -20,6 +21,9 @@ sealed class IntervalConverter(PgConverter<NpgsqlRange<Instant>> rangeConverter,
             ? await rangeConverter.ReadAsync(reader, cancellationToken).ConfigureAwait(false)
             // ReSharper disable once MethodHasAsyncOverloadWithCancellation
             : rangeConverter.Read(reader);
+
+        if (range.IsEmpty)
+            throw new InvalidCastException("Cannot read an empty range as a NodaTime Interval.");
 
         // NodaTime Interval includes the start instant and excludes the end instant.
         Instant? start = range.LowerBoundInfinite

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -140,7 +140,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <param name="lowerBound">The lower bound of the range.</param>
     /// <param name="upperBound">The upper bound of the range.</param>
     public NpgsqlRange(T lowerBound, T upperBound)
-        : this(lowerBound, true, false, upperBound, true, false) { }
+        : this(lowerBound, lowerBoundIsInclusive: true, lowerBoundInfinite: false, upperBound, upperBoundIsInclusive: true, upperBoundInfinite: false) { }
 
     /// <summary>
     /// Constructs an <see cref="NpgsqlRange{T}"/> with definite bounds.
@@ -150,7 +150,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <param name="upperBound">The upper bound of the range.</param>
     /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
     public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, T upperBound, bool upperBoundIsInclusive)
-        : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) { }
+        : this(lowerBound, lowerBoundIsInclusive, lowerBoundInfinite: false, upperBound, upperBoundIsInclusive, upperBoundInfinite: false) { }
 
     /// <summary>
     /// Constructs an <see cref="NpgsqlRange{T}"/>.

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -95,14 +95,12 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <summary>
     /// The lower bound of the range. Only valid when <see cref="LowerBoundInfinite"/> is false.
     /// </summary>
-    [MaybeNull, AllowNull]
-    public T LowerBound { get; }
+    public T? LowerBound { get; }
 
     /// <summary>
     /// The upper bound of the range. Only valid when <see cref="UpperBoundInfinite"/> is false.
     /// </summary>
-    [MaybeNull, AllowNull]
-    public T UpperBound { get; }
+    public T? UpperBound { get; }
 
     /// <summary>
     /// The characteristics of the boundaries.
@@ -122,11 +120,13 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <summary>
     /// True if the lower bound is indefinite (i.e. infinite or unbounded); otherwise, false.
     /// </summary>
+    [MemberNotNullWhen(false, nameof(LowerBound))]
     public bool LowerBoundInfinite => (Flags & RangeFlags.LowerBoundInfinite) != 0;
 
     /// <summary>
     /// True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.
     /// </summary>
+    [MemberNotNullWhen(false, nameof(UpperBound))]
     public bool UpperBoundInfinite => (Flags & RangeFlags.UpperBoundInfinite) != 0;
 
     /// <summary>
@@ -139,7 +139,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// </summary>
     /// <param name="lowerBound">The lower bound of the range.</param>
     /// <param name="upperBound">The upper bound of the range.</param>
-    public NpgsqlRange([AllowNull] T lowerBound, [AllowNull] T upperBound)
+    public NpgsqlRange(T lowerBound, T upperBound)
         : this(lowerBound, true, false, upperBound, true, false) { }
 
     /// <summary>
@@ -149,9 +149,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <param name="lowerBoundIsInclusive">True if the lower bound is is part of the range (i.e. inclusive); otherwise, false.</param>
     /// <param name="upperBound">The upper bound of the range.</param>
     /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
-    public NpgsqlRange(
-        [AllowNull] T lowerBound, bool lowerBoundIsInclusive,
-        [AllowNull] T upperBound, bool upperBoundIsInclusive)
+    public NpgsqlRange(T lowerBound, bool lowerBoundIsInclusive, T upperBound, bool upperBoundIsInclusive)
         : this(lowerBound, lowerBoundIsInclusive, false, upperBound, upperBoundIsInclusive, false) { }
 
     /// <summary>
@@ -163,9 +161,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <param name="upperBound">The upper bound of the range.</param>
     /// <param name="upperBoundIsInclusive">True if the upper bound is part of the range (i.e. inclusive); otherwise, false.</param>
     /// <param name="upperBoundInfinite">True if the upper bound is indefinite (i.e. infinite or unbounded); otherwise, false.</param>
-    public NpgsqlRange(
-        [AllowNull] T lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite,
-        [AllowNull] T upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
+    public NpgsqlRange(T? lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite, T? upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite)
         : this(
             lowerBound,
             upperBound,
@@ -181,7 +177,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <param name="lowerBound">The lower bound of the range.</param>
     /// <param name="upperBound">The upper bound of the range.</param>
     /// <param name="flags">The characteristics of the range boundaries.</param>
-    internal NpgsqlRange([AllowNull] T lowerBound, [AllowNull] T upperBound, RangeFlags flags) : this()
+    internal NpgsqlRange(T? lowerBound, T? upperBound, RangeFlags flags) : this()
     {
         // TODO: We need to check if the bounds are implicitly empty. E.g. '(1,1)' or '(0,0]'.
         // See: https://github.com/npgsql/npgsql/issues/1943.
@@ -207,7 +203,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     /// <returns>
     /// True if the range is implicitly empty; otherwise, false.
     /// </returns>
-    static bool IsEmptyRange([AllowNull] T lowerBound, [AllowNull] T upperBound, RangeFlags flags)
+    static bool IsEmptyRange(T? lowerBound, T? upperBound, RangeFlags flags)
     {
         // ---------------------------------------------------------------------------------
         // We only want to check for those conditions that are unambiguously erroneous:
@@ -234,7 +230,7 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
             return false;
 
         if (!HasEquatableBounds)
-            return lowerBound?.Equals(upperBound) ?? false;
+            return lowerBound.Equals(upperBound);
 
         var lower = (IEquatable<T>)lowerBound;
         var upper = (IEquatable<T>)upperBound;

--- a/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
+++ b/src/Npgsql/NpgsqlTypes/NpgsqlRange.cs
@@ -93,12 +93,12 @@ public readonly struct NpgsqlRange<T> : IEquatable<NpgsqlRange<T>>
     public static readonly NpgsqlRange<T> Empty = new(default, default, RangeFlags.Empty);
 
     /// <summary>
-    /// The lower bound of the range. Only valid when <see cref="LowerBoundInfinite"/> is false.
+    /// The lower bound of the range. Only valid when <see cref="LowerBoundInfinite"/> is false (i.e. the range is non-empty with a finite lower bound).
     /// </summary>
     public T? LowerBound { get; }
 
     /// <summary>
-    /// The upper bound of the range. Only valid when <see cref="UpperBoundInfinite"/> is false.
+    /// The upper bound of the range. Only valid when <see cref="UpperBoundInfinite"/> is false (i.e. the range is non-empty with a finite upper bound).
     /// </summary>
     public T? UpperBound { get; }
 

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -40,3 +40,6 @@
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.SetLength(long value) -> void
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Write(byte[]! buffer, int offset, int count) -> void
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.WriteAsync(byte[]! buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+NpgsqlTypes.NpgsqlRange<T>.LowerBound.get -> T?
+NpgsqlTypes.NpgsqlRange<T>.UpperBound.get -> T?
+NpgsqlTypes.NpgsqlRange<T>.NpgsqlRange(T? lowerBound, bool lowerBoundIsInclusive, bool lowerBoundInfinite, T? upperBound, bool upperBoundIsInclusive, bool upperBoundInfinite) -> void


### PR DESCRIPTION
This was still using .NET 3.0 annotation style for unconstrained generics. 

The two constructors that don't flow infinite flags should only accept T because any nulls + non infinite bounds is not valid. 

For the 6 parameter constructor we do have a bit of missing validation as far as I understand. Currently a user can pass e.g. a null string and say the bound is not infinite, we then later normalize this in the RangeConverter as infinite again. But why not also in the type itself? I see how there is some ugliness around default(NpgsqlRange) values with implications on the flags we believe are enabled (though we could fix this in the type too). 

Maybe you have some more historical context @roji?