### PR TITLE
Add consistent nullable unwrapping to dynamic resolvers

### DIFF
--- a/src/Npgsql.Json.NET/Internal/JsonNetPocoTypeInfoResolverFactory.cs
+++ b/src/Npgsql.Json.NET/Internal/JsonNetPocoTypeInfoResolverFactory.cs
@@ -63,7 +63,9 @@ sealed class JsonNetPocoTypeInfoResolverFactory(
                              || dataTypeName != JsonbDataTypeName && dataTypeName != JsonDataTypeName)
                 return null;
 
-            return CreateCollection().AddMapping(type, dataTypeName, (options, mapping, _) =>
+            var matchedType = Nullable.GetUnderlyingType(type) ?? type;
+
+            return CreateCollection().AddMapping(matchedType, dataTypeName, (options, mapping, _) =>
             {
                 var jsonb = dataTypeName == JsonbDataTypeName;
                 return mapping.CreateInfo(options,
@@ -98,7 +100,12 @@ sealed class JsonNetPocoTypeInfoResolverFactory(
 
             var dynamicMappings = CreateCollection(baseMappings);
             foreach (var mapping in baseMappings.Items)
+            {
+                // Always handle Nullable<T> mappings as part of the underlying type.
+                if (Nullable.GetUnderlyingType(mapping.Type) is not null)
+                    continue;
                 dynamicMappings.AddArrayMapping(mapping.Type, mapping.DataTypeName);
+            }
             mappings.AddRange(dynamicMappings.ToTypeInfoMappingCollection());
 
             return mappings;
@@ -106,9 +113,8 @@ sealed class JsonNetPocoTypeInfoResolverFactory(
 
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
             => type is not null && IsArrayLikeType(type, out var elementType) && IsArrayDataTypeName(dataTypeName, options, out var elementDataTypeName)
-                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(elementType, elementDataTypeName)
+                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(Nullable.GetUnderlyingType(elementType) ?? elementType, elementDataTypeName)
                 : null;
     }
-
 }
 

--- a/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
+++ b/src/Npgsql/Internal/DynamicTypeInfoResolver.cs
@@ -55,10 +55,11 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
 
         public DynamicMappingCollection AddMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type type, string dataTypeName, TypeInfoFactory factory, Func<TypeInfoMapping, TypeInfoMapping>? configureMapping = null)
         {
-            if (type.IsValueType && Nullable.GetUnderlyingType(type) is not null)
-                throw new NotSupportedException("Mapping nullable types is not supported, map its underlying type instead to get both.");
-
             if (type.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(type) is not null)
+                    throw new NotSupportedException("Mapping nullable types is not supported, map its underlying type instead to get both.");
+
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddStructType), [typeof(string), typeof(TypeInfoFactory), typeof(Func<TypeInfoMapping, TypeInfoMapping>)])!
                     .MakeGenericMethod(type).Invoke(_mappings ??= new(),
@@ -67,7 +68,9 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
                         factory,
                         configureMapping
                     ]);
+            }
             else
+            {
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddType), [typeof(string), typeof(TypeInfoFactory), typeof(Func<TypeInfoMapping, TypeInfoMapping>)])!
                     .MakeGenericMethod(type).Invoke(_mappings ??= new(),
@@ -76,28 +79,37 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
                         factory,
                         configureMapping
                     ]);
+            }
             return this;
         }
 
         public DynamicMappingCollection AddArrayMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type elementType, string dataTypeName)
         {
             if (elementType.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(elementType) is not null)
+                    throw new NotSupportedException("Mapping nullable types is not supported, map its underlying type instead to get both.");
+
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddStructArrayType), [typeof(string)])!
                     .MakeGenericMethod(elementType).Invoke(_mappings ??= new(), [dataTypeName]);
+            }
             else
+            {
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddArrayType), [typeof(string)])!
                     .MakeGenericMethod(elementType).Invoke(_mappings ??= new(), [dataTypeName]);
+            }
             return this;
         }
 
         public DynamicMappingCollection AddResolverMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type type, string dataTypeName, TypeInfoFactory factory, Func<TypeInfoMapping, TypeInfoMapping>? configureMapping = null)
         {
-            if (type.IsValueType && Nullable.GetUnderlyingType(type) is not null)
-                throw new NotSupportedException("Mapping nullable types is not supported");
-
             if (type.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(type) is not null)
+                    throw new NotSupportedException("Mapping nullable types is not supported, map its underlying type instead to get both.");
+
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddProviderStructType), [typeof(string), typeof(TypeInfoFactory), typeof(Func<TypeInfoMapping, TypeInfoMapping>)])!
                     .MakeGenericMethod(type).Invoke(_mappings ??= new(),
@@ -106,7 +118,9 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
                         factory,
                         configureMapping
                     ]);
+            }
             else
+            {
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddProviderType), [typeof(string), typeof(TypeInfoFactory), typeof(Func<TypeInfoMapping, TypeInfoMapping>)])!
                     .MakeGenericMethod(type).Invoke(_mappings ??= new(),
@@ -115,19 +129,27 @@ public abstract class DynamicTypeInfoResolver : IPgTypeInfoResolver
                         factory,
                         configureMapping
                     ]);
+            }
             return this;
         }
 
         public DynamicMappingCollection AddResolverArrayMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]Type elementType, string dataTypeName)
         {
             if (elementType.IsValueType)
+            {
+                if (Nullable.GetUnderlyingType(elementType) is not null)
+                    throw new NotSupportedException("Mapping nullable types is not supported, map its underlying type instead to get both.");
+
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddProviderStructArrayType), [typeof(string)])!
                     .MakeGenericMethod(elementType).Invoke(_mappings ??= new(), [dataTypeName]);
+            }
             else
+            {
                 typeof(TypeInfoMappingCollection)
                     .GetMethod(nameof(TypeInfoMappingCollection.AddProviderArrayType), [typeof(string)])!
                     .MakeGenericMethod(elementType).Invoke(_mappings ??= new(), [dataTypeName]);
+            }
             return this;
         }
 

--- a/src/Npgsql/Internal/ResolverFactories/JsonDynamicTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/JsonDynamicTypeInfoResolverFactory.cs
@@ -98,7 +98,9 @@ sealed class JsonDynamicTypeInfoResolverFactory(
                                        || dataTypeName != DataTypeNames.Jsonb && dataTypeName != DataTypeNames.Json)
                 return null;
 
-            return CreateCollection().AddMapping(type, dataTypeName, (options, mapping, _) =>
+            var matchedType = Nullable.GetUnderlyingType(type) ?? type;
+
+            return CreateCollection().AddMapping(matchedType, dataTypeName, (options, mapping, _) =>
             {
                 var jsonb = dataTypeName == DataTypeNames.Jsonb;
 
@@ -133,7 +135,8 @@ sealed class JsonDynamicTypeInfoResolverFactory(
 
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
             => type is not null && IsArrayLikeType(type, out var elementType) && IsArrayDataTypeName(dataTypeName, options, out var elementDataTypeName)
-                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(elementType, elementDataTypeName)
+                ? base.GetMappings(elementType, elementDataTypeName, options)
+                    ?.AddArrayMapping(Nullable.GetUnderlyingType(elementType) ?? elementType, elementDataTypeName)
                 : null;
 
         static TypeInfoMappingCollection AddMappings(TypeInfoMappingCollection mappings, TypeInfoMappingCollection baseMappings)
@@ -143,7 +146,12 @@ sealed class JsonDynamicTypeInfoResolverFactory(
 
             var dynamicMappings = CreateCollection(baseMappings);
             foreach (var mapping in baseMappings.Items)
+            {
+                // Always handle Nullable<T> mappings as part of the underlying type.
+                if (Nullable.GetUnderlyingType(mapping.Type) is not null)
+                    continue;
                 dynamicMappings.AddArrayMapping(mapping.Type, mapping.DataTypeName);
+            }
             mappings.AddRange(dynamicMappings.ToTypeInfoMappingCollection());
 
             return mappings;

--- a/src/Npgsql/Internal/ResolverFactories/TupledRecordTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/TupledRecordTypeInfoResolverFactory.cs
@@ -19,12 +19,13 @@ sealed class TupledRecordTypeInfoResolverFactory : PgTypeInfoResolverFactory
     {
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
-            if (!(dataTypeName == DataTypeNames.Record && type is { IsConstructedGenericType: true, FullName: not null } && (
-                    type.FullName.StartsWith("System.Tuple", StringComparison.Ordinal)
-                    || type.FullName.StartsWith("System.ValueTuple", StringComparison.Ordinal))))
+            if (dataTypeName != DataTypeNames.Record || type is null || !IsTypeOrNullableOfType(type,
+                    static type => type is { IsConstructedGenericType: true, FullName: not null } &&
+                        (type.FullName.StartsWith("System.Tuple", StringComparison.Ordinal) ||
+                        type.FullName.StartsWith("System.ValueTuple", StringComparison.Ordinal)), out var matchedType))
                 return null;
 
-            return CreateCollection().AddMapping(type, dataTypeName, (options, mapping, _) =>
+            return CreateCollection().AddMapping(matchedType, dataTypeName, (options, mapping, _) =>
             {
                 var constructors = mapping.Type.GetConstructors();
                 ConstructorInfo? constructor = null;
@@ -68,7 +69,7 @@ sealed class TupledRecordTypeInfoResolverFactory : PgTypeInfoResolverFactory
     {
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
             => type is not null && IsArrayLikeType(type, out var elementType) && IsArrayDataTypeName(dataTypeName, options, out var elementDataTypeName)
-                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(elementType, elementDataTypeName)
+                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(Nullable.GetUnderlyingType(elementType) ?? elementType, elementDataTypeName)
                 : null;
     }
 }

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -58,7 +58,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
     {
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
             => type is not null && IsArrayLikeType(type, out var elementType) && IsArrayDataTypeName(dataTypeName, options, out var elementDataTypeName)
-                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(elementType, elementDataTypeName)
+                ? base.GetMappings(elementType, elementDataTypeName, options)?.AddArrayMapping(Nullable.GetUnderlyingType(elementType) ?? elementType, elementDataTypeName)
                 : null;
     }
 
@@ -114,7 +114,12 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 return null;
 
             var mappings = base.GetMappings(elementType, elementDataTypeName, options);
+
             elementType ??= mappings?.Find(null, elementDataTypeName, options)?.Type; // Try to get the default mapping.
+
+            if (elementType is not null && Nullable.GetUnderlyingType(elementType) is { } underlyingType)
+                elementType = underlyingType;
+
             return elementType is null ? null : mappings?.AddArrayMapping(elementType, elementDataTypeName);
         }
     }
@@ -168,7 +173,12 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 return null;
 
             var mappings = base.GetMappings(elementType, elementDataTypeName, options);
+
             elementType ??= mappings?.Find(null, elementDataTypeName, options)?.Type; // Try to get the default mapping.
+
+            if (elementType is not null && Nullable.GetUnderlyingType(elementType) is { } underlyingType)
+                elementType = underlyingType;
+
             return elementType is null ? null : mappings?.AddArrayMapping(elementType, elementDataTypeName);
         }
     }


### PR DESCRIPTION
Closes #6547

This should be backported until 8.x as well.