### PR TITLE
Fix global mapper chain order

### DIFF
--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -55,12 +55,13 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
             if (_typeMappingOptions is { } existing)
                 return existing;
 
+            // We need to add our factories in reverse order because we first have to run the builder factory, which comes pre-seeded.
             var builder = _builderFactory?.Invoke() ?? new();
-            builder.AppendResolverFactory(_userTypeMapper);
-            foreach (var factory in _pluginResolverFactories)
-                builder.AppendResolverFactory(factory);
             foreach (var factory in _typeMappingResolvers)
-                builder.AppendResolverFactory(factory);
+                builder.PrependResolverFactory(factory);
+            foreach (var factory in _pluginResolverFactories)
+                builder.PrependResolverFactory(factory);
+            builder.PrependResolverFactory(_userTypeMapper);
             var chain = builder.Build();
             var options = new PgSerializerOptions(PostgresMinimalDatabaseInfo.DefaultTypeCatalog, chain)
             {


### PR DESCRIPTION
Ran into this while implementing https://github.com/npgsql/npgsql/issues/3303, as the user mapper currently isn't in front global pg enum tests started failing. This change aligns the global mapper order with the data sources.