### PR TITLE
Centralization of mapping resolution and binding logic

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -330,7 +330,7 @@ public sealed class FieldDescription
                 lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
             ), "Cache is bleeding over");
 
-        if (!lastColumnInfo.ConverterInfo.IsDefault && lastColumnInfo.ConverterInfo.TypeToConvert == type)
+        if (lastColumnInfo.ConverterInfo is { IsDefault: false, TypeToConvert: var typeToConvert } && typeToConvert == type)
             return;
 
         var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectInfo : _objectInfo.ConverterInfo;

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -294,6 +294,17 @@ public sealed class FieldDescription
     /// </summary>
     internal DataFormat DataFormat { get; set; }
 
+    /// <summary>
+    /// Whether this field's data was requested in text format because the user opted into UnknownResultType
+    /// (via NpgsqlCommand.UnknownResultTypeList or AllResultTypesAreUnknown). Bindings for such fields are
+    /// expected to reinterpret the text bytes through a converter that could potentially only support binary formats.
+    /// </summary>
+    /// <remarks>
+    /// DataFormat.Text today exclusively signals that we executed with an UnknownResultTypeList.
+    /// If we ever want to fully support DataFormat.Text we'll need to flow UnknownResultType status separately.
+    /// </remarks>
+    internal bool IsUnknownResultType => DataFormat is DataFormat.Text;
+
     internal Field Field { get; private set; }
 
     internal string TypeDisplayName => PostgresType.GetDisplayNameWithFacets(TypeModifier);
@@ -328,7 +339,7 @@ public sealed class FieldDescription
     {
         Debug.Assert(result.IsDefault || (
             ReferenceEquals(_serializerOptions, result.TypeInfo.Options) && (
-                IsUnknownResultType() && result.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
+                IsUnknownResultType && result.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
                 // Normal resolution
                 result.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
             ), "Cache is bleeding over");
@@ -344,6 +355,9 @@ public sealed class FieldDescription
         }
 
         Core(type, out result);
+        if (!result.IsDefault && result.Binding.DataFormat != DataFormat)
+            ThrowHelper.ThrowInvalidOperationException(
+                $"Binding for column '{Name}' produced format '{result.Binding.DataFormat}' but the field format is '{DataFormat}'.");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void Core(Type? type, out ReadConversionContext lastReadConversionContext)
@@ -351,20 +365,16 @@ public sealed class FieldDescription
             PgFieldBinding binding;
             switch (DataFormat)
             {
-            case DataFormat.Text when IsUnknownResultType():
+            case DataFormat.Text when IsUnknownResultType:
             {
-                // Try to resolve some 'pg_catalog.text' type info for the expected clr type.
+                // Resolve the converter against pg_catalog.text, UnknownResultType reads text bytes
+                // for any column type. Every pg_catalog.text mapping we own declares text-format support, so a converter that
+                // can't bind to text here throws and surfaces as a missing mapping rather than getting silently reinterpreted.
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgTypeId, _serializerOptions);
                 var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field);
 
-                // We start binding to DataFormat.Binary as it's the broadest supported format.
-                // The format however is irrelevant as 'pg_catalog.text' data is identical across either.
-                // Given we did a resolution against 'pg_catalog.text' and not the actual field type we're in reinterpretation territory anyway.
-                if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out binding))
-                    binding = concreteTypeInfo.BindField(DataFormat.Text);
-
+                binding = concreteTypeInfo.BindField(DataFormat.Text);
                 lastReadConversionContext = new(concreteTypeInfo, binding);
-
                 break;
             }
             case DataFormat.Binary or DataFormat.Text:
@@ -388,10 +398,6 @@ public sealed class FieldDescription
             if (_objectConversionContext.TypeInfo is null && type is not null)
                 _ = ObjectConversionContext;
         }
-
-        // DataFormat.Text today exclusively signals that we executed with an UnknownResultTypeList.
-        // If we ever want to fully support DataFormat.Text we'll need to flow UnknownResultType status separately.
-        bool IsUnknownResultType() => DataFormat is DataFormat.Text;
     }
 
     /// <summary>

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -371,7 +371,7 @@ public sealed class FieldDescription
                 // for any column type. Every pg_catalog.text mapping we own declares text-format support, so a converter that
                 // can't bind to text here throws and surfaces as a missing mapping rather than getting silently reinterpreted.
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgTypeId, _serializerOptions);
-                var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field);
+                var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
 
                 binding = concreteTypeInfo.BindField(DataFormat.Text);
                 lastReadConversionContext = new(concreteTypeInfo, binding);
@@ -380,7 +380,7 @@ public sealed class FieldDescription
             case DataFormat.Binary or DataFormat.Text:
             {
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(object), _serializerOptions.ToCanonicalTypeId(PostgresType), _serializerOptions);
-                var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field);
+                var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
 
                 // If we don't support the DataFormat we'll just throw.
                 binding = concreteTypeInfo.BindField(DataFormat);

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -11,12 +11,11 @@ using Npgsql.Replication.PgOutput.Messages;
 
 namespace Npgsql.BackendMessages;
 
-readonly struct ColumnInfo(PgConcreteTypeInfo typeInfo, PgFieldBinding binding)
+readonly struct ReadConversionContext(PgConcreteTypeInfo typeInfo, PgFieldBinding binding)
 {
     public bool IsDefault => TypeInfo is null;
     public PgConcreteTypeInfo TypeInfo { get; } = typeInfo;
     public PgFieldBinding Binding { get; } = binding;
-    public DataFormat DataFormat => Binding.DataFormat;
 }
 
 /// <summary>
@@ -37,7 +36,7 @@ sealed class RowDescriptionMessage : IBackendMessage
     FieldDescription?[] _fields;
     readonly Dictionary<string, int> _nameIndex;
     Dictionary<string, int>? _insensitiveIndex;
-    ColumnInfo[]? _lastConverterInfoCache;
+    ReadConversionContext[]? _lastConverterInfoCache;
 
     internal RowDescriptionMessage(bool connectorOwned, int numFields = 10)
     {
@@ -136,14 +135,18 @@ sealed class RowDescriptionMessage : IBackendMessage
         }
     }
 
-    internal void SetColumnInfoCache(ReadOnlySpan<ColumnInfo> values)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal void GetConversionContext(int ordinal, Type type, ref ReadConversionContext result)
+        => this[ordinal].GetConversionContext(type, ref result);
+
+    internal void SetColumnInfoCache(ReadOnlySpan<ReadConversionContext> values)
     {
         if (_connectorOwned || _lastConverterInfoCache is not null)
             return;
         Interlocked.CompareExchange(ref _lastConverterInfoCache, values.ToArray(), null);
     }
 
-    internal void LoadColumnInfoCache(PgSerializerOptions options, ColumnInfo[] values)
+    internal void LoadColumnInfoCache(PgSerializerOptions options, ReadConversionContext[] values)
     {
         if (_lastConverterInfoCache is not { } cache)
             return;
@@ -233,7 +236,7 @@ public sealed class FieldDescription
         DataFormat = source.DataFormat;
         PostgresType = source.PostgresType;
         Field = source.Field;
-        _objectInfo = source._objectInfo;
+        _objectConversionContext = source._objectConversionContext;
     }
 
     internal void Populate(
@@ -251,7 +254,7 @@ public sealed class FieldDescription
         DataFormat = dataFormat;
         PostgresType = _serializerOptions.DatabaseInfo.FindPostgresType((Oid)TypeOID)?.GetRepresentationalType() ?? UnknownBackendType.Instance;
         Field = new(Name, _serializerOptions.ToCanonicalTypeId(PostgresType), TypeModifier);
-        _objectInfo = default;
+        _objectConversionContext = default;
     }
 
     /// <summary>
@@ -297,19 +300,18 @@ public sealed class FieldDescription
 
     internal PostgresType PostgresType { get; private set; }
 
-    internal Type FieldType => ObjectInfo.TypeInfo.Type;
+    internal Type FieldType => ObjectConversionContext.TypeInfo.Type;
 
-    ColumnInfo _objectInfo;
-    internal (PgConcreteTypeInfo TypeInfo, PgFieldBinding Binding) ObjectInfo
+    ReadConversionContext _objectConversionContext;
+    internal ReadConversionContext ObjectConversionContext
     {
         get
         {
-            if (!_objectInfo.IsDefault)
-                return (_objectInfo.TypeInfo, _objectInfo.Binding);
+            if (!_objectConversionContext.IsDefault)
+                return _objectConversionContext;
 
-            ref var info = ref _objectInfo;
-            GetInfoCore(null, ref _objectInfo);
-            return (info.TypeInfo, info.Binding);
+            GetInfoAndBind(null, ref _objectConversionContext);
+            return _objectConversionContext;
         }
     }
 
@@ -321,30 +323,30 @@ public sealed class FieldDescription
         return field;
     }
 
-    internal void GetInfo(Type type, ref ColumnInfo lastColumnInfo) => GetInfoCore(type, ref lastColumnInfo);
-    void GetInfoCore(Type? type, ref ColumnInfo lastColumnInfo)
+    internal void GetConversionContext(Type type, ref ReadConversionContext result) => GetInfoAndBind(type, ref result);
+    void GetInfoAndBind(Type? type, ref ReadConversionContext result)
     {
-        Debug.Assert(lastColumnInfo.IsDefault || (
-            ReferenceEquals(_serializerOptions, lastColumnInfo.TypeInfo.Options) && (
-                IsUnknownResultType() && lastColumnInfo.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
+        Debug.Assert(result.IsDefault || (
+            ReferenceEquals(_serializerOptions, result.TypeInfo.Options) && (
+                IsUnknownResultType() && result.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
                 // Normal resolution
-                lastColumnInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
+                result.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
             ), "Cache is bleeding over");
 
-        if (lastColumnInfo is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
+        if (result is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
             return;
 
-        var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectInfo : (_objectInfo.TypeInfo, Binding: _objectInfo.Binding);
+        var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectConversionContext : _objectConversionContext;
         if (objectInfo.TypeInfo is not null && (typeof(object) == type || objectInfo.TypeInfo.Type == type))
         {
-            lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding);
+            result = objectInfo;
             return;
         }
 
-        GetInfoSlow(type, out lastColumnInfo);
+        Core(type, out result);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void GetInfoSlow(Type? type, out ColumnInfo lastColumnInfo)
+        void Core(Type? type, out ReadConversionContext lastReadConversionContext)
         {
             PgFieldBinding binding;
             switch (DataFormat)
@@ -361,7 +363,7 @@ public sealed class FieldDescription
                 if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out binding))
                     binding = concreteTypeInfo.BindField(DataFormat.Text);
 
-                lastColumnInfo = new(concreteTypeInfo, binding);
+                lastReadConversionContext = new(concreteTypeInfo, binding);
 
                 break;
             }
@@ -372,19 +374,19 @@ public sealed class FieldDescription
 
                 // If we don't support the DataFormat we'll just throw.
                 binding = concreteTypeInfo.BindField(DataFormat);
-                lastColumnInfo = new(concreteTypeInfo, binding);
+                lastReadConversionContext = new(concreteTypeInfo, binding);
                 break;
             }
             default:
                 ThrowHelper.ThrowUnreachableException("Unknown data format {0}", DataFormat);
-                lastColumnInfo = default;
+                lastReadConversionContext = default;
                 break;
             }
 
             // We delay initializing ObjectOrDefaultInfo until after the first lookup (unless it is itself the first lookup).
             // When passed in an unsupported type it allows the error to be more specific, instead of just having object/null to deal with.
-            if (_objectInfo.TypeInfo is null && type is not null)
-                _ = ObjectInfo;
+            if (_objectConversionContext.TypeInfo is null && type is not null)
+                _ = ObjectConversionContext;
         }
 
         // DataFormat.Text today exclusively signals that we executed with an UnknownResultTypeList.

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -372,6 +372,8 @@ public sealed class FieldDescription
                 // can't bind to text here throws and surfaces as a missing mapping rather than getting silently reinterpreted.
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgTypeId, _serializerOptions);
                 var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
+                if (!concreteTypeInfo.SupportsReading)
+                    AdoSerializerHelpers.ThrowReadingNotSupported(type, _serializerOptions, _serializerOptions.TextPgTypeId, resolved: true);
 
                 binding = concreteTypeInfo.BindField(DataFormat.Text);
                 lastReadConversionContext = new(concreteTypeInfo, binding);
@@ -381,6 +383,8 @@ public sealed class FieldDescription
             {
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(object), _serializerOptions.ToCanonicalTypeId(PostgresType), _serializerOptions);
                 var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
+                if (!concreteTypeInfo.SupportsReading)
+                    AdoSerializerHelpers.ThrowReadingNotSupported(type, _serializerOptions, _serializerOptions.ToCanonicalTypeId(PostgresType), resolved: true);
 
                 // If we don't support the DataFormat we'll just throw.
                 binding = concreteTypeInfo.BindField(DataFormat);

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -11,10 +11,12 @@ using Npgsql.Replication.PgOutput.Messages;
 
 namespace Npgsql.BackendMessages;
 
-readonly struct ColumnInfo(PgConverterInfo converterInfo, DataFormat dataFormat, bool asObject)
+readonly struct ColumnInfo(PgConcreteTypeInfo typeInfo, PgFieldBinding binding, bool asObject)
 {
-    public PgConverterInfo ConverterInfo { get; } = converterInfo;
-    public DataFormat DataFormat { get; } = dataFormat;
+    public bool IsDefault => TypeInfo is null;
+    public PgConcreteTypeInfo TypeInfo { get; } = typeInfo;
+    public PgFieldBinding Binding { get; } = binding;
+    public DataFormat DataFormat => Binding.DataFormat;
     public bool AsObject { get; } = asObject;
 }
 
@@ -296,19 +298,19 @@ public sealed class FieldDescription
 
     internal PostgresType PostgresType { get; private set; }
 
-    internal Type FieldType => ObjectInfo.TypeToConvert;
+    internal Type FieldType => ObjectInfo.TypeInfo.Type;
 
     ColumnInfo _objectInfo;
-    internal PgConverterInfo ObjectInfo
+    internal (PgConcreteTypeInfo TypeInfo, PgFieldBinding Binding) ObjectInfo
     {
         get
         {
-            if (!_objectInfo.ConverterInfo.IsDefault)
-                return _objectInfo.ConverterInfo;
+            if (!_objectInfo.IsDefault)
+                return (_objectInfo.TypeInfo, _objectInfo.Binding);
 
             ref var info = ref _objectInfo;
             GetInfoCore(null, ref _objectInfo);
-            return info.ConverterInfo;
+            return (info.TypeInfo, info.Binding);
         }
     }
 
@@ -323,30 +325,31 @@ public sealed class FieldDescription
     internal void GetInfo(Type type, ref ColumnInfo lastColumnInfo) => GetInfoCore(type, ref lastColumnInfo);
     void GetInfoCore(Type? type, ref ColumnInfo lastColumnInfo)
     {
-        Debug.Assert(lastColumnInfo.ConverterInfo.IsDefault || (
-            ReferenceEquals(_serializerOptions, lastColumnInfo.ConverterInfo.TypeInfo.Options) && (
-                IsUnknownResultType() && lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
+        Debug.Assert(lastColumnInfo.IsDefault || (
+            ReferenceEquals(_serializerOptions, lastColumnInfo.TypeInfo.Options) && (
+                IsUnknownResultType() && lastColumnInfo.TypeInfo.PgTypeId == _serializerOptions.TextPgTypeId ||
                 // Normal resolution
-                lastColumnInfo.ConverterInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
+                lastColumnInfo.TypeInfo.PgTypeId == _serializerOptions.ToCanonicalTypeId(PostgresType))
             ), "Cache is bleeding over");
 
-        if (lastColumnInfo.ConverterInfo is { IsDefault: false, TypeToConvert: var typeToConvert } && typeToConvert == type)
+        if (lastColumnInfo is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
             return;
 
-        var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectInfo : _objectInfo.ConverterInfo;
-        if (objectInfo is { IsDefault: false })
+        var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectInfo : (_objectInfo.TypeInfo, Binding: _objectInfo.Binding);
+        if (objectInfo.TypeInfo is not null)
         {
             if (typeof(object) == type)
             {
-                lastColumnInfo = new(objectInfo, DataFormat, true);
+                lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding, true);
                 return;
             }
-            if (objectInfo.TypeToConvert == type)
+            if (objectInfo.TypeInfo.Type == type)
             {
-                // As TypeInfoMappingCollection is always adding object mappings for
+                // As TypeInfoMappingCollection always adds object mappings for
                 // default/datatypename mappings, we'll also check Converter.TypeToConvert.
                 // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
-                lastColumnInfo = new(objectInfo, DataFormat, objectInfo.IsBoxingConverter && objectInfo.Converter.TypeToConvert != type);
+                lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding,
+                    objectInfo.TypeInfo.IsBoxing && objectInfo.TypeInfo.Converter.TypeToConvert != type);
                 return;
             }
         }
@@ -356,7 +359,7 @@ public sealed class FieldDescription
         [MethodImpl(MethodImplOptions.NoInlining)]
         void GetInfoSlow(Type? type, out ColumnInfo lastColumnInfo)
         {
-            PgConverterInfo converterInfo;
+            PgFieldBinding binding;
             switch (DataFormat)
             {
             case DataFormat.Text when IsUnknownResultType():
@@ -368,10 +371,10 @@ public sealed class FieldDescription
                 // We start binding to DataFormat.Binary as it's the broadest supported format.
                 // The format however is irrelevant as 'pg_catalog.text' data is identical across either.
                 // Given we did a resolution against 'pg_catalog.text' and not the actual field type we're in reinterpretation territory anyway.
-                if (!concreteTypeInfo.TryBind(DataFormat.Binary, out converterInfo))
-                    converterInfo = concreteTypeInfo.Bind(DataFormat.Text);
+                if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out binding))
+                    binding = concreteTypeInfo.BindField(DataFormat.Text);
 
-                lastColumnInfo = new(converterInfo, DataFormat, type != converterInfo.TypeToConvert || converterInfo.IsBoxingConverter);
+                lastColumnInfo = new(concreteTypeInfo, binding, type != concreteTypeInfo.Type || concreteTypeInfo.IsBoxing);
 
                 break;
             }
@@ -381,8 +384,8 @@ public sealed class FieldDescription
                 var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field);
 
                 // If we don't support the DataFormat we'll just throw.
-                converterInfo = concreteTypeInfo.Bind(DataFormat);
-                lastColumnInfo = new(converterInfo, DataFormat, typeof(object) == type || converterInfo.IsBoxingConverter);
+                binding = concreteTypeInfo.BindField(DataFormat);
+                lastColumnInfo = new(concreteTypeInfo, binding, typeof(object) == type || concreteTypeInfo.IsBoxing);
                 break;
             }
             default:
@@ -393,7 +396,7 @@ public sealed class FieldDescription
 
             // We delay initializing ObjectOrDefaultInfo until after the first lookup (unless it is itself the first lookup).
             // When passed in an unsupported type it allows the error to be more specific, instead of just having object/null to deal with.
-            if (_objectInfo.ConverterInfo.IsDefault && type is not null)
+            if (_objectInfo.TypeInfo is null && type is not null)
                 _ = ObjectInfo;
         }
 

--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -11,13 +11,12 @@ using Npgsql.Replication.PgOutput.Messages;
 
 namespace Npgsql.BackendMessages;
 
-readonly struct ColumnInfo(PgConcreteTypeInfo typeInfo, PgFieldBinding binding, bool asObject)
+readonly struct ColumnInfo(PgConcreteTypeInfo typeInfo, PgFieldBinding binding)
 {
     public bool IsDefault => TypeInfo is null;
     public PgConcreteTypeInfo TypeInfo { get; } = typeInfo;
     public PgFieldBinding Binding { get; } = binding;
     public DataFormat DataFormat => Binding.DataFormat;
-    public bool AsObject { get; } = asObject;
 }
 
 /// <summary>
@@ -336,22 +335,10 @@ public sealed class FieldDescription
             return;
 
         var objectInfo = DataFormat is DataFormat.Text && type is not null ? ObjectInfo : (_objectInfo.TypeInfo, Binding: _objectInfo.Binding);
-        if (objectInfo.TypeInfo is not null)
+        if (objectInfo.TypeInfo is not null && (typeof(object) == type || objectInfo.TypeInfo.Type == type))
         {
-            if (typeof(object) == type)
-            {
-                lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding, true);
-                return;
-            }
-            if (objectInfo.TypeInfo.Type == type)
-            {
-                // As TypeInfoMappingCollection always adds object mappings for
-                // default/datatypename mappings, we'll also check Converter.TypeToConvert.
-                // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
-                lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding,
-                    objectInfo.TypeInfo.IsBoxing && objectInfo.TypeInfo.Converter.TypeToConvert != type);
-                return;
-            }
+            lastColumnInfo = new(objectInfo.TypeInfo, objectInfo.Binding);
+            return;
         }
 
         GetInfoSlow(type, out lastColumnInfo);
@@ -374,7 +361,7 @@ public sealed class FieldDescription
                 if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out binding))
                     binding = concreteTypeInfo.BindField(DataFormat.Text);
 
-                lastColumnInfo = new(concreteTypeInfo, binding, type != concreteTypeInfo.Type || concreteTypeInfo.IsBoxing);
+                lastColumnInfo = new(concreteTypeInfo, binding);
 
                 break;
             }
@@ -385,7 +372,7 @@ public sealed class FieldDescription
 
                 // If we don't support the DataFormat we'll just throw.
                 binding = concreteTypeInfo.BindField(DataFormat);
-                lastColumnInfo = new(concreteTypeInfo, binding, typeof(object) == type || concreteTypeInfo.IsBoxing);
+                lastColumnInfo = new(concreteTypeInfo, binding);
                 break;
             }
             default:

--- a/src/Npgsql/Internal/AdoSerializerHelpers.cs
+++ b/src/Npgsql/Internal/AdoSerializerHelpers.cs
@@ -15,23 +15,12 @@ static class AdoSerializerHelpers
         try
         {
             typeInfo = options.GetTypeInfoInternal(type, pgTypeId);
-            if (typeInfo is { SupportsReading: false })
-                typeInfo = null;
         }
         catch (Exception ex)
         {
             inner = ex;
         }
         return typeInfo ?? ThrowReadingNotSupported(type, options, pgTypeId, inner);
-
-        // InvalidCastException thrown to align with ADO.NET convention.
-        [DoesNotReturn]
-        static PgTypeInfo ThrowReadingNotSupported(Type? type, PgSerializerOptions options, PgTypeId pgTypeId, Exception? inner = null)
-        {
-            throw new InvalidCastException(
-                $"Reading{(type is null ? "" : $" as '{type.FullName}'")} is not supported for fields having DataTypeName '{options.DatabaseInfo.FindPostgresType(pgTypeId)?.DisplayName ?? "unknown"}'",
-                inner);
-        }
     }
 
     public static PgTypeInfo GetTypeInfoForWriting(Type? type, PgTypeId? pgTypeId, PgSerializerOptions options, NpgsqlDbType? npgsqlDbType = null)
@@ -43,27 +32,40 @@ static class AdoSerializerHelpers
         try
         {
             typeInfo = options.GetTypeInfoInternal(type, pgTypeId);
-            if (typeInfo is { SupportsWriting: false })
-                typeInfo = null;
         }
         catch (Exception ex)
         {
             inner = ex;
         }
-        return typeInfo ?? ThrowWritingNotSupported(type, options, pgTypeId, npgsqlDbType, inner);
+        return typeInfo ?? ThrowWritingNotSupported(type, options, pgTypeId, npgsqlDbType, inner: inner);
+    }
 
-        // InvalidCastException thrown to align with ADO.NET convention.
-        [DoesNotReturn]
-        static PgTypeInfo ThrowWritingNotSupported(Type? type, PgSerializerOptions options, PgTypeId? pgTypeId, NpgsqlDbType? npgsqlDbType, Exception? inner = null)
-        {
-            var pgTypeString = pgTypeId is null
-                ? "no NpgsqlDbType or DataTypeName. Try setting one of these values to the expected database type."
-                : npgsqlDbType is null
-                    ? $"DataTypeName '{options.DatabaseInfo.FindPostgresType(pgTypeId.GetValueOrDefault())?.DisplayName ?? "unknown"}'"
-                    : $"NpgsqlDbType '{npgsqlDbType}'";
+    // InvalidCastException thrown to align with ADO.NET convention.
+    // resolved=true distinguishes the "resolution succeeded but the resolved converter opted out of this
+    // direction" case (e.g. read-only converters) from the "no converter could be found / resolution threw"
+    // case — important for diagnosing user reports.
+    [DoesNotReturn]
+    internal static PgTypeInfo ThrowReadingNotSupported(Type? type, PgSerializerOptions options, PgTypeId pgTypeId, Exception? inner = null, bool resolved = false)
+    {
+        var typeFragment = type is null ? "" : $" as '{type.FullName}'{(resolved ? " (resolved)" : "")}";
+        var dataTypeNameFragment = $"DataTypeName '{options.DatabaseInfo.FindPostgresType(pgTypeId)?.DisplayName ?? "unknown"}'";
+        var innerHint = inner is null ? "" : " See the inner exception for details.";
 
-            throw new InvalidCastException(
-                $"Writing{(type is null ? "" : $" values of '{type.FullName}'")} is not supported for parameters having {pgTypeString}.", inner);
-        }
+        throw new InvalidCastException($"Reading{typeFragment} is not supported for fields having {dataTypeNameFragment}.{innerHint}", inner);
+    }
+
+    [DoesNotReturn]
+    internal static PgTypeInfo ThrowWritingNotSupported(Type? type, PgSerializerOptions options, PgTypeId? pgTypeId, NpgsqlDbType? npgsqlDbType = null, string? parameterName = null, Exception? inner = null, bool resolved = false)
+    {
+        var pgTypeFragment = pgTypeId is null
+            ? "no NpgsqlDbType or DataTypeName. Try setting one of these values to the expected database type."
+            : npgsqlDbType is null
+                ? $"DataTypeName '{options.DatabaseInfo.FindPostgresType(pgTypeId.GetValueOrDefault())?.DisplayName ?? "unknown"}'"
+                : $"NpgsqlDbType '{npgsqlDbType}'";
+        var parameterFragment = parameterName is null ? "parameters" : $"parameter '{parameterName}'";
+        var typeFragment = type is null ? "" : $" values of type '{type.FullName}'{(resolved ? " (resolved)" : "")}";
+        var innerHint = inner is null ? "" : " See the inner exception for details.";
+
+        throw new InvalidCastException($"Writing{typeFragment} is not supported for {parameterFragment} having {pgTypeFragment}.{innerHint}", inner);
     }
 }

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -51,7 +51,7 @@ abstract class CompositeFieldInfo
             return;
         }
 
-        if (concrete.GetBufferRequirements(concrete.Converter, DataFormat.Binary) is not { } bufferRequirements)
+        if (concrete.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             return;
@@ -233,7 +233,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
         var concreteTypeInfo = PgTypeInfo.IsBoxing
             ? PgTypeInfo.GetObjectConcreteTypeInfo(value, out writeState)
             : PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
-        if (concreteTypeInfo.GetBufferRequirements(concreteTypeInfo.Converter, DataFormat.Binary) is not { } bufferRequirements)
+        if (concreteTypeInfo.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             writeRequirement = default;

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -235,7 +235,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     protected override PgConverter BindValue(object instance, out Size writeRequirement, out object? writeState)
     {
         var value = _getter(instance);
-        var concreteTypeInfo = PgTypeInfo.IsBoxing
+        var concreteTypeInfo = !PgTypeInfo.HasExactType
             ? PgTypeInfo.GetObjectConcreteTypeInfo(value, out writeState)
             : PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
         if (concreteTypeInfo.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -235,9 +235,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     protected override PgConverter BindValue(object instance, out Size writeRequirement, out object? writeState)
     {
         var value = _getter(instance);
-        var concreteTypeInfo = !PgTypeInfo.HasExactType
-            ? PgTypeInfo.GetObjectConcreteTypeInfo(value, out writeState)
-            : PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
+        var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
         if (concreteTypeInfo.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -70,6 +70,8 @@ abstract class CompositeFieldInfo
         }
 
         var concreteTypeInfo = PgTypeInfo.MakeConcreteForField(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
+        if (!concreteTypeInfo.SupportsReading)
+            AdoSerializerHelpers.ThrowReadingNotSupported(PgTypeInfo.Type, PgTypeInfo.Options, concreteTypeInfo.PgTypeId, resolved: true);
         if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out var binding))
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
 
@@ -236,6 +238,8 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     {
         var value = _getter(instance);
         var concreteTypeInfo = PgTypeInfo.MakeConcreteForValue(value, out writeState);
+        if (!concreteTypeInfo.SupportsWriting)
+            AdoSerializerHelpers.ThrowWritingNotSupported(typeof(T), PgTypeInfo.Options, concreteTypeInfo.PgTypeId, resolved: true);
         if (!concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,25 +66,27 @@ abstract class CompositeFieldInfo
         if (!IsProviderBacked)
         {
             readRequirement = _binaryBufferRequirements.Read;
-            return Converter!;
+            return Converter;
         }
 
         var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
-        if (!concreteTypeInfo.TryBind(DataFormat.Binary, out var converterInfo))
+        if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out var binding))
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
 
-        readRequirement = converterInfo.BufferRequirement;
-        return converterInfo.Converter;
+        readRequirement = binding.BufferRequirement;
+        return concreteTypeInfo.Converter;
     }
 
     public PgConverter GetWriteInfo(object instance, out Size writeRequirement, out object? writeState)
     {
-        if (IsProviderBacked)
-            return BindValue(instance, out writeRequirement, out writeState);
+        if (!IsProviderBacked)
+        {
+            writeState = null;
+            writeRequirement = _binaryBufferRequirements.Write;
+            return Converter;
+        }
 
-        writeState = null;
-        writeRequirement = _binaryBufferRequirements.Write;
-        return Converter!;
+        return BindValue(instance, out writeRequirement, out writeState);
     }
 
     /// <summary>
@@ -137,6 +140,7 @@ abstract class CompositeFieldInfo
     public Size BinaryWriteRequirement => _binaryBufferRequirements.Write;
 
     /// True when this field defers converter resolution to bind time via a provider.
+    [MemberNotNullWhen(false, nameof(Converter))]
     public bool IsProviderBacked { get; }
 
     public abstract Type Type { get; }

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -52,7 +52,7 @@ abstract class CompositeFieldInfo
             return;
         }
 
-        if (concrete.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)
+        if (!concrete.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             return;
@@ -236,7 +236,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     {
         var value = _getter(instance);
         var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
-        if (concreteTypeInfo.GetBufferRequirements(DataFormat.Binary) is not { } bufferRequirements)
+        if (!concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             writeRequirement = default;

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -43,7 +43,7 @@ abstract class CompositeFieldInfo
             // that's where provider-backed fields (DateTime kind, late-bound, etc.) surface deterministic
             // errors. The cached default is reused by GetDefaultWriteInfo on CompositeConverter's Path A,
             // where per-value resolution has already completed without producing state.
-            concrete = providerTypeInfo.GetDefaultConcreteTypeInfo(null);
+            concrete = providerTypeInfo.GetDefault(null);
             IsProviderBacked = true;
         }
         else
@@ -69,7 +69,7 @@ abstract class CompositeFieldInfo
             return Converter;
         }
 
-        var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
+        var concreteTypeInfo = PgTypeInfo.MakeConcreteForField(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
         if (!concreteTypeInfo.TryBindField(DataFormat.Binary, out var binding))
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
 
@@ -235,7 +235,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     protected override PgConverter BindValue(object instance, out Size writeRequirement, out object? writeState)
     {
         var value = _getter(instance);
-        var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(value, out writeState);
+        var concreteTypeInfo = PgTypeInfo.MakeConcreteForValue(value, out writeState);
         if (!concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -68,7 +68,8 @@ abstract class CompositeFieldInfo
             return Converter!;
         }
 
-        if (!PgTypeInfo.TryBind(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1), DataFormat.Binary, out var converterInfo))
+        var concreteTypeInfo = PgTypeInfo.GetConcreteTypeInfo(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
+        if (!concreteTypeInfo.TryBind(DataFormat.Binary, out var converterInfo))
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
 
         readRequirement = converterInfo.BufferRequirement;

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -156,7 +156,7 @@ abstract class CompositeFieldInfo
     public abstract void ReadDbNull(CompositeBuilder builder);
     public abstract ValueTask Read(bool async, PgConverter converter, CompositeBuilder builder, PgReader reader, CancellationToken cancellationToken = default);
     public abstract bool IsDbNull(PgConverter converter, object instance, object? writeState);
-    public abstract Size? GetSizeOrDbNull(PgConverter converter, DataFormat format, Size writeRequirement, object instance, ref object? writeState);
+    public abstract Size? IsDbNullOrGetSize(PgConverter converter, DataFormat format, Size writeRequirement, object instance, ref object? writeState);
     public abstract ValueTask Write(bool async, PgConverter converter, PgWriter writer, object instance, CancellationToken cancellationToken);
 }
 
@@ -281,12 +281,12 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
         return AsObject(converter) ? converter.IsDbNullAsObject(value, writeState) : ((PgConverter<T>)converter).IsDbNull(value, writeState);
     }
 
-    public override Size? GetSizeOrDbNull(PgConverter converter, DataFormat format, Size writeRequirement, object instance, ref object? writeState)
+    public override Size? IsDbNullOrGetSize(PgConverter converter, DataFormat format, Size writeRequirement, object instance, ref object? writeState)
     {
         var value = _getter(instance);
         return AsObject(converter)
-            ? converter.GetSizeOrDbNullAsObject(format, writeRequirement, value, ref writeState)
-            : ((PgConverter<T>)converter).GetSizeOrDbNull(format, writeRequirement, value, ref writeState);
+            ? converter.IsDbNullOrGetSizeAsObject(format, writeRequirement, value, ref writeState)
+            : ((PgConverter<T>)converter).IsDbNullOrGetSize(format, writeRequirement, value, ref writeState);
     }
 
     public override ValueTask Write(bool async, PgConverter converter, PgWriter writer, object instance, CancellationToken cancellationToken)

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -52,7 +52,7 @@ abstract class CompositeFieldInfo
             return;
         }
 
-        if (!concrete.CanConvert(DataFormat.Binary, out var bufferRequirements))
+        if (!concrete.Converter.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             return;
@@ -240,7 +240,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
         var concreteTypeInfo = PgTypeInfo.MakeConcreteForValue(value, out writeState);
         if (!concreteTypeInfo.SupportsWriting)
             AdoSerializerHelpers.ThrowWritingNotSupported(typeof(T), PgTypeInfo.Options, concreteTypeInfo.PgTypeId, resolved: true);
-        if (!concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements))
+        if (!concreteTypeInfo.Converter.CanConvert(DataFormat.Binary, out var bufferRequirements))
         {
             ThrowHelper.ThrowInvalidOperationException("Converter must support binary format to participate in composite types.");
             writeRequirement = default;

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -250,7 +250,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
     }
 }
 
-sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeInfo, Type effectiveType)
+sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeInfo, Type requestedType)
     : PgComposingTypeInfoProvider<T>(elementTypeInfo.PgTypeId is { } id ? elementTypeInfo.Options.GetArrayTypeId(id) : null,
         elementTypeInfo)
     where T : notnull
@@ -260,13 +260,19 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => Options.GetArrayElementTypeId(pgTypeId);
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => Options.GetArrayTypeId(effectivePgTypeId);
 
-    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo)
+    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
     {
         if (typeof(T) == typeof(Array) || typeof(T).IsArray)
-            return ArrayConverter<T>.CreateArrayBased<TElement>(effectiveConcreteTypeInfo, effectiveType);
+        {
+            unboxedType = requestedType == typeof(object) ? typeof(Array) : requestedType;
+            return ArrayConverter<T>.CreateArrayBased<TElement>(effectiveConcreteTypeInfo, requestedType);
+        }
 
         if (typeof(T).IsConstructedGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IList<>))
+        {
+            unboxedType = requestedType;
             return ArrayConverter<T>.CreateListBased<TElement>(effectiveConcreteTypeInfo);
+        }
 
         throw new NotSupportedException($"Unknown type T: {typeof(T).FullName}");
     }

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -514,7 +514,7 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
             static (_, state) =>
                 new(state.ConcreteInfo.Options,
                     new PolymorphicArrayConverter<TBase>((PgConverter<TBase>)state.ConcreteInfo.Converter, (PgConverter<TBase>)state.ConcreteNullableInfo.Converter),
-                    state.ConcreteInfo.PgTypeId),
+                    state.ConcreteInfo.PgTypeId) { SupportsWriting = false },
             state);
     }
 }

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -291,7 +291,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out _), null);
             foreach (var value in array)
             {
-                var result = EffectiveTypeInfo.GetConcreteTypeInfo(effectiveContext, value, out var state);
+                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -322,7 +322,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = EffectiveTypeInfo.GetConcreteTypeInfo(effectiveContext, value, out var state);
+                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -353,7 +353,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = EffectiveTypeInfo.GetConcreteTypeInfo(effectiveContext, value, out var state);
+                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -384,7 +384,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out var dimensionLengths), dimensionLengths);
             foreach (var value in array)
             {
-                var result = EffectiveTypeInfo.GetAsObjectConcreteTypeInfo(effectiveContext, value, out var state);
+                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -492,15 +492,15 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
     }
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
-        => GetOrAdd(_effectiveTypeInfo.GetDefaultConcreteTypeInfo(pgTypeId), _effectiveNullableTypeInfo.GetDefaultConcreteTypeInfo(pgTypeId));
+        => GetOrAdd(_effectiveTypeInfo.GetDefault(pgTypeId), _effectiveNullableTypeInfo.GetDefault(pgTypeId));
 
     protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, TBase? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        var concreteTypeInfo = _effectiveTypeInfo.GetConcreteTypeInfo(field);
-        var concreteNullableTypeInfo = _effectiveNullableTypeInfo.GetConcreteTypeInfo(field);
+        var concreteTypeInfo = _effectiveTypeInfo.GetForField(field);
+        var concreteNullableTypeInfo = _effectiveNullableTypeInfo.GetForField(field);
 
         return concreteTypeInfo is not null && concreteNullableTypeInfo is not null
             ? GetOrAdd(concreteTypeInfo, concreteNullableTypeInfo)

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -250,7 +250,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
     }
 }
 
-sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeInfo, Type requestedType)
+sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeInfo, Type requestedMappingType)
     : PgComposingTypeInfoProvider<T>(elementTypeInfo.PgTypeId is { } id ? elementTypeInfo.Options.GetArrayTypeId(id) : null,
         elementTypeInfo)
     where T : notnull
@@ -260,17 +260,17 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => Options.GetArrayElementTypeId(pgTypeId);
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => Options.GetArrayTypeId(effectivePgTypeId);
 
-    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
+    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType)
     {
         if (typeof(T) == typeof(Array) || typeof(T).IsArray)
         {
-            unboxedType = requestedType == typeof(object) ? typeof(Array) : requestedType;
+            requestedType = requestedMappingType;
             return ArrayConverter<T>.CreateArrayBased<TElement>(effectiveConcreteTypeInfo, requestedType);
         }
 
         if (typeof(T).IsConstructedGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IList<>))
         {
-            unboxedType = requestedType;
+            requestedType = requestedMappingType;
             return ArrayConverter<T>.CreateListBased<TElement>(effectiveConcreteTypeInfo);
         }
 

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -137,8 +137,8 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         int IElementOperations.GetCollectionCount(object collection, out int[]? lengths)
             => ArrayConverterCore.GetArrayLengths((Array)collection, out lengths);
 
-        Size? IElementOperations.GetSizeOrDbNull(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
-            => _elemConverter.GetSizeOrDbNull(context.Format, context.BufferRequirement, GetValue(collection, indices), ref writeState);
+        Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
+            => _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, GetValue(collection, indices), ref writeState);
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)
         {
@@ -207,8 +207,8 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
             return ((IList<TElement?>)collection).Count;
         }
 
-        Size? IElementOperations.GetSizeOrDbNull(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
-            => _elemConverter.GetSizeOrDbNull(context.Format, context.BufferRequirement, GetValue(collection, indices.One), ref writeState);
+        Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
+            => _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, GetValue(collection, indices.One), ref writeState);
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)
         {

--- a/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
@@ -14,7 +14,7 @@ interface IElementOperations
 {
     object CreateCollection(ReadOnlySpan<int> lengths);
     int GetCollectionCount(object collection, out int[]? lengths);
-    Size? GetSizeOrDbNull(SizeContext context, object collection, IterationIndices indices, ref object? writeState);
+    Size? IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState);
     ValueTask Read(bool async, PgReader reader, bool isDbNull, object collection,  IterationIndices indices, CancellationToken cancellationToken = default);
     ValueTask Write(bool async, PgWriter writer, object collection,  IterationIndices indices, CancellationToken cancellationToken = default);
 }
@@ -42,7 +42,7 @@ readonly struct ArrayConverterCore(
         // leave writeState alone — any mutation is a contract violation in the element converter.
         Debug.Assert(binaryRequirements.Write.Kind is SizeKind.Exact);
         var originalWriteState = writeState;
-        var isDbNull = elemOps.GetSizeOrDbNull(new(DataFormat.Binary, binaryRequirements.Write), values, arrayIndices, ref writeState) is null;
+        var isDbNull = elemOps.IsDbNullOrGetSize(new(DataFormat.Binary, binaryRequirements.Write), values, arrayIndices, ref writeState) is null;
         Debug.Assert(ReferenceEquals(writeState, originalWriteState), "Fixed-size element converter mutated writeState during a null probe.");
         return isDbNull;
     }
@@ -51,7 +51,7 @@ readonly struct ArrayConverterCore(
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     Size SizeElement(SizeContext context, object values, IterationIndices indices, ref object? elemState, ref Size size, ref bool anyWriteState)
     {
-        var elemSize = elemOps.GetSizeOrDbNull(context, values, indices, ref elemState);
+        var elemSize = elemOps.IsDbNullOrGetSize(context, values, indices, ref elemState);
         anyWriteState = anyWriteState || elemState is not null;
         size = size.Combine(elemSize ?? 0);
         return elemSize ?? -1;

--- a/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
@@ -38,7 +38,7 @@ readonly struct ArrayConverterCore(
     bool IsDbNull(object values, IterationIndices arrayIndices, object? writeState)
     {
         // This call will only skip GetSize if we are dealing with fixed size elements, otherwise we'll repeat sizing costs.
-        // Fixed-size element converters cannot produce per-value write state, so GetSizeOrDbNull must
+        // Fixed-size element converters cannot produce per-value write state, so IsDbNullOrGetSize must
         // leave writeState alone — any mutation is a contract violation in the element converter.
         Debug.Assert(binaryRequirements.Write.Kind is SizeKind.Exact);
         var originalWriteState = writeState;

--- a/src/Npgsql/Internal/Converters/BitStringConverters.cs
+++ b/src/Npgsql/Internal/Converters/BitStringConverters.cs
@@ -230,8 +230,8 @@ sealed class StringBitStringConverter : PgStreamingConverter<string>
 /// Otherwise we return a BitArray converter. Polymorphic writing through this provider is not supported.
 sealed class PolymorphicBitStringTypeInfoProvider(PgSerializerOptions options, PgTypeId bitString) : PgConcreteTypeInfoProvider<object>
 {
-    readonly PgConcreteTypeInfo _boolConcreteTypeInfo = new(options, new BoolBitStringConverter(), bitString);
-    readonly PgConcreteTypeInfo _bitArrayConcreteTypeInfo = new(options, new BitArrayBitStringConverter(), bitString);
+    readonly PgConcreteTypeInfo _boolConcreteTypeInfo = new(options, new BoolBitStringConverter(), bitString) { SupportsWriting = false };
+    readonly PgConcreteTypeInfo _bitArrayConcreteTypeInfo = new(options, new BitArrayBitStringConverter(), bitString) { SupportsWriting = false };
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
         => GetConcreteInfo(field: null);

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
+using Npgsql.Util;
 
 namespace Npgsql.Internal.Converters;
 
@@ -15,8 +16,11 @@ public sealed class CastingConverter<T> : PgConverter<T>
 
     public CastingConverter(PgConverter effectiveConverter) : base(effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
     {
-        if (typeof(T) != typeof(object) && !typeof(T).IsAssignableTo(effectiveConverter.TypeToConvert))
-            throw new ArgumentException($"Values from the given converter cannot be assigned to {typeof(T)}", nameof(effectiveConverter));
+        if (!typeof(T).IsInSubtypeRelationshipWith(effectiveConverter.TypeToConvert))
+            throw new ArgumentException(
+                $"Values for the effective converter's type {effectiveConverter.TypeToConvert} cannot be cast to the type {typeof(T)} for this converter.",
+                nameof(effectiveConverter));
+
         _effectiveConverter = effectiveConverter;
     }
 

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -7,39 +7,48 @@ using Npgsql.Internal.Postgres;
 namespace Npgsql.Internal.Converters;
 
 /// A converter to map strongly typed apis onto boxed converter results to produce a strongly typed converter over T.
-sealed class CastingConverter<T>(PgConverter effectiveConverter)
-    : PgConverter<T>(effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+public sealed class CastingConverter<T> : PgConverter<T>
 {
-    protected override bool IsDbNullValue(T? value, object? writeState) => effectiveConverter.IsDbNullAsObject(value, writeState);
+    readonly PgConverter _effectiveConverter;
+
+    public CastingConverter(PgConverter effectiveConverter) : base(effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+    {
+        if (typeof(T) != typeof(object) && !typeof(T).IsAssignableTo(effectiveConverter.TypeToConvert))
+            throw new ArgumentException($"Values from the given converter cannot be assigned to {typeof(T)}", nameof(effectiveConverter));
+        _effectiveConverter = effectiveConverter;
+    }
+
+    protected override bool IsDbNullValue(T? value, object? writeState) => _effectiveConverter.IsDbNullAsObject(value, writeState);
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
-        => effectiveConverter.CanConvert(format, out bufferRequirements);
+        => _effectiveConverter.CanConvert(format, out bufferRequirements);
 
-    public override T Read(PgReader reader) => (T)effectiveConverter.ReadAsObject(reader);
+    public override T Read(PgReader reader) => (T)_effectiveConverter.ReadAsObject(reader);
 
     public override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
-        => this.ReadAsObjectAsyncAsT(effectiveConverter, reader, cancellationToken);
+        => this.ReadAsObjectAsyncAsT(_effectiveConverter, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, T value, ref object? writeState)
-        => effectiveConverter.GetSizeAsObject(context, value!, ref writeState);
+        => _effectiveConverter.GetSizeAsObject(context, value!, ref writeState);
 
     public override void Write(PgWriter writer, T value)
-        => effectiveConverter.WriteAsObject(writer, value!);
+        => _effectiveConverter.WriteAsObject(writer, value!);
 
     public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
-        => effectiveConverter.WriteAsObjectAsync(writer, value!, cancellationToken);
+        => _effectiveConverter.WriteAsObjectAsync(writer, value!, cancellationToken);
 
     internal override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => async
-            ? effectiveConverter.ReadAsObjectAsync(reader, cancellationToken)
-            : new(effectiveConverter.ReadAsObject(reader));
+            ? _effectiveConverter.ReadAsObjectAsync(reader, cancellationToken)
+            : new(_effectiveConverter.ReadAsObject(reader));
 
     internal override ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken)
     {
+        // Cast here to keep our T contract, and otherwise return more accurate invalid cast exceptions (as the effective converter will cast as well).
         if (async)
-            return effectiveConverter.WriteAsObjectAsync(writer, value, cancellationToken);
+            return _effectiveConverter.WriteAsObjectAsync(writer, (T)value, cancellationToken);
 
-        effectiveConverter.WriteAsObject(writer, value);
+        _effectiveConverter.WriteAsObject(writer, (T)value);
         return new();
     }
 }
@@ -63,7 +72,7 @@ sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderType
 
 static class CastingTypeInfoExtensions
 {
-    [RequiresDynamicCode("Changing boxing converters to their non-boxing counterpart can require creating new generic types or methods, which requires creating code at runtime. This may not be AOT  when AOT compiling")]
+    [RequiresDynamicCode("Changing boxing type infos to their non-boxing counterpart can require creating new generic types or methods, which requires creating code at runtime. This may not be AOT  when AOT compiling")]
     internal static PgTypeInfo ToNonBoxing(this PgTypeInfo typeInfo)
     {
         if (!typeInfo.IsBoxing)

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -6,7 +6,9 @@ using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal.Converters;
 
-/// A converter to map strongly typed apis onto boxed converter results to produce a strongly typed converter over T.
+/// A converter that adapts a boxed converter's results to an exact-type converter over T, wrapping the read/write
+/// paths through object to present a typed surface for a converter whose TypeToConvert is only a base of T.
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class CastingConverter<T> : PgConverter<T>
 {
     readonly PgConverter _effectiveConverter;
@@ -72,10 +74,10 @@ sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderType
 
 static class CastingTypeInfoExtensions
 {
-    [RequiresDynamicCode("Changing boxing type infos to their non-boxing counterpart can require creating new generic types or methods, which requires creating code at runtime. This may not be AOT  when AOT compiling")]
-    internal static PgTypeInfo ToNonBoxing(this PgTypeInfo typeInfo)
+    [RequiresDynamicCode("Producing an exact-type info from one without an exact type can require creating new generic types or methods at runtime, which may not work when AOT compiling.")]
+    internal static PgTypeInfo ToExactTypeInfo(this PgTypeInfo typeInfo)
     {
-        if (!typeInfo.IsBoxing)
+        if (typeInfo.HasExactType)
             return typeInfo;
 
         var type = typeInfo.Type;

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -73,7 +73,7 @@ sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderType
     }
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
-        => EffectiveTypeInfo.GetAsObjectConcreteTypeInfo(effectiveContext, value, out writeState);
+        => EffectiveTypeInfo.GetForValueAsObject(effectiveContext, value, out writeState);
 }
 
 static class CastingTypeInfoExtensions

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -51,8 +51,11 @@ sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderType
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 
-    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo)
-        => new CastingConverter<T>(effectiveConcreteTypeInfo.Converter);
+    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
+    {
+        unboxedType = null;
+        return new CastingConverter<T>(effectiveConcreteTypeInfo.Converter);
+    }
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => EffectiveTypeInfo.GetAsObjectConcreteTypeInfo(effectiveContext, value, out writeState);

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -51,9 +51,9 @@ sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderType
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 
-    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
+    protected override PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType)
     {
-        unboxedType = null;
+        requestedType = null;
         return new CastingConverter<T>(effectiveConcreteTypeInfo.Converter);
     }
 

--- a/src/Npgsql/Internal/Converters/CompositeConverter.cs
+++ b/src/Npgsql/Internal/Converters/CompositeConverter.cs
@@ -188,7 +188,7 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
             return _writeSizePrecomputed;
         }
 
-        // Variable-size or nullable fields — per-field GetSizeOrDbNull is needed to compute the total,
+        // Variable-size or nullable fields — per-field IsDbNullOrGetSize is needed to compute the total,
         // and per-field sizes must flow forward to Write. Always rent.
         var arrayPool = ArrayPool<ElementState>.Shared;
         var slowData = arrayPool.Rent(_composite.Fields.Count);
@@ -198,7 +198,7 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
         {
             var field = _composite.Fields[i];
             var converter = field.GetWriteInfo(boxedInstance, out var writeRequirement, out var fieldState);
-            var fieldSizeOrNull = field.GetSizeOrDbNull(converter, context.Format, writeRequirement, boxedInstance, ref fieldState);
+            var fieldSizeOrNull = field.IsDbNullOrGetSize(converter, context.Format, writeRequirement, boxedInstance, ref fieldState);
             anyWriteState = anyWriteState || fieldState is not null;
             slowData[i] = new()
             {

--- a/src/Npgsql/Internal/Converters/MultirangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/MultirangeConverter.cs
@@ -77,7 +77,7 @@ sealed class MultirangeConverter<T, TRange> : PgStreamingConverter<T>
         for (var i = 0; i < value.Count; i++)
         {
             object? innerState = null;
-            var rangeSize = _rangeConverter.GetSizeOrDbNull(context.Format, _rangeRequirements.Write, value[i], ref innerState);
+            var rangeSize = _rangeConverter.IsDbNullOrGetSize(context.Format, _rangeRequirements.Write, value[i], ref innerState);
             anyWriteState = anyWriteState || innerState is not null;
             // Ranges should never be NULL.
             Debug.Assert(rangeSize.HasValue);

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -47,9 +47,9 @@ sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 
-    protected override PgConverter<T?> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
+    protected override PgConverter<T?> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType)
     {
-        unboxedType = null;
+        requestedType = null;
         return new NullableConverter<T>((PgConverter<T>)effectiveConcreteTypeInfo.Converter);
     }
 

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,8 +47,11 @@ sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 
-    protected override PgConverter<T?> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo)
-        => new NullableConverter<T>((PgConverter<T>)effectiveConcreteTypeInfo.Converter);
+    protected override PgConverter<T?> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType)
+    {
+        unboxedType = null;
+        return new NullableConverter<T>((PgConverter<T>)effectiveConcreteTypeInfo.Converter);
+    }
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => value is not null

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -55,6 +55,6 @@ sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => value is not null
-            ? EffectiveTypeInfo.GetConcreteTypeInfo(effectiveContext, value.GetValueOrDefault(), out writeState)
+            ? EffectiveTypeInfo.GetForValue(effectiveContext, value.GetValueOrDefault(), out writeState)
             : null;
 }

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -116,7 +116,7 @@ sealed class LateBoundTypeInfoProvider(PgSerializerOptions options, PgTypeId typ
         }
 
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForWriting(value.GetType(), context.ExpectedPgTypeId ?? typeId, options);
-        var concreteTypeInfo = typeInfo.GetObjectConcreteTypeInfo(value, out var effectiveState);
+        var concreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(value, out var effectiveState);
         writeState = effectiveState is not null
             ? new ObjectConverter.WriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState }
             : concreteTypeInfo;

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -32,9 +32,9 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        if (concreteTypeInfo.GetBufferRequirements(context.Format) is not { } bufferRequirements)
+        if (!concreteTypeInfo.CanConvert(context.Format, out var bufferRequirements))
         {
-            ThrowHelper.ThrowNotSupportedException($"Resolved converter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
+            ThrowHelper.ThrowNotSupportedException($"Resolvedconverter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
             return default;
         }
 
@@ -69,7 +69,9 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        var writeRequirement = concreteTypeInfo.GetBufferRequirements(DataFormat.Binary)!.Value.Write;
+        var found = concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements);
+        Debug.Assert(found);
+        var writeRequirement = bufferRequirements.Write;
         using var _ = await writer.BeginNestedWrite(async, writeRequirement, writer.Current.Size.Value, effectiveState, cancellationToken).ConfigureAwait(false);
         await concreteTypeInfo.Converter.WriteAsObject(async, writer, value, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -115,8 +115,11 @@ sealed class LateBoundTypeInfoProvider(PgSerializerOptions options, PgTypeId typ
             return GetDefaultCore(context.ExpectedPgTypeId);
         }
 
-        var typeInfo = AdoSerializerHelpers.GetTypeInfoForWriting(value.GetType(), context.ExpectedPgTypeId ?? typeId, options);
+        var valueType = value.GetType();
+        var typeInfo = AdoSerializerHelpers.GetTypeInfoForWriting(valueType, context.ExpectedPgTypeId ?? typeId, options);
         var concreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(value, out var effectiveState);
+        if (!concreteTypeInfo.SupportsWriting)
+            AdoSerializerHelpers.ThrowWritingNotSupported(valueType, options, concreteTypeInfo.PgTypeId, resolved: true);
         writeState = effectiveState is not null
             ? new ObjectConverter.WriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState }
             : concreteTypeInfo;

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -32,7 +32,7 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        if (concreteTypeInfo.GetBufferRequirements(concreteTypeInfo.Converter, context.Format) is not { } bufferRequirements)
+        if (concreteTypeInfo.GetBufferRequirements(context.Format) is not { } bufferRequirements)
         {
             ThrowHelper.ThrowNotSupportedException($"Resolved converter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
             return default;
@@ -69,7 +69,7 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        var writeRequirement = concreteTypeInfo.GetBufferRequirements(concreteTypeInfo.Converter, DataFormat.Binary)!.Value.Write;
+        var writeRequirement = concreteTypeInfo.GetBufferRequirements(DataFormat.Binary)!.Value.Write;
         using var _ = await writer.BeginNestedWrite(async, writeRequirement, writer.Current.Size.Value, effectiveState, cancellationToken).ConfigureAwait(false);
         await concreteTypeInfo.Converter.WriteAsObject(async, writer, value, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -34,7 +34,7 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
 
         if (!concreteTypeInfo.Converter.CanConvert(context.Format, out var bufferRequirements))
         {
-            ThrowHelper.ThrowNotSupportedException($"Resolvedconverter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
+            ThrowHelper.ThrowNotSupportedException($"Resolved converter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
             return default;
         }
 

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -32,7 +32,7 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        if (!concreteTypeInfo.CanConvert(context.Format, out var bufferRequirements))
+        if (!concreteTypeInfo.Converter.CanConvert(context.Format, out var bufferRequirements))
         {
             ThrowHelper.ThrowNotSupportedException($"Resolvedconverter '{concreteTypeInfo.Converter.GetType()}' has to support the {context.Format} format to be compatible.");
             return default;
@@ -69,7 +69,7 @@ sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredic
             _ => throw new InvalidOperationException("Invalid state")
         };
 
-        var found = concreteTypeInfo.CanConvert(DataFormat.Binary, out var bufferRequirements);
+        var found = concreteTypeInfo.Converter.CanConvert(DataFormat.Binary, out var bufferRequirements);
         Debug.Assert(found);
         var writeRequirement = bufferRequirements.Write;
         using var _ = await writer.BeginNestedWrite(async, writeRequirement, writer.Current.Size.Value, effectiveState, cancellationToken).ConfigureAwait(false);

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -29,14 +29,14 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
     }
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
-        => GetOrAdd(_elementTypeInfo.GetDefaultConcreteTypeInfo(_elementPgTypeId));
+        => GetOrAdd(_elementTypeInfo.GetDefault(_elementPgTypeId));
 
     protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        var elementConcreteTypeInfo = _elementTypeInfo.GetConcreteTypeInfo(field with { PgTypeId = _elementPgTypeId });
+        var elementConcreteTypeInfo = _elementTypeInfo.GetForField(field with { PgTypeId = _elementPgTypeId });
         return elementConcreteTypeInfo is not null ? GetOrAdd(elementConcreteTypeInfo) : null;
     }
 

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -5,7 +5,7 @@ using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal.Converters;
 
-// Many ways to achieve strongly typed composition on top of a polymorphic element type.
+// Many ways to achieve exact-type composition on top of a polymorphic element type.
 // Including pushing construction through a GVM visitor pattern on the element handler,
 // manual reimplementation of the element logic in the array provider, and other ways.
 // This one however is by far the most lightweight on both the implementation duplication and code bloat axes.

--- a/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/ByteaConverters.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -9,8 +8,16 @@ using System.Threading.Tasks;
 // ReSharper disable once CheckNamespace
 namespace Npgsql.Internal.Converters;
 
-abstract class ByteaConverters<T> : PgStreamingConverter<T>
+abstract class ByteaConverters<T>(bool supportsTextFormat) : PgStreamingConverter<T>
 {
+    public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        bufferRequirements = BufferRequirements.None;
+        return supportsTextFormat
+            ? format is DataFormat.Binary or DataFormat.Text
+            : format is DataFormat.Binary;
+    }
+
     public override T Read(PgReader reader)
         => Read(async: false, reader, CancellationToken.None).Result;
 
@@ -42,7 +49,7 @@ abstract class ByteaConverters<T> : PgStreamingConverter<T>
     protected abstract T ConvertFrom(Memory<byte> value);
 }
 
-sealed class ArraySegmentByteaConverter : ByteaConverters<ArraySegment<byte>>
+sealed class ArraySegmentByteaConverter(bool supportsTextFormat) : ByteaConverters<ArraySegment<byte>>(supportsTextFormat)
 {
     protected override Memory<byte> ConvertTo(ArraySegment<byte> value) => value;
     protected override ArraySegment<byte> ConvertFrom(Memory<byte> value)
@@ -51,8 +58,16 @@ sealed class ArraySegmentByteaConverter : ByteaConverters<ArraySegment<byte>>
             : throw new UnreachableException("Expected array-backed memory");
 }
 
-sealed class ArrayByteaConverter : PgStreamingConverter<byte[]>
+sealed class ArrayByteaConverter(bool supportsTextFormat) : PgStreamingConverter<byte[]>
 {
+    public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        bufferRequirements = BufferRequirements.None;
+        return supportsTextFormat
+            ? format is DataFormat.Binary or DataFormat.Text
+            : format is DataFormat.Binary;
+    }
+
     public override byte[] Read(PgReader reader)
     {
         var bytes = new byte[reader.CurrentRemaining];
@@ -77,13 +92,13 @@ sealed class ArrayByteaConverter : PgStreamingConverter<byte[]>
         => writer.WriteBytesAsync(value, cancellationToken);
 }
 
-sealed class ReadOnlyMemoryByteaConverter : ByteaConverters<ReadOnlyMemory<byte>>
+sealed class ReadOnlyMemoryByteaConverter(bool supportsTextFormat) : ByteaConverters<ReadOnlyMemory<byte>>(supportsTextFormat)
 {
     protected override Memory<byte> ConvertTo(ReadOnlyMemory<byte> value) => MemoryMarshal.AsMemory(value);
     protected override ReadOnlyMemory<byte> ConvertFrom(Memory<byte> value) => value;
 }
 
-sealed class MemoryByteaConverter : ByteaConverters<Memory<byte>>
+sealed class MemoryByteaConverter(bool supportsTextFormat) : ByteaConverters<Memory<byte>>(supportsTextFormat)
 {
     protected override Memory<byte> ConvertTo(Memory<byte> value) => value;
     protected override Memory<byte> ConvertFrom(Memory<byte> value) => value;

--- a/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
@@ -202,6 +202,12 @@ readonly struct GetChars(int read)
 
 sealed class GetCharsTextConverter(Encoding encoding) : PgStreamingConverter<GetChars>
 {
+    public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        bufferRequirements = BufferRequirements.None;
+        return format is DataFormat.Binary or DataFormat.Text;
+    }
+
     public override GetChars Read(PgReader reader)
         => reader.CharsReadActive
             ? ResumableRead(reader)

--- a/src/Npgsql/Internal/Converters/RangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/RangeConverter.cs
@@ -106,7 +106,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         {
             totalSize = totalSize.Combine(sizeof(int));
             var subTypeState = (object?)null;
-            if (_subtypeConverter.GetSizeOrDbNull(context.Format, _subtypeRequirements.Write, value.LowerBound, ref subTypeState) is { } size)
+            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.LowerBound, ref subTypeState) is { } size)
             {
                 totalSize = totalSize.Combine(size);
                 (state ??= new WriteState()).LowerBoundSize = size;
@@ -120,7 +120,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         {
             totalSize = totalSize.Combine(sizeof(int));
             var subTypeState = (object?)null;
-            if (_subtypeConverter.GetSizeOrDbNull(context.Format, _subtypeRequirements.Write, value.UpperBound, ref subTypeState) is { } size)
+            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.UpperBound, ref subTypeState) is { } size)
             {
                 totalSize = totalSize.Combine(size);
                 (state ??= new WriteState()).UpperBoundSize = size;

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -44,7 +44,8 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
-            var converterInfo = typeInfo.Bind(new Field("?", pgTypeId, -1), DataFormat.Binary);
+            var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field.CreateUnspecified(pgTypeId));
+            var converterInfo = concreteTypeInfo.Bind(DataFormat.Binary);
             var scope = await reader.BeginNestedRead(async, length, converterInfo.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try
             {

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -39,7 +39,7 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
             var pgTypeId = options.ToCanonicalTypeId(postgresType);
 
             // TODO resolve based on types expected by _factory (pass in a Type[] during construcion)
-            // Only allow object polymorphism for object[] records, valuetuple records are always strongly typed.
+            // Only allow object polymorphism for object[] records; valuetuple records always have exact types.
             var typeInfo = (IsObjectArrayRecord ? options.GetTypeInfo(typeof(object), pgTypeId) : options.GetDefaultTypeInfo(pgTypeId))
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -45,6 +45,8 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
             var concreteTypeInfo = typeInfo.MakeConcreteForField(Field.CreateUnspecified(pgTypeId));
+            if (!concreteTypeInfo.SupportsReading)
+                AdoSerializerHelpers.ThrowReadingNotSupported(IsObjectArrayRecord ? typeof(object) : null, options, pgTypeId, resolved: true);
             var binding = concreteTypeInfo.BindField(DataFormat.Binary);
             var scope = await reader.BeginNestedRead(async, length, binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -44,7 +44,7 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
-            var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field.CreateUnspecified(pgTypeId));
+            var concreteTypeInfo = typeInfo.MakeConcreteForField(Field.CreateUnspecified(pgTypeId));
             var binding = concreteTypeInfo.BindField(DataFormat.Binary);
             var scope = await reader.BeginNestedRead(async, length, binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -45,11 +45,11 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
             var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(Field.CreateUnspecified(pgTypeId));
-            var converterInfo = concreteTypeInfo.Bind(DataFormat.Binary);
-            var scope = await reader.BeginNestedRead(async, length, converterInfo.BufferRequirement, cancellationToken).ConfigureAwait(false);
+            var binding = concreteTypeInfo.BindField(DataFormat.Binary);
+            var scope = await reader.BeginNestedRead(async, length, binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try
             {
-                result[i] = await converterInfo.Converter.ReadAsObject(async, reader, cancellationToken).ConfigureAwait(false);
+                result[i] = await concreteTypeInfo.Converter.ReadAsObject(async, reader, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -29,7 +29,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
     {
         PgTypeId? effectiveTypeId = pgTypeId is { } id ? GetEffectiveTypeId(id) : null;
-        var concreteTypeInfo = EffectiveTypeInfo.GetDefaultConcreteTypeInfo(effectiveTypeId);
+        var concreteTypeInfo = EffectiveTypeInfo.GetDefault(effectiveTypeId);
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);
         return GetOrAdd(concreteTypeInfo, composingPgTypeId);
     }
@@ -46,7 +46,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        if (EffectiveTypeInfo.GetConcreteTypeInfo(field with { PgTypeId = GetEffectivePgTypeId(field.PgTypeId)}) is not { } concreteTypeInfo)
+        if (EffectiveTypeInfo.GetForField(field with { PgTypeId = GetEffectivePgTypeId(field.PgTypeId)}) is not { } concreteTypeInfo)
             return null;
 
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -74,7 +74,11 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
                 => new(state.ConcreteTypeInfo.Options,
                     state.Instance.CreateConverter(state.ConcreteTypeInfo, out var requestedType),
                     state.PgTypeId,
-                    requestedType: requestedType),
+                    requestedType: requestedType)
+                {
+                    SupportsReading = state.ConcreteTypeInfo.SupportsReading,
+                    SupportsWriting = state.ConcreteTypeInfo.SupportsWriting
+                },
             state);
     }
 }

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -23,7 +23,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
-    protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType);
+    protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType);
     protected abstract PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState);
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
@@ -72,9 +72,9 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
             concreteTypeInfo,
             static (_, state)
                 => new(state.ConcreteTypeInfo.Options,
-                    state.Instance.CreateConverter(state.ConcreteTypeInfo, out var unboxedType),
+                    state.Instance.CreateConverter(state.ConcreteTypeInfo, out var requestedType),
                     state.PgTypeId,
-                    unboxedType),
+                    requestedType: requestedType),
             state);
     }
 }

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -13,6 +13,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     protected PgComposingTypeInfoProvider(PgTypeId? pgTypeId, PgProviderTypeInfo effectiveTypeInfo)
     {
+        ArgumentNullException.ThrowIfNull(effectiveTypeInfo);
         if (pgTypeId is null && effectiveTypeInfo.PgTypeId is not null)
             throw new ArgumentNullException(nameof(pgTypeId), $"Cannot be null if {nameof(effectiveTypeInfo)}.{nameof(PgTypeInfo.PgTypeId)} is not null.");
 
@@ -22,7 +23,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
-    protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo);
+    protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? unboxedType);
     protected abstract PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState);
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
@@ -70,7 +71,10 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
         return _concreteInfoCache.GetOrAdd(
             concreteTypeInfo,
             static (_, state)
-                => new(state.ConcreteTypeInfo.Options, state.Instance.CreateConverter(state.ConcreteTypeInfo), state.PgTypeId),
+                => new(state.ConcreteTypeInfo.Options,
+                    state.Instance.CreateConverter(state.ConcreteTypeInfo, out var unboxedType),
+                    state.PgTypeId,
+                    unboxedType),
             state);
     }
 }

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -179,6 +179,7 @@ public abstract class PgConverter<T> : PgConverter
     private protected override bool IsDbNullValueAsObject(object? value, object? writeState)
         => (default(T) is null || value is not null) && IsDbNullValue((T?)value, writeState);
 
+    /// Checks whether <paramref name="value"/> is considered a database null by this converter.
     public bool IsDbNull([NotNullWhen(false)] T? value, object? writeState)
         => DbNullPredicateKind switch
         {
@@ -195,13 +196,18 @@ public abstract class PgConverter<T> : PgConverter
     public bool IsDbNull([NotNullWhen(false)] T? value, ref object? writeState)
         => IsDbNull(value, writeState);
 
+    /// Reads a <typeparamref name="T"/> value from the reader.
     public abstract T Read(PgReader reader);
+    /// Asynchronously reads a <typeparamref name="T"/> value from the reader.
     public abstract ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default);
 
+    /// Computes the serialized size for <paramref name="value"/>, producing any required <paramref name="writeState"/>.
     public abstract Size GetSize(SizeContext context, [DisallowNull]T value, ref object? writeState);
-    public abstract void Write(PgWriter writer, [DisallowNull] T value);
-    public abstract ValueTask WriteAsync(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default);
 
+    /// Writes a <typeparamref name="T"/> value to the writer.
+    public abstract void Write(PgWriter writer, [DisallowNull] T value);
+    /// Asynchronously writes a <typeparamref name="T"/> value to the writer.
+    public abstract ValueTask WriteAsync(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default);
 
     internal sealed override Size GetSizeAsObject(SizeContext context, object value, ref object? writeState)
         => GetSize(context, (T)value, ref writeState);

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -16,7 +16,10 @@ public abstract class PgConverter
     public bool IsDbNullable => DbNullPredicateKind is not DbNullPredicate.None;
 
     private protected PgConverter(Type type, bool isNullDefaultValue, bool customDbNullPredicate = false)
-        => DbNullPredicateKind = customDbNullPredicate ? DbNullPredicate.Custom : InferDbNullPredicate(type, isNullDefaultValue);
+    {
+        TypeToConvert = type;
+        DbNullPredicateKind = customDbNullPredicate ? DbNullPredicate.Custom : InferDbNullPredicate(type, isNullDefaultValue);
+    }
 
     /// <summary>
     /// Whether this converter can handle the given format and with which buffer requirements.
@@ -27,7 +30,63 @@ public abstract class PgConverter
     /// <remarks>The buffer requirements should not cover database NULL reads or writes, these are handled by the caller.</remarks>
     public abstract bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements);
 
-    internal abstract Type TypeToConvert { get; }
+    internal Type TypeToConvert { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    PgConverter<T> UnsafeAs<T>()
+    {
+        // Justification: avoid perf cost of casting to a known base class type per dispatch call.
+        Debug.Assert(typeof(T) == TypeToConvert);
+        Debug.Assert(this is PgConverter<T>);
+        return Unsafe.As<PgConverter<T>>(this);
+    }
+
+    /// <summary>Reads a value from the reader as <typeparamref name="T"/>.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T Read<T>(PgReader reader)
+        => typeof(T) != TypeToConvert
+            ? (T)ReadAsObject(reader)
+            : UnsafeAs<T>().Read(reader);
+
+    /// <summary>Asynchronously reads a value from the reader as <typeparamref name="T"/>.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<T> ReadAsync<T>(PgReader reader, CancellationToken cancellationToken = default)
+    {
+        if (typeof(T) != TypeToConvert)
+        {
+            var task = ReadAsObjectAsync(reader, cancellationToken);
+            return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
+        }
+
+        return UnsafeAs<T>().ReadAsync(reader, cancellationToken);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
+            => (T)await task.ConfigureAwait(false);
+    }
+
+    /// <summary>Writes a <typeparamref name="T"/> value to the writer.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Write<T>(PgWriter writer, [DisallowNull] T value)
+    {
+        if (typeof(T) != TypeToConvert)
+        {
+            WriteAsObject(writer, value);
+            return;
+        }
+        UnsafeAs<T>().Write(writer, value);
+    }
+
+    /// <summary>Asynchronously writes a <typeparamref name="T"/> value to the writer.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask WriteAsync<T>(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default)
+        => typeof(T) != TypeToConvert
+            ? WriteAsObjectAsync(writer, value, cancellationToken)
+            : UnsafeAs<T>().WriteAsync(writer, value, cancellationToken);
 
     internal bool IsDbNullAsObject([NotNullWhen(false)] object? value, object? writeState)
         => DbNullPredicateKind switch
@@ -151,7 +210,6 @@ public abstract class PgConverter<T> : PgConverter
     public abstract void Write(PgWriter writer, [DisallowNull] T value);
     public abstract ValueTask WriteAsync(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default);
 
-    internal sealed override Type TypeToConvert => typeof(T);
 
     internal sealed override Size GetSizeAsObject(SizeContext context, object value, ref object? writeState)
         => GetSize(context, (T)value, ref writeState);

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -209,7 +209,7 @@ public abstract class PgConverter<T> : PgConverter
 
 static class PgConverterExtensions
 {
-    public static Size? GetSizeOrDbNull<T>(this PgConverter<T> converter, DataFormat format, Size writeRequirement, T? value, ref object? writeState)
+    public static Size? IsDbNullOrGetSize<T>(this PgConverter<T> converter, DataFormat format, Size writeRequirement, T? value, ref object? writeState)
     {
         if (converter.IsDbNull(value, writeState))
             return null;
@@ -232,7 +232,7 @@ static class PgConverterExtensions
         return size;
     }
 
-    public static Size? GetSizeOrDbNullAsObject(this PgConverter converter, DataFormat format, Size writeRequirement, object? value, ref object? writeState)
+    public static Size? IsDbNullOrGetSizeAsObject(this PgConverter converter, DataFormat format, Size writeRequirement, object? value, ref object? writeState)
     {
         if (converter.IsDbNullAsObject(value, writeState))
             return null;

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -99,15 +99,7 @@ public abstract class PgConverter
             _ => ThrowDbNullPredicateOutOfRange()
         };
 
-    [Obsolete("Use the overload without ref.")]
-    internal bool IsDbNullAsObject([NotNullWhen(false)] object? value, ref object? writeState)
-        => IsDbNullAsObject(value, writeState);
-
     private protected abstract bool IsDbNullValueAsObject(object? value, object? writeState);
-
-    [Obsolete("Use the overload without ref.")]
-    private protected bool IsDbNullValueAsObject(object? value, ref object? writeState)
-        => IsDbNullValueAsObject(value, writeState);
 
     internal abstract Size GetSizeAsObject(SizeContext context, object value, ref object? writeState);
 

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -204,13 +204,6 @@ static class PgConverterExtensions
 
         return size;
     }
-
-    internal static PgConverter<T> UnsafeDowncast<T>(this PgConverter converter)
-    {
-        // Justification: avoid perf cost of casting to a known base class type per read/write, see callers.
-        Debug.Assert(converter is PgConverter<T>);
-        return Unsafe.As<PgConverter<T>>(converter);
-    }
 }
 
 [method: SetsRequiredMembers]

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -477,7 +477,7 @@ public class PgReader
         _charsReadBuffer = null;
     }
 
-    internal void Init(int fieldSize, bool resumable = false)
+    internal void Init(DataFormat fieldFormat, int fieldSize, bool resumable = false)
     {
         if (Initialized)
             ThrowHelper.ThrowInvalidOperationException("Already initialized");
@@ -486,14 +486,14 @@ public class PgReader
         _fieldEndPos = _fieldStartPos + fieldSize;
         _fieldSize = fieldSize;
         _resumable = resumable;
+        _fieldFormat = fieldFormat;
     }
 
-    internal void StartRead(DataFormat dataFormat, Size bufferRequirement)
+    internal void StartRead(PgFieldBinding binding)
     {
         Debug.Assert(FieldSize >= 0);
-        _fieldFormat = dataFormat;
-        _fieldBufferRequirement = bufferRequirement;
-        var byteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, FieldSize);
+        var byteCount = BufferRequirements.GetMinimumBufferByteCount(binding.BufferRequirement, FieldSize);
+        _fieldBufferRequirement = binding.BufferRequirement;
         if (ShouldBuffer(byteCount))
             BufferNoInlined(byteCount);
 
@@ -502,12 +502,11 @@ public class PgReader
             => Buffer(byteCount);
     }
 
-    internal ValueTask StartReadAsync(DataFormat dataFormat, Size bufferRequirement, CancellationToken cancellationToken)
+    internal ValueTask StartReadAsync(PgFieldBinding binding, CancellationToken cancellationToken)
     {
         Debug.Assert(FieldSize >= 0);
-        _fieldFormat = dataFormat;
-        _fieldBufferRequirement = bufferRequirement;
-        var byteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, FieldSize);
+        var byteCount = BufferRequirements.GetMinimumBufferByteCount(binding.BufferRequirement, FieldSize);
+        _fieldBufferRequirement = binding.BufferRequirement;
         return ShouldBuffer(byteCount) ? BufferAsync(byteCount, cancellationToken) : new();
     }
 
@@ -669,6 +668,7 @@ public class PgReader
         _currentSize = UninitializedSentinel;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int Restart(bool resumable)
     {
         if (!Initialized)

--- a/src/Npgsql/Internal/PgReader.cs
+++ b/src/Npgsql/Internal/PgReader.cs
@@ -477,7 +477,7 @@ public class PgReader
         _charsReadBuffer = null;
     }
 
-    internal void Init(int fieldSize, DataFormat fieldFormat, bool resumable = false)
+    internal void Init(int fieldSize, bool resumable = false)
     {
         if (Initialized)
             ThrowHelper.ThrowInvalidOperationException("Already initialized");
@@ -485,13 +485,13 @@ public class PgReader
         _fieldStartPos = _buffer.CumulativeReadPosition;
         _fieldEndPos = _fieldStartPos + fieldSize;
         _fieldSize = fieldSize;
-        _fieldFormat = fieldFormat;
         _resumable = resumable;
     }
 
-    internal void StartRead(Size bufferRequirement)
+    internal void StartRead(DataFormat dataFormat, Size bufferRequirement)
     {
         Debug.Assert(FieldSize >= 0);
+        _fieldFormat = dataFormat;
         _fieldBufferRequirement = bufferRequirement;
         var byteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, FieldSize);
         if (ShouldBuffer(byteCount))
@@ -502,9 +502,10 @@ public class PgReader
             => Buffer(byteCount);
     }
 
-    internal ValueTask StartReadAsync(Size bufferRequirement, CancellationToken cancellationToken)
+    internal ValueTask StartReadAsync(DataFormat dataFormat, Size bufferRequirement, CancellationToken cancellationToken)
     {
         Debug.Assert(FieldSize >= 0);
+        _fieldFormat = dataFormat;
         _fieldBufferRequirement = bufferRequirement;
         var byteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, FieldSize);
         return ShouldBuffer(byteCount) ? BufferAsync(byteCount, cancellationToken) : new();

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -29,7 +29,7 @@ public sealed class PgSerializerOptions
         _resolverChain = resolverChain ?? new();
         _timeZoneProvider = timeZoneProvider;
         DatabaseInfo = databaseInfo;
-        UnspecifiedDBNullTypeInfo = new(this, new Converters.Internal.VoidConverter(), DataTypeName.Unspecified, unboxedType: typeof(DBNull));
+        UnspecifiedDBNullTypeInfo = new(this, new Converters.Internal.VoidConverter(), DataTypeName.Unspecified, requestedType: typeof(DBNull));
     }
 
     internal PgConcreteTypeInfo UnspecifiedDBNullTypeInfo { get; }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -273,12 +273,6 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return result;
     }
 
-    public BufferRequirements? GetBufferRequirements(DataFormat format)
-    {
-        var success = CanConvert(format, out var bufferRequirements);
-        return success ? bufferRequirements : null;
-    }
-
     // Having it here so we can easily extend any behavior.
     internal void DisposeWriteState(object writeState)
     {
@@ -347,7 +341,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return new(format, bufferRequirements.Write, size, writeState);
     }
 
-    bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    public bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
     {
         switch (format)
         {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -48,21 +48,52 @@ public abstract class PgTypeInfo
 
     public PgTypeId? PgTypeId { get; }
 
-    public PgConcreteTypeInfo GetConcreteTypeInfo(Field field)
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field.
+    /// </summary>
+    /// <param name="field">The field whose metadata drives the concrete type info selection.</param>
+    /// <returns>The <see cref="PgConcreteTypeInfo"/> to use for the field.</returns>
+    /// <remarks>
+    /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
+    /// using the field's metadata (e.g. <see cref="Field.PgTypeId"/>) to select the appropriate concrete type info.
+    /// </remarks>
+    public PgConcreteTypeInfo MakeConcreteForField(Field field)
     {
         if (this is not PgProviderTypeInfo providerTypeInfo)
             return (PgConcreteTypeInfo)this;
 
         // Decided providers skip GetDefault's validation. The prior GetForField call already validated
         // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
-        return providerTypeInfo.GetConcreteTypeInfo(field)
-            ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? field.PgTypeId : null);
+        return providerTypeInfo.GetForField(field)
+               ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? field.PgTypeId : null);
     }
 
-    public PgConcreteTypeInfo GetConcreteTypeInfo<T>(T? value, out object? writeState)
-        => GetConcreteTypeInfo(default, value, out writeState);
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given value.
+    /// </summary>
+    /// <param name="value">The value whose content drive the concrete type info selection.</param>
+    /// <param name="writeState">Contains any write state that was produced.</param>
+    /// <typeparam name="T">The CLR type of the value.</typeparam>
+    /// <returns>The <see cref="PgConcreteTypeInfo"/> to use for the value.</returns>
+    /// <remarks>
+    /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
+    /// using the value to select the appropriate concrete type info.
+    /// </remarks>
+    public PgConcreteTypeInfo MakeConcreteForValue<T>(T? value, out object? writeState)
+        => MakeConcreteForValue(default, value, out writeState);
 
-    public PgConcreteTypeInfo GetConcreteTypeInfo<T>(ProviderValueContext context, T? value, out object? writeState)
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given value, with an explicit provider context.
+    /// </summary>
+    /// <param name="context">The context used when this instance is a provider based info.</param>
+    /// <param name="value">The value whose content drives the concrete type info selection.</param>
+    /// <param name="writeState">Contains any write state that was produced.</param>
+    /// <typeparam name="T">The CLR type of the value.</typeparam>
+    /// <remarks>
+    /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
+    /// using the value and the supplied context to select the appropriate concrete type info.
+    /// </remarks>
+    public PgConcreteTypeInfo MakeConcreteForValue<T>(ProviderValueContext context, T? value, out object? writeState)
     {
         if (this is not PgProviderTypeInfo providerTypeInfo)
         {
@@ -70,46 +101,55 @@ public abstract class PgTypeInfo
             return (PgConcreteTypeInfo)this;
         }
 
-        // Make sure we handle the weakly typed provider case.
-        // This will never cause boxing as weakly typed infos only happen for subtype relationships, i.e. reference types.
-        // We make sure to fall through to ProvideConcreteTypeInfo which has a better error if T is not at all related to this info.
+        // Make sure we handle the non-exact typed provider case.
+        // This will never cause boxing as non-exact typed infos only happen for subtype relationships, i.e. reference types.
+        // We make sure to fall through to GetForValue which has a better error if T is not at all related to this info.
         var concreteTypeInfo = PgProviderTypeInfo.GetProvider(providerTypeInfo) is not PgConcreteTypeInfoProvider<T> && providerTypeInfo.Type == typeof(T)
-            ? providerTypeInfo.GetAsObjectConcreteTypeInfo(context, (object?)value, out writeState)
-            : providerTypeInfo.GetConcreteTypeInfo(context, value, out writeState);
+            ? providerTypeInfo.GetForValueAsObject(context, (object?)value, out writeState)
+            : providerTypeInfo.GetForValue(context, value, out writeState);
 
         // Decided providers skip GetDefault's validation. The prior GetForValue call already validated
         // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
-        return concreteTypeInfo
-            ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
+        return concreteTypeInfo ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
     }
 
-    public PgConcreteTypeInfo GetObjectConcreteTypeInfo(object? value, out object? writeState)
-        => GetObjectConcreteTypeInfo(default, value, out writeState);
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given object value.
+    /// </summary>
+    /// <param name="value">The untyped value whose content drives the concrete type info selection.</param>
+    /// <param name="writeState">Contains any write state that was produced.</param>
+    /// <returns>The <see cref="PgConcreteTypeInfo"/> to use for the value.</returns>
+    /// <remarks>
+    /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
+    /// using the value to select the appropriate concrete type info.
+    /// </remarks>
+    public PgConcreteTypeInfo MakeConcreteForValueAsObject(object? value, out object? writeState)
+        => MakeConcreteForValueAsObject(default, value, out writeState);
 
-    // Note: this api is not called GetConcreteTypeInfoAsObject as the semantics are extended, DBNull is a NULL value for all object values.
-    public PgConcreteTypeInfo GetObjectConcreteTypeInfo(ProviderValueContext context, object? value, out object? writeState)
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given object value.
+    /// </summary>
+    /// <param name="context">The context used when this instance is a provider based info.</param>
+    /// <param name="value">The untyped value whose content drives the concrete type info selection.</param>
+    /// <param name="writeState">Contains any write state that was produced.</param>
+    /// <returns>The <see cref="PgConcreteTypeInfo"/> to use for the value.</returns>
+    /// <remarks>
+    /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
+    /// using the value to select the appropriate concrete type info.
+    /// </remarks>
+    public PgConcreteTypeInfo MakeConcreteForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
     {
         writeState = null;
-        switch (this)
-        {
-        case PgConcreteTypeInfo v:
-            return v;
-        case PgProviderTypeInfo providerTypeInfo:
-            PgConcreteTypeInfo? concreteTypeInfo = null;
-            if (value is not DBNull)
-                concreteTypeInfo = providerTypeInfo.GetAsObjectConcreteTypeInfo(context, value, out writeState);
-            // Decided providers skip GetDefault's validation. The prior GetForValueAsObject call already
-            // validated the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
-            return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
-        default:
-            return ThrowNotSupported();
-        }
+        if (this is not PgProviderTypeInfo providerTypeInfo)
+            return (PgConcreteTypeInfo)this;
 
-        static PgConcreteTypeInfo ThrowNotSupported()
-            => throw new NotSupportedException("Should not happen, please file a bug.");
+        // Decided providers skip GetDefault's validation. The prior GetForValueAsObject call already validated
+        // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        return providerTypeInfo.GetForValueAsObject(context, value, out writeState)
+               ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
     }
 
-    // We assume an info without an exact type does not support reading as the converter won't be able to produce the derived type statically.
+    // We assume a weakly typed info does not support reading as the converter won't be able to produce the derived type statically.
     // Cases like Array converters reading int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
         => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
@@ -143,7 +183,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         _defaultConcrete = result;
     }
 
-    public PgConcreteTypeInfo GetDefaultConcreteTypeInfo(PgTypeId? pgTypeId)
+    public PgConcreteTypeInfo GetDefault(PgTypeId? pgTypeId)
     {
         if (pgTypeId is { } id && PgTypeId is { } decidedId)
         {
@@ -159,7 +199,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
-    public new PgConcreteTypeInfo? GetConcreteTypeInfo(Field field)
+    public PgConcreteTypeInfo? GetForField(Field field)
     {
         if (PgTypeId is { } decidedId && field.PgTypeId != decidedId)
             ThrowUnexpectedPgTypeId(nameof(field));
@@ -170,7 +210,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
-    public new PgConcreteTypeInfo? GetConcreteTypeInfo<T>(ProviderValueContext context, T? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValue<T>(ProviderValueContext context, T? value, out object? writeState)
     {
         if (PgTypeId is { } pgTypeId)
         {
@@ -193,11 +233,11 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
         PgConcreteTypeInfo ThrowNotSupportedType(Type? type)
             => throw new NotSupportedException(type == Type
-                ? $"PgProviderTypeInfo does not exactly match type {type}, call {nameof(GetAsObjectConcreteTypeInfo)} instead."
+                ? $"PgProviderTypeInfo does not exactly match type {type}, call {nameof(GetForValueAsObject)} instead."
                 : $"PgProviderTypeInfo is incompatible with type {type}");
     }
 
-    public PgConcreteTypeInfo? GetAsObjectConcreteTypeInfo(ProviderValueContext context, object? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
     {
         if (PgTypeId is { } pgTypeId)
         {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -251,11 +253,81 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return converter.CanConvert(format, out bufferRequirements);
     }
 
+    // If we have an exact type match we can use e.g. a converter for ints in a strongly typed fashion.
+    // If it's not a value type it doesn't matter so we can skip the check there.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool ShouldReadAsObject<T>()
-        // If we have an exact type match we can use e.g. a converter for ints in a strongly typed fashion.
-        // If it's not a value type it doesn't matter so we can skip the check there.
-        => typeof(T) == typeof(object) || (IsBoxing && (!typeof(T).IsValueType || typeof(T) == Converter.TypeToConvert));
+    bool ShouldReadAsObject<T>()
+        => typeof(T) == typeof(object) || (IsBoxing && (!typeof(T).IsValueType || typeof(T) != Converter.TypeToConvert));
+
+    internal T ConverterRead<T>(PgReader reader)
+    {
+        if (ShouldReadAsObject<T>())
+            return (T)Converter.ReadAsObject(reader);
+
+        // Justification: avoid perf cost of casting to a known base class type per field read.
+        Debug.Assert(Converter is PgConverter<T>);
+        return Unsafe.As<PgConverter<T>>(Converter).Read(reader);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ValueTask<T> ConverterReadAsync<T>(PgReader reader, CancellationToken cancellationToken)
+    {
+        var converter = Converter;
+        if (ShouldReadAsObject<T>())
+        {
+            var task = converter.ReadAsObjectAsync(reader, cancellationToken);
+            return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
+        }
+
+        // Justification: avoid perf cost of casting to a known base class type per field read.
+        Debug.Assert(converter is PgConverter<T>);
+        return Unsafe.As<PgConverter<T>>(converter).ReadAsync(reader, cancellationToken);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
+            => (T)await task.ConfigureAwait(false);
+    }
+
+    // TODO move asObject checks from NpgsqlParameter to here.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ConverterWrite<T>(PgWriter writer, [DisallowNull]T value)
+    {
+        // Justification: avoid perf cost of casting to a known base class type per parameter write.
+        Debug.Assert(Converter is PgConverter<T>);
+        Unsafe.As<PgConverter<T>>(Converter).Write(writer, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ValueTask ConverterWriteAsync<T>(PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken)
+    {
+        // Justification: avoid perf cost of casting to a known base class type per parameter write.
+        Debug.Assert(Converter is PgConverter<T>);
+        return Unsafe.As<PgConverter<T>>(Converter).WriteAsync(writer, value, cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal T ReadFieldValue<T>(PgReader reader, DataFormat dataFormat)
+    {
+        var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
+        reader.StartRead(dataFormat, bufferRequirement);
+        var result = ConverterRead<T>(reader);
+        reader.EndRead();
+        return result;
+    }
+
+    internal async ValueTask<T> ReadFieldValueAsync<T>(PgReader reader, DataFormat dataFormat, CancellationToken cancellationToken)
+    {
+        var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
+        await reader.StartReadAsync(dataFormat, bufferRequirement, cancellationToken).ConfigureAwait(false);
+
+        // Copy of ConverterReadAsync to keep everything in one async frame.
+        var result = ShouldReadAsObject<T>()
+            ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+            : await Unsafe.As<PgConverter<T>>(Converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+
+        await reader.EndReadAsync().ConfigureAwait(false);
+        return result;
+    }
 
     public BufferRequirements? GetBufferRequirements(DataFormat format)
     {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -127,7 +127,7 @@ public abstract class PgTypeInfo
                 info = default;
                 return false;
             }
-            info = new(this, concreteTypeInfo.Converter, bufferRequirements.Read);
+            info = new(concreteTypeInfo, concreteTypeInfo.Converter, bufferRequirements.Read);
             return true;
         default:
             throw new NotSupportedException("Should not happen, please file a bug.");
@@ -358,18 +358,11 @@ readonly struct PgConverterInfo
         _typeInfo = pgTypeInfo;
         Converter = converter;
         BufferRequirement = bufferRequirement;
-
-        // Object typed providers can return any type of converter, so we check the type of the converter instead.
-        // We cannot do this in general as we should respect the 'unboxed type' of infos, which can differ from the converter type.
-        if (pgTypeInfo is PgProviderTypeInfo && pgTypeInfo.Type == typeof(object))
-            TypeToConvert = Converter.TypeToConvert;
-        else
-            TypeToConvert = pgTypeInfo.Type;
     }
 
     public bool IsDefault => _typeInfo is null;
 
-    public Type TypeToConvert { get; }
+    public Type TypeToConvert => _typeInfo.Type;
 
     public PgTypeInfo TypeInfo => _typeInfo;
 

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -228,8 +228,6 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     readonly bool _canTextConvert;
     readonly BufferRequirements _textBufferRequirements;
 
-    readonly Type _typeToConvert;
-
     public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId)
         : this(options, converter, pgTypeId, requestedType: null)
     {}
@@ -238,7 +236,6 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         : base(options, converter, pgTypeId, requestedType)
     {
         Converter = converter;
-        _typeToConvert = converter.TypeToConvert;
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
     }
@@ -246,69 +243,18 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     Type TypeToConvert
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            Debug.Assert(Converter.TypeToConvert == _typeToConvert);
-            return _typeToConvert;
-        }
+        get => Converter.TypeToConvert;
     }
 
     public PgConverter Converter { get; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConverter<T> UnsafeGetConverter<T>()
-    {
-        // Justification: avoid perf cost of casting to a known base class type per field read.
-        Debug.Assert(Converter is PgConverter<T>);
-        return Unsafe.As<PgConverter<T>>(Converter);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal T ConverterRead<T>(PgReader reader)
-        => typeof(T) != TypeToConvert
-            ? (T)Converter.ReadAsObject(reader)
-            : UnsafeGetConverter<T>().Read(reader);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ValueTask<T> ConverterReadAsync<T>(PgReader reader, CancellationToken cancellationToken)
-    {
-        if (typeof(T) != TypeToConvert)
-        {
-            var task = Converter.ReadAsObjectAsync(reader, cancellationToken);
-            return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
-        }
-
-        return UnsafeGetConverter<T>().ReadAsync(reader, cancellationToken);
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
-            => (T)await task.ConfigureAwait(false);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ConverterWrite<T>(PgWriter writer, [DisallowNull]T value)
-    {
-        if (typeof(T) != TypeToConvert)
-        {
-            Converter.WriteAsObject(writer, value);
-            return;
-        }
-        UnsafeGetConverter<T>().Write(writer, value);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ValueTask ConverterWriteAsync<T>(PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken)
-        => typeof(T) != TypeToConvert
-            ? Converter.WriteAsObjectAsync(writer, value, cancellationToken)
-            : UnsafeGetConverter<T>().WriteAsync(writer, value, cancellationToken);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal T ReadFieldValue<T>(PgReader reader, DataFormat dataFormat)
     {
         var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
         reader.StartRead(dataFormat, bufferRequirement);
-        var result = ConverterRead<T>(reader);
+        var result = Converter.Read<T>(reader);
         reader.EndRead();
         return result;
     }
@@ -318,10 +264,10 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
         await reader.StartReadAsync(dataFormat, bufferRequirement, cancellationToken).ConfigureAwait(false);
 
-        // Copy of ConverterReadAsync to keep everything in one async frame.
+        // Inline copy of Converter.ReadAsync<T> to keep everything in one async frame.
         var result = typeof(T) != TypeToConvert
             ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-            : await UnsafeGetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            : await Unsafe.As<PgConverter<T>>(Converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false);
 
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;
@@ -374,7 +320,8 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
         var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
-        if (UnsafeGetConverter<T>().IsDbNullOrGetSize(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        Debug.Assert(Converter is PgConverter<T>);
+        if (Unsafe.As<PgConverter<T>>(Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
             return new(format, bufferRequirements.Write, null, null);
 
         return new(format, bufferRequirements.Write, size, writeState);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -53,7 +53,10 @@ public abstract class PgTypeInfo
         if (this is not PgProviderTypeInfo providerTypeInfo)
             return (PgConcreteTypeInfo)this;
 
-        return providerTypeInfo.GetConcreteTypeInfo(field) ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
+        // Decided providers skip GetDefault's validation. The prior GetForField call already validated
+        // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        return providerTypeInfo.GetConcreteTypeInfo(field)
+            ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? field.PgTypeId : null);
     }
 
     public PgConcreteTypeInfo GetConcreteTypeInfo<T>(T? value, out object? writeState)
@@ -74,7 +77,10 @@ public abstract class PgTypeInfo
             ? providerTypeInfo.GetAsObjectConcreteTypeInfo(context, (object?)value, out writeState)
             : providerTypeInfo.GetConcreteTypeInfo(context, value, out writeState);
 
-        return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
+        // Decided providers skip GetDefault's validation. The prior GetForValue call already validated
+        // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        return concreteTypeInfo
+            ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
     }
 
     public PgConcreteTypeInfo GetObjectConcreteTypeInfo(object? value, out object? writeState)
@@ -92,7 +98,9 @@ public abstract class PgTypeInfo
             PgConcreteTypeInfo? concreteTypeInfo = null;
             if (value is not DBNull)
                 concreteTypeInfo = providerTypeInfo.GetAsObjectConcreteTypeInfo(context, value, out writeState);
-            return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
+            // Decided providers skip GetDefault's validation. The prior GetForValueAsObject call already
+            // validated the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+            return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
         default:
             return ThrowNotSupported();
         }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -329,7 +329,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
         Debug.Assert(Converter is PgConverter<T>);
-        if (Unsafe.As<PgConverter<T>>(Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        if (Unsafe.As<PgConverter<T>>(Converter).IsDbNullOrGetSize(format, bufferRequirements.Write, value, ref writeState) is not { } size)
             return new(format, bufferRequirements.Write, null, null);
 
         return new(format, bufferRequirements.Write, size, writeState);
@@ -347,7 +347,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
         // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
-        if (value is DBNull && Type != typeof(DBNull) || Converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        if (value is DBNull && Type != typeof(DBNull) || Converter.IsDbNullOrGetSizeAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } size)
         {
             return new(format, bufferRequirements.Write, null, null);
         }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -18,9 +18,6 @@ public abstract class PgTypeInfo
 
         HasExactType = requestedType is null || requestedType == type;
         Type = requestedType is null ? type : GetReportedType(type, requestedType) ?? type;
-
-        SupportsReading = GetDefaultSupportsReading(type, requestedType);
-        SupportsWriting = true;
     }
 
     private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? requestedType = null)
@@ -33,8 +30,6 @@ public abstract class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
-    public bool SupportsReading { get; init; }
-    public bool SupportsWriting { get; init; }
     public DataFormat? PreferredFormat { get; init; }
 
     // True when the reported type matches the converter's type exactly (no reported type given at construction, or
@@ -149,12 +144,12 @@ public abstract class PgTypeInfo
                ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
     }
 
-    // We assume a weakly typed info does not support reading as the converter won't be able to produce the derived type statically.
-    // Cases like Array converters reading int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
-    internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
-        => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
-
-    static Type? GetReportedType(Type converterType, Type requestedType)
+    /// <summary>
+    /// Validates that <paramref name="requestedType"/> is in a subtype relationship with <paramref name="converterType"/>
+    /// and returns the type to surface as the reported type — the requested type if it widens the converter type,
+    /// or null when the converter type itself is the right reported type.
+    /// </summary>
+    protected static Type? GetReportedType(Type converterType, Type requestedType)
     {
         if (!requestedType.IsInSubtypeRelationshipWith(converterType))
             throw new ArgumentException($"The requested type {requestedType} is not in a subtype relationship with the converter's type {converterType}.", nameof(requestedType));
@@ -292,6 +287,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         Converter = converter;
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
+
+        SupportsReading = GetDefaultSupportsReading(converter.TypeToConvert, requestedType);
+        SupportsWriting = true;
     }
 
     Type TypeToConvert
@@ -301,6 +299,15 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     }
 
     public PgConverter Converter { get; }
+
+    public bool SupportsReading { get; init; }
+    public bool SupportsWriting { get; init; }
+
+    // We assume a non-exact typed info does not support reading as the converter won't be able to produce the derived type statically.
+    // Cases like Array converters reading int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
+    internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
+        => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
+
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
     internal bool CanReadTo(Type type) => Type == type || (!HasExactType && Type.IsAssignableTo(type));

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -387,7 +387,6 @@ readonly struct PgFieldBinding
         BufferRequirement = bufferRequirement;
     }
 
-    // DataFormat can differ from the actual field format if data will be reintrepreted for this binding (e.g. UnknownResultType)
     public DataFormat DataFormat { get; }
     public Size BufferRequirement { get; }
 }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
 
@@ -20,23 +19,13 @@ public abstract class PgTypeInfo
         SupportsWriting = true;
     }
 
-    private protected PgTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null)
-        : this(options, converter.TypeToConvert, unboxedType)
-    {
-        Converter = converter;
-        PgTypeId = options.GetCanonicalTypeId(pgTypeId);
-    }
-
-    private protected PgTypeInfo(PgSerializerOptions options, Type type, PgConcreteTypeInfo? defaultConcrete, Type? unboxedType = null)
+    private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? unboxedType = null)
         : this(options, type, unboxedType)
-    {
-        if (defaultConcrete is not null)
-        {
-            Debug.Assert(options.PortableTypeIds && defaultConcrete.PgTypeId.IsDataTypeName || !options.PortableTypeIds && defaultConcrete.PgTypeId.IsOid);
-            PgTypeId = defaultConcrete.PgTypeId;
-            Converter = defaultConcrete.Converter;
-        }
-    }
+        => PgTypeId = pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null;
+
+    private protected PgTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null)
+        : this(options, converter.TypeToConvert, pgTypeId, unboxedType)
+        => Converter = converter;
 
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
@@ -48,9 +37,6 @@ public abstract class PgTypeInfo
     // Doubles as the storage for the converter coming from a default provider result (used to confirm whether we can use cached info).
     protected PgConverter? Converter { get; }
 
-    // TODO pull validate from options + internal exempt for perf?
-    internal bool ValidateProviderResults => true;
-
     // Used for internal converters to save on binary bloat.
     internal bool IsBoxing { get; }
 
@@ -58,10 +44,10 @@ public abstract class PgTypeInfo
 
     public PgConcreteTypeInfo GetConcreteTypeInfo(Field field)
     {
-        if (this is not PgProviderTypeInfo resolverInfo)
+        if (this is not PgProviderTypeInfo providerTypeInfo)
             return (PgConcreteTypeInfo)this;
 
-        return resolverInfo.GetConcreteTypeInfo(field) ?? resolverInfo.GetDefaultConcreteTypeInfo(field.PgTypeId);
+        return providerTypeInfo.GetConcreteTypeInfo(field) ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
     }
 
     public PgConcreteTypeInfo GetConcreteTypeInfo<T>(T? value, out object? writeState)
@@ -102,24 +88,21 @@ public abstract class PgTypeInfo
         => unboxedType is null || unboxedType == type;
 }
 
-public sealed class PgProviderTypeInfo(
-    PgSerializerOptions options,
-    PgConcreteTypeInfoProvider typeInfoProvider,
-    PgTypeId? pgTypeId,
-    Type? unboxedType = null)
-    : PgTypeInfo(options,
-        typeInfoProvider.TypeToConvert,
-        pgTypeId is { } typeId ? GetDefault(options, typeInfoProvider, typeId) : null,
-        unboxedType)
+public sealed class PgProviderTypeInfo : PgTypeInfo
 {
-    readonly PgConcreteTypeInfoProvider _typeInfoProvider = typeInfoProvider;
+    readonly PgConcreteTypeInfoProvider _typeInfoProvider;
+    readonly PgConcreteTypeInfo? _defaultConcrete;
 
-    // We'll always validate the default provider result, the info will be re-used so there is no real downside.
-    static PgConcreteTypeInfo GetDefault(PgSerializerOptions options, PgConcreteTypeInfoProvider concreteTypeInfoProvider, PgTypeId typeId)
+    // We always mark providers with type object as boxing, as they may freely return converters for any type (see PgConcreteTypeInfoProvider.Validate).
+    public PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? unboxedType = null)
+        : base(options, typeInfoProvider.TypeToConvert, pgTypeId, unboxedType ?? (typeInfoProvider.TypeToConvert == typeof(object) ? typeof(object) : null))
     {
-        var result = concreteTypeInfoProvider.GetDefault(options.GetCanonicalTypeId(typeId));
-        ValidateResult(nameof(GetDefault), result, concreteTypeInfoProvider.TypeToConvert, options.PortableTypeIds);
-        return result;
+        _typeInfoProvider = typeInfoProvider;
+
+        // Always validate the default provider result, the info will be re-used so there is no real downside.
+        var result = typeInfoProvider.GetDefault(pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null);
+        ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result, typeInfoProvider.TypeToConvert, options.PortableTypeIds);
+        _defaultConcrete = result;
     }
 
     public PgConcreteTypeInfo GetDefaultConcreteTypeInfo(PgTypeId? pgTypeId)

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -57,6 +57,9 @@ public abstract class PgTypeInfo
     }
 
     public PgConcreteTypeInfo GetConcreteTypeInfo<T>(T? value, out object? writeState)
+        => GetConcreteTypeInfo(default, value, out writeState);
+
+    public PgConcreteTypeInfo GetConcreteTypeInfo<T>(ProviderValueContext context, T? value, out object? writeState)
     {
         if (this is not PgProviderTypeInfo providerTypeInfo)
         {
@@ -68,14 +71,17 @@ public abstract class PgTypeInfo
         // This will never cause boxing as weakly typed infos only happen for subtype relationships, i.e. reference types.
         // We make sure to fall through to ProvideConcreteTypeInfo which has a better error if T is not at all related to this info.
         var concreteTypeInfo = PgProviderTypeInfo.GetProvider(providerTypeInfo) is not PgConcreteTypeInfoProvider<T> && providerTypeInfo.Type == typeof(T)
-            ? providerTypeInfo.GetAsObjectConcreteTypeInfo(default, (object?)value, out writeState)
-            : providerTypeInfo.GetConcreteTypeInfo(default, value, out writeState);
+            ? providerTypeInfo.GetAsObjectConcreteTypeInfo(context, (object?)value, out writeState)
+            : providerTypeInfo.GetConcreteTypeInfo(context, value, out writeState);
 
         return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
     }
 
-    // Note: this api is not called GetConcreteTypeInfoAsObject as the semantics are extended, DBNull is a NULL value for all object values.
     public PgConcreteTypeInfo GetObjectConcreteTypeInfo(object? value, out object? writeState)
+        => GetObjectConcreteTypeInfo(default, value, out writeState);
+
+    // Note: this api is not called GetConcreteTypeInfoAsObject as the semantics are extended, DBNull is a NULL value for all object values.
+    public PgConcreteTypeInfo GetObjectConcreteTypeInfo(ProviderValueContext context, object? value, out object? writeState)
     {
         writeState = null;
         switch (this)
@@ -85,7 +91,7 @@ public abstract class PgTypeInfo
         case PgProviderTypeInfo providerTypeInfo:
             PgConcreteTypeInfo? concreteTypeInfo = null;
             if (value is not DBNull)
-                concreteTypeInfo = providerTypeInfo.GetAsObjectConcreteTypeInfo(default, value, out writeState);
+                concreteTypeInfo = providerTypeInfo.GetAsObjectConcreteTypeInfo(context, value, out writeState);
             return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
         default:
             return ThrowNotSupported();
@@ -156,7 +162,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
-    public PgConcreteTypeInfo? GetConcreteTypeInfo<T>(ProviderValueContext context, T? value, out object? writeState)
+    public new PgConcreteTypeInfo? GetConcreteTypeInfo<T>(ProviderValueContext context, T? value, out object? writeState)
     {
         if (PgTypeId is { } pgTypeId)
         {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -8,12 +8,6 @@ namespace Npgsql.Internal;
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgTypeInfo
 {
-    readonly bool _canBinaryConvert;
-    readonly BufferRequirements _binaryBufferRequirements;
-
-    readonly bool _canTextConvert;
-    readonly BufferRequirements _textBufferRequirements;
-
     PgTypeInfo(PgSerializerOptions options, Type type, Type? unboxedType)
     {
         if (unboxedType is not null && !type.IsAssignableFrom(unboxedType))
@@ -31,8 +25,6 @@ public abstract class PgTypeInfo
     {
         Converter = converter;
         PgTypeId = options.GetCanonicalTypeId(pgTypeId);
-        _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
-        _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
     }
 
     private protected PgTypeInfo(PgSerializerOptions options, Type type, PgConcreteTypeInfo? defaultConcrete, Type? unboxedType = null)
@@ -43,12 +35,8 @@ public abstract class PgTypeInfo
             Debug.Assert(options.PortableTypeIds && defaultConcrete.PgTypeId.IsDataTypeName || !options.PortableTypeIds && defaultConcrete.PgTypeId.IsOid);
             PgTypeId = defaultConcrete.PgTypeId;
             Converter = defaultConcrete.Converter;
-            _canBinaryConvert = defaultConcrete.Converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
-            _canTextConvert = defaultConcrete.Converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
         }
     }
-
-    bool HasCachedInfo(PgConverter converter) => ReferenceEquals(Converter, converter);
 
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
@@ -106,24 +94,6 @@ public abstract class PgTypeInfo
 
         static PgConcreteTypeInfo ThrowNotSupported()
             => throw new NotSupportedException("Should not happen, please file a bug.");
-    }
-
-    protected bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
-    {
-        if (HasCachedInfo(converter))
-        {
-            switch (format)
-            {
-            case DataFormat.Binary:
-                bufferRequirements = _binaryBufferRequirements;
-                return _canBinaryConvert;
-            case DataFormat.Text:
-                bufferRequirements = _textBufferRequirements;
-                return _canTextConvert;
-            }
-        }
-
-        return converter.CanConvert(format, out bufferRequirements);
     }
 
     // We assume a boxing type info does not support reading as the converter won't be able to produce the derived type statically.
@@ -237,11 +207,37 @@ public sealed class PgProviderTypeInfo(
     }
 }
 
-public sealed class PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null)
-    : PgTypeInfo(options, converter, pgTypeId, unboxedType)
+public sealed class PgConcreteTypeInfo : PgTypeInfo
 {
+    readonly bool _canBinaryConvert;
+    readonly BufferRequirements _binaryBufferRequirements;
+
+    readonly bool _canTextConvert;
+    readonly BufferRequirements _textBufferRequirements;
+
+    public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null) : base(options, converter, pgTypeId, unboxedType)
+    {
+        _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
+        _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
+    }
+
     public new PgConverter Converter => base.Converter!;
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
+
+    bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        switch (format)
+        {
+        case DataFormat.Binary:
+            bufferRequirements = _binaryBufferRequirements;
+            return _canBinaryConvert;
+        case DataFormat.Text:
+            bufferRequirements = _textBufferRequirements;
+            return _canTextConvert;
+        }
+
+        return converter.CanConvert(format, out bufferRequirements);
+    }
 
     public BufferRequirements? GetBufferRequirements(DataFormat format)
     {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -133,8 +133,14 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
     public PgConcreteTypeInfo GetDefaultConcreteTypeInfo(PgTypeId? pgTypeId)
     {
-        if (pgTypeId is { } id && PgTypeId is { } decidedId && id != decidedId)
-            ThrowUnexpectedPgTypeId(nameof(pgTypeId));
+        if (pgTypeId is { } id && PgTypeId is { } decidedId)
+        {
+            if (id != decidedId)
+                ThrowUnexpectedPgTypeId(nameof(pgTypeId));
+
+            Debug.Assert(_defaultConcrete is not null);
+            return _defaultConcrete;
+        }
 
         var result = _typeInfoProvider.GetDefault(pgTypeId ?? PgTypeId);
         ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -278,46 +278,38 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
     // Bind for writing.
     /// When result is null, the value was interpreted to be a SQL NULL.
-    internal PgConverterInfo? Bind<T>(T? value, out Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
+    internal PgValueBinding BindParameterValue<T>(T? value, object? writeState, DataFormat? formatPreference = null)
     {
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
 
-        writeState = null;
-        if (((PgConverter<T>)Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
-        {
-            size = default;
-            return null;
-        }
+        if (((PgConverter<T>)Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+            return new(format, bufferRequirements.Write, null, null);
 
-        size = sizeOrDbNull;
-        return new(this, bufferRequirements.Write);
+        return new(format, bufferRequirements.Write, size, writeState);
     }
 
     // Bind for writing.
     // Note: this api is not called BindAsObject as the semantics are extended, DBNull is a NULL value for all object values.
     /// When result is null or DBNull, the value was interpreted to be a SQL NULL.
-    internal PgConverterInfo? BindObject(object? value, out Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
+    internal PgValueBinding BindParameterObjectValue(object? value, object? writeState, DataFormat? formatPreference = null)
     {
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
 
         // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
-        writeState = null;
-        if (value is DBNull && Type != typeof(DBNull) || Converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
+        if (value is DBNull && Type != typeof(DBNull) || Converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } size)
         {
-            size = default;
-            return null;
+            return new(format, bufferRequirements.Write, null, null);
         }
 
-        size = sizeOrDbNull;
-        return new(this, bufferRequirements.Write);
+        return new(format, bufferRequirements.Write, size, writeState);
     }
 
     DataFormat ResolveFormat(PgConverter converter, out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
@@ -341,6 +333,25 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
             return default;
         }
     }
+}
+
+readonly struct PgValueBinding
+{
+    public DataFormat DataFormat { get; }
+    public Size BufferRequirement { get; }
+    public Size? Size { get; }
+    public object? WriteState { get; }
+
+    internal PgValueBinding(DataFormat dataFormat, Size bufferRequirement, Size? size, object? writeState)
+    {
+        DataFormat = dataFormat;
+        BufferRequirement = bufferRequirement;
+        Size = size;
+        WriteState = writeState;
+    }
+
+    [MemberNotNullWhen(false, nameof(Size))]
+    public bool IsDbNullBinding => Size is null;
 }
 
 readonly struct PgConverterInfo

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -155,9 +155,8 @@ public abstract class PgTypeInfo
     }
 
     /// <summary>
-    /// Validates that <paramref name="requestedType"/> is in a subtype relationship with <paramref name="converterType"/>
-    /// and returns the type to surface as the reported type — the requested type if it widens the converter type,
-    /// or null when the converter type itself is the right reported type.
+    /// Returns <paramref name="requestedType"/> when it is a strict subtype of <paramref name="converterType"/>, otherwise null.
+    /// Throws when the two are not in a subtype relationship.
     /// </summary>
     protected static Type? GetReportedType(Type converterType, Type requestedType)
     {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -52,11 +52,12 @@ public abstract class PgTypeInfo
     /// </remarks>
     public PgConcreteTypeInfo MakeConcreteForField(Field field)
     {
-        if (this is not PgProviderTypeInfo providerTypeInfo)
-            return (PgConcreteTypeInfo)this;
+        if (this is PgConcreteTypeInfo concrete)
+            return concrete;
 
         // Decided providers skip GetDefault's validation. The prior GetForField call already validated
         // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        var providerTypeInfo = (PgProviderTypeInfo)this;
         return providerTypeInfo.GetForField(field)
                ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? field.PgTypeId : null);
     }
@@ -88,15 +89,16 @@ public abstract class PgTypeInfo
     /// </remarks>
     public PgConcreteTypeInfo MakeConcreteForValue<T>(ProviderValueContext context, T? value, out object? writeState)
     {
-        if (this is not PgProviderTypeInfo providerTypeInfo)
+        if (this is PgConcreteTypeInfo concrete)
         {
             writeState = null;
-            return (PgConcreteTypeInfo)this;
+            return concrete;
         }
 
         // Make sure we handle the non-exact typed provider case.
         // This will never cause boxing as non-exact typed infos only happen for subtype relationships, i.e. reference types.
         // We make sure to fall through to GetForValue which has a better error if T is not at all related to this info.
+        var providerTypeInfo = (PgProviderTypeInfo)this;
         var concreteTypeInfo = PgProviderTypeInfo.GetProvider(providerTypeInfo) is not PgConcreteTypeInfoProvider<T> && providerTypeInfo.Type == typeof(T)
             ? providerTypeInfo.GetForValueAsObject(context, (object?)value, out writeState)
             : providerTypeInfo.GetForValue(context, value, out writeState);
@@ -132,14 +134,24 @@ public abstract class PgTypeInfo
     /// </remarks>
     public PgConcreteTypeInfo MakeConcreteForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
     {
-        writeState = null;
-        if (this is not PgProviderTypeInfo providerTypeInfo)
-            return (PgConcreteTypeInfo)this;
+        if (this is PgConcreteTypeInfo concrete)
+        {
+            writeState = null;
+            return concrete;
+        }
 
         // Decided providers skip GetDefault's validation. The prior GetForValueAsObject call already validated
         // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        var providerTypeInfo = (PgProviderTypeInfo)this;
         return providerTypeInfo.GetForValueAsObject(context, value, out writeState)
                ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? context.ExpectedPgTypeId : null);
+    }
+
+    // Having it here so we can easily extend any behavior.
+    internal void DisposeWriteState(object writeState)
+    {
+        if (writeState is IDisposable disposable)
+            disposable.Dispose();
     }
 
     /// <summary>
@@ -312,7 +324,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     internal bool CanReadTo(Type type) => Type == type || (!HasExactType && Type.IsAssignableTo(type));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal T ReadFieldValue<T>(PgReader reader, PgFieldBinding binding)
+    internal T ReadFieldValue<T>(PgReader reader, in PgFieldBinding binding)
     {
         reader.StartRead(binding);
         var result = Converter.Read<T>(reader);
@@ -331,13 +343,6 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;
-    }
-
-    // Having it here so we can easily extend any behavior.
-    internal void DisposeWriteState(object writeState)
-    {
-        if (writeState is IDisposable disposable)
-            disposable.Dispose();
     }
 
     // TryBind for reading.

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -68,7 +68,14 @@ public abstract class PgTypeInfo
             return (PgConcreteTypeInfo)this;
         }
 
-        return providerTypeInfo.GetConcreteTypeInfo(default, value, out writeState) ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
+        // Make sure we handle the weakly typed provider case.
+        // This will never cause boxing as weakly typed infos only happen for subtype relationships, i.e. reference types.
+        // We make sure to fall through to ProvideConcreteTypeInfo which has a better error if T is not at all related to this info.
+        var concreteTypeInfo = PgProviderTypeInfo.GetProvider(providerTypeInfo) is not PgConcreteTypeInfoProvider<T> && providerTypeInfo.Type == typeof(T)
+            ? providerTypeInfo.GetAsObjectConcreteTypeInfo(default, (object?)value, out writeState)
+            : providerTypeInfo.GetConcreteTypeInfo(default, value, out writeState);
+
+        return concreteTypeInfo ?? providerTypeInfo.GetDefaultConcreteTypeInfo(null);
     }
 
     // Note: this api is not called GetConcreteTypeInfoAsObject as the semantics are extended, DBNull is a NULL value for all object values.

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -243,18 +243,22 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
     }
 
+    Type TypeToConvert
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            Debug.Assert(Converter.TypeToConvert == _typeToConvert);
+            return _typeToConvert;
+        }
+    }
+
     public PgConverter Converter { get; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    bool ShouldReadAsObject<T>() => typeof(T) != _typeToConvert;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConverter<T> GetConverter<T>()
+    PgConverter<T> UnsafeGetConverter<T>()
     {
-        if (ShouldReadAsObject<T>())
-            ThrowHelper.ThrowInvalidCastException("Invalid type for converter.");
-
         // Justification: avoid perf cost of casting to a known base class type per field read.
         Debug.Assert(Converter is PgConverter<T>);
         return Unsafe.As<PgConverter<T>>(Converter);
@@ -262,24 +266,20 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal T ConverterRead<T>(PgReader reader)
-    {
-        if (ShouldReadAsObject<T>())
-            return (T)Converter.ReadAsObject(reader);
-
-        return GetConverter<T>().Read(reader);
-    }
+        => typeof(T) != TypeToConvert
+            ? (T)Converter.ReadAsObject(reader)
+            : UnsafeGetConverter<T>().Read(reader);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ValueTask<T> ConverterReadAsync<T>(PgReader reader, CancellationToken cancellationToken)
     {
-        var converter = Converter;
-        if (ShouldReadAsObject<T>())
+        if (typeof(T) != TypeToConvert)
         {
-            var task = converter.ReadAsObjectAsync(reader, cancellationToken);
+            var task = Converter.ReadAsObjectAsync(reader, cancellationToken);
             return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
         }
 
-        return GetConverter<T>().ReadAsync(reader, cancellationToken);
+        return UnsafeGetConverter<T>().ReadAsync(reader, cancellationToken);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
@@ -288,11 +288,20 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void ConverterWrite<T>(PgWriter writer, [DisallowNull]T value)
-        => GetConverter<T>().Write(writer, value);
+    {
+        if (typeof(T) != TypeToConvert)
+        {
+            Converter.WriteAsObject(writer, value);
+            return;
+        }
+        UnsafeGetConverter<T>().Write(writer, value);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ValueTask ConverterWriteAsync<T>(PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken)
-        => GetConverter<T>().WriteAsync(writer, value, cancellationToken);
+        => typeof(T) != TypeToConvert
+            ? Converter.WriteAsObjectAsync(writer, value, cancellationToken)
+            : UnsafeGetConverter<T>().WriteAsync(writer, value, cancellationToken);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal T ReadFieldValue<T>(PgReader reader, DataFormat dataFormat)
@@ -310,9 +319,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         await reader.StartReadAsync(dataFormat, bufferRequirement, cancellationToken).ConfigureAwait(false);
 
         // Copy of ConverterReadAsync to keep everything in one async frame.
-        var result = ShouldReadAsObject<T>()
+        var result = typeof(T) != TypeToConvert
             ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-            : await GetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            : await UnsafeGetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
 
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;
@@ -356,13 +365,16 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     /// When result is null, the value was interpreted to be a SQL NULL.
     internal PgValueBinding BindParameterValue<T>(T? value, object? writeState, DataFormat? formatPreference = null)
     {
+        if (typeof(T) != TypeToConvert)
+            return BindParameterObjectValue(value, writeState, formatPreference);
+
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
         var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
-        if (GetConverter<T>().GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        if (UnsafeGetConverter<T>().IsDbNullOrGetSize(format, bufferRequirements.Write, value, ref writeState) is not { } size)
             return new(format, bufferRequirements.Write, null, null);
 
         return new(format, bufferRequirements.Write, size, writeState);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -107,30 +107,6 @@ public abstract class PgTypeInfo
             => throw new NotSupportedException("Should not happen, please file a bug.");
     }
 
-    bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
-    {
-        if (HasCachedInfo(converter))
-        {
-            switch (format)
-            {
-            case DataFormat.Binary:
-                bufferRequirements = _binaryBufferRequirements;
-                return _canBinaryConvert;
-            case DataFormat.Text:
-                bufferRequirements = _textBufferRequirements;
-                return _canTextConvert;
-            }
-        }
-
-        return converter.CanConvert(format, out bufferRequirements);
-    }
-
-    public BufferRequirements? GetBufferRequirements(PgConverter converter, DataFormat format)
-    {
-        var success = CanConvert(converter, format, out var bufferRequirements);
-        return success ? bufferRequirements : null;
-    }
-
     // TryBind for reading.
     internal bool TryBind(Field field, DataFormat format, out PgConverterInfo info)
     {
@@ -207,6 +183,24 @@ public abstract class PgTypeInfo
 
         size = sizeOrDbNull;
         return new(this, converter, bufferRequirements.Write);
+    }
+
+    protected bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        if (HasCachedInfo(converter))
+        {
+            switch (format)
+            {
+            case DataFormat.Binary:
+                bufferRequirements = _binaryBufferRequirements;
+                return _canBinaryConvert;
+            case DataFormat.Text:
+                bufferRequirements = _textBufferRequirements;
+                return _canTextConvert;
+            }
+        }
+
+        return converter.CanConvert(format, out bufferRequirements);
     }
 
     DataFormat ResolveFormat(PgConverter converter, out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
@@ -347,6 +341,12 @@ public sealed class PgConcreteTypeInfo(PgSerializerOptions options, PgConverter 
 {
     public new PgConverter Converter => base.Converter!;
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
+
+    public BufferRequirements? GetBufferRequirements(DataFormat format)
+    {
+        var success = CanConvert(Converter, format, out var bufferRequirements);
+        return success ? bufferRequirements : null;
+    }
 }
 
 readonly struct PgConverterInfo

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -110,8 +110,12 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
     readonly PgConcreteTypeInfoProvider _typeInfoProvider;
     readonly PgConcreteTypeInfo? _defaultConcrete;
 
+    public PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId)
+        : this(options, typeInfoProvider, pgTypeId, requestedType: null)
+    {}
+
     // We always mark providers with type object as boxing, as they may freely return converters for any type (see PgConcreteTypeInfoProvider.Validate).
-    public PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? requestedType = null)
+    internal PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? requestedType)
         : base(options, typeInfoProvider.TypeToConvert, pgTypeId,
             (requestedType is null ? null : ComputeUnboxedType(typeInfoProvider.TypeToConvert, requestedType))
             ?? (typeInfoProvider.TypeToConvert == typeof(object) ? typeof(object) : null))
@@ -217,7 +221,11 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     readonly bool _canTextConvert;
     readonly BufferRequirements _textBufferRequirements;
 
-    public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType = null)
+    public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId)
+        : this(options, converter, pgTypeId, requestedType: null)
+    {}
+
+    internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType)
         : base(options, converter, pgTypeId, requestedType is null ? null : ComputeUnboxedType(converter.TypeToConvert, requestedType))
     {
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -68,11 +68,12 @@ public abstract class PgTypeInfo
 
     public PgTypeId? PgTypeId { get; }
 
-    // Having it here so we can easily extend any behavior.
-    internal void DisposeWriteState(object writeState)
+    public PgConcreteTypeInfo GetConcreteTypeInfo(Field field)
     {
-        if (writeState is IDisposable disposable)
-            disposable.Dispose();
+        if (this is not PgProviderTypeInfo resolverInfo)
+            return (PgConcreteTypeInfo)this;
+
+        return resolverInfo.GetConcreteTypeInfo(field) ?? resolverInfo.GetDefaultConcreteTypeInfo(field.PgTypeId);
     }
 
     public PgConcreteTypeInfo GetConcreteTypeInfo<T>(T? value, out object? writeState)
@@ -107,84 +108,6 @@ public abstract class PgTypeInfo
             => throw new NotSupportedException("Should not happen, please file a bug.");
     }
 
-    // TryBind for reading.
-    internal bool TryBind(Field field, DataFormat format, out PgConverterInfo info)
-    {
-        switch (this)
-        {
-        case PgConcreteTypeInfo v:
-            if (!CanConvert(v.Converter, format, out var bufferRequirements))
-            {
-                info = default;
-                return false;
-            }
-            info = new(this, v.Converter, bufferRequirements.Read);
-            return true;
-        case PgProviderTypeInfo providerTypeInfo:
-            var concreteTypeInfo = providerTypeInfo.GetConcreteTypeInfo(field) ?? providerTypeInfo.GetDefaultConcreteTypeInfo(field.PgTypeId);
-            if (!CanConvert(concreteTypeInfo.Converter, format, out bufferRequirements))
-            {
-                info = default;
-                return false;
-            }
-            info = new(concreteTypeInfo, concreteTypeInfo.Converter, bufferRequirements.Read);
-            return true;
-        default:
-            throw new NotSupportedException("Should not happen, please file a bug.");
-        }
-    }
-
-    // Bind for reading.
-    internal PgConverterInfo Bind(Field field, DataFormat format)
-    {
-        if (!TryBind(field, format, out var info))
-            ThrowHelper.ThrowInvalidOperationException($"Resolved converter does not support {format} format.");
-
-        return info;
-    }
-
-    // Bind for writing.
-    /// When result is null, the value was interpreted to be a SQL NULL.
-    internal PgConverterInfo? Bind<T>(PgConverter<T> converter, T? value, out Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
-    {
-        // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
-        if (!SupportsWriting)
-            ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
-
-        format = ResolveFormat(converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
-
-        if (converter.GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
-        {
-            size = default;
-            return null;
-        }
-
-        size = sizeOrDbNull;
-        return new(this, converter, bufferRequirements.Write);
-    }
-
-    // Bind for writing.
-    // Note: this api is not called BindAsObject as the semantics are extended, DBNull is a NULL value for all object values.
-    /// When result is null or DBNull, the value was interpreted to be a SQL NULL.
-    internal PgConverterInfo? BindObject(PgConverter converter, object? value, ref Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
-    {
-        // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
-        if (!SupportsWriting)
-            throw new NotSupportedException($"Writing {Type} is not supported for this type info.");
-
-        format = ResolveFormat(converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
-
-        // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
-        if (value is DBNull && Type != typeof(DBNull) || converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
-        {
-            size = default;
-            return null;
-        }
-
-        size = sizeOrDbNull;
-        return new(this, converter, bufferRequirements.Write);
-    }
-
     protected bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
     {
         if (HasCachedInfo(converter))
@@ -201,28 +124,6 @@ public abstract class PgTypeInfo
         }
 
         return converter.CanConvert(format, out bufferRequirements);
-    }
-
-    DataFormat ResolveFormat(PgConverter converter, out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
-    {
-        // First try to check for preferred support.
-        switch (formatPreference)
-        {
-        case DataFormat.Binary when CanConvert(converter, DataFormat.Binary, out bufferRequirements):
-            return DataFormat.Binary;
-        case DataFormat.Text when CanConvert(converter, DataFormat.Text, out bufferRequirements):
-            return DataFormat.Text;
-        default:
-            // The common case, no preference given (or no match) means we default to binary if supported.
-            if (CanConvert(converter, DataFormat.Binary, out bufferRequirements))
-                return DataFormat.Binary;
-            if (CanConvert(converter, DataFormat.Text, out bufferRequirements))
-                return DataFormat.Text;
-
-            ThrowHelper.ThrowInvalidOperationException("Converter doesn't support any data format.");
-            bufferRequirements = default;
-            return default;
-        }
     }
 
     // We assume a boxing type info does not support reading as the converter won't be able to produce the derived type statically.
@@ -261,7 +162,7 @@ public sealed class PgProviderTypeInfo(
         return result;
     }
 
-    public PgConcreteTypeInfo? GetConcreteTypeInfo(Field field)
+    public new PgConcreteTypeInfo? GetConcreteTypeInfo(Field field)
     {
         if (PgTypeId is { } decidedId && field.PgTypeId != decidedId)
             ThrowUnexpectedPgTypeId(nameof(field));
@@ -347,16 +248,109 @@ public sealed class PgConcreteTypeInfo(PgSerializerOptions options, PgConverter 
         var success = CanConvert(Converter, format, out var bufferRequirements);
         return success ? bufferRequirements : null;
     }
+
+    // Having it here so we can easily extend any behavior.
+    internal void DisposeWriteState(object writeState)
+    {
+        if (writeState is IDisposable disposable)
+            disposable.Dispose();
+    }
+
+    // TryBind for reading.
+    internal bool TryBind(DataFormat format, out PgConverterInfo info)
+    {
+        if (!CanConvert(Converter, format, out var bufferRequirements))
+        {
+            info = default;
+            return false;
+        }
+        info = new(this, bufferRequirements.Read);
+        return true;
+    }
+
+    // Bind for reading.
+    internal PgConverterInfo Bind(DataFormat format)
+    {
+        if (!TryBind(format, out var info))
+            ThrowHelper.ThrowInvalidOperationException($"Converter does not support {format} format.");
+
+        return info;
+    }
+
+    // Bind for writing.
+    /// When result is null, the value was interpreted to be a SQL NULL.
+    internal PgConverterInfo? Bind<T>(T? value, out Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
+    {
+        // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
+        if (!SupportsWriting)
+            ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
+
+        format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+
+        writeState = null;
+        if (((PgConverter<T>)Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
+        {
+            size = default;
+            return null;
+        }
+
+        size = sizeOrDbNull;
+        return new(this, bufferRequirements.Write);
+    }
+
+    // Bind for writing.
+    // Note: this api is not called BindAsObject as the semantics are extended, DBNull is a NULL value for all object values.
+    /// When result is null or DBNull, the value was interpreted to be a SQL NULL.
+    internal PgConverterInfo? BindObject(object? value, out Size size, ref object? writeState, out DataFormat format, DataFormat? formatPreference = null)
+    {
+        // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
+        if (!SupportsWriting)
+            ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
+
+        format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+
+        // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
+        writeState = null;
+        if (value is DBNull && Type != typeof(DBNull) || Converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } sizeOrDbNull)
+        {
+            size = default;
+            return null;
+        }
+
+        size = sizeOrDbNull;
+        return new(this, bufferRequirements.Write);
+    }
+
+    DataFormat ResolveFormat(PgConverter converter, out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
+    {
+        // First try to check for preferred support.
+        switch (formatPreference)
+        {
+        case DataFormat.Binary when CanConvert(converter, DataFormat.Binary, out bufferRequirements):
+            return DataFormat.Binary;
+        case DataFormat.Text when CanConvert(converter, DataFormat.Text, out bufferRequirements):
+            return DataFormat.Text;
+        default:
+            // The common case, no preference given (or no match) means we default to binary if supported.
+            if (CanConvert(converter, DataFormat.Binary, out bufferRequirements))
+                return DataFormat.Binary;
+            if (CanConvert(converter, DataFormat.Text, out bufferRequirements))
+                return DataFormat.Text;
+
+            ThrowHelper.ThrowInvalidOperationException("Converter doesn't support any data format.");
+            bufferRequirements = default;
+            return default;
+        }
+    }
 }
 
 readonly struct PgConverterInfo
 {
-    readonly PgTypeInfo _typeInfo;
+    readonly PgConcreteTypeInfo _typeInfo;
 
-    public PgConverterInfo(PgTypeInfo pgTypeInfo, PgConverter converter, Size bufferRequirement)
+    public PgConverterInfo(PgConcreteTypeInfo pgTypeInfo, Size bufferRequirement)
     {
         _typeInfo = pgTypeInfo;
-        Converter = converter;
         BufferRequirement = bufferRequirement;
     }
 
@@ -366,7 +360,7 @@ readonly struct PgConverterInfo
 
     public PgTypeInfo TypeInfo => _typeInfo;
 
-    public PgConverter Converter { get; }
+    public PgConverter Converter => _typeInfo.Converter;
     public Size BufferRequirement { get; }
 
     /// Whether Converter.TypeToConvert matches PgTypeInfo.Type, if it doesn't object apis should be used.

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -343,7 +343,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     // TryBind for reading.
     internal bool TryBindField(DataFormat format, out PgFieldBinding binding)
     {
-        if (!CanConvert(format, out var bufferRequirements))
+        if (!Converter.CanConvert(format, out var bufferRequirements))
         {
             binding = default;
             return false;
@@ -401,36 +401,30 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return new(format, bufferRequirements.Write, size, writeState);
     }
 
-    public bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
-    {
-        switch (format)
-        {
-        case DataFormat.Binary:
-            bufferRequirements = _binaryBufferRequirements;
-            return _canBinaryConvert;
-        case DataFormat.Text:
-            bufferRequirements = _textBufferRequirements;
-            return _canTextConvert;
-        }
-
-        return Converter.CanConvert(format, out bufferRequirements);
-    }
-
     DataFormat ResolveFormat(out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
     {
         // First try to check for preferred support.
         switch (formatPreference)
         {
-        case DataFormat.Binary when CanConvert(DataFormat.Binary, out bufferRequirements):
+        case DataFormat.Binary when _canBinaryConvert:
+            bufferRequirements = _binaryBufferRequirements;
             return DataFormat.Binary;
-        case DataFormat.Text when CanConvert(DataFormat.Text, out bufferRequirements):
+        case DataFormat.Text when _canTextConvert:
+            bufferRequirements = _textBufferRequirements;
             return DataFormat.Text;
         default:
             // The common case, no preference given (or no match) means we default to binary if supported.
-            if (CanConvert(DataFormat.Binary, out bufferRequirements))
+            if (_canBinaryConvert)
+            {
+                bufferRequirements = _binaryBufferRequirements;
                 return DataFormat.Binary;
-            if (CanConvert(DataFormat.Text, out bufferRequirements))
+            }
+
+            if (Converter.CanConvert(DataFormat.Text, out bufferRequirements))
+            {
+                bufferRequirements = _textBufferRequirements;
                 return DataFormat.Text;
+            }
 
             ThrowHelper.ThrowInvalidOperationException("Converter doesn't support any data format.");
             bufferRequirements = default;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -256,21 +256,21 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     }
 
     // TryBind for reading.
-    internal bool TryBind(DataFormat format, out PgConverterInfo info)
+    internal bool TryBindField(DataFormat format, out PgFieldBinding binding)
     {
         if (!CanConvert(Converter, format, out var bufferRequirements))
         {
-            info = default;
+            binding = default;
             return false;
         }
-        info = new(this, bufferRequirements.Read);
+        binding = new(format, bufferRequirements.Read);
         return true;
     }
 
     // Bind for reading.
-    internal PgConverterInfo Bind(DataFormat format)
+    internal PgFieldBinding BindField(DataFormat format)
     {
-        if (!TryBind(format, out var info))
+        if (!TryBindField(format, out var info))
             ThrowHelper.ThrowInvalidOperationException($"Converter does not support {format} format.");
 
         return info;
@@ -335,6 +335,18 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     }
 }
 
+readonly struct PgFieldBinding
+{
+    internal PgFieldBinding(DataFormat dataFormat, Size bufferRequirement)
+    {
+        DataFormat = dataFormat;
+        BufferRequirement = bufferRequirement;
+    }
+
+    public DataFormat DataFormat { get; }
+    public Size BufferRequirement { get; }
+}
+
 readonly struct PgValueBinding
 {
     public DataFormat DataFormat { get; }
@@ -352,27 +364,4 @@ readonly struct PgValueBinding
 
     [MemberNotNullWhen(false, nameof(Size))]
     public bool IsDbNullBinding => Size is null;
-}
-
-readonly struct PgConverterInfo
-{
-    readonly PgConcreteTypeInfo _typeInfo;
-
-    public PgConverterInfo(PgConcreteTypeInfo pgTypeInfo, Size bufferRequirement)
-    {
-        _typeInfo = pgTypeInfo;
-        BufferRequirement = bufferRequirement;
-    }
-
-    public bool IsDefault => _typeInfo is null;
-
-    public Type TypeToConvert => _typeInfo.Type;
-
-    public PgTypeInfo TypeInfo => _typeInfo;
-
-    public PgConverter Converter => _typeInfo.Converter;
-    public Size BufferRequirement { get; }
-
-    /// Whether Converter.TypeToConvert matches PgTypeInfo.Type, if it doesn't object apis should be used.
-    public bool IsBoxingConverter => _typeInfo.IsBoxing;
 }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -5,30 +5,30 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
+using Npgsql.Util;
 
 namespace Npgsql.Internal;
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgTypeInfo
 {
-    PgTypeInfo(PgSerializerOptions options, Type type, Type? unboxedType)
+    PgTypeInfo(PgSerializerOptions options, Type type, Type? requestedType)
     {
-        if (unboxedType is not null && !type.IsAssignableFrom(unboxedType))
-            throw new ArgumentException("A value of unboxed type is not assignable to converter type", nameof(unboxedType));
-
         Options = options;
-        IsBoxing = unboxedType is not null;
-        Type = unboxedType ?? type;
-        SupportsReading = GetDefaultSupportsReading(type, unboxedType);
+
+        HasExactType = requestedType is null || requestedType == type;
+        Type = requestedType is null ? type : GetReportedType(type, requestedType) ?? type;
+
+        SupportsReading = GetDefaultSupportsReading(type, requestedType);
         SupportsWriting = true;
     }
 
-    private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? unboxedType = null)
-        : this(options, type, unboxedType)
+    private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? requestedType = null)
+        : this(options, type, requestedType)
         => PgTypeId = pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null;
 
-    private protected PgTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null)
-        : this(options, converter.TypeToConvert, pgTypeId, unboxedType)
+    private protected PgTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType = null)
+        : this(options, converter.TypeToConvert, pgTypeId, requestedType)
         => Converter = converter;
 
     public Type Type { get; }
@@ -41,8 +41,14 @@ public abstract class PgTypeInfo
     // Doubles as the storage for the converter coming from a default provider result (used to confirm whether we can use cached info).
     protected PgConverter? Converter { get; }
 
-    // Used for internal converters to save on binary bloat.
-    internal bool IsBoxing { get; }
+    // True when the reported type matches the converter's type exactly (no reported type given at construction, or
+    // the given reported type equals the converter type). When false, the reported type is a widening of the converter
+    // type (e.g. Array/Stream base-type reporting, enum-underlying widening) and the caller must dispatch through the
+    // info — the info routes reference-variance cases through the object APIs and layout-identity cases (enum) through
+    // the typed path with Unsafe.As, as appropriate for the widening kind.
+    // Having a single converter cover multiple reported types (Arrays, Streams) reduces the number of generic
+    // instantiations that need to be compiled for AOT.
+    internal bool HasExactType { get; }
 
     public PgTypeId? PgTypeId { get; }
 
@@ -86,25 +92,17 @@ public abstract class PgTypeInfo
             => throw new NotSupportedException("Should not happen, please file a bug.");
     }
 
-    // We assume a boxing type info does not support reading as the converter won't be able to produce the derived type statically.
-    // Cases like Array converters unboxing to int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
+    // We assume an info without an exact type does not support reading as the converter won't be able to produce the derived type statically.
+    // Cases like Array converters reading int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
-        => requestedType is null || ComputeUnboxedType(type, requestedType) is not { } unboxedType || unboxedType == type;
+        => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
 
-    protected static Type? ComputeUnboxedType(Type converterType, Type requestedType)
+    static Type? GetReportedType(Type converterType, Type requestedType)
     {
-        // The hierarchy that should hold for things to work correctly is object < converterType < requestedType.
-        Debug.Assert(converterType.IsAssignableFrom(requestedType) || requestedType == typeof(object));
+        if (!requestedType.IsInSubtypeRelationshipWith(converterType))
+            throw new ArgumentException($"The requested type {requestedType} is not in a subtype relationship with the converter's type {converterType}.", nameof(requestedType));
 
-        // A special case for object matches, where we return a more specific type than was requested.
-        // This is to report e.g. Array converters as Array when their requested type was object.
-        if (requestedType == typeof(object))
-        {
-            return converterType != typeof(object) ? converterType : null;
-        }
-
-        // This is to report e.g. Array converters as int[,,,] when their requested type was such.
-        return requestedType != converterType ? requestedType : null;
+        return requestedType != converterType && requestedType.IsAssignableTo(converterType) ? requestedType : null;
     }
 }
 
@@ -117,11 +115,8 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         : this(options, typeInfoProvider, pgTypeId, requestedType: null)
     {}
 
-    // We always mark providers with type object as boxing, as they may freely return converters for any type (see PgConcreteTypeInfoProvider.Validate).
     internal PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? requestedType)
-        : base(options, typeInfoProvider.TypeToConvert, pgTypeId,
-            (requestedType is null ? null : ComputeUnboxedType(typeInfoProvider.TypeToConvert, requestedType))
-            ?? (typeInfoProvider.TypeToConvert == typeof(object) ? typeof(object) : null))
+        : base(options, typeInfoProvider.TypeToConvert, pgTypeId, requestedType)
     {
         _typeInfoProvider = typeInfoProvider;
 
@@ -180,9 +175,9 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
 
         PgConcreteTypeInfo ThrowNotSupportedType(Type? type)
-            => throw new NotSupportedException(IsBoxing
-                ? $"TypeInfo only supports boxing conversions, call {nameof(GetAsObjectConcreteTypeInfo)} or {nameof(GetObjectConcreteTypeInfo)} instead."
-                : $"TypeInfo is not of type {type}");
+            => throw new NotSupportedException(type == Type
+                ? $"PgProviderTypeInfo does not exactly match type {type}, call {nameof(GetAsObjectConcreteTypeInfo)} instead."
+                : $"PgProviderTypeInfo is incompatible with type {type}");
     }
 
     public PgConcreteTypeInfo? GetAsObjectConcreteTypeInfo(ProviderValueContext context, object? value, out object? writeState)
@@ -235,7 +230,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     {}
 
     internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType)
-        : base(options, converter, pgTypeId, requestedType is null ? null : ComputeUnboxedType(converter.TypeToConvert, requestedType))
+        : base(options, converter, pgTypeId, requestedType)
     {
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
@@ -263,7 +258,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     // If it's not a value type it doesn't matter so we can skip the check there.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     bool ShouldReadAsObject<T>()
-        => typeof(T) == typeof(object) || (IsBoxing && (!typeof(T).IsValueType || typeof(T) != Converter.TypeToConvert));
+        => typeof(T) == typeof(object) || (!HasExactType && (!typeof(T).IsValueType || typeof(T) != Converter.TypeToConvert));
 
     internal T ConverterRead<T>(PgReader reader)
     {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -249,20 +249,20 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     public PgConverter Converter { get; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
+    internal bool CanReadTo(Type type) => Type == type || (!HasExactType && Type.IsAssignableTo(type));
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal T ReadFieldValue<T>(PgReader reader, DataFormat dataFormat)
+    internal T ReadFieldValue<T>(PgReader reader, PgFieldBinding binding)
     {
-        var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
-        reader.StartRead(dataFormat, bufferRequirement);
+        reader.StartRead(binding);
         var result = Converter.Read<T>(reader);
         reader.EndRead();
         return result;
     }
 
-    internal async ValueTask<T> ReadFieldValueAsync<T>(PgReader reader, DataFormat dataFormat, CancellationToken cancellationToken)
+    internal async ValueTask<T> ReadFieldValueAsync<T>(PgReader reader, PgFieldBinding binding, CancellationToken cancellationToken)
     {
-        var bufferRequirement = (dataFormat is DataFormat.Binary ? _binaryBufferRequirements : _textBufferRequirements).Read;
-        await reader.StartReadAsync(dataFormat, bufferRequirement, cancellationToken).ConfigureAwait(false);
+        await reader.StartReadAsync(binding, cancellationToken).ConfigureAwait(false);
 
         // Inline copy of Converter.ReadAsync<T> to keep everything in one async frame.
         var result = typeof(T) != TypeToConvert
@@ -387,6 +387,7 @@ readonly struct PgFieldBinding
         BufferRequirement = bufferRequirement;
     }
 
+    // DataFormat can differ from the actual field format if data will be reintrepreted for this binding (e.g. UnknownResultType)
     public DataFormat DataFormat { get; }
     public Size BufferRequirement { get; }
 }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql.Internal.Postgres;
 
@@ -84,8 +85,24 @@ public abstract class PgTypeInfo
 
     // We assume a boxing type info does not support reading as the converter won't be able to produce the derived type statically.
     // Cases like Array converters unboxing to int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
-    internal static bool GetDefaultSupportsReading(Type type, Type? unboxedType)
-        => unboxedType is null || unboxedType == type;
+    internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
+        => requestedType is null || ComputeUnboxedType(type, requestedType) is not { } unboxedType || unboxedType == type;
+
+    protected static Type? ComputeUnboxedType(Type converterType, Type requestedType)
+    {
+        // The hierarchy that should hold for things to work correctly is object < converterType < requestedType.
+        Debug.Assert(converterType.IsAssignableFrom(requestedType) || requestedType == typeof(object));
+
+        // A special case for object matches, where we return a more specific type than was requested.
+        // This is to report e.g. Array converters as Array when their requested type was object.
+        if (requestedType == typeof(object))
+        {
+            return converterType != typeof(object) ? converterType : null;
+        }
+
+        // This is to report e.g. Array converters as int[,,,] when their requested type was such.
+        return requestedType != converterType ? requestedType : null;
+    }
 }
 
 public sealed class PgProviderTypeInfo : PgTypeInfo
@@ -94,8 +111,10 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
     readonly PgConcreteTypeInfo? _defaultConcrete;
 
     // We always mark providers with type object as boxing, as they may freely return converters for any type (see PgConcreteTypeInfoProvider.Validate).
-    public PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? unboxedType = null)
-        : base(options, typeInfoProvider.TypeToConvert, pgTypeId, unboxedType ?? (typeInfoProvider.TypeToConvert == typeof(object) ? typeof(object) : null))
+    public PgProviderTypeInfo(PgSerializerOptions options, PgConcreteTypeInfoProvider typeInfoProvider, PgTypeId? pgTypeId, Type? requestedType = null)
+        : base(options, typeInfoProvider.TypeToConvert, pgTypeId,
+            (requestedType is null ? null : ComputeUnboxedType(typeInfoProvider.TypeToConvert, requestedType))
+            ?? (typeInfoProvider.TypeToConvert == typeof(object) ? typeof(object) : null))
     {
         _typeInfoProvider = typeInfoProvider;
 
@@ -198,7 +217,8 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     readonly bool _canTextConvert;
     readonly BufferRequirements _textBufferRequirements;
 
-    public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? unboxedType = null) : base(options, converter, pgTypeId, unboxedType)
+    public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType = null)
+        : base(options, converter, pgTypeId, requestedType is null ? null : ComputeUnboxedType(converter.TypeToConvert, requestedType))
     {
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -249,6 +250,12 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
         return converter.CanConvert(format, out bufferRequirements);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool ShouldReadAsObject<T>()
+        // If we have an exact type match we can use e.g. a converter for ints in a strongly typed fashion.
+        // If it's not a value type it doesn't matter so we can skip the check there.
+        => typeof(T) == typeof(object) || (IsBoxing && (!typeof(T).IsValueType || typeof(T) == Converter.TypeToConvert));
 
     public BufferRequirements? GetBufferRequirements(DataFormat format)
     {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -28,8 +28,7 @@ public abstract class PgTypeInfo
         => PgTypeId = pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null;
 
     private protected PgTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType = null)
-        : this(options, converter.TypeToConvert, pgTypeId, requestedType)
-        => Converter = converter;
+        : this(options, converter.TypeToConvert, pgTypeId, requestedType) {}
 
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
@@ -37,9 +36,6 @@ public abstract class PgTypeInfo
     public bool SupportsReading { get; init; }
     public bool SupportsWriting { get; init; }
     public DataFormat? PreferredFormat { get; init; }
-
-    // Doubles as the storage for the converter coming from a default provider result (used to confirm whether we can use cached info).
-    protected PgConverter? Converter { get; }
 
     // True when the reported type matches the converter's type exactly (no reported type given at construction, or
     // the given reported type equals the converter type). When false, the reported type is a widening of the converter
@@ -232,6 +228,8 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     readonly bool _canTextConvert;
     readonly BufferRequirements _textBufferRequirements;
 
+    readonly Type _typeToConvert;
+
     public PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId)
         : this(options, converter, pgTypeId, requestedType: null)
     {}
@@ -239,42 +237,36 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType)
         : base(options, converter, pgTypeId, requestedType)
     {
+        Converter = converter;
+        _typeToConvert = converter.TypeToConvert;
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
     }
 
-    public new PgConverter Converter => base.Converter!;
+    public PgConverter Converter { get; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
-    bool CanConvert(PgConverter converter, DataFormat format, out BufferRequirements bufferRequirements)
-    {
-        switch (format)
-        {
-        case DataFormat.Binary:
-            bufferRequirements = _binaryBufferRequirements;
-            return _canBinaryConvert;
-        case DataFormat.Text:
-            bufferRequirements = _textBufferRequirements;
-            return _canTextConvert;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    bool ShouldReadAsObject<T>() => typeof(T) != _typeToConvert;
 
-        return converter.CanConvert(format, out bufferRequirements);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    PgConverter<T> GetConverter<T>()
+    {
+        if (ShouldReadAsObject<T>())
+            ThrowHelper.ThrowInvalidCastException("Invalid type for converter.");
+
+        // Justification: avoid perf cost of casting to a known base class type per field read.
+        Debug.Assert(Converter is PgConverter<T>);
+        return Unsafe.As<PgConverter<T>>(Converter);
     }
 
-    // If we have an exact type match we can use e.g. a converter for ints in a strongly typed fashion.
-    // If it's not a value type it doesn't matter so we can skip the check there.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    bool ShouldReadAsObject<T>()
-        => typeof(T) == typeof(object) || (!HasExactType && (!typeof(T).IsValueType || typeof(T) != Converter.TypeToConvert));
-
     internal T ConverterRead<T>(PgReader reader)
     {
         if (ShouldReadAsObject<T>())
             return (T)Converter.ReadAsObject(reader);
 
-        // Justification: avoid perf cost of casting to a known base class type per field read.
-        Debug.Assert(Converter is PgConverter<T>);
-        return Unsafe.As<PgConverter<T>>(Converter).Read(reader);
+        return GetConverter<T>().Read(reader);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -287,31 +279,20 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
             return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
         }
 
-        // Justification: avoid perf cost of casting to a known base class type per field read.
-        Debug.Assert(converter is PgConverter<T>);
-        return Unsafe.As<PgConverter<T>>(converter).ReadAsync(reader, cancellationToken);
+        return GetConverter<T>().ReadAsync(reader, cancellationToken);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
             => (T)await task.ConfigureAwait(false);
     }
 
-    // TODO move asObject checks from NpgsqlParameter to here.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void ConverterWrite<T>(PgWriter writer, [DisallowNull]T value)
-    {
-        // Justification: avoid perf cost of casting to a known base class type per parameter write.
-        Debug.Assert(Converter is PgConverter<T>);
-        Unsafe.As<PgConverter<T>>(Converter).Write(writer, value);
-    }
+        => GetConverter<T>().Write(writer, value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ValueTask ConverterWriteAsync<T>(PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken)
-    {
-        // Justification: avoid perf cost of casting to a known base class type per parameter write.
-        Debug.Assert(Converter is PgConverter<T>);
-        return Unsafe.As<PgConverter<T>>(Converter).WriteAsync(writer, value, cancellationToken);
-    }
+        => GetConverter<T>().WriteAsync(writer, value, cancellationToken);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal T ReadFieldValue<T>(PgReader reader, DataFormat dataFormat)
@@ -331,7 +312,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         // Copy of ConverterReadAsync to keep everything in one async frame.
         var result = ShouldReadAsObject<T>()
             ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-            : await Unsafe.As<PgConverter<T>>(Converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            : await GetConverter<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
 
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;
@@ -339,7 +320,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
     public BufferRequirements? GetBufferRequirements(DataFormat format)
     {
-        var success = CanConvert(Converter, format, out var bufferRequirements);
+        var success = CanConvert(format, out var bufferRequirements);
         return success ? bufferRequirements : null;
     }
 
@@ -353,7 +334,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     // TryBind for reading.
     internal bool TryBindField(DataFormat format, out PgFieldBinding binding)
     {
-        if (!CanConvert(Converter, format, out var bufferRequirements))
+        if (!CanConvert(format, out var bufferRequirements))
         {
             binding = default;
             return false;
@@ -379,9 +360,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        var format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
-        if (((PgConverter<T>)Converter).GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        if (GetConverter<T>().GetSizeOrDbNull(format, bufferRequirements.Write, value, ref writeState) is not { } size)
             return new(format, bufferRequirements.Write, null, null);
 
         return new(format, bufferRequirements.Write, size, writeState);
@@ -396,7 +377,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        var format = ResolveFormat(Converter, out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
 
         // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
         if (value is DBNull && Type != typeof(DBNull) || Converter.GetSizeOrDbNullAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } size)
@@ -407,20 +388,35 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return new(format, bufferRequirements.Write, size, writeState);
     }
 
-    DataFormat ResolveFormat(PgConverter converter, out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
+    bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        switch (format)
+        {
+        case DataFormat.Binary:
+            bufferRequirements = _binaryBufferRequirements;
+            return _canBinaryConvert;
+        case DataFormat.Text:
+            bufferRequirements = _textBufferRequirements;
+            return _canTextConvert;
+        }
+
+        return Converter.CanConvert(format, out bufferRequirements);
+    }
+
+    DataFormat ResolveFormat(out BufferRequirements bufferRequirements, DataFormat? formatPreference = null)
     {
         // First try to check for preferred support.
         switch (formatPreference)
         {
-        case DataFormat.Binary when CanConvert(converter, DataFormat.Binary, out bufferRequirements):
+        case DataFormat.Binary when CanConvert(DataFormat.Binary, out bufferRequirements):
             return DataFormat.Binary;
-        case DataFormat.Text when CanConvert(converter, DataFormat.Text, out bufferRequirements):
+        case DataFormat.Text when CanConvert(DataFormat.Text, out bufferRequirements):
             return DataFormat.Text;
         default:
             // The common case, no preference given (or no match) means we default to binary if supported.
-            if (CanConvert(converter, DataFormat.Binary, out bufferRequirements))
+            if (CanConvert(DataFormat.Binary, out bufferRequirements))
                 return DataFormat.Binary;
-            if (CanConvert(converter, DataFormat.Text, out bufferRequirements))
+            if (CanConvert(DataFormat.Text, out bufferRequirements))
                 return DataFormat.Text;
 
             ThrowHelper.ThrowInvalidOperationException("Converter doesn't support any data format.");

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -30,8 +30,6 @@ public abstract class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
-    public DataFormat? PreferredFormat { get; init; }
-
     // True when the reported type matches the converter's type exactly (no reported type given at construction, or
     // the given reported type equals the converter type). When false, the reported type is a widening of the converter
     // type (e.g. Array/Stream base-type reporting, enum-underlying widening) and the caller must dispatch through the
@@ -308,6 +306,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
         => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
 
+    public DataFormat? PreferredFormat { get; init; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
     internal bool CanReadTo(Type type) => Type == type || (!HasExactType && Type.IsAssignableTo(type));

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -194,27 +194,26 @@ public sealed class PgWriter
         if (binding.IsDbNullBinding)
             ThrowHelper.ThrowArgumentException("Binding context cannot be for a DbNull.", nameof(binding));
 
-        // TODO maybe we can share PgValueBinding in the writer.
+        var bufferRequirement = binding.BufferRequirement;
+        var size = binding.Size.GetValueOrDefault();
         _current = new ValueMetadata
         {
             Format = binding.DataFormat,
-            BufferRequirement = binding.BufferRequirement,
-            Size = binding.Size.GetValueOrDefault(),
+            BufferRequirement = bufferRequirement,
+            Size = size,
             // WriteState is generally null, checking for null and showing the null literal to the JIT allows us to skip the write barrier if so.
             WriteState = binding.WriteState is null ? null : binding.WriteState
         };
 
-        return ShouldFlush(binding.BufferRequirement.GetValueOrDefault()) ? Flush(async, cancellationToken) : new();
+        return ShouldFlush(BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, size.GetValueOrDefault()))
+            ? Flush(async, cancellationToken)
+            : new();
     }
 
     internal void EndWrite(Size expectedByteCount)
         => CommitAndResetTotal(expectedByteCount.GetValueOrDefault());
 
     public ValueMetadata Current => _current;
-    internal Size CurrentBufferRequirement => _current.BufferRequirement;
-
-    // When we don't know the size during writing we're using the writer buffer as a sizing mechanism.
-    internal bool BufferingWrite => Current.Size.Kind is SizeKind.Unknown;
 
     // This method lives here to remove the chances oids will be cached on converters inadvertently when data type names should be used.
     // Such a mapping (for instance for array element oids) should be done per operation to ensure it is done in the context of a specific backend.
@@ -479,10 +478,6 @@ public sealed class PgWriter
     /// <returns>The stream.</returns>
     public Stream GetStream(bool allowMixedIO = false)
         => new PgWriterStream(this, allowMixedIO);
-
-    // We also check pos != offset to speed up simple value writes, as field level buffering was handled by writer.StartWrite() already.
-    public bool ShouldFlushCurrent()
-        => !BufferingWrite && _pos != _offset && ShouldFlush(BufferRequirements.GetMinimumBufferByteCount(Current.BufferRequirement, Current.Size.GetValueOrDefault()));
 
     public bool ShouldFlush(int byteCount) => Remaining < byteCount && FlushMode is not FlushMode.None;
 

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -171,31 +171,44 @@ public sealed class PgWriter
 
     void Advance(int count) => _pos += count;
 
-    internal void Commit(int? expectedByteCount = null)
+    void Commit()
     {
-        _totalBytesWritten += _pos - _offset;
-        _writer.Advance(_pos - _offset);
+        var written = _pos - _offset;
+        _totalBytesWritten += written;
+        _writer.Advance(written);
         _offset = _pos;
-
-        if (expectedByteCount is not null)
-        {
-            var totalBytesWritten = _totalBytesWritten;
-            _totalBytesWritten = 0;
-            if (totalBytesWritten != expectedByteCount)
-                ThrowHelper.ThrowInvalidOperationException($"Bytes written ({totalBytesWritten}) and expected byte count ({expectedByteCount}) don't match.");
-        }
     }
 
-    internal ValueTask BeginWrite(bool async, ValueMetadata current, CancellationToken cancellationToken)
+    internal void CommitAndResetTotal(int expectedByteCount)
     {
-        _current = current;
+        Commit();
 
-        var bufferRequirementByteCount = BufferRequirements.GetMinimumBufferByteCount(current.BufferRequirement, current.Size.GetValueOrDefault());
-        if (ShouldFlush(bufferRequirementByteCount))
-            return Flush(async, cancellationToken);
-
-        return new();
+        var totalBytesWritten = _totalBytesWritten;
+        _totalBytesWritten = 0;
+        if (totalBytesWritten != expectedByteCount)
+            ThrowHelper.ThrowInvalidOperationException($"Bytes written ({totalBytesWritten}) and expected byte count ({expectedByteCount}) don't match.");
     }
+
+    internal ValueTask StartWrite(bool async, in PgValueBinding binding, CancellationToken cancellationToken)
+    {
+        if (binding.IsDbNullBinding)
+            ThrowHelper.ThrowArgumentException("Binding context cannot be for a DbNull.", nameof(binding));
+
+        // TODO maybe we can share PgValueBinding in the writer.
+        _current = new ValueMetadata
+        {
+            Format = binding.DataFormat,
+            BufferRequirement = binding.BufferRequirement,
+            Size = binding.Size.GetValueOrDefault(),
+            // WriteState is generally null, checking for null and showing the null literal to the JIT allows us to skip the write barrier if so.
+            WriteState = binding.WriteState is null ? null : binding.WriteState
+        };
+
+        return ShouldFlush(binding.BufferRequirement.GetValueOrDefault()) ? Flush(async, cancellationToken) : new();
+    }
+
+    internal void EndWrite(Size expectedByteCount)
+        => CommitAndResetTotal(expectedByteCount.GetValueOrDefault());
 
     public ValueMetadata Current => _current;
     internal Size CurrentBufferRequirement => _current.BufferRequirement;

--- a/src/Npgsql/Internal/Postgres/Field.cs
+++ b/src/Npgsql/Internal/Postgres/Field.cs
@@ -9,4 +9,6 @@ public readonly struct Field(string name, PgTypeId pgTypeId, int typeModifier)
     public string Name { get; init; } = name;
     public PgTypeId PgTypeId { get; init; } = pgTypeId;
     public int TypeModifier { get; init; } = typeModifier;
+
+    public static Field CreateUnspecified(PgTypeId pgTypeId) => new("?", pgTypeId, -1);
 }

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -52,8 +52,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 || options.DatabaseInfo.GetPostgresType(dataTypeName) is not PostgresEnumType)
                 return null;
 
-            return new PgConcreteTypeInfo(options, TextConverter.CreateStringConverter(options.TextEncoding), dataTypeName,
-                unboxedType: type == typeof(object) ? typeof(string) : null);
+            return new PgConcreteTypeInfo(options, TextConverter.CreateStringConverter(options.TextEncoding), dataTypeName, requestedType: type);
         }
 
         static TypeInfoMappingCollection AddMappings(TypeInfoMappingCollection mappings)
@@ -97,7 +96,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
                 MatchRequirement.DataTypeName);
             mappings.AddType<Stream>(DataTypeNames.Text,
-                static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+                static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Text,
@@ -124,7 +123,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                     static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
                     MatchRequirement.DataTypeName);
                 mappings.AddType<Stream>(dataTypeName,
-                    static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+                    static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
                     mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
                 //Special mappings, these have no corresponding array mapping.
                 mappings.AddType<TextReader>(dataTypeName,
@@ -148,7 +147,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<ReadOnlyMemory<byte>>(jsonbVersion, new ReadOnlyMemoryByteaConverter())),
                 MatchRequirement.DataTypeName);
             mappings.AddType<Stream>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => new PgConcreteTypeInfo(options, new VersionPrefixedTextConverter<Stream>(jsonbVersion, new StreamConverter(supportsTextFormat: true)), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+                static (options, mapping, _) => new PgConcreteTypeInfo(options, new VersionPrefixedTextConverter<Stream>(jsonbVersion, new StreamConverter(supportsTextFormat: true)), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName, TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
             //Special mappings, these have no corresponding array mapping.
             mappings.AddType<TextReader>(DataTypeNames.Jsonb,
@@ -177,7 +176,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()));
             mappings.AddType<Stream>(DataTypeNames.Bytea,
                 // TODO handling bytea textually would require conversions to hex strings, so currently we don't support it.
-                static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: false), new DataTypeName(mapping.DataTypeName), unboxedType: mapping.Type != typeof(Stream) ? mapping.Type : null),
+                static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: false), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
                 mapping => mapping with { TypeMatchPredicate = type => typeof(Stream).IsAssignableFrom(type) });
 
             // Varbit

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -182,7 +182,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Varbit
             mappings.AddType<object>(DataTypeNames.Varbit,
                 static (options, mapping, _) => mapping.CreateInfo(options,
-                    new PolymorphicBitStringTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Varbit)), includeDataTypeName: true, supportsWriting: false));
+                    new PolymorphicBitStringTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Varbit)), includeDataTypeName: true));
             mappings.AddType<BitArray>(DataTypeNames.Varbit,
                 static (options, mapping, _) => mapping.CreateInfo(options, new BitArrayBitStringConverter()), isDefault: true);
             mappings.AddStructType<bool>(DataTypeNames.Varbit,
@@ -193,7 +193,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // Bit
             mappings.AddType<object>(DataTypeNames.Bit,
                 static (options, mapping, _) => mapping.CreateInfo(options,
-                    new PolymorphicBitStringTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Bit)), includeDataTypeName: true, supportsWriting: false));
+                    new PolymorphicBitStringTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Bit)), includeDataTypeName: true));
             mappings.AddType<BitArray>(DataTypeNames.Bit,
                 static (options, mapping, _) => mapping.CreateInfo(options, new BitArrayBitStringConverter()), isDefault: true);
             mappings.AddStructType<bool>(DataTypeNames.Bit,

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -90,10 +90,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
             // Uses the bytea converters, as neither type has a header.
             mappings.AddType<byte[]>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter()),
+                static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter(supportsTextFormat: true)),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Text,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
+                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter(supportsTextFormat: true)),
                 MatchRequirement.DataTypeName);
             mappings.AddType<Stream>(DataTypeNames.Text,
                 static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
@@ -117,10 +117,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                     static (options, mapping, _) => mapping.CreateInfo(options, new CharTextConverter(options.TextEncoding), preferredFormat: DataFormat.Text));
                 // Uses the bytea converters, as neither type has a header.
                 mappings.AddType<byte[]>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter()),
+                    static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter(supportsTextFormat: true)),
                     MatchRequirement.DataTypeName);
                 mappings.AddStructType<ReadOnlyMemory<byte>>(dataTypeName,
-                    static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()),
+                    static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter(supportsTextFormat: true)),
                     MatchRequirement.DataTypeName);
                 mappings.AddType<Stream>(dataTypeName,
                     static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: true), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
@@ -141,10 +141,10 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             mappings.AddStructType<char>(DataTypeNames.Jsonb,
                 static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<char>(jsonbVersion, new CharTextConverter(options.TextEncoding))));
             mappings.AddType<byte[]>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<byte[]>(jsonbVersion, new ArrayByteaConverter())),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<byte[]>(jsonbVersion, new ArrayByteaConverter(supportsTextFormat: true))),
                 MatchRequirement.DataTypeName);
             mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Jsonb,
-                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<ReadOnlyMemory<byte>>(jsonbVersion, new ReadOnlyMemoryByteaConverter())),
+                static (options, mapping, _) => mapping.CreateInfo(options, new VersionPrefixedTextConverter<ReadOnlyMemory<byte>>(jsonbVersion, new ReadOnlyMemoryByteaConverter(supportsTextFormat: true))),
                 MatchRequirement.DataTypeName);
             mappings.AddType<Stream>(DataTypeNames.Jsonb,
                 static (options, mapping, _) => new PgConcreteTypeInfo(options, new VersionPrefixedTextConverter<Stream>(jsonbVersion, new StreamConverter(supportsTextFormat: true)), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),
@@ -171,9 +171,9 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             // Bytea
             mappings.AddType<byte[]>(DataTypeNames.Bytea,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter()), isDefault: true);
+                static (options, mapping, _) => mapping.CreateInfo(options, new ArrayByteaConverter(supportsTextFormat: false)), isDefault: true);
             mappings.AddStructType<ReadOnlyMemory<byte>>(DataTypeNames.Bytea,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter()));
+                static (options, mapping, _) => mapping.CreateInfo(options, new ReadOnlyMemoryByteaConverter(supportsTextFormat: false)));
             mappings.AddType<Stream>(DataTypeNames.Bytea,
                 // TODO handling bytea textually would require conversions to hex strings, so currently we don't support it.
                 static (options, mapping, _) => new PgConcreteTypeInfo(options, new StreamConverter(supportsTextFormat: false), new DataTypeName(mapping.DataTypeName), requestedType: mapping.Type),

--- a/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/ExtraConversionsTypeInfoResolverFactory.cs
@@ -91,9 +91,9 @@ sealed class ExtraConversionResolverFactory : PgTypeInfoResolverFactory
 
             // Bytea
             mappings.AddStructType<ArraySegment<byte>>(DataTypeNames.Bytea,
-                static (options, mapping, _) => mapping.CreateInfo(options, new ArraySegmentByteaConverter()));
+                static (options, mapping, _) => mapping.CreateInfo(options, new ArraySegmentByteaConverter(supportsTextFormat: false)));
             mappings.AddStructType<Memory<byte>>(DataTypeNames.Bytea,
-                static (options, mapping, _) => mapping.CreateInfo(options, new MemoryByteaConverter()));
+                static (options, mapping, _) => mapping.CreateInfo(options, new MemoryByteaConverter(supportsTextFormat: false)));
 
             // Varbit
             mappings.AddType<string>(DataTypeNames.Varbit,

--- a/src/Npgsql/Internal/ResolverFactories/NetworkTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/NetworkTypeInfoResolverFactory.cs
@@ -33,7 +33,7 @@ sealed class NetworkTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // There are certain IPAddress values like Loopback or Any that return a *private* derived type (see https://github.com/dotnet/runtime/issues/27870).
             mappings.AddType<IPAddress>(DataTypeNames.Inet,
                 static (options, mapping, _) => new PgConcreteTypeInfo(options, new IPAddressConverter(), new DataTypeName(mapping.DataTypeName),
-                    unboxedType: mapping.Type != typeof(IPAddress) ? mapping.Type : null),
+                    requestedType: mapping.Type),
                 mapping => mapping with
                 {
                     MatchRequirement = MatchRequirement.Single,

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -86,6 +86,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 return null;
 
             subInfo = subInfo.ToExactTypeInfo();
+            var subConcrete = (PgConcreteTypeInfo)subInfo;
 
             var converterType = typeof(NpgsqlRange<>).MakeGenericType(subInfo.Type);
 
@@ -97,7 +98,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                             ((PgConcreteTypeInfo)subInfo).Converter)!,
                         new DataTypeName(mapping.DataTypeName),
                         requestedType: matchedType
-                    ) { PreferredFormat = subInfo.PreferredFormat, SupportsWriting = subInfo.SupportsWriting },
+                    ) { PreferredFormat = subConcrete.PreferredFormat, SupportsWriting = subConcrete.SupportsWriting },
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName });
         }
     }
@@ -145,6 +146,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 return null;
 
             subInfo = subInfo.ToExactTypeInfo();
+            var subConcrete = (PgConcreteTypeInfo)subInfo;
 
             var converterType = subInfo.Type.MakeArrayType();
 
@@ -156,7 +158,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                             ((PgConcreteTypeInfo)subInfo).Converter)!,
                         new DataTypeName(mapping.DataTypeName),
                         requestedType: type
-                    ) { PreferredFormat = subInfo.PreferredFormat, SupportsWriting = subInfo.SupportsWriting },
+                    ) { PreferredFormat = subConcrete.PreferredFormat, SupportsWriting = subConcrete.SupportsWriting },
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName });
         }
     }

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -96,7 +96,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                         (PgConverter)Activator.CreateInstance(typeof(RangeConverter<>).MakeGenericType(subInfo.Type),
                             ((PgConcreteTypeInfo)subInfo).Converter)!,
                         new DataTypeName(mapping.DataTypeName),
-                        unboxedType: matchedType is not null && matchedType != converterType ? converterType : null
+                        requestedType: matchedType
                     ) { PreferredFormat = subInfo.PreferredFormat, SupportsWriting = subInfo.SupportsWriting },
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName });
         }
@@ -155,7 +155,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                         (PgConverter)Activator.CreateInstance(typeof(MultirangeConverter<,>).MakeGenericType(converterType, subInfo.Type),
                             ((PgConcreteTypeInfo)subInfo).Converter)!,
                         new DataTypeName(mapping.DataTypeName),
-                        unboxedType: type is not null && type != converterType ? converterType : null
+                        requestedType: type
                     ) { PreferredFormat = subInfo.PreferredFormat, SupportsWriting = subInfo.SupportsWriting },
                 mapping => mapping with { MatchRequirement = MatchRequirement.DataTypeName });
         }

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -85,7 +85,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (subInfo is not PgConcreteTypeInfo)
                 return null;
 
-            subInfo = subInfo.ToNonBoxing();
+            subInfo = subInfo.ToExactTypeInfo();
 
             var converterType = typeof(NpgsqlRange<>).MakeGenericType(subInfo.Type);
 
@@ -144,7 +144,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (subInfo is not PgConcreteTypeInfo)
                 return null;
 
-            subInfo = subInfo.ToNonBoxing();
+            subInfo = subInfo.ToExactTypeInfo();
 
             var converterType = subInfo.Type.MakeArrayType();
 

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -126,7 +126,7 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             {
                 // Types were not equal, throw for IsBoxing = false, otherwise we throw when the returned type isn't assignable to the requested type (after unboxing).
                 if (!info.IsBoxing || !info.Type.IsAssignableTo(type))
-                    throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have an equal Type: {info.Type}.");
+                    throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have a compatible type: {info.Type}.");
             }
 
             return info;

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -124,8 +124,8 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
 
             if (type is not null && info.Type != type)
             {
-                // Types were not equal, throw for IsBoxing = false, otherwise we throw when the returned type isn't assignable to the requested type (after unboxing).
-                if (!info.IsBoxing || !info.Type.IsAssignableTo(type))
+                // Types were not equal, throw for HasExactType = true, otherwise we throw when the returned type isn't assignable to the requested type.
+                if (info.HasExactType || !info.Type.IsAssignableTo(type))
                     throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have a compatible type: {info.Type}.");
             }
 

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -681,43 +681,39 @@ public sealed class TypeInfoMappingCollection
 
     static ArrayConverter<Array> CreateArrayBasedConverter<TElement>(TypeInfoMapping mapping, PgTypeInfo elemInfo)
     {
-        if (!elemInfo.IsBoxing)
-            return ArrayConverter<Array>.CreateArrayBased<TElement>((PgConcreteTypeInfo)elemInfo, mapping.Type);
+        if (!elemInfo.HasExactType)
+            ThrowRequiresExactType(provider: false);
 
-        ThrowBoxingNotSupported(provider: false);
-        return default;
+        return ArrayConverter<Array>.CreateArrayBased<TElement>((PgConcreteTypeInfo)elemInfo, mapping.Type);
     }
 
     static ArrayConverter<IList<TElement>> CreateListBasedConverter<TElement>(TypeInfoMapping mapping, PgTypeInfo elemInfo)
     {
-        if (!elemInfo.IsBoxing)
-            return ArrayConverter<IList<TElement>>.CreateListBased<TElement>((PgConcreteTypeInfo)elemInfo);
+        if (!elemInfo.HasExactType)
+            ThrowRequiresExactType(provider: false);
 
-        ThrowBoxingNotSupported(provider: false);
-        return default;
+        return ArrayConverter<IList<TElement>>.CreateListBased<TElement>((PgConcreteTypeInfo)elemInfo);
     }
 
     static ArrayTypeInfoProvider<Array, TElement> CreateArrayBasedTypeInfoProvider<TElement>(TypeInfoMapping mapping, PgProviderTypeInfo elemInfo)
     {
-        if (!elemInfo.IsBoxing)
-            return new ArrayTypeInfoProvider<Array, TElement>(elemInfo, mapping.Type);
+        if (!elemInfo.HasExactType)
+            ThrowRequiresExactType(provider: true);
 
-        ThrowBoxingNotSupported(provider: true);
-        return default;
+        return new ArrayTypeInfoProvider<Array, TElement>(elemInfo, mapping.Type);
     }
 
     static ArrayTypeInfoProvider<IList<TElement>, TElement> CreateListBasedTypeInfoProvider<TElement>(TypeInfoMapping mapping, PgProviderTypeInfo elemInfo)
     {
-        if (!elemInfo.IsBoxing)
-            return new ArrayTypeInfoProvider<IList<TElement>, TElement>(elemInfo, mapping.Type);
+        if (!elemInfo.HasExactType)
+            ThrowRequiresExactType(provider: true);
 
-        ThrowBoxingNotSupported(provider: true);
-        return default;
+        return new ArrayTypeInfoProvider<IList<TElement>, TElement>(elemInfo, mapping.Type);
     }
 
     [DoesNotReturn]
-    static void ThrowBoxingNotSupported(bool provider)
-        => throw new InvalidOperationException($"Boxing converters are not supported, manually construct a mapping over a casting converter{(provider ? " type info provider" : "")} instead.");
+    static void ThrowRequiresExactType(bool provider)
+        => throw new InvalidOperationException($"An exact-type info is required here; manually construct a mapping over a casting converter{(provider ? " type info provider" : "")} instead.");
 }
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -156,8 +156,9 @@ public sealed class TypeInfoMappingCollection
 
         if (fallback is { } fbMapping)
         {
+            Debug.Assert(type is not null);
             var resolvedDataTypeName = ResolveFullyQualifiedDataTypeName(dataTypeName, fbMapping.DataTypeName, options);
-            return fbMapping.Factory(options, fbMapping with { Type = type!, DataTypeName = resolvedDataTypeName }, dataTypeName is not null);
+            return fbMapping.Factory(options, fbMapping with { Type = type, DataTypeName = resolvedDataTypeName }, dataTypeName is not null);
         }
 
         return null;
@@ -206,11 +207,11 @@ public sealed class TypeInfoMappingCollection
             var innerInfo = innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
             var converter = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var unboxedType = ComputeUnboxedType(defaultType: mappingType, converter.TypeToConvert, mapping.Type);
-            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, unboxedType));
+            var readingSupported = innerInfo.SupportsReading
+                                   && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, requestedType: mapping.Type));
             var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
 
-            return new PgConcreteTypeInfo(options, converter, options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), unboxedType)
+            return new PgConcreteTypeInfo(options, converter, options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), requestedType: mapping.Type)
             {
                 PreferredFormat = preferredFormat,
                 SupportsReading = readingSupported,
@@ -229,47 +230,20 @@ public sealed class TypeInfoMappingCollection
             var innerInfo = (PgProviderTypeInfo)innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
             var typeInfoProvider = mapper(mapping, innerInfo);
             var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var unboxedType = ComputeUnboxedType(defaultType: mappingType, typeInfoProvider.TypeToConvert, mapping.Type);
-            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(typeInfoProvider.TypeToConvert, unboxedType));
+            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(typeInfoProvider.TypeToConvert, mapping.Type));
             var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
             // We include the data type name if the inner info did so as well.
             // This way we can rely on its logic around resolvedDataTypeName, including when it ignores that flag.
             PgTypeId? pgTypeId = innerInfo.PgTypeId is not null
                 ? options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName))
                 : null;
-            return new PgProviderTypeInfo(options, typeInfoProvider, pgTypeId, unboxedType)
+            return new PgProviderTypeInfo(options, typeInfoProvider, pgTypeId, requestedType: mapping.Type)
             {
                 PreferredFormat = preferredFormat,
                 SupportsReading = readingSupported,
                 SupportsWriting = writingSupported
             };
         };
-
-    static Type? ComputeUnboxedType(Type defaultType, Type converterType, Type matchedType)
-    {
-        // The minimal hierarchy that should hold for things to work is object < converterType < matchedType.
-        // Though these types could often be seen in a hierarchy: object < converterType < defaultType < matchedType.
-        // Some caveats with the latter being for instance Array being the matchedType while the defaultType is int[].
-        Debug.Assert(converterType.IsAssignableFrom(matchedType) || matchedType == typeof(object));
-        Debug.Assert(converterType.IsAssignableFrom(defaultType));
-
-        // A special case for object matches, where we return a more specific type than was matched.
-        // This is to report e.g. Array converters as Array when their matched type was object.
-        if (matchedType == typeof(object))
-            return converterType;
-
-        // This is to report e.g. Array converters as int[,,,] when their matched type was such.
-        if (matchedType != defaultType)
-            return matchedType;
-
-        // If defaultType does not equal converterType we take defaultType as it's more specific.
-        // This is to report e.g. Array converters as int[] when their matched type was their default type.
-        if (defaultType != converterType)
-            return defaultType;
-
-        // Keep the converter type.
-        return null;
-    }
 
     public void Add(TypeInfoMapping mapping) => _items.Add(mapping);
 
@@ -526,7 +500,7 @@ public sealed class TypeInfoMappingCollection
                     (PgConverter<Array>)((PgConcreteTypeInfo)nullableInnerInfo).Converter);
 
             return new PgConcreteTypeInfo(innerInfo.Options, converter,
-                innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), unboxedType: typeof(Array)) { SupportsWriting = false };
+                innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), requestedType: typeof(object)) { SupportsWriting = false };
         }
     }
 
@@ -640,7 +614,7 @@ public sealed class TypeInfoMappingCollection
                         (PgProviderTypeInfo)nullableInnerInfo);
 
                 return new PgProviderTypeInfo(innerInfo.Options, provider,
-                    innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), unboxedType: typeof(Array)) { SupportsWriting = false };
+                    innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), requestedType: typeof(object)) { SupportsWriting = false };
             }
         }
 

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -236,10 +236,7 @@ public sealed class TypeInfoMappingCollection
             PgTypeId? pgTypeId = innerInfo.PgTypeId is not null
                 ? options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName))
                 : null;
-            return new PgProviderTypeInfo(options, typeInfoProvider, pgTypeId, requestedType: mapping.Type)
-            {
-                PreferredFormat = copyPreferredFormat ? providerInfo.PreferredFormat : null,
-            };
+            return new PgProviderTypeInfo(options, typeInfoProvider, pgTypeId, requestedType: mapping.Type);
         };
 
     public void Add(TypeInfoMapping mapping) => _items.Add(mapping);
@@ -779,25 +776,9 @@ public static class TypeInfoMappingHelpers
     /// <param name="provider">The provider to create a PgProviderTypeInfo for.</param>
     /// <param name="includeDataTypeName">Whether to pass mapping.DataTypeName to the PgProviderTypeInfo constructor, mandatory when TypeInfoFactory(..., requiresDataTypeName: true).</param>
     /// <returns>The created info instance.</returns>
-    public static PgProviderTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConcreteTypeInfoProvider provider, bool includeDataTypeName)
-        => new(options, provider, includeDataTypeName ? new DataTypeName(mapping.DataTypeName) : null)
-        {
-            PreferredFormat = null
-        };
-
-    /// <summary>
-    /// Creates a PgProviderTypeInfo from a mapping, options, and a provider.
-    /// </summary>
-    /// <param name="mapping">The mapping to create an info for.</param>
-    /// <param name="options">The options to use.</param>
-    /// <param name="provider">The provider to create a PgProviderTypeInfo for.</param>
-    /// <param name="includeDataTypeName">Whether to pass mapping.DataTypeName to the PgProviderTypeInfo constructor, mandatory when TypeInfoFactory(..., requiresDataTypeName: true).</param>
-    /// <param name="preferredFormat">Whether to prefer a specific data format for this info, when null it defaults to the most suitable format.</param>
-    /// <param name="supportsWriting">Whether the converters returned from the given provider support writing.</param>
-    /// <returns>The created info instance.</returns>
-    public static PgProviderTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConcreteTypeInfoProvider provider, bool includeDataTypeName, DataFormat? preferredFormat = null, bool supportsWriting = true)
-        => new(options, provider, includeDataTypeName ? new DataTypeName(mapping.DataTypeName) : null)
-        {
-            PreferredFormat = preferredFormat,
-        };
+    public static PgTypeInfo CreateInfo(this TypeInfoMapping mapping, PgSerializerOptions options, PgConcreteTypeInfoProvider provider, bool includeDataTypeName)
+    {
+        PgTypeId? pgTypeId = includeDataTypeName ? new PgTypeId(new DataTypeName(mapping.DataTypeName)) : null;
+        return new PgProviderTypeInfo(options, provider, pgTypeId);
+    }
 }

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -204,12 +204,12 @@ public sealed class TypeInfoMappingCollection
             if (!DataTypeName.IsFullyQualified(innerMapping.DataTypeName.AsSpan()))
                 resolvedInnerMapping = innerMapping with { DataTypeName = new DataTypeName(mapping.DataTypeName).Schema + "." + innerMapping.DataTypeName };
 
-            var innerInfo = innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
-            var converter = mapper(mapping, innerInfo);
-            var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var readingSupported = innerInfo.SupportsReading
-                                   && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, requestedType: mapping.Type));
-            var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
+            var innerConcrete = (PgConcreteTypeInfo)innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
+            var converter = mapper(mapping, innerConcrete);
+            var preferredFormat = copyPreferredFormat ? innerConcrete.PreferredFormat : null;
+            var readingSupported = innerConcrete.SupportsReading
+                                   && (supportsReading ?? PgConcreteTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, requestedType: mapping.Type));
+            var writingSupported = innerConcrete.SupportsWriting && (supportsWriting ?? true);
 
             return new PgConcreteTypeInfo(options, converter, options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), requestedType: mapping.Type)
             {
@@ -227,11 +227,10 @@ public sealed class TypeInfoMappingCollection
             if (!DataTypeName.IsFullyQualified(innerMapping.DataTypeName.AsSpan()))
                 resolvedInnerMapping = innerMapping with { DataTypeName = new DataTypeName(mapping.DataTypeName).Schema + "." + innerMapping.DataTypeName };
 
-            var innerInfo = (PgProviderTypeInfo)innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
-            var typeInfoProvider = mapper(mapping, innerInfo);
-            var preferredFormat = copyPreferredFormat ? innerInfo.PreferredFormat : null;
-            var readingSupported = innerInfo.SupportsReading && (supportsReading ?? PgTypeInfo.GetDefaultSupportsReading(typeInfoProvider.TypeToConvert, mapping.Type));
-            var writingSupported = innerInfo.SupportsWriting && (supportsWriting ?? true);
+            var innerInfo = innerMapping.Factory(options, resolvedInnerMapping, requiresDataTypeName);
+
+            var providerInfo = (PgProviderTypeInfo)innerInfo;
+            var typeInfoProvider = mapper(mapping, providerInfo);
             // We include the data type name if the inner info did so as well.
             // This way we can rely on its logic around resolvedDataTypeName, including when it ignores that flag.
             PgTypeId? pgTypeId = innerInfo.PgTypeId is not null
@@ -239,9 +238,7 @@ public sealed class TypeInfoMappingCollection
                 : null;
             return new PgProviderTypeInfo(options, typeInfoProvider, pgTypeId, requestedType: mapping.Type)
             {
-                PreferredFormat = preferredFormat,
-                SupportsReading = readingSupported,
-                SupportsWriting = writingSupported
+                PreferredFormat = copyPreferredFormat ? providerInfo.PreferredFormat : null,
             };
         };
 
@@ -614,7 +611,7 @@ public sealed class TypeInfoMappingCollection
                         (PgProviderTypeInfo)nullableInnerInfo);
 
                 return new PgProviderTypeInfo(innerInfo.Options, provider,
-                    innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), requestedType: typeof(object)) { SupportsWriting = false };
+                    innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), requestedType: typeof(object));
             }
         }
 
@@ -802,6 +799,5 @@ public static class TypeInfoMappingHelpers
         => new(options, provider, includeDataTypeName ? new DataTypeName(mapping.DataTypeName) : null)
         {
             PreferredFormat = preferredFormat,
-            SupportsWriting = supportsWriting
         };
 }

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -356,12 +356,13 @@ public sealed class NpgsqlBinaryExporter : ICancelable
                 // Handle plugin types via lookup.
                 : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
         }
-        var info = options.GetTypeInfoInternal(type, pgTypeId)
+        var typeInfo = options.GetTypeInfoInternal(type, pgTypeId)
                    ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
         // Binary export has no type info so we only do caller-directed interpretation of data.
-        return info.Bind(new Field("?",
-            info.PgTypeId ?? ((PgProviderTypeInfo)info).GetDefaultConcreteTypeInfo(null).PgTypeId, -1), DataFormat.Binary);
+        var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(
+            Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefaultConcreteTypeInfo(null).PgTypeId));
+        return concreteTypeInfo.Bind(DataFormat.Binary);
 
         PgTypeId GetRepresentationalOrDefault(string dataTypeName)
         {

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -276,15 +276,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var typeInfo = GetInfo(typeof(T), type, out var bufferRequirement);
-
-            reader.StartRead(bufferRequirement);
-            var result = typeInfo.ShouldReadAsObject<T>()
-                ? (T)typeInfo.Converter.ReadAsObject(reader)
-                : typeInfo.Converter.UnsafeDowncast<T>().Read(reader);
-            reader.EndRead();
-
-            return result;
+            var typeInfo = GetInfo(typeof(T), type);
+            return typeInfo.ReadFieldValue<T>(reader, DataFormat.Binary);
         }
         finally
         {
@@ -310,15 +303,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var typeInfo = GetInfo(typeof(T), type, out var bufferRequirement);
-
-            await reader.StartReadAsync(bufferRequirement, cancellationToken).ConfigureAwait(false);
-            var result = typeInfo.ShouldReadAsObject<T>()
-                ? (T)await typeInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-                : await typeInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-            await reader.EndReadAsync().ConfigureAwait(false);
-
-            return result;
+            var typeInfo = GetInfo(typeof(T), type);
+            return await typeInfo.ReadFieldValueAsync<T>(reader, DataFormat.Binary, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -338,12 +324,10 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     }
 
 
-    PgConcreteTypeInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out Size bufferRequirement)
+    PgConcreteTypeInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType)
     {
         ref var cachedInfo = ref _columnInfoCache[_column];
-        var info = cachedInfo.IsDefault ? cachedInfo = GetInfoSlow(type, npgsqlDbType) : cachedInfo;
-        bufferRequirement = info.Binding.BufferRequirement;
-        return info.TypeInfo;
+        return (cachedInfo.IsDefault ? cachedInfo = GetInfoSlow(type, npgsqlDbType) : cachedInfo).TypeInfo;
 
         ColumnInfo GetInfoSlow(Type type, NpgsqlDbType? npgsqlDbType = null)
         {
@@ -430,7 +414,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         _column++;
         _buf.Ensure(sizeof(int));
         var columnLen = _buf.ReadInt32();
-        PgReader.Init(columnLen, DataFormat.Binary, resumableOp);
+        PgReader.Init(columnLen, resumableOp);
     }
 
     async ValueTask MoveNextColumnAsync(bool resumableOp)
@@ -442,7 +426,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         _column++;
         await _buf.Ensure(sizeof(int), async: true).ConfigureAwait(false);
         var columnLen = _buf.ReadInt32();
-        PgReader.Init(columnLen, DataFormat.Binary, resumableOp);
+        PgReader.Init(columnLen, resumableOp);
     }
 
     void ThrowIfNotOnRow()

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -276,12 +276,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            GetInfo(typeof(T), type, out var converter, out var bufferRequirement, out var asObject);
+            var typeInfo = GetInfo(typeof(T), type, out var bufferRequirement);
 
             reader.StartRead(bufferRequirement);
-            var result = asObject
-                ? (T)converter.ReadAsObject(reader)
-                : converter.UnsafeDowncast<T>().Read(reader);
+            var result = typeInfo.ShouldReadAsObject<T>()
+                ? (T)typeInfo.Converter.ReadAsObject(reader)
+                : typeInfo.Converter.UnsafeDowncast<T>().Read(reader);
             reader.EndRead();
 
             return result;
@@ -310,12 +310,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            GetInfo(typeof(T), type, out var converter, out var bufferRequirement, out var asObject);
+            var typeInfo = GetInfo(typeof(T), type, out var bufferRequirement);
 
             await reader.StartReadAsync(bufferRequirement, cancellationToken).ConfigureAwait(false);
-            var result = asObject
-                ? (T)await converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-                : await converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            var result = typeInfo.ShouldReadAsObject<T>()
+                ? (T)await typeInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+                : await typeInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
             await reader.EndReadAsync().ConfigureAwait(false);
 
             return result;
@@ -338,13 +338,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     }
 
 
-    void GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out PgConverter converter, out Size bufferRequirement, out bool asObject)
+    PgConcreteTypeInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out Size bufferRequirement)
     {
         ref var cachedInfo = ref _columnInfoCache[_column];
         var info = cachedInfo.IsDefault ? cachedInfo = GetInfoSlow(type, npgsqlDbType) : cachedInfo;
-        converter = info.TypeInfo.Converter;
         bufferRequirement = info.Binding.BufferRequirement;
-        asObject = info.AsObject;
+        return info.TypeInfo;
 
         ColumnInfo GetInfoSlow(Type type, NpgsqlDbType? npgsqlDbType = null)
         {
@@ -363,7 +362,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             // Binary export has no type info so we only do caller-directed interpretation of data.
             var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(
                 Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefaultConcreteTypeInfo(null).PgTypeId));
-            return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary), concreteTypeInfo.IsBoxing);
+            return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary));
 
             PgTypeId GetRepresentationalOrDefault(string dataTypeName)
             {

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -38,7 +38,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// </summary>
     int NumColumns { get; set; }
 
-    PgConverterInfo[] _columnInfoCache;
+    ColumnInfo[] _columnInfoCache;
 
     readonly ILogger _copyLogger;
 
@@ -101,7 +101,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
 
             _state = ExporterState.Ready;
             NumColumns = copyOutResponse.NumColumns;
-            _columnInfoCache = new PgConverterInfo[NumColumns];
+            _columnInfoCache = new ColumnInfo[NumColumns];
             _rowsExported = 0;
             _endOfMessagePos = _buf.CumulativeReadPosition;
             await ReadHeader(async).ConfigureAwait(false);
@@ -276,12 +276,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var info = GetInfo(typeof(T), type, out var asObject);
+            GetInfo(typeof(T), type, out var converter, out var bufferRequirement, out var asObject);
 
-            reader.StartRead(info.BufferRequirement);
+            reader.StartRead(bufferRequirement);
             var result = asObject
-                ? (T)info.Converter.ReadAsObject(reader)
-                : info.Converter.UnsafeDowncast<T>().Read(reader);
+                ? (T)converter.ReadAsObject(reader)
+                : converter.UnsafeDowncast<T>().Read(reader);
             reader.EndRead();
 
             return result;
@@ -310,12 +310,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var info = GetInfo(typeof(T), type, out var asObject);
+            GetInfo(typeof(T), type, out var converter, out var bufferRequirement, out var asObject);
 
-            await reader.StartReadAsync(info.BufferRequirement, cancellationToken).ConfigureAwait(false);
+            await reader.StartReadAsync(bufferRequirement, cancellationToken).ConfigureAwait(false);
             var result = asObject
-                ? (T)await info.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-                : await info.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+                ? (T)await converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+                : await converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
             await reader.EndReadAsync().ConfigureAwait(false);
 
             return result;
@@ -337,37 +337,39 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         throw new InvalidCastException("Column is null");
     }
 
-    PgConverterInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out bool asObject)
+
+    void GetInfo(Type type, NpgsqlDbType? npgsqlDbType, out PgConverter converter, out Size bufferRequirement, out bool asObject)
     {
         ref var cachedInfo = ref _columnInfoCache[_column];
-        var converterInfo = cachedInfo.IsDefault ? cachedInfo = CreateConverterInfo(type, npgsqlDbType) : cachedInfo;
-        asObject = converterInfo.IsBoxingConverter;
-        return converterInfo;
-    }
+        var info = cachedInfo.IsDefault ? cachedInfo = GetInfoSlow(type, npgsqlDbType) : cachedInfo;
+        converter = info.TypeInfo.Converter;
+        bufferRequirement = info.Binding.BufferRequirement;
+        asObject = info.AsObject;
 
-    PgConverterInfo CreateConverterInfo(Type type, NpgsqlDbType? npgsqlDbType = null)
-    {
-        var options = _connector.SerializerOptions;
-        PgTypeId? pgTypeId = null;
-        if (npgsqlDbType.HasValue)
+        ColumnInfo GetInfoSlow(Type type, NpgsqlDbType? npgsqlDbType = null)
         {
-            pgTypeId = npgsqlDbType.Value.ToDataTypeName() is { } name
-                ? options.GetCanonicalTypeId(name)
-                // Handle plugin types via lookup.
-                : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
-        }
-        var typeInfo = options.GetTypeInfoInternal(type, pgTypeId)
-                   ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
+            var options = _connector.SerializerOptions;
+            PgTypeId? pgTypeId = null;
+            if (npgsqlDbType.HasValue)
+            {
+                pgTypeId = npgsqlDbType.Value.ToDataTypeName() is { } name
+                    ? options.GetCanonicalTypeId(name)
+                    // Handle plugin types via lookup.
+                    : GetRepresentationalOrDefault(npgsqlDbType.Value.ToUnqualifiedDataTypeNameOrThrow());
+            }
+            var typeInfo = options.GetTypeInfoInternal(type, pgTypeId)
+                           ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
-        // Binary export has no type info so we only do caller-directed interpretation of data.
-        var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(
-            Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefaultConcreteTypeInfo(null).PgTypeId));
-        return concreteTypeInfo.Bind(DataFormat.Binary);
+            // Binary export has no type info so we only do caller-directed interpretation of data.
+            var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(
+                Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefaultConcreteTypeInfo(null).PgTypeId));
+            return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary), concreteTypeInfo.IsBoxing);
 
-        PgTypeId GetRepresentationalOrDefault(string dataTypeName)
-        {
-            var type = options.DatabaseInfo.GetPostgresType(dataTypeName);
-            return options.ToCanonicalTypeId(type.GetRepresentationalType());
+            PgTypeId GetRepresentationalOrDefault(string dataTypeName)
+            {
+                var type = options.DatabaseInfo.GetPostgresType(dataTypeName);
+                return options.ToCanonicalTypeId(type.GetRepresentationalType());
+            }
         }
     }
 

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -347,6 +347,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             // Binary export has no type info so we only do caller-directed interpretation of data.
             var concreteTypeInfo = typeInfo.MakeConcreteForField(
                 Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefault(null).PgTypeId));
+            if (!concreteTypeInfo.SupportsReading)
+                AdoSerializerHelpers.ThrowReadingNotSupported(type, options, concreteTypeInfo.PgTypeId, resolved: true);
             return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary));
 
             PgTypeId GetRepresentationalOrDefault(string dataTypeName)

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -38,7 +38,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
     /// </summary>
     int NumColumns { get; set; }
 
-    ColumnInfo[] _columnInfoCache;
+    ReadConversionContext[] _conversionContextCache;
 
     readonly ILogger _copyLogger;
 
@@ -61,7 +61,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         _connector = connector;
         _buf = connector.ReadBuffer;
         _column = BeforeRow;
-        _columnInfoCache = null!;
+        _conversionContextCache = null!;
         _copyLogger = connector.LoggingConfiguration.CopyLogger;
     }
 
@@ -101,7 +101,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
 
             _state = ExporterState.Ready;
             NumColumns = copyOutResponse.NumColumns;
-            _columnInfoCache = new ColumnInfo[NumColumns];
+            _conversionContextCache = new ReadConversionContext[NumColumns];
             _rowsExported = 0;
             _endOfMessagePos = _buf.CumulativeReadPosition;
             await ReadHeader(async).ConfigureAwait(false);
@@ -276,8 +276,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var typeInfo = GetInfo(typeof(T), type);
-            return typeInfo.ReadFieldValue<T>(reader, DataFormat.Binary);
+            var typeInfo = GetConversionContext(typeof(T), type, out var bindingContext);
+            return typeInfo.ReadFieldValue<T>(reader, bindingContext);
         }
         finally
         {
@@ -303,8 +303,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             if (reader.FieldIsDbNull)
                 return DbNullOrThrow<T>();
 
-            var typeInfo = GetInfo(typeof(T), type);
-            return await typeInfo.ReadFieldValueAsync<T>(reader, DataFormat.Binary, cancellationToken).ConfigureAwait(false);
+            var typeInfo = GetConversionContext(typeof(T), type, out var bindingContext);
+            return await typeInfo.ReadFieldValueAsync<T>(reader, bindingContext, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -323,13 +323,14 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         throw new InvalidCastException("Column is null");
     }
 
-
-    PgConcreteTypeInfo GetInfo(Type type, NpgsqlDbType? npgsqlDbType)
+    PgConcreteTypeInfo GetConversionContext(Type type, NpgsqlDbType? npgsqlDbType, out PgFieldBinding binding)
     {
-        ref var cachedInfo = ref _columnInfoCache[_column];
-        return (cachedInfo.IsDefault ? cachedInfo = GetInfoSlow(type, npgsqlDbType) : cachedInfo).TypeInfo;
+        ref var contextRef = ref _conversionContextCache[_column];
+        var context = contextRef.IsDefault ? contextRef = GetInfoAndBind(type, npgsqlDbType) : contextRef;
+        binding = context.Binding;
+        return context.TypeInfo;
 
-        ColumnInfo GetInfoSlow(Type type, NpgsqlDbType? npgsqlDbType = null)
+        ReadConversionContext GetInfoAndBind(Type type, NpgsqlDbType? npgsqlDbType)
         {
             var options = _connector.SerializerOptions;
             PgTypeId? pgTypeId = null;
@@ -414,7 +415,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         _column++;
         _buf.Ensure(sizeof(int));
         var columnLen = _buf.ReadInt32();
-        PgReader.Init(columnLen, resumableOp);
+        PgReader.Init(DataFormat.Binary, columnLen, resumableOp);
     }
 
     async ValueTask MoveNextColumnAsync(bool resumableOp)
@@ -426,7 +427,7 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         _column++;
         await _buf.Ensure(sizeof(int), async: true).ConfigureAwait(false);
         var columnLen = _buf.ReadInt32();
-        PgReader.Init(columnLen, resumableOp);
+        PgReader.Init(DataFormat.Binary, columnLen, resumableOp);
     }
 
     void ThrowIfNotOnRow()

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -345,8 +345,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
                            ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
             // Binary export has no type info so we only do caller-directed interpretation of data.
-            var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(
-                Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefaultConcreteTypeInfo(null).PgTypeId));
+            var concreteTypeInfo = typeInfo.MakeConcreteForField(
+                Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefault(null).PgTypeId));
             return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary));
 
             PgTypeId GetRepresentationalOrDefault(string dataTypeName)

--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -557,6 +557,16 @@ public sealed class NpgsqlBinaryImporter : ICancelable
             _connector = null;
         }
 
+        // Deterministically release each parameter's provider-produced write state and binding state.
+        // ResetDbType cascades through ResetTypeInfo which disposes both; clearing the type hints is
+        // incidental (the params aren't reused after the importer closes). GC would eventually catch
+        // anything we miss, but we'd rather not leak pooled buffers held in write state.
+        if (_params is not null)
+        {
+            foreach (var p in _params)
+                p?.ResetDbType();
+        }
+
         _buf = null;
         _state = ImporterState.Disposed;
     }

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1481,7 +1481,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         ThrowIfNotInResult();
 
         // Check whether we have a GetChars implementation for this column type.
-        var converter = GetInfo(ordinal, typeof(GetChars), out var dataFormat, out var bufferRequirement, out var asObject);
+        var typeInfo = GetInfo(ordinal, typeof(GetChars), out var dataFormat, out var bufferRequirement);
 
         if (dataOffset is < 0 or > int.MaxValue)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(dataOffset), "dataOffset must be between 0 and {0}", int.MaxValue);
@@ -1502,9 +1502,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             buffer is not null ? new ArraySegment<char>(buffer, bufferOffset, length) : (ArraySegment<char>?)null);
 
         reader.StartRead(bufferRequirement);
-        var result = asObject
-            ? (GetChars)converter.ReadAsObject(reader)
-            : ((PgConverter<GetChars>)converter).Read(reader);
+        var result = typeInfo.ShouldReadAsObject<GetChars>()
+            ? (GetChars)typeInfo.Converter.ReadAsObject(reader)
+            : ((PgConverter<GetChars>)typeInfo.Converter).Read(reader);
         reader.EndRead();
 
         reader.EndCharsRead();
@@ -1561,7 +1561,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         async Task<T> Core(int ordinal, CancellationToken cancellationToken)
         {
             ThrowIfNotInResult();
-            var converter = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement, out var asObject);
+            var typeInfo = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement);
 
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
             if (await SeekToColumnAsync(ordinal, dataFormat).ConfigureAwait(false) is DbNullSentinel)
@@ -1569,10 +1569,10 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
             var reader = PgReader;
             await reader.StartReadAsync(bufferRequirement, cancellationToken).ConfigureAwait(false);
-            var result = asObject
-                ? (T)await converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-                : await converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-            await reader.EndReadAsync().ConfigureAwait(false);
+            var result = typeInfo.ShouldReadAsObject<T>()
+                ? (T)await typeInfo.Converter.ReadAsObjectAsync(PgReader, cancellationToken).ConfigureAwait(false)
+                : await typeInfo.Converter.UnsafeDowncast<T>().ReadAsync(PgReader, cancellationToken).ConfigureAwait(false);
+            await PgReader.EndReadAsync().ConfigureAwait(false);
             return result;
         }
     }
@@ -1588,16 +1588,16 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     T GetFieldValueCore<T>(int ordinal)
     {
         ThrowIfNotInResult();
-        var converter = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement, out var asObject);
+        var typeInfo = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement);
 
         if (SeekToColumn(ordinal, dataFormat) is DbNullSentinel)
             return DbNullValueOrThrow<T>(ordinal);
 
         var reader = PgReader;
         reader.StartRead(bufferRequirement);
-        var result = asObject
-            ? (T)converter.ReadAsObject(reader)
-            : converter.UnsafeDowncast<T>().Read(reader);
+        var result = typeInfo.ShouldReadAsObject<T>()
+            ? (T)typeInfo.Converter.ReadAsObject(PgReader)
+            : typeInfo.Converter.UnsafeDowncast<T>().Read(PgReader);
         reader.EndRead();
         return result;
     }
@@ -2051,7 +2051,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConverter GetInfo(int ordinal, Type type, out DataFormat format, out Size bufferRequirement, out bool asObject)
+    PgConcreteTypeInfo GetInfo(int ordinal, Type type, out DataFormat dataFormat, out Size bufferRequirement)
     {
         if ((uint)ordinal >= (uint)ColumnCount)
             ThrowHelper.ThrowIndexOutOfRangeException("Ordinal is out of range, value must be between 0 and {0} (exclusive).", ColumnCount);
@@ -2062,23 +2062,21 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         if (info is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
         {
-            format = info.DataFormat;
+            dataFormat = info.DataFormat;
             bufferRequirement = info.Binding.BufferRequirement;
-            asObject = info.AsObject;
-            return info.TypeInfo.Converter;
+            return info.TypeInfo;
         }
 
-        return Slow(ref info, out format, out bufferRequirement, out asObject);
+        return Slow(ref info, out dataFormat, out bufferRequirement);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        PgConverter Slow(ref ColumnInfo info, out DataFormat format, out Size bufferRequirement, out bool asObject)
+        PgConcreteTypeInfo Slow(ref ColumnInfo info, out DataFormat dataFormat, out Size bufferRequirement)
         {
             var field = RowDescription![ordinal];
             field.GetInfo(type, ref info);
-            format = field.DataFormat;
+            dataFormat = info.DataFormat;
             bufferRequirement = info.Binding.BufferRequirement;
-            asObject = info.AsObject;
-            return info.TypeInfo.Converter;
+            return info.TypeInfo;
         }
     }
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1375,7 +1375,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (field.DataFormat is DataFormat.Text || (elementType.InternalName != "record" && compositeType == null))
             ThrowHelper.ThrowInvalidCastException("GetData() not supported for type " + field.TypeDisplayName);
 
-        if (SeekToColumn(ordinal, field.DataFormat, resumableOp: true) is DbNullSentinel)
+        if (SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(field);
 
         Debug.Assert(!PgReader.NestedInitialized, "Unexpected nested read active, Seek(0) would seek to the start of the nested data.");
@@ -1423,7 +1423,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))
             ThrowHelper.ThrowIndexOutOfRangeException("bufferOffset must be between 0 and {0}", buffer.Length - bufferOffset);
 
-        if (SeekToColumn(ordinal, field.DataFormat, resumableOp: true) is var columnLength && columnLength is DbNullSentinel)
+        if (SeekToColumn(ordinal, resumableOp: true) is var columnLength && columnLength is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(field);
 
         if (buffer is null)
@@ -1481,7 +1481,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         ThrowIfNotInResult();
 
         // Check whether we have a GetChars implementation for this column type.
-        var typeInfo = GetInfo(ordinal, typeof(GetChars), out var dataFormat, out var bufferRequirement);
+        var typeInfo = GetBindingInfo(ordinal, typeof(GetChars), out var dataFormat);
 
         if (dataOffset is < 0 or > int.MaxValue)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(dataOffset), "dataOffset must be between 0 and {0}", int.MaxValue);
@@ -1490,7 +1490,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))
             ThrowHelper.ThrowIndexOutOfRangeException("bufferOffset must be between 0 and {0}", buffer.Length - bufferOffset);
 
-        if (SeekToColumn(ordinal, dataFormat, resumableOp: true) is DbNullSentinel)
+        if (SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(RowDescription[ordinal]);
 
         var reader = PgReader;
@@ -1500,13 +1500,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         reader.StartCharsRead(checked((int)dataOffset),
             buffer is not null ? new ArraySegment<char>(buffer, bufferOffset, length) : (ArraySegment<char>?)null);
-
-        reader.StartRead(bufferRequirement);
-        var result = typeInfo.ShouldReadAsObject<GetChars>()
-            ? (GetChars)typeInfo.Converter.ReadAsObject(reader)
-            : ((PgConverter<GetChars>)typeInfo.Converter).Read(reader);
-        reader.EndRead();
-
+        var result = typeInfo.ReadFieldValue<GetChars>(reader, dataFormat);
         reader.EndCharsRead();
         return result.Read;
     }
@@ -1561,19 +1555,14 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         async Task<T> Core(int ordinal, CancellationToken cancellationToken)
         {
             ThrowIfNotInResult();
-            var typeInfo = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement);
+            var typeInfo = GetBindingInfo(ordinal, typeof(T), out var dataFormat);
 
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
-            if (await SeekToColumnAsync(ordinal, dataFormat).ConfigureAwait(false) is DbNullSentinel)
+
+            if (await SeekToColumnAsync(ordinal).ConfigureAwait(false) is DbNullSentinel)
                 return DbNullValueOrThrow<T>(ordinal);
 
-            var reader = PgReader;
-            await reader.StartReadAsync(bufferRequirement, cancellationToken).ConfigureAwait(false);
-            var result = typeInfo.ShouldReadAsObject<T>()
-                ? (T)await typeInfo.Converter.ReadAsObjectAsync(PgReader, cancellationToken).ConfigureAwait(false)
-                : await typeInfo.Converter.UnsafeDowncast<T>().ReadAsync(PgReader, cancellationToken).ConfigureAwait(false);
-            await PgReader.EndReadAsync().ConfigureAwait(false);
-            return result;
+            return await typeInfo.ReadFieldValueAsync<T>(PgReader, dataFormat, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -1588,18 +1577,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     T GetFieldValueCore<T>(int ordinal)
     {
         ThrowIfNotInResult();
-        var typeInfo = GetInfo(ordinal, typeof(T), out var dataFormat, out var bufferRequirement);
+        var typeInfo = GetBindingInfo(ordinal, typeof(T), out var dataFormat);
 
-        if (SeekToColumn(ordinal, dataFormat) is DbNullSentinel)
-            return DbNullValueOrThrow<T>(ordinal);
-
-        var reader = PgReader;
-        reader.StartRead(bufferRequirement);
-        var result = typeInfo.ShouldReadAsObject<T>()
-            ? (T)typeInfo.Converter.ReadAsObject(PgReader)
-            : typeInfo.Converter.UnsafeDowncast<T>().Read(PgReader);
-        reader.EndRead();
-        return result;
+        return SeekToColumn(ordinal) is DbNullSentinel ? DbNullValueOrThrow<T>(ordinal) : typeInfo.ReadFieldValue<T>(PgReader, dataFormat);
     }
 
     #endregion
@@ -1614,16 +1594,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     public override object GetValue(int ordinal)
     {
         ThrowIfNotInResult();
-        var format = GetDefaultInfo(ordinal, out var converter, out var bufferRequirement);
-        if (SeekToColumn(ordinal, format) is DbNullSentinel)
-            return DBNull.Value;
+        var typeInfo = GetDefaultBindingInfo(ordinal, out var dataFormat);
 
-        var reader = PgReader;
-        reader.StartRead(bufferRequirement);
-        var result = converter.ReadAsObject(reader);
-        reader.EndRead();
-
-        return result;
+        return SeekToColumn(ordinal) is DbNullSentinel ? DBNull.Value : typeInfo.ReadFieldValue<object>(PgReader, dataFormat);
     }
 
     /// <summary>
@@ -1645,7 +1618,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     public override bool IsDBNull(int ordinal)
     {
         ThrowIfNotInResult();
-        return SeekToColumn(ordinal, RowDescription[ordinal].DataFormat, resumableOp: true) is DbNullSentinel;
+        return SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel;
     }
 
     /// <summary>
@@ -1668,7 +1641,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         {
             ThrowIfNotInResult();
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
-            return await SeekToColumnAsync(ordinal, RowDescription[ordinal].DataFormat, resumableOp: true).ConfigureAwait(false) is DbNullSentinel;
+            return await SeekToColumnAsync(ordinal, resumableOp: true).ConfigureAwait(false) is DbNullSentinel;
         }
     }
 
@@ -1861,7 +1834,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     #region Seeking
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    int SeekToColumn(int ordinal, DataFormat dataFormat, bool resumableOp = false)
+    int SeekToColumn(int ordinal, bool resumableOp = false)
     {
         Debug.Assert(_isRowBuffered || _isSequential);
         var reader = PgReader;
@@ -1883,7 +1856,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         reader.Commit();
         var columnLength = BufferSeekToColumn(column, ordinal, !_isRowBuffered);
-        reader.Init(columnLength, dataFormat, resumableOp);
+        reader.Init(columnLength, resumableOp);
         return columnLength;
 
         static void ThrowInvalidSequentialSeek(int column, int ordinal)
@@ -1892,23 +1865,23 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 $"you may only read from column ordinal '{column}' or greater.");
     }
 
-    ValueTask<int> SeekToColumnAsync(int ordinal, DataFormat dataFormat, bool resumableOp = false)
+    ValueTask<int> SeekToColumnAsync(int ordinal, bool resumableOp = false)
     {
         // When the row is buffered or we're rereading previous data no IO will be done.
         if (_isRowBuffered || _column >= ordinal)
-            return new(SeekToColumn(ordinal, dataFormat, resumableOp));
+            return new(SeekToColumn(ordinal, resumableOp));
 
-        return Core(ordinal, dataFormat, resumableOp);
+        return Core(ordinal, resumableOp);
 
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-        async ValueTask<int> Core(int ordinal, DataFormat dataFormat, bool resumableOp)
+        async ValueTask<int> Core(int ordinal, bool resumableOp)
         {
             Debug.Assert(!_isRowBuffered && _column < ordinal);
 
             var reader = PgReader;
             await reader.CommitAsync().ConfigureAwait(false);
             var columnLength = await BufferSeekToColumnAsync(_column, ordinal, !_isRowBuffered).ConfigureAwait(false);
-            reader.Init(columnLength, dataFormat, resumableOp);
+            reader.Init(columnLength, resumableOp);
             return columnLength;
         }
     }
@@ -2051,7 +2024,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConcreteTypeInfo GetInfo(int ordinal, Type type, out DataFormat dataFormat, out Size bufferRequirement)
+    PgConcreteTypeInfo GetBindingInfo(int ordinal, Type type, out DataFormat dataFormat)
     {
         if ((uint)ordinal >= (uint)ColumnCount)
             ThrowHelper.ThrowIndexOutOfRangeException("Ordinal is out of range, value must be between 0 and {0} (exclusive).", ColumnCount);
@@ -2063,31 +2036,20 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (info is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
         {
             dataFormat = info.DataFormat;
-            bufferRequirement = info.Binding.BufferRequirement;
             return info.TypeInfo;
         }
 
-        return Slow(ref info, out dataFormat, out bufferRequirement);
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        PgConcreteTypeInfo Slow(ref ColumnInfo info, out DataFormat dataFormat, out Size bufferRequirement)
-        {
-            var field = RowDescription![ordinal];
-            field.GetInfo(type, ref info);
-            dataFormat = info.DataFormat;
-            bufferRequirement = info.Binding.BufferRequirement;
-            return info.TypeInfo;
-        }
+        RowDescription![ordinal].GetInfo(type, ref info);
+        dataFormat = info.DataFormat;
+        return info.TypeInfo;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    DataFormat GetDefaultInfo(int ordinal, out PgConverter converter, out Size bufferRequirement)
+    PgConcreteTypeInfo GetDefaultBindingInfo(int ordinal, out DataFormat dataFormat)
     {
         var field = RowDescription![ordinal];
-
-        converter = field.ObjectInfo.TypeInfo.Converter;
-        bufferRequirement = field.ObjectInfo.Binding.BufferRequirement;
-        return field.DataFormat;
+        dataFormat = field.DataFormat;
+        return field.ObjectInfo.TypeInfo;
     }
 
     /// <summary>

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1852,10 +1852,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             ThrowInvalidSequentialSeek(column, ordinal);
 
         if (column == ordinal)
-        {
-            Debug.Assert(reader.Current.Format == fieldFormat, "Field reinterpretation happened?");
             return reader.Restart(resumableOp);
-        }
 
         reader.Commit();
         var columnLength = BufferSeekToColumn(column, ordinal, !_isRowBuffered);

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -111,7 +111,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// <summary>
     /// Stores the last converter info resolved by column, to speed up repeated reading.
     /// </summary>
-    ColumnInfo[]? ColumnInfoCache { get; set; }
+    ReadConversionContext[]? ConversionContextCache { get; set; }
 
     ulong? _recordsAffected;
 
@@ -146,7 +146,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         long startTimestamp = 0,
         Task? sendTask = null)
     {
-        Debug.Assert(ColumnInfoCache is null);
+        Debug.Assert(ConversionContextCache is null);
         Command = command;
         _connection = command.InternalConnection;
         _behavior = behavior;
@@ -364,7 +364,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             var statementIndex = StatementIndex;
             if (statementIndex >= 0)
             {
-                if (RowDescription is { } description && statements[statementIndex].IsPrepared && ColumnInfoCache is { } cache)
+                if (RowDescription is { } description && statements[statementIndex].IsPrepared && ConversionContextCache is { } cache)
                     description.SetColumnInfoCache(new(cache, 0, ColumnCount));
 
                 if (statementIndex is 0 && _behavior.HasFlag(CommandBehavior.SingleResult) && !isConsuming)
@@ -429,16 +429,16 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
                 if (RowDescription is not null)
                 {
-                    if (ColumnInfoCache?.Length >= ColumnCount)
-                        Array.Clear(ColumnInfoCache, 0, ColumnCount);
+                    if (ConversionContextCache?.Length >= ColumnCount)
+                        Array.Clear(ConversionContextCache, 0, ColumnCount);
                     else
                     {
-                        if (ColumnInfoCache is { } cache)
-                            ArrayPool<ColumnInfo>.Shared.Return(cache, clearArray: true);
-                        ColumnInfoCache = ArrayPool<ColumnInfo>.Shared.Rent(ColumnCount);
+                        if (ConversionContextCache is { } cache)
+                            ArrayPool<ReadConversionContext>.Shared.Return(cache, clearArray: true);
+                        ConversionContextCache = ArrayPool<ReadConversionContext>.Shared.Rent(ColumnCount);
                     }
                     if (statement.IsPrepared)
-                        RowDescription.LoadColumnInfoCache(Connector.SerializerOptions, ColumnInfoCache);
+                        RowDescription.LoadColumnInfoCache(Connector.SerializerOptions, ConversionContextCache);
                 }
                 else
                 {
@@ -630,8 +630,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                     ProcessMessage(completedMsg);
 
                     var statement = _statements[StatementIndex];
-                    if (statement.IsPrepared && ColumnInfoCache is not null)
-                        RowDescription!.SetColumnInfoCache(new(ColumnInfoCache, 0, ColumnCount));
+                    if (statement.IsPrepared && ConversionContextCache is not null)
+                        RowDescription!.SetColumnInfoCache(new(ConversionContextCache, 0, ColumnCount));
 
                     if (statement.AppendErrorBarrier ?? Command.EnableErrorBarriers)
                         Expect<ReadyForQueryMessage>(await Connector.ReadMessage(async).ConfigureAwait(false), Connector);
@@ -1186,10 +1186,10 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             }
         }
 
-        if (ColumnInfoCache is { } cache)
+        if (ConversionContextCache is { } cache)
         {
-            ColumnInfoCache = null;
-            ArrayPool<ColumnInfo>.Shared.Return(cache, clearArray: true);
+            ConversionContextCache = null;
+            ArrayPool<ReadConversionContext>.Shared.Return(cache, clearArray: true);
         }
 
         // Drop any reference to a potential oversized buffer.
@@ -1375,27 +1375,28 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (field.DataFormat is DataFormat.Text || (elementType.InternalName != "record" && compositeType == null))
             ThrowHelper.ThrowInvalidCastException("GetData() not supported for type " + field.TypeDisplayName);
 
-        if (SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel)
+        if (SeekToColumn(ordinal, field.DataFormat, resumableOp: true) is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(field);
 
         Debug.Assert(!PgReader.NestedInitialized, "Unexpected nested read active, Seek(0) would seek to the start of the nested data.");
-        PgReader.Seek(0);
+        var reader = PgReader;
+        reader.Seek(0);
 
-        var reader = CachedFreeNestedDataReader;
-        if (reader != null)
+        var nestedReader = CachedFreeNestedDataReader;
+        if (nestedReader != null)
         {
             CachedFreeNestedDataReader = null;
-            reader.Init(compositeType);
+            nestedReader.Init(compositeType);
         }
         else
         {
-            reader = new NpgsqlNestedDataReader(this, null, 1, compositeType);
+            nestedReader = new NpgsqlNestedDataReader(this, null, 1, compositeType);
         }
         if (isArray)
-            reader.InitArray();
+            nestedReader.InitArray();
         else
-            reader.InitSingleRow();
-        return reader;
+            nestedReader.InitSingleRow();
+        return nestedReader;
     }
 
     #endregion
@@ -1423,7 +1424,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))
             ThrowHelper.ThrowIndexOutOfRangeException("bufferOffset must be between 0 and {0}", buffer.Length - bufferOffset);
 
-        if (SeekToColumn(ordinal, resumableOp: true) is var columnLength && columnLength is DbNullSentinel)
+        if (SeekToColumn(ordinal, field.DataFormat, resumableOp: true) is var columnLength && columnLength is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(field);
 
         if (buffer is null)
@@ -1481,7 +1482,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         ThrowIfNotInResult();
 
         // Check whether we have a GetChars implementation for this column type.
-        var typeInfo = GetBindingInfo(ordinal, typeof(GetChars), out var dataFormat);
+        var context = GetConversionContext(ordinal, typeof(GetChars));
 
         if (dataOffset is < 0 or > int.MaxValue)
             ThrowHelper.ThrowArgumentOutOfRangeException(nameof(dataOffset), "dataOffset must be between 0 and {0}", int.MaxValue);
@@ -1490,17 +1491,17 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         if (buffer != null && (length < 0 || length > buffer.Length - bufferOffset))
             ThrowHelper.ThrowIndexOutOfRangeException("bufferOffset must be between 0 and {0}", buffer.Length - bufferOffset);
 
-        if (SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel)
+        var reader = PgReader;
+        if (SeekToColumn(ordinal, context.Binding.DataFormat, resumableOp: true) is DbNullSentinel)
             ThrowHelper.ThrowInvalidCastException_NoValue(RowDescription[ordinal]);
 
-        var reader = PgReader;
         dataOffset = buffer is null ? 0 : dataOffset;
         if (_isSequential && reader.GetCharsRead > dataOffset)
             ThrowHelper.ThrowInvalidOperationException("Attempt to read a position in the column which has already been read");
 
         reader.StartCharsRead(checked((int)dataOffset),
             buffer is not null ? new ArraySegment<char>(buffer, bufferOffset, length) : (ArraySegment<char>?)null);
-        var result = typeInfo.ReadFieldValue<GetChars>(reader, dataFormat);
+        var result = context.TypeInfo.ReadFieldValue<GetChars>(reader, context.Binding);
         reader.EndCharsRead();
         return result.Read;
     }
@@ -1555,14 +1556,15 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         async Task<T> Core(int ordinal, CancellationToken cancellationToken)
         {
             ThrowIfNotInResult();
-            var typeInfo = GetBindingInfo(ordinal, typeof(T), out var dataFormat);
+
+            var context = GetConversionContext(ordinal, type: typeof(T) == typeof(object) ? null : typeof(T));
 
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
 
-            if (await SeekToColumnAsync(ordinal).ConfigureAwait(false) is DbNullSentinel)
-                return DbNullValueOrThrow<T>(ordinal);
-
-            return await typeInfo.ReadFieldValueAsync<T>(PgReader, dataFormat, cancellationToken).ConfigureAwait(false);
+            var reader = PgReader;
+            return await SeekToColumnAsync(ordinal, context.Binding.DataFormat).ConfigureAwait(false) is DbNullSentinel
+                ? DbNullValueOrThrow<T>(ordinal)
+                : await context.TypeInfo.ReadFieldValueAsync<T>(reader, context.Binding, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -1577,9 +1579,11 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     T GetFieldValueCore<T>(int ordinal)
     {
         ThrowIfNotInResult();
-        var typeInfo = GetBindingInfo(ordinal, typeof(T), out var dataFormat);
+        var context = GetConversionContext(ordinal, type: typeof(T) == typeof(object) ? null : typeof(T));
 
-        return SeekToColumn(ordinal) is DbNullSentinel ? DbNullValueOrThrow<T>(ordinal) : typeInfo.ReadFieldValue<T>(PgReader, dataFormat);
+        return SeekToColumn(ordinal, context.Binding.DataFormat) is DbNullSentinel
+            ? DbNullValueOrThrow<T>(ordinal)
+            : context.TypeInfo.ReadFieldValue<T>(PgReader, context.Binding);
     }
 
     #endregion
@@ -1591,13 +1595,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// </summary>
     /// <param name="ordinal">The zero-based column ordinal.</param>
     /// <returns>The value of the specified column.</returns>
-    public override object GetValue(int ordinal)
-    {
-        ThrowIfNotInResult();
-        var typeInfo = GetDefaultBindingInfo(ordinal, out var dataFormat);
-
-        return SeekToColumn(ordinal) is DbNullSentinel ? DBNull.Value : typeInfo.ReadFieldValue<object>(PgReader, dataFormat);
-    }
+    public override object GetValue(int ordinal) => GetFieldValueCore<object>(ordinal);
 
     /// <summary>
     /// Gets the value of the specified column as an instance of <see cref="object"/>.
@@ -1618,7 +1616,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     public override bool IsDBNull(int ordinal)
     {
         ThrowIfNotInResult();
-        return SeekToColumn(ordinal, resumableOp: true) is DbNullSentinel;
+        var field = RowDescription[ordinal];
+        return SeekToColumn(ordinal, field.DataFormat, resumableOp: true) is DbNullSentinel;
     }
 
     /// <summary>
@@ -1640,8 +1639,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         async Task<bool> Core(int ordinal, CancellationToken cancellationToken)
         {
             ThrowIfNotInResult();
+            var field = RowDescription[ordinal];
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
-            return await SeekToColumnAsync(ordinal, resumableOp: true).ConfigureAwait(false) is DbNullSentinel;
+            return await SeekToColumnAsync(ordinal, field.DataFormat, resumableOp: true).ConfigureAwait(false) is DbNullSentinel;
         }
     }
 
@@ -1833,8 +1833,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
     #region Seeking
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    int SeekToColumn(int ordinal, bool resumableOp = false)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    int SeekToColumn(int ordinal, DataFormat fieldFormat, bool resumableOp = false)
     {
         Debug.Assert(_isRowBuffered || _isSequential);
         var reader = PgReader;
@@ -1852,11 +1852,14 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             ThrowInvalidSequentialSeek(column, ordinal);
 
         if (column == ordinal)
+        {
+            Debug.Assert(reader.Current.Format == fieldFormat, "Field reinterpretation happened?");
             return reader.Restart(resumableOp);
+        }
 
         reader.Commit();
         var columnLength = BufferSeekToColumn(column, ordinal, !_isRowBuffered);
-        reader.Init(columnLength, resumableOp);
+        reader.Init(fieldFormat, columnLength, resumableOp);
         return columnLength;
 
         static void ThrowInvalidSequentialSeek(int column, int ordinal)
@@ -1865,28 +1868,27 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 $"you may only read from column ordinal '{column}' or greater.");
     }
 
-    ValueTask<int> SeekToColumnAsync(int ordinal, bool resumableOp = false)
+    ValueTask<int> SeekToColumnAsync(int ordinal, DataFormat fieldFormat, bool resumableOp = false)
     {
         // When the row is buffered or we're rereading previous data no IO will be done.
         if (_isRowBuffered || _column >= ordinal)
-            return new(SeekToColumn(ordinal, resumableOp));
+            return new(SeekToColumn(ordinal, fieldFormat, resumableOp));
 
-        return Core(ordinal, resumableOp);
+        return Core(ordinal, fieldFormat, resumableOp);
 
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-        async ValueTask<int> Core(int ordinal, bool resumableOp)
+        async ValueTask<int> Core(int ordinal, DataFormat fieldFormat, bool resumableOp)
         {
             Debug.Assert(!_isRowBuffered && _column < ordinal);
 
             var reader = PgReader;
             await reader.CommitAsync().ConfigureAwait(false);
             var columnLength = await BufferSeekToColumnAsync(_column, ordinal, !_isRowBuffered).ConfigureAwait(false);
-            reader.Init(columnLength, resumableOp);
+            reader.Init(fieldFormat, columnLength, resumableOp);
             return columnLength;
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     int BufferSeekToColumn(int column, int ordinal, bool allowIO)
     {
         Debug.Assert(column < ordinal || !allowIO);
@@ -2024,32 +2026,30 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConcreteTypeInfo GetBindingInfo(int ordinal, Type type, out DataFormat dataFormat)
+    ReadConversionContext GetConversionContext(int ordinal, Type? type)
     {
-        if ((uint)ordinal >= (uint)ColumnCount)
-            ThrowHelper.ThrowIndexOutOfRangeException("Ordinal is out of range, value must be between 0 and {0} (exclusive).", ColumnCount);
-
-        ref var info = ref ColumnInfoCache![ordinal];
-
-        Debug.Assert(info.IsDefault || ReferenceEquals(Connector.SerializerOptions, info.TypeInfo.Options), "Cache is bleeding over");
-
-        if (info is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
+        ReadConversionContext context;
+        if (type is not null)
         {
-            dataFormat = info.DataFormat;
-            return info.TypeInfo;
+            // Do the same check as the RowDescription indexer before we access the cache.
+            if ((uint)ordinal >= (uint)ColumnCount)
+                ThrowHelper.ThrowIndexOutOfRangeException("Ordinal is out of range, value must be between 0 and {0} (exclusive).", ColumnCount);
+
+            ref var contextRef = ref ConversionContextCache![ordinal];
+
+            Debug.Assert(contextRef.IsDefault || ReferenceEquals(Connector.SerializerOptions, contextRef.TypeInfo.Options), "Cache is bleeding over");
+
+            if (contextRef.TypeInfo is not { } typeInfo || !typeInfo.CanReadTo(type))
+                RowDescription!.GetConversionContext(ordinal, type, ref contextRef);
+
+            context = contextRef;
+        }
+        else
+        {
+            context = RowDescription![ordinal].ObjectConversionContext;
         }
 
-        RowDescription![ordinal].GetInfo(type, ref info);
-        dataFormat = info.DataFormat;
-        return info.TypeInfo;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    PgConcreteTypeInfo GetDefaultBindingInfo(int ordinal, out DataFormat dataFormat)
-    {
-        var field = RowDescription![ordinal];
-        dataFormat = field.DataFormat;
-        return field.ObjectInfo.TypeInfo;
+        return context;
     }
 
     /// <summary>
@@ -2072,6 +2072,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             ThrowInvalidState(state);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [MemberNotNull(nameof(RowDescription))]
     void ThrowIfNotInResult()
     {

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -2060,7 +2060,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         Debug.Assert(info.ConverterInfo.IsDefault || ReferenceEquals(Connector.SerializerOptions, info.ConverterInfo.TypeInfo.Options), "Cache is bleeding over");
 
-        if (info.ConverterInfo.TypeToConvert == type)
+        if (info.ConverterInfo is { IsDefault: false, TypeToConvert: var typeToConvert } && typeToConvert == type)
         {
             format = info.DataFormat;
             bufferRequirement = info.ConverterInfo.BufferRequirement;

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -2058,14 +2058,14 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 
         ref var info = ref ColumnInfoCache![ordinal];
 
-        Debug.Assert(info.ConverterInfo.IsDefault || ReferenceEquals(Connector.SerializerOptions, info.ConverterInfo.TypeInfo.Options), "Cache is bleeding over");
+        Debug.Assert(info.IsDefault || ReferenceEquals(Connector.SerializerOptions, info.TypeInfo.Options), "Cache is bleeding over");
 
-        if (info.ConverterInfo is { IsDefault: false, TypeToConvert: var typeToConvert } && typeToConvert == type)
+        if (info is { IsDefault: false, TypeInfo.Type: var typeToConvert } && typeToConvert == type)
         {
             format = info.DataFormat;
-            bufferRequirement = info.ConverterInfo.BufferRequirement;
+            bufferRequirement = info.Binding.BufferRequirement;
             asObject = info.AsObject;
-            return info.ConverterInfo.Converter;
+            return info.TypeInfo.Converter;
         }
 
         return Slow(ref info, out format, out bufferRequirement, out asObject);
@@ -2076,9 +2076,9 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             var field = RowDescription![ordinal];
             field.GetInfo(type, ref info);
             format = field.DataFormat;
-            bufferRequirement = info.ConverterInfo.BufferRequirement;
+            bufferRequirement = info.Binding.BufferRequirement;
             asObject = info.AsObject;
-            return info.ConverterInfo.Converter;
+            return info.TypeInfo.Converter;
         }
     }
 
@@ -2087,8 +2087,8 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     {
         var field = RowDescription![ordinal];
 
-        converter = field.ObjectInfo.Converter;
-        bufferRequirement = field.ObjectInfo.BufferRequirement;
+        converter = field.ObjectInfo.TypeInfo.Converter;
+        bufferRequirement = field.ObjectInfo.Binding.BufferRequirement;
         return field.DataFormat;
     }
 

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using Npgsql.BackendMessages;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql;
@@ -29,24 +30,28 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     int _nextRowBufferPos;
     ReaderState _readerState;
 
-    readonly List<ColumnInfo> _columns = [];
+    readonly List<NestedColumnInfo> _columns = [];
     long _startPos;
 
-    DataFormat Format => DataFormat.Binary;
+    DataFormat DataFormat => DataFormat.Binary;
 
-    readonly struct ColumnInfo(PostgresType postgresType, int bufferPos, PgTypeInfo objectOrDefaultTypeInfo, DataFormat format)
+    readonly struct NestedColumnInfo
     {
-        public PostgresType PostgresType { get; } = postgresType;
-        public int BufferPos { get; } = bufferPos;
-        public PgConverterInfo LastConverterInfo { get; init; }
+        public PostgresType PostgresType { get; }
+        public int BufferPos { get; }
+        public ColumnInfo LastInfo { get; init; }
+        public PgConcreteTypeInfo ObjectTypeInfo { get; }
+        public PgFieldBinding ObjectBinding { get; }
 
-        public PgTypeInfo ObjectOrDefaultTypeInfo { get; } = objectOrDefaultTypeInfo;
-        public PgConverterInfo GetObjectOrDefaultInfo()
-            => ObjectOrDefaultTypeInfo.GetConcreteTypeInfo(Field).Bind(format);
+        public NestedColumnInfo(PostgresType postgresType, int bufferPos, PgTypeInfo objectTypeInfo, DataFormat format)
+        {
+            PostgresType = postgresType;
+            BufferPos = bufferPos;
+            ObjectTypeInfo = objectTypeInfo.GetConcreteTypeInfo(Field.CreateUnspecified(objectTypeInfo.Options.ToCanonicalTypeId(postgresType)));
+            ObjectBinding = ObjectTypeInfo.BindField(format);
+        }
 
-        Field Field => new("?", ObjectOrDefaultTypeInfo.Options.PortableTypeIds ? PostgresType.DataTypeName : (Oid)PostgresType.OID, -1);
-
-        public PgConverterInfo Bind(PgTypeInfo typeInfo) => typeInfo.GetConcreteTypeInfo(Field).Bind(format);
+        public Field Field => Field.CreateUnspecified(ObjectTypeInfo.PgTypeId);
     }
 
     PgReader PgReader => _outermostReader.Buffer.PgReader;
@@ -286,19 +291,18 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     public override Type GetFieldType(int ordinal)
     {
         var column = CheckRowAndColumn(ordinal);
-        return column.GetObjectOrDefaultInfo().TypeToConvert;
+        return column.ObjectTypeInfo.Type;
     }
 
     /// <inheritdoc />
     public override object GetValue(int ordinal)
     {
         var columnLength = CheckRowAndColumnAndSeek(ordinal, out var column);
-        var info = column.GetObjectOrDefaultInfo();
         if (columnLength == -1)
             return DBNull.Value;
 
-        using var _ = PgReader.BeginNestedRead(columnLength, info.BufferRequirement);
-        return info.Converter.ReadAsObject(PgReader);
+        using var _ = PgReader.BeginNestedRead(columnLength, column.ObjectBinding.BufferRequirement);
+        return column.ObjectTypeInfo.Converter.ReadAsObject(PgReader);
     }
 
     /// <inheritdoc />
@@ -327,7 +331,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             return (T)(object)GetTextReader(ordinal);
 
         var columnLength = CheckRowAndColumnAndSeek(ordinal, out var column);
-        var info = GetOrAddConverterInfo(typeof(T), column, ordinal, out var asObject);
+        var info = GetOrAddConverterInfo(typeof(T), column, ordinal);
 
         if (columnLength == -1)
         {
@@ -341,10 +345,10 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             ThrowHelper.ThrowInvalidCastException_NoValue();
         }
 
-        using var _ = PgReader.BeginNestedRead(columnLength, info.BufferRequirement);
-        return asObject
-            ? (T)info.Converter.ReadAsObject(PgReader)!
-            : info.Converter.UnsafeDowncast<T>().Read(PgReader);
+        using var _ = PgReader.BeginNestedRead(columnLength, info.Binding.BufferRequirement);
+        return info.AsObject
+            ? (T)info.TypeInfo.Converter.ReadAsObject(PgReader)!
+            : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(PgReader);
     }
 
     /// <inheritdoc />
@@ -372,8 +376,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             {
                 var pgType = SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
                 var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
-                _columns.Add(new ColumnInfo(pgType, bufferPos,
-                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), Format));
+                _columns.Add(new NestedColumnInfo(pgType, bufferPos,
+                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat));
             }
             else
             {
@@ -381,8 +385,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
                     ? _columns[i].PostgresType
                     : SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
                 var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
-                _columns[i] = new ColumnInfo(pgType, bufferPos,
-                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), Format);
+                _columns[i] = new NestedColumnInfo(pgType, bufferPos,
+                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat);
             }
 
             var columnLen = PgReader.ReadInt32();
@@ -466,7 +470,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             throw new InvalidOperationException("No row is available");
     }
 
-    ColumnInfo CheckRowAndColumn(int column)
+    NestedColumnInfo CheckRowAndColumn(int column)
     {
         CheckOnRow();
 
@@ -476,46 +480,41 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         return _columns[column];
     }
 
-    int CheckRowAndColumnAndSeek(int ordinal, out ColumnInfo column)
+    int CheckRowAndColumnAndSeek(int ordinal, out NestedColumnInfo nestedColumn)
     {
-        column = CheckRowAndColumn(ordinal);
-        PgReader.Seek(column.BufferPos);
+        nestedColumn = CheckRowAndColumn(ordinal);
+        PgReader.Seek(nestedColumn.BufferPos);
         return PgReader.ReadInt32();
     }
 
-    PgConverterInfo GetOrAddConverterInfo(Type type, ColumnInfo column, int ordinal, out bool asObject)
+    ColumnInfo GetOrAddConverterInfo(Type type, NestedColumnInfo nestedColumn, int ordinal)
     {
-        if (column.LastConverterInfo is { IsDefault: false } lastInfo && lastInfo.TypeToConvert == type)
-        {
-            // As TypeInfoMappingCollection is always adding object mappings for
-            // default/datatypename mappings, we'll also check Converter.TypeToConvert.
-            // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
-            asObject = lastInfo.IsBoxingConverter && lastInfo.Converter.TypeToConvert != type;
+        if (nestedColumn.LastInfo is { IsDefault: false } lastInfo && lastInfo.TypeInfo.Type == type)
             return lastInfo;
-        }
 
-        if (column.GetObjectOrDefaultInfo() is { IsDefault: false } odfInfo)
+        var objectInfo = (TypeInfo: nestedColumn.ObjectTypeInfo, Binding: nestedColumn.ObjectBinding);
+        if (objectInfo.TypeInfo is not null)
         {
             if (typeof(object) == type)
             {
-                asObject = true;
-                return odfInfo;
+                return new(objectInfo.TypeInfo, objectInfo.Binding, true);
             }
-
-            if (odfInfo.TypeToConvert == type)
+            if (objectInfo.TypeInfo.Type == type)
             {
-                // As TypeInfoMappingCollection is always adding object mappings for
+                // As TypeInfoMappingCollection always adds object mappings for
                 // default/datatypename mappings, we'll also check Converter.TypeToConvert.
                 // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
-                asObject = odfInfo.IsBoxingConverter && odfInfo.Converter.TypeToConvert != type;
-                return odfInfo;
+                return new(objectInfo.TypeInfo, objectInfo.Binding,
+                    objectInfo.TypeInfo.IsBoxing && objectInfo.TypeInfo.Converter.TypeToConvert != type);
             }
         }
 
-        var converterInfo = column.Bind(AdoSerializerHelpers.GetTypeInfoForReading(type, SerializerOptions.ToCanonicalTypeId(column.PostgresType), SerializerOptions));
-        _columns[ordinal] = column with { LastConverterInfo = converterInfo };
-        asObject = converterInfo.IsBoxingConverter;
-        return converterInfo;
+        var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
+        var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
+        var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(nestedColumn.Field);
+        var columnInfo = new ColumnInfo(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat), concreteTypeInfo.IsBoxing);
+        _columns[ordinal] = nestedColumn with { LastInfo = columnInfo };
+        return columnInfo;
     }
 
     enum ReaderState

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -47,7 +47,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         {
             PostgresType = postgresType;
             BufferPos = bufferPos;
-            ObjectTypeInfo = objectTypeInfo.GetConcreteTypeInfo(Field.CreateUnspecified(objectTypeInfo.Options.ToCanonicalTypeId(postgresType)));
+            ObjectTypeInfo = objectTypeInfo.MakeConcreteForField(Field.CreateUnspecified(objectTypeInfo.Options.ToCanonicalTypeId(postgresType)));
             ObjectBinding = ObjectTypeInfo.BindField(format);
         }
 
@@ -496,7 +496,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
 
         var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
-        var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(nestedColumn.Field);
+        var concreteTypeInfo = typeInfo.MakeConcreteForField(nestedColumn.Field);
         var columnInfo = new ReadConversionContext(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));
         _columns[ordinal] = nestedColumn with { LastInfo = columnInfo };
         return columnInfo;

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -39,7 +39,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
     {
         public PostgresType PostgresType { get; }
         public int BufferPos { get; }
-        public ColumnInfo LastInfo { get; init; }
+        public ReadConversionContext LastInfo { get; init; }
         public PgConcreteTypeInfo ObjectTypeInfo { get; }
         public PgFieldBinding ObjectBinding { get; }
 
@@ -485,7 +485,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         return PgReader.ReadInt32();
     }
 
-    ColumnInfo GetOrAddConverterInfo(Type type, NestedColumnInfo nestedColumn, int ordinal)
+    ReadConversionContext GetOrAddConverterInfo(Type type, NestedColumnInfo nestedColumn, int ordinal)
     {
         if (nestedColumn.LastInfo is { IsDefault: false } lastInfo && lastInfo.TypeInfo.Type == type)
             return lastInfo;
@@ -497,7 +497,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
         var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(nestedColumn.Field);
-        var columnInfo = new ColumnInfo(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));
+        var columnInfo = new ReadConversionContext(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));
         _columns[ordinal] = nestedColumn with { LastInfo = columnInfo };
         return columnInfo;
     }

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -48,6 +48,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             PostgresType = postgresType;
             BufferPos = bufferPos;
             ObjectTypeInfo = objectTypeInfo.MakeConcreteForField(Field.CreateUnspecified(objectTypeInfo.Options.ToCanonicalTypeId(postgresType)));
+            if (!ObjectTypeInfo.SupportsReading)
+                AdoSerializerHelpers.ThrowReadingNotSupported(typeof(object), objectTypeInfo.Options, ObjectTypeInfo.PgTypeId, resolved: true);
             ObjectBinding = ObjectTypeInfo.BindField(format);
         }
 
@@ -497,6 +499,8 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
         var concreteTypeInfo = typeInfo.MakeConcreteForField(nestedColumn.Field);
+        if (!concreteTypeInfo.SupportsReading)
+            AdoSerializerHelpers.ThrowReadingNotSupported(type, SerializerOptions, typeId, resolved: true);
         var columnInfo = new ReadConversionContext(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));
         _columns[ordinal] = nestedColumn with { LastInfo = columnInfo };
         return columnInfo;

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -346,7 +346,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         }
 
         using var _ = PgReader.BeginNestedRead(columnLength, info.Binding.BufferRequirement);
-        return info.TypeInfo.ConverterRead<T>(PgReader);
+        return info.TypeInfo.Converter.Read<T>(PgReader);
     }
 
     /// <inheritdoc />

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -346,7 +346,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         }
 
         using var _ = PgReader.BeginNestedRead(columnLength, info.Binding.BufferRequirement);
-        return info.AsObject
+        return info.TypeInfo.ShouldReadAsObject<T>()
             ? (T)info.TypeInfo.Converter.ReadAsObject(PgReader)!
             : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(PgReader);
     }
@@ -493,26 +493,13 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             return lastInfo;
 
         var objectInfo = (TypeInfo: nestedColumn.ObjectTypeInfo, Binding: nestedColumn.ObjectBinding);
-        if (objectInfo.TypeInfo is not null)
-        {
-            if (typeof(object) == type)
-            {
-                return new(objectInfo.TypeInfo, objectInfo.Binding, true);
-            }
-            if (objectInfo.TypeInfo.Type == type)
-            {
-                // As TypeInfoMappingCollection always adds object mappings for
-                // default/datatypename mappings, we'll also check Converter.TypeToConvert.
-                // If we have an exact match we are still able to use e.g. a converter for ints in an unboxed fashion.
-                return new(objectInfo.TypeInfo, objectInfo.Binding,
-                    objectInfo.TypeInfo.IsBoxing && objectInfo.TypeInfo.Converter.TypeToConvert != type);
-            }
-        }
+        if (objectInfo.TypeInfo is not null && (typeof(object) == type || objectInfo.TypeInfo.Type == type))
+            return new(objectInfo.TypeInfo, objectInfo.Binding);
 
         var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
         var concreteTypeInfo = typeInfo.GetConcreteTypeInfo(nestedColumn.Field);
-        var columnInfo = new ColumnInfo(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat), concreteTypeInfo.IsBoxing);
+        var columnInfo = new ColumnInfo(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));
         _columns[ordinal] = nestedColumn with { LastInfo = columnInfo };
         return columnInfo;
     }

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -346,9 +346,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         }
 
         using var _ = PgReader.BeginNestedRead(columnLength, info.Binding.BufferRequirement);
-        return info.TypeInfo.ShouldReadAsObject<T>()
-            ? (T)info.TypeInfo.Converter.ReadAsObject(PgReader)!
-            : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(PgReader);
+        return info.TypeInfo.ConverterRead<T>(PgReader);
     }
 
     /// <inheritdoc />

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -696,11 +696,14 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
             // If no Bind follows (SchemaOnly), release the provider-produced state immediately so
             // lifecycle stays contained inside the parameter.
-            if (!willBind && _writeState is { } ws)
+            if ((!willBind || !ConcreteTypeInfo.SupportsWriting) && _writeState is { } ws)
             {
                 ConcreteTypeInfo.DisposeWriteState(ws);
                 _writeState = null;
             }
+
+            if (!ConcreteTypeInfo.SupportsWriting)
+                AdoSerializerHelpers.ThrowWritingNotSupported(GetValueType(staticValueType), options, ConcreteTypeInfo.PgTypeId, _npgsqlDbType, ParameterName, resolved: true);
         }
 
         void ThrowNoTypeInfo()

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -686,11 +686,12 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             if (staticValueType == typeof(object))
             {
                 // Pull from Value (not _value) so we also support object typed generic params.
-                ConcreteTypeInfo = typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState);
+                var value = Value;
+                ConcreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(value is DBNull ? null : value, out _writeState);
             }
             else
             {
-                ConcreteTypeInfo = GetConcreteTypeInfoForTypedValue(typeInfo);
+                ConcreteTypeInfo = MakeConcreteTypeInfoForTypedValue(typeInfo);
             }
 
             // If no Bind follows (SchemaOnly), release the provider-produced state immediately so
@@ -920,7 +921,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         }
     }
 
-    private protected virtual PgConcreteTypeInfo GetConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
+    private protected virtual PgConcreteTypeInfo MakeConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
         => throw new NotSupportedException();
 
     private protected virtual PgValueBinding BindTypedValue(PgConcreteTypeInfo typeInfo, DataFormat? formatPreference)

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -43,9 +43,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
     IDbTypeResolver? _dbTypeResolver;
     private protected PgTypeInfo? TypeInfo { get; private set; }
+    private protected PgConcreteTypeInfo? ConcreteTypeInfo { get; private set; }
 
-    internal PgTypeId PgTypeId { get; private set; }
-    private protected PgConverter? Converter { get; private set; }
+    internal PgTypeId PgTypeId => ConcreteTypeInfo?.PgTypeId ?? default;
+    private protected PgConverter? Converter => ConcreteTypeInfo?.Converter;
 
     internal DataFormat Format { get; private protected set; }
     private protected Size? WriteSize { get; set; }
@@ -570,21 +571,19 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         return valueType != typeof(DBNull) && currentType != valueType;
     }
 
-    internal void GetResolutionInfo(out PgTypeInfo? typeInfo, out PgConverter? converter, out PgTypeId pgTypeId)
+    internal void GetResolutionInfo(out PgTypeInfo? typeInfo, out PgConcreteTypeInfo? concreteTypeInfo)
     {
         typeInfo = TypeInfo;
-        converter = Converter;
-        pgTypeId = PgTypeId;
+        concreteTypeInfo = ConcreteTypeInfo;
     }
 
-    internal void SetResolutionInfo(PgTypeInfo typeInfo, PgConverter converter, PgTypeId pgTypeId)
+    internal void SetResolutionInfo(PgTypeInfo typeInfo, PgConcreteTypeInfo concreteTypeInfo)
     {
         if (WriteSize is not null)
             ResetBindingInfo();
 
         TypeInfo = typeInfo;
-        Converter = converter;
-        PgTypeId = pgTypeId;
+        ConcreteTypeInfo = concreteTypeInfo;
     }
 
     /// Attempt to resolve a type info based on available (postgres) type information on the parameter.
@@ -665,9 +664,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (!previouslyResolved || typeInfo is not PgConcreteTypeInfo)
         {
             ResetBindingInfo();
-            var concreteTypeInfo = GetConcreteTypeInfo(typeInfo!);
-            Converter = concreteTypeInfo.Converter;
-            PgTypeId = concreteTypeInfo.PgTypeId;
+            ConcreteTypeInfo = GetConcreteTypeInfo(typeInfo!);
         }
 
         void ThrowNoTypeInfo()
@@ -845,8 +842,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     {
         TypeInfo = null;
         _asObject = false;
-        Converter = null;
-        PgTypeId = default;
+        ConcreteTypeInfo = null;
         ResetBindingInfo();
     }
 

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -579,12 +579,23 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (_binding is not null)
             DisposeBindingState();
 
+        // Dispose any provider-produced _writeState against its current ConcreteTypeInfo before we
+        // overwrite it — once reassigned, the restored ConcreteTypeInfo can't dispose state produced
+        // by the about-to-be-discarded one.
+        if (_writeState is { } ws)
+        {
+            ConcreteTypeInfo?.DisposeWriteState(ws);
+            _writeState = null;
+        }
+
         TypeInfo = typeInfo;
         ConcreteTypeInfo = concreteTypeInfo;
     }
 
     /// Attempt to resolve a type info based on available (postgres) type information on the parameter.
-    internal void ResolveTypeInfo(PgSerializerOptions options, IDbTypeResolver? dbTypeResolver)
+    /// When <paramref name="willBind"/> is false (e.g. SchemaOnly), any provider-produced write state is
+    /// disposed immediately because no Bind call will follow to take ownership of it.
+    internal void ResolveTypeInfo(PgSerializerOptions options, IDbTypeResolver? dbTypeResolver, bool willBind = true)
     {
         var typeInfo = TypeInfo;
         var staticValueType = StaticValueType;
@@ -662,6 +673,16 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         {
             Debug.Assert(typeInfo is not null);
             DisposeBindingState();
+
+            // Dispose any stale _writeState from a previous resolution against its current
+            // ConcreteTypeInfo before the branches below overwrite it — this covers the "failed resolution,
+            // caller fixed the value, called again" self-heal path (e.g. NpgsqlBinaryImporter's PgTypeId check).
+            if (_writeState is { } staleWs)
+            {
+                ConcreteTypeInfo?.DisposeWriteState(staleWs);
+                _writeState = null;
+            }
+
             if (staticValueType == typeof(object))
             {
                 // Pull from Value (not _value) so we also support object typed generic params.
@@ -670,6 +691,14 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             else
             {
                 ConcreteTypeInfo = GetConcreteTypeInfoForTypedValue(typeInfo);
+            }
+
+            // If no Bind follows (SchemaOnly), release the provider-produced state immediately so
+            // lifecycle stays contained inside the parameter.
+            if (!willBind && _writeState is { } ws)
+            {
+                ConcreteTypeInfo.DisposeWriteState(ws);
+                _writeState = null;
             }
         }
 
@@ -687,16 +716,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 $"Your database details or Npgsql type loading configuration may be incorrect. Alternatively your PostgreSQL installation might need to be upgraded, or an extension adding the missing data type might not have been installed.");
     }
 
-    /// Dispose write state produced during ResolveTypeInfo when Bind won't follow (e.g. SchemaOnly).
-    internal void DisposeResolutionWriteState()
-    {
-        if (_writeState is { } ws)
-        {
-            _writeState = null;
-            ConcreteTypeInfo?.DisposeWriteState(ws);
-        }
-    }
-
     /// Bind the current value to the type info, truncate (if applicable), take its size, and do any final validation before writing.
     internal void Bind(out DataFormat format, out Size size, DataFormat? requiredFormat = null)
     {
@@ -704,34 +723,70 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             ThrowHelper.ThrowInvalidOperationException($"Missing type info, {nameof(ResolveTypeInfo)} needs to be called before {nameof(Bind)}.");
 
         // We might call this twice, once during validation and once during WriteBind, only compute things once.
+        // Bind is atomic *and* self-cleaning: the local binding is only committed to _binding
+        // (and _writeState nulled) after every check passes, and any exception before commit disposes
+        // the resolution-time _writeState ourselves so callers don't need to know about it.
         if (_binding is null)
         {
             if (_size > 0)
                 HandleSizeTruncation(ConcreteTypeInfo);
 
-            if (_useSubStream)
+            try
             {
-                _binding = BindSubStream();
-            }
-            else if (StaticValueType == typeof(object))
-            {
-                // Pull from Value so we also support object typed generic params.
-                var value = Value;
-                if (value is null)
-                    ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
+                PgValueBinding binding;
+                if (_useSubStream)
+                {
+                    binding = BindSubStream();
+                }
+                else if (StaticValueType == typeof(object))
+                {
+                    // Pull from Value so we also support object typed generic params.
+                    var value = Value;
+                    if (value is null)
+                        ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
 
-                _binding = ConcreteTypeInfo.BindParameterObjectValue(value, _writeState, requiredFormat);
+                    binding = ConcreteTypeInfo.BindParameterObjectValue(value, _writeState, requiredFormat);
+                }
+                else
+                {
+                    binding = BindTypedValue(ConcreteTypeInfo, formatPreference: requiredFormat);
+                }
+
+                // Enforce that provider-produced _writeState flows end-to-end through the binding unchanged.
+                // A converter that accepts _writeState as input must thread the same instance into its returned
+                // binding's WriteState. Swapping to a different instance is a contract violation because it
+                // forks the lifecycle (the resolution-time state would be orphaned and the bind-time state
+                // would be unowned by this parameter).
+                if (_writeState is not null && !ReferenceEquals(_writeState, binding.WriteState))
+                    ThrowHelper.ThrowInvalidOperationException(
+                        $"Binding for parameter '{ParameterName}' replaced the provider-produced write state with a different instance. " +
+                        "Converters must thread the write state through unchanged.");
+
+                if (requiredFormat is not null && binding.DataFormat != requiredFormat)
+                    ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
+
+                // Binding and ownership transfer of state happen together.
+                _binding = binding;
+                _writeState = null;
             }
-            else
+            catch
             {
-                _binding = BindTypedValue(ConcreteTypeInfo, formatPreference: requiredFormat);
+                // DisposeWriteState is assumed not to throw. Any broken contract surfaces its exception here over the bind exception.
+                if (_writeState is { } ws)
+                {
+                    ConcreteTypeInfo.DisposeWriteState(ws);
+                    _writeState = null;
+                }
+                throw;
             }
+        }
+        else if (requiredFormat is not null && _binding.GetValueOrDefault().DataFormat != requiredFormat)
+        {
+            ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
         }
 
         format = Format;
         size = _binding.GetValueOrDefault().Size ?? -1;
-        if (requiredFormat is not null && format != requiredFormat)
-            ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         PgValueBinding BindSubStream()
@@ -787,6 +842,12 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 }
                 else if (value is Stream)
                 {
+                    // Substream path abandons the resolver-produced state, we must dispose it here to prevent the no swap exception.
+                    if (_writeState is { } ws)
+                    {
+                        typeInfo.DisposeWriteState(ws);
+                        _writeState = null;
+                    }
                     _useSubStream = true;
                 }
             }
@@ -877,9 +938,17 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
     private protected void ResetTypeInfo()
     {
+        DisposeBindingState();
+
+        // Dispose any provider-produced _writeState as well.
+        if (_writeState is { } ws)
+        {
+            ConcreteTypeInfo?.DisposeWriteState(ws);
+            _writeState = null;
+        }
+
         TypeInfo = null;
         ConcreteTypeInfo = null;
-        DisposeBindingState();
     }
 
     private protected void DisposeBindingState()

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -661,14 +661,16 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         {
             Debug.Assert(typeInfo is not null);
             DisposeBindingState();
-            if (staticValueType == typeof(object) || typeInfo.IsBoxing)
+            if (staticValueType == typeof(object))
             {
                 // Pull from Value (not _value) so we also support object typed generic params.
                 ConcreteTypeInfo = typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState);
             }
             else
             {
-                ConcreteTypeInfo = GetConcreteTypeInfoForTypedValue(typeInfo);
+                ConcreteTypeInfo = !typeInfo.HasExactType
+                    ? typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState)
+                    : GetConcreteTypeInfoForTypedValue(typeInfo);
             }
         }
 
@@ -723,7 +725,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             }
             else
             {
-                _binding = ConcreteTypeInfo.IsBoxing
+                _binding = !ConcreteTypeInfo.HasExactType
                     ? ConcreteTypeInfo.BindParameterObjectValue(Value, _writeState, requiredFormat)
                     : BindTypedValue(ConcreteTypeInfo, requiredFormat);
             }
@@ -827,7 +829,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 {
                     await writer.StartWrite(async, binding, cancellationToken).ConfigureAwait(false);
                     var typeInfo = ConcreteTypeInfo;
-                    if (typeof(object) == StaticValueType || typeInfo.IsBoxing)
+                    if (StaticValueType == typeof(object) || !typeInfo.HasExactType)
                     {
                         // Pull from Value so we also support object typed generic params.
                         var value = Value;

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -48,10 +48,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     internal PgTypeId PgTypeId => ConcreteTypeInfo?.PgTypeId ?? default;
     private protected PgConverter? Converter => ConcreteTypeInfo?.Converter;
 
-    internal DataFormat Format { get; private protected set; }
-    private protected Size? WriteSize { get; set; }
+    internal DataFormat Format => _binding?.DataFormat ?? DataFormat.Binary;
     private protected object? _writeState;
-    private protected Size _bufferRequirement;
+    private protected PgValueBinding? _binding;
     private protected bool _asObject;
 
     #endregion
@@ -284,7 +283,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             if (ShouldResetObjectTypeInfo(value))
                 ResetTypeInfo();
             else
-                ResetBindingInfo();
+                DisposeBindingState();
             _value = value;
         }
     }
@@ -484,7 +483,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             if (value < -1)
                 ThrowHelper.ThrowArgumentException($"Invalid parameter Size value '{value}'. The value must be greater than or equal to 0.");
 
-            ResetBindingInfo();
+            DisposeBindingState();
             _size = value;
         }
     }
@@ -579,8 +578,8 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
     internal void SetResolutionInfo(PgTypeInfo typeInfo, PgConcreteTypeInfo concreteTypeInfo)
     {
-        if (WriteSize is not null)
-            ResetBindingInfo();
+        if (_binding is not null)
+            DisposeBindingState();
 
         TypeInfo = typeInfo;
         ConcreteTypeInfo = concreteTypeInfo;
@@ -663,7 +662,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         // TODO we could expose a property on a Converter/TypeInfo to indicate whether it's immutable, at that point we can reuse.
         if (!previouslyResolved || typeInfo is not PgConcreteTypeInfo)
         {
-            ResetBindingInfo();
+            DisposeBindingState();
             ConcreteTypeInfo = GetConcreteTypeInfo(typeInfo!);
         }
 
@@ -705,7 +704,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             ThrowHelper.ThrowInvalidOperationException($"Missing type info, {nameof(ResolveTypeInfo)} needs to be called before {nameof(Bind)}.");
 
         // We might call this twice, once during validation and once during WriteBind, only compute things once.
-        if (WriteSize is null)
+        if (_binding is null)
         {
             if (_size > 0)
                 HandleSizeTruncation();
@@ -714,7 +713,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         }
 
         format = Format;
-        size = WriteSize!.Value;
+        size = _binding.GetValueOrDefault().Size ?? -1;
         if (requiredFormat is not null && format != requiredFormat)
             ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
 
@@ -766,23 +765,12 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (_useSubStream && value is not null)
             value = _subStream = new SubReadStream((Stream)value, _size);
 
-        if (ConcreteTypeInfo!.BindObject(value, out var size, ref _writeState, out var dataFormat, formatPreference) is { } info)
-        {
-            WriteSize = size;
-            _bufferRequirement = info.BufferRequirement;
-        }
-        else
-        {
-            WriteSize = -1;
-            _bufferRequirement = default;
-        }
-
-        Format = dataFormat;
+        _binding = ConcreteTypeInfo!.BindParameterObjectValue(value, _writeState, formatPreference);
     }
 
     internal async ValueTask Write(bool async, PgWriter writer, CancellationToken cancellationToken)
     {
-        if (WriteSize is not { } writeSize)
+        if (_binding is not { } binding)
         {
             ThrowHelper.ThrowInvalidOperationException("Missing type info or binding info.");
             return;
@@ -793,27 +781,20 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             if (writer.ShouldFlush(sizeof(int)))
                 await writer.Flush(async, cancellationToken).ConfigureAwait(false);
 
-            writer.WriteInt32(writeSize.Value);
-            if (writeSize.Value is -1)
-            {
-                writer.Commit(sizeof(int));
-                return;
-            }
+            var size = binding.Size?.Value ?? -1;
+            writer.WriteInt32(size);
+            writer.CommitAndResetTotal(sizeof(int));
 
-            var current = new ValueMetadata
+            if (!binding.IsDbNullBinding)
             {
-                Format = Format,
-                BufferRequirement = _bufferRequirement,
-                Size = writeSize,
-                WriteState = _writeState
-            };
-            await writer.BeginWrite(async, current, cancellationToken).ConfigureAwait(false);
-            await WriteValue(async, writer, cancellationToken).ConfigureAwait(false);
-            writer.Commit(writeSize.Value + sizeof(int));
+                await writer.StartWrite(async, binding, cancellationToken).ConfigureAwait(false);
+                await WriteValue(async, writer, cancellationToken).ConfigureAwait(false);
+                writer.EndWrite(size);
+            }
         }
         finally
         {
-            ResetBindingInfo();
+            DisposeBindingState();
         }
     }
 
@@ -842,31 +823,53 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         TypeInfo = null;
         _asObject = false;
         ConcreteTypeInfo = null;
-        ResetBindingInfo();
+        DisposeBindingState();
     }
 
-    private protected void ResetBindingInfo()
+    private protected void DisposeBindingState()
     {
-        if (WriteSize is null)
+        try
         {
-            Debug.Assert(_writeState == default && _useSubStream == default && Format == default && _bufferRequirement == default);
-            return;
-        }
+            if (_binding is not { } binding)
+            {
+                Debug.Assert(!_useSubStream && _subStream is null);
+                return;
+            }
 
-        if (_writeState is not null)
-        {
-            ConcreteTypeInfo?.DisposeWriteState(_writeState);
-            _writeState = null;
+            // Dispose write state first as it may hold a reference to _subStream.
+            Debug.Assert(ConcreteTypeInfo is not null);
+            Exception? disposalException = null;
+            if (binding.WriteState is { } writeState)
+            {
+                try
+                {
+                    ConcreteTypeInfo.DisposeWriteState(writeState);
+                }
+                catch (Exception ex)
+                {
+                    disposalException = ex;
+                }
+            }
+
+            if (_useSubStream)
+            {
+                Debug.Assert(_subStream is not null);
+                try
+                {
+                    _subStream.Dispose();
+                }
+                catch (Exception ex) when (disposalException is not null)
+                {
+                    throw new AggregateException(disposalException, ex);
+                }
+            }
         }
-        if (_useSubStream)
+        finally
         {
             _useSubStream = false;
-            _subStream?.Dispose();
             _subStream = null;
+            _binding = null;
         }
-        WriteSize = null;
-        Format = default;
-        _bufferRequirement = default;
     }
 
     internal bool IsInputDirection => Direction == ParameterDirection.InputOutput || Direction == ParameterDirection.Input;

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -694,7 +694,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (_writeState is { } ws)
         {
             _writeState = null;
-            TypeInfo?.DisposeWriteState(ws);
+            ConcreteTypeInfo?.DisposeWriteState(ws);
         }
     }
 
@@ -766,8 +766,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (_useSubStream && value is not null)
             value = _subStream = new SubReadStream((Stream)value, _size);
 
-        Size size = default;
-        if (TypeInfo!.BindObject(Converter!, value, ref size, ref _writeState, out var dataFormat, formatPreference) is { } info)
+        if (ConcreteTypeInfo!.BindObject(value, out var size, ref _writeState, out var dataFormat, formatPreference) is { } info)
         {
             WriteSize = size;
             _bufferRequirement = info.BufferRequirement;
@@ -856,7 +855,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
         if (_writeState is not null)
         {
-            TypeInfo?.DisposeWriteState(_writeState);
+            ConcreteTypeInfo?.DisposeWriteState(_writeState);
             _writeState = null;
         }
         if (_useSubStream)

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -806,7 +806,8 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             int subSize;
             if (stream.CanSeek)
             {
-                subSize = Math.Min(_size, checked((int)(stream.Length - stream.Position)));
+                var remaining = Math.Max(0, stream.Length - stream.Position);
+                subSize = remaining < _size ? (int)remaining : _size;
                 _subStream = new SubReadStream(stream, _size);
             }
             else

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal;
@@ -922,6 +923,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                     throw new AggregateException(disposalException, ex);
                 }
             }
+
+            if (disposalException is not null)
+                ExceptionDispatchInfo.Throw(disposalException);
         }
         finally
         {

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -771,12 +771,17 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             }
             catch
             {
-                // DisposeWriteState is assumed not to throw. Any broken contract surfaces its exception here over the bind exception.
                 if (_writeState is { } ws)
                 {
                     ConcreteTypeInfo.DisposeWriteState(ws);
                     _writeState = null;
                 }
+                if (_subStream is not null)
+                {
+                    _subStream.Dispose();
+                    _subStream = null;
+                }
+                _useSubStream = false;
                 throw;
             }
         }

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -669,9 +669,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             }
             else
             {
-                ConcreteTypeInfo = !typeInfo.HasExactType
-                    ? typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState)
-                    : GetConcreteTypeInfoForTypedValue(typeInfo);
+                ConcreteTypeInfo = GetConcreteTypeInfoForTypedValue(typeInfo);
             }
         }
 
@@ -726,9 +724,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             }
             else
             {
-                _binding = !ConcreteTypeInfo.HasExactType
-                    ? ConcreteTypeInfo.BindParameterObjectValue(Value, _writeState, requiredFormat)
-                    : BindTypedValue(ConcreteTypeInfo, requiredFormat);
+                _binding = BindTypedValue(ConcreteTypeInfo, formatPreference: requiredFormat);
             }
         }
 
@@ -830,7 +826,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 {
                     await writer.StartWrite(async, binding, cancellationToken).ConfigureAwait(false);
                     var typeInfo = ConcreteTypeInfo;
-                    if (StaticValueType == typeof(object) || !typeInfo.HasExactType)
+                    if (StaticValueType == typeof(object))
                     {
                         // Pull from Value so we also support object typed generic params.
                         var value = Value;

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -35,7 +35,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected string _name = string.Empty;
     object? _value;
     private protected bool _useSubStream;
-    private protected SubReadStream? _subStream;
+    private protected Stream? _subStream;
     private protected string _sourceColumn;
 
     internal string TrimmedName { get; private protected set; } = PositionalName;
@@ -46,12 +46,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected PgConcreteTypeInfo? ConcreteTypeInfo { get; private set; }
 
     internal PgTypeId PgTypeId => ConcreteTypeInfo?.PgTypeId ?? default;
-    private protected PgConverter? Converter => ConcreteTypeInfo?.Converter;
 
     internal DataFormat Format => _binding?.DataFormat ?? DataFormat.Binary;
     private protected object? _writeState;
     private protected PgValueBinding? _binding;
-    private protected bool _asObject;
 
     #endregion
 
@@ -551,13 +549,12 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
     internal void SetOutputValue(NpgsqlDataReader reader, int ordinal)
     {
-        if (GetType() == typeof(NpgsqlParameter))
+        // Set Value (not _value) so we also support object typed generic params.
+        if (StaticValueType == typeof(object))
             Value = reader.GetValue(ordinal);
         else
-            SetOutputValueCore(reader, ordinal);
+            SetOutputTypedValue(reader, ordinal);
     }
-
-    private protected virtual void SetOutputValueCore(NpgsqlDataReader reader, int ordinal) {}
 
     internal bool ShouldResetObjectTypeInfo(object? value)
     {
@@ -589,10 +586,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     internal void ResolveTypeInfo(PgSerializerOptions options, IDbTypeResolver? dbTypeResolver)
     {
         var typeInfo = TypeInfo;
+        var staticValueType = StaticValueType;
         var previouslyResolved = ReferenceEquals(typeInfo?.Options, options);
         if (!previouslyResolved)
         {
-            var staticValueType = StaticValueType;
             var valueType = GetValueType(staticValueType);
 
             string? dataTypeName = null;
@@ -662,8 +659,17 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         // TODO we could expose a property on a Converter/TypeInfo to indicate whether it's immutable, at that point we can reuse.
         if (!previouslyResolved || typeInfo is not PgConcreteTypeInfo)
         {
+            Debug.Assert(typeInfo is not null);
             DisposeBindingState();
-            ConcreteTypeInfo = GetConcreteTypeInfo(typeInfo!);
+            if (staticValueType == typeof(object) || typeInfo.IsBoxing)
+            {
+                // Pull from Value (not _value) so we also support object typed generic params.
+                ConcreteTypeInfo = typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState);
+            }
+            else
+            {
+                ConcreteTypeInfo = GetConcreteTypeInfoForTypedValue(typeInfo);
+            }
         }
 
         void ThrowNoTypeInfo()
@@ -680,13 +686,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 $"Your database details or Npgsql type loading configuration may be incorrect. Alternatively your PostgreSQL installation might need to be upgraded, or an extension adding the missing data type might not have been installed.");
     }
 
-    // Pull from Value so we also support object typed generic params.
-    private protected virtual PgConcreteTypeInfo GetConcreteTypeInfo(PgTypeInfo typeInfo)
-    {
-        _asObject = true;
-        return typeInfo.GetObjectConcreteTypeInfo(Value, out _writeState);
-    }
-
     /// Dispose write state produced during ResolveTypeInfo when Bind won't follow (e.g. SchemaOnly).
     internal void DisposeResolutionWriteState()
     {
@@ -700,16 +699,34 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     /// Bind the current value to the type info, truncate (if applicable), take its size, and do any final validation before writing.
     internal void Bind(out DataFormat format, out Size size, DataFormat? requiredFormat = null)
     {
-        if (TypeInfo is null)
+        if (TypeInfo is null || ConcreteTypeInfo is null)
             ThrowHelper.ThrowInvalidOperationException($"Missing type info, {nameof(ResolveTypeInfo)} needs to be called before {nameof(Bind)}.");
 
         // We might call this twice, once during validation and once during WriteBind, only compute things once.
         if (_binding is null)
         {
             if (_size > 0)
-                HandleSizeTruncation();
+                HandleSizeTruncation(ConcreteTypeInfo);
 
-            BindCore(requiredFormat);
+            if (_useSubStream)
+            {
+                _binding = BindSubStream();
+            }
+            else if (StaticValueType == typeof(object))
+            {
+                // Pull from Value so we also support object typed generic params.
+                var value = Value;
+                if (value is null)
+                    ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
+
+                _binding = ConcreteTypeInfo.BindParameterObjectValue(value, _writeState, requiredFormat);
+            }
+            else
+            {
+                _binding = ConcreteTypeInfo.IsBoxing
+                    ? ConcreteTypeInfo.BindParameterObjectValue(Value, _writeState, requiredFormat)
+                    : BindTypedValue(ConcreteTypeInfo, requiredFormat);
+            }
         }
 
         format = Format;
@@ -717,16 +734,39 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         if (requiredFormat is not null && format != requiredFormat)
             ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        PgValueBinding BindSubStream()
+        {
+            // Pull from Value so we also support object typed generic params.
+            var stream = (Stream?)Value;
+            Debug.Assert(stream is not null, "_useSubStream should only be true if we had a value during HandleSizeTruncation");
+            int subSize;
+            if (stream.CanSeek)
+            {
+                subSize = Math.Min(_size, checked((int)(stream.Length - stream.Position)));
+                _subStream = new SubReadStream(stream, _size);
+            }
+            else
+            {
+                // TODO maybe we can move this IO.
+                var buffer = new byte[_size];
+                var read = stream.ReadAtLeast(buffer, _size, throwOnEndOfStream: false);
+                subSize = Math.Min(_size, read);
+                _subStream = new MemoryStream(buffer, 0, subSize);
+            }
+            return new(DataFormat.Binary, 0, subSize, null);
+        }
+
         // Handle Size truncate behavior for a predetermined set of types and pg types.
         // Doesn't matter if we 'box' Value, all supported types are reference types.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void HandleSizeTruncation()
+        void HandleSizeTruncation(PgConcreteTypeInfo typeInfo)
         {
-            var type = Converter!.TypeToConvert;
-            if ((type != typeof(string) && type != typeof(char[]) && type != typeof(byte[]) && type != typeof(Stream)) || Value is not { } value)
+            var type = typeInfo.Type;
+            if ((type != typeof(string) && type != typeof(char[]) && type != typeof(byte[]) && !type.IsAssignableTo(typeof(Stream))) || Value is not { } value)
                 return;
 
-            var dataTypeName = TypeInfo!.Options.GetDataTypeName(PgTypeId);
+            var dataTypeName = typeInfo.Options.GetDataTypeName(PgTypeId);
             if (dataTypeName == DataTypeNames.Text || dataTypeName == DataTypeNames.Varchar || dataTypeName == DataTypeNames.Bpchar)
             {
                 if (value is string s && s.Length > _size)
@@ -748,24 +788,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                 }
                 else if (value is Stream)
                 {
-                    _asObject = true;
                     _useSubStream = true;
                 }
             }
         }
-    }
-
-    private protected virtual void BindCore(DataFormat? formatPreference, bool allowNullReference = false)
-    {
-        // Pull from Value so we also support object typed generic params.
-        var value = Value;
-        if (value is null && !allowNullReference)
-            ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
-
-        if (_useSubStream && value is not null)
-            value = _subStream = new SubReadStream((Stream)value, _size);
-
-        _binding = ConcreteTypeInfo!.BindParameterObjectValue(value, _writeState, formatPreference);
     }
 
     internal async ValueTask Write(bool async, PgWriter writer, CancellationToken cancellationToken)
@@ -775,6 +801,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             ThrowHelper.ThrowInvalidOperationException("Missing type info or binding info.");
             return;
         }
+        Debug.Assert(ConcreteTypeInfo is not null);
 
         try
         {
@@ -787,9 +814,39 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
             if (!binding.IsDbNullBinding)
             {
-                await writer.StartWrite(async, binding, cancellationToken).ConfigureAwait(false);
-                await WriteValue(async, writer, cancellationToken).ConfigureAwait(false);
-                writer.EndWrite(size);
+                if (_useSubStream)
+                {
+                    Debug.Assert(_subStream is not null);
+                    if (async)
+                        await _subStream.CopyToAsync(writer.GetStream(), cancellationToken).ConfigureAwait(false);
+                    else
+                        _subStream.CopyTo(writer.GetStream());
+                    writer.CommitAndResetTotal(size);
+                }
+                else
+                {
+                    await writer.StartWrite(async, binding, cancellationToken).ConfigureAwait(false);
+                    var typeInfo = ConcreteTypeInfo;
+                    if (typeof(object) == StaticValueType || typeInfo.IsBoxing)
+                    {
+                        // Pull from Value so we also support object typed generic params.
+                        var value = Value;
+                        Debug.Assert(value is not null);
+                        if (async)
+                        {
+                            await typeInfo.Converter.WriteAsObjectAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            typeInfo.Converter.WriteAsObject(writer, value);
+                        }
+                    }
+                    else
+                    {
+                        await WriteTypedValue(async, typeInfo, writer, cancellationToken).ConfigureAwait(false);
+                    }
+                    writer.EndWrite(size);
+                }
             }
         }
         finally
@@ -798,16 +855,17 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         }
     }
 
-    private protected virtual ValueTask WriteValue(bool async, PgWriter writer, CancellationToken cancellationToken)
-    {
-        // Pull from Value so we also support base calls from generic parameters.
-        var value = (_useSubStream ? _subStream : Value)!;
-        if (async)
-            return Converter!.WriteAsObjectAsync(writer, value, cancellationToken);
+    private protected virtual PgConcreteTypeInfo GetConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
+        => throw new NotSupportedException();
 
-        Converter!.WriteAsObject(writer, value);
-        return new();
-    }
+    private protected virtual PgValueBinding BindTypedValue(PgConcreteTypeInfo typeInfo, DataFormat? formatPreference)
+        => throw new NotSupportedException();
+
+    private protected virtual ValueTask WriteTypedValue(bool async, PgConcreteTypeInfo typeInfo, PgWriter writer, CancellationToken cancellationToken)
+        => throw new NotSupportedException();
+
+    private protected virtual void SetOutputTypedValue(NpgsqlDataReader reader, int ordinal)
+        => throw new NotSupportedException();
 
     /// <inheritdoc />
     public override void ResetDbType()
@@ -821,7 +879,6 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected void ResetTypeInfo()
     {
         TypeInfo = null;
-        _asObject = false;
         ConcreteTypeInfo = null;
         DisposeBindingState();
     }

--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -760,25 +760,9 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
                 break;
             }
 
-            // Resolution can produce a provider-level write state that normally gets consumed by Bind.
-            // If Bind is skipped (SchemaOnly) or either step throws, that state needs to be cleaned up
-            // here. wasBound tracks whether Bind completed successfully and took ownership; every other
-            // exit path (SchemaOnly, ResolveTypeInfo throws, Bind throws) disposes.
-            var wasBound = false;
-            try
-            {
-                p.ResolveTypeInfo(reloadableState.SerializerOptions, reloadableState.DbTypeResolver);
-                if (validateValues)
-                {
-                    p.Bind(out _, out _);
-                    wasBound = true;
-                }
-            }
-            finally
-            {
-                if (!wasBound)
-                    p.DisposeResolutionWriteState();
-            }
+            p.ResolveTypeInfo(reloadableState.SerializerOptions, reloadableState.DbTypeResolver, willBind: validateValues);
+            if (validateValues)
+                p.Bind(out _, out _);
         }
     }
 

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -111,9 +111,9 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
             return base.WriteValue(async, writer, cancellationToken);
 
         if (async)
-            return Converter!.UnsafeDowncast<T>().WriteAsync(writer, TypedValue!, cancellationToken);
+            return ConcreteTypeInfo!.ConverterWriteAsync(writer, TypedValue!, cancellationToken);
 
-        Converter!.UnsafeDowncast<T>().Write(writer, TypedValue!);
+        ConcreteTypeInfo!.ConverterWrite(writer, TypedValue!);
         return new();
     }
 

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Data;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal;
@@ -104,7 +102,7 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
         }
 
         var value = TypedValue;
-        if (TypeInfo!.Bind(Converter!.UnsafeDowncast<T>(), value, out var size, ref _writeState, out var dataFormat, formatPreference) is { } info)
+        if (ConcreteTypeInfo!.Bind(value, out var size, ref _writeState, out var dataFormat, formatPreference) is { } info)
         {
             WriteSize = size;
             _bufferRequirement = info.BufferRequirement;

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal;
@@ -14,21 +15,19 @@ namespace Npgsql;
 /// <typeparam name="T">The type of the value that will be stored in the parameter.</typeparam>
 public sealed class NpgsqlParameter<T> : NpgsqlParameter
 {
-    T? _typedValue;
-
     /// <summary>
     /// Gets or sets the strongly-typed value of the parameter.
     /// </summary>
     public T? TypedValue
     {
-        get => _typedValue;
+        get;
         set
         {
             if (typeof(T) == typeof(object) && ShouldResetObjectTypeInfo(value))
                 ResetTypeInfo();
             else
                 DisposeBindingState();
-            _typedValue = value;
+            field = value;
         }
     }
 
@@ -79,43 +78,24 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
 
     #endregion Constructors
 
-    private protected override void SetOutputValueCore(NpgsqlDataReader reader, int ordinal)
-        => TypedValue = reader.GetFieldValue<T>(ordinal);
+    private protected override PgConcreteTypeInfo GetConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
+        => typeInfo.GetConcreteTypeInfo(TypedValue, out _writeState);
 
-    private protected override PgConcreteTypeInfo GetConcreteTypeInfo(PgTypeInfo typeInfo)
+    private protected override PgValueBinding BindTypedValue(PgConcreteTypeInfo typeInfo, DataFormat? formatPreference)
+        => typeInfo.BindParameterValue(TypedValue, _writeState, formatPreference);
+
+    private protected override ValueTask WriteTypedValue(bool async, PgConcreteTypeInfo typeInfo, PgWriter writer, CancellationToken cancellationToken)
     {
-        if (typeof(T) == typeof(object) || TypeInfo!.IsBoxing)
-            return base.GetConcreteTypeInfo(typeInfo);
-
-        _asObject = false;
-        return typeInfo.GetConcreteTypeInfo(TypedValue, out _writeState);
-    }
-
-    // We ignore allowNullReference, it's just there to control the base implementation.
-    private protected override void BindCore(DataFormat? formatPreference, bool allowNullReference = false)
-    {
-        if (_asObject)
-        {
-            // If we're object typed we should not support null.
-            base.BindCore(formatPreference, typeof(T) != typeof(object));
-            return;
-        }
-
-        var value = TypedValue;
-        _binding = ConcreteTypeInfo!.BindParameterValue(value, _writeState, formatPreference);
-    }
-
-    private protected override ValueTask WriteValue(bool async, PgWriter writer, CancellationToken cancellationToken)
-    {
-        if (_asObject)
-            return base.WriteValue(async, writer, cancellationToken);
-
+        Debug.Assert(TypedValue is not null);
         if (async)
-            return ConcreteTypeInfo!.ConverterWriteAsync(writer, TypedValue!, cancellationToken);
+            return typeInfo.ConverterWriteAsync(writer, TypedValue, cancellationToken);
 
-        ConcreteTypeInfo!.ConverterWrite(writer, TypedValue!);
+        typeInfo.ConverterWrite(writer, TypedValue);
         return new();
     }
+
+    private protected override void SetOutputTypedValue(NpgsqlDataReader reader, int ordinal)
+        => TypedValue = reader.GetFieldValue<T>(ordinal);
 
     private protected override NpgsqlParameter CloneCore() =>
         // use fields instead of properties

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -78,8 +78,8 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
 
     #endregion Constructors
 
-    private protected override PgConcreteTypeInfo GetConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
-        => typeInfo.GetConcreteTypeInfo(TypedValue, out _writeState);
+    private protected override PgConcreteTypeInfo MakeConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
+        => typeInfo.MakeConcreteForValue(TypedValue, out _writeState);
 
     private protected override PgValueBinding BindTypedValue(PgConcreteTypeInfo typeInfo, DataFormat? formatPreference)
         => typeInfo.BindParameterValue(TypedValue, _writeState, formatPreference);

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -27,7 +27,7 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
             if (typeof(T) == typeof(object) && ShouldResetObjectTypeInfo(value))
                 ResetTypeInfo();
             else
-                ResetBindingInfo();
+                DisposeBindingState();
             _typedValue = value;
         }
     }
@@ -102,18 +102,7 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
         }
 
         var value = TypedValue;
-        if (ConcreteTypeInfo!.Bind(value, out var size, ref _writeState, out var dataFormat, formatPreference) is { } info)
-        {
-            WriteSize = size;
-            _bufferRequirement = info.BufferRequirement;
-        }
-        else
-        {
-            WriteSize = -1;
-            _bufferRequirement = default;
-        }
-
-        Format = dataFormat;
+        _binding = ConcreteTypeInfo!.BindParameterValue(value, _writeState, formatPreference);
     }
 
     private protected override ValueTask WriteValue(bool async, PgWriter writer, CancellationToken cancellationToken)

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -88,9 +88,9 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
     {
         Debug.Assert(TypedValue is not null);
         if (async)
-            return typeInfo.ConverterWriteAsync(writer, TypedValue, cancellationToken);
+            return typeInfo.Converter.WriteAsync(writer, TypedValue, cancellationToken);
 
-        typeInfo.ConverterWrite(writer, TypedValue);
+        typeInfo.Converter.Write(writer, TypedValue);
         return new();
     }
 

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -26,7 +26,7 @@ public class ReplicationValue
     public TupleDataKind Kind { get; private set; }
 
     FieldDescription _fieldDescription = null!;
-    ColumnInfo _lastInfo;
+    ReadConversionContext _lastConversionContext;
     bool _isConsumed;
 
     PgReader PgReader => _readBuffer.PgReader;
@@ -38,7 +38,7 @@ public class ReplicationValue
         Kind = kind;
         Length = length;
         _fieldDescription = fieldDescription;
-        _lastInfo = default;
+        _lastConversionContext = default;
         _isConsumed = false;
     }
 
@@ -118,7 +118,7 @@ public class ReplicationValue
 
         var reader = PgReader;
         if (!reader.Initialized)
-            reader.Init(Length);
+            reader.Init(_fieldDescription.DataFormat, Length);
         await reader.ConsumeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         await reader.CommitAsync().ConfigureAwait(false);
 
@@ -129,8 +129,8 @@ public class ReplicationValue
     {
         ThrowIfInitialized();
 
-        _fieldDescription.GetInfo(typeof(T), ref _lastInfo);
-        var info = _lastInfo;
+        _fieldDescription.GetConversionContext(typeof(T), ref _lastConversionContext);
+        var conversionContext = _lastConversionContext;
 
         switch (Kind)
         {
@@ -151,16 +151,16 @@ public class ReplicationValue
         }
 
         var reader = PgReader;
-        reader.Init(Length);
-        return info.TypeInfo.ReadFieldValue<T>(PgReader, _fieldDescription.DataFormat);
+        reader.Init(conversionContext.Binding.DataFormat, Length);
+        return conversionContext.TypeInfo.ReadFieldValue<T>(PgReader, conversionContext.Binding);
     }
 
     async ValueTask<T> GetAsyncCore<T>(CancellationToken cancellationToken)
     {
         ThrowIfInitialized();
 
-        _fieldDescription.GetInfo(typeof(T), ref _lastInfo);
-        var info = _lastInfo;
+        _fieldDescription.GetConversionContext(typeof(T), ref _lastConversionContext);
+        var conversionContext = _lastConversionContext;
 
         switch (Kind)
         {
@@ -183,8 +183,8 @@ public class ReplicationValue
         using var registration = _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
 
         var reader = PgReader;
-        reader.Init(Length);
-        return await info.TypeInfo.ReadFieldValueAsync<T>(PgReader, _fieldDescription.DataFormat, cancellationToken).ConfigureAwait(false);
+        reader.Init(conversionContext.Binding.DataFormat, Length);
+        return await conversionContext.TypeInfo.ReadFieldValueAsync<T>(PgReader, conversionContext.Binding, cancellationToken).ConfigureAwait(false);
     }
 
     void ThrowIfInitialized()

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -152,10 +152,10 @@ public class ReplicationValue
 
         var reader = PgReader;
         reader.Init(Length, _fieldDescription.DataFormat);
-        reader.StartRead(info.ConverterInfo.BufferRequirement);
+        reader.StartRead(info.Binding.BufferRequirement);
         var result = info.AsObject
-            ? (T)info.ConverterInfo.Converter.ReadAsObject(reader)
-            : info.ConverterInfo.Converter.UnsafeDowncast<T>().Read(reader);
+            ? (T)info.TypeInfo.Converter.ReadAsObject(reader)
+            : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(reader);
         reader.EndRead();
         return result;
     }
@@ -189,10 +189,10 @@ public class ReplicationValue
 
         var reader = PgReader;
         reader.Init(Length, _fieldDescription.DataFormat);
-        await reader.StartReadAsync(info.ConverterInfo.BufferRequirement, cancellationToken).ConfigureAwait(false);
+        await reader.StartReadAsync(info.Binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
         var result = info.AsObject
-            ? (T)await info.ConverterInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-            : await info.ConverterInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
+            ? (T)await info.TypeInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+            : await info.TypeInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;
     }

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -153,7 +153,7 @@ public class ReplicationValue
         var reader = PgReader;
         reader.Init(Length, _fieldDescription.DataFormat);
         reader.StartRead(info.Binding.BufferRequirement);
-        var result = info.AsObject
+        var result = info.TypeInfo.ShouldReadAsObject<T>()
             ? (T)info.TypeInfo.Converter.ReadAsObject(reader)
             : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(reader);
         reader.EndRead();
@@ -190,7 +190,7 @@ public class ReplicationValue
         var reader = PgReader;
         reader.Init(Length, _fieldDescription.DataFormat);
         await reader.StartReadAsync(info.Binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
-        var result = info.AsObject
+        var result = info.TypeInfo.ShouldReadAsObject<T>()
             ? (T)await info.TypeInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
             : await info.TypeInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
         await reader.EndReadAsync().ConfigureAwait(false);

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -118,7 +118,7 @@ public class ReplicationValue
 
         var reader = PgReader;
         if (!reader.Initialized)
-            reader.Init(Length, _fieldDescription.DataFormat);
+            reader.Init(Length);
         await reader.ConsumeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         await reader.CommitAsync().ConfigureAwait(false);
 
@@ -188,13 +188,8 @@ public class ReplicationValue
         using var registration = _readBuffer.Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
 
         var reader = PgReader;
-        reader.Init(Length, _fieldDescription.DataFormat);
-        await reader.StartReadAsync(info.Binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
-        var result = info.TypeInfo.ShouldReadAsObject<T>()
-            ? (T)await info.TypeInfo.Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
-            : await info.TypeInfo.Converter.UnsafeDowncast<T>().ReadAsync(reader, cancellationToken).ConfigureAwait(false);
-        await reader.EndReadAsync().ConfigureAwait(false);
-        return result;
+        reader.Init(Length);
+        return await info.TypeInfo.ReadFieldValueAsync<T>(PgReader, _fieldDescription.DataFormat, cancellationToken).ConfigureAwait(false);
     }
 
     void ThrowIfInitialized()

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -151,13 +151,8 @@ public class ReplicationValue
         }
 
         var reader = PgReader;
-        reader.Init(Length, _fieldDescription.DataFormat);
-        reader.StartRead(info.Binding.BufferRequirement);
-        var result = info.TypeInfo.ShouldReadAsObject<T>()
-            ? (T)info.TypeInfo.Converter.ReadAsObject(reader)
-            : info.TypeInfo.Converter.UnsafeDowncast<T>().Read(reader);
-        reader.EndRead();
-        return result;
+        reader.Init(Length);
+        return info.TypeInfo.ReadFieldValue<T>(PgReader, _fieldDescription.DataFormat);
     }
 
     async ValueTask<T> GetAsyncCore<T>(CancellationToken cancellationToken)

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -82,7 +82,7 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
             var typeInfo = TypeMappingOptions.GetTypeInfoInternal(type, null);
             if (typeInfo is PgProviderTypeInfo providerInfo)
             {
-                var concreteTypeInfo = providerInfo.GetObjectConcreteTypeInfo(value, out var state);
+                var concreteTypeInfo = providerInfo.MakeConcreteForValueAsObject(value is DBNull ? null : value, out var state);
                 if (state is not null)
                     concreteTypeInfo.DisposeWriteState(state);
                 dataTypeName = concreteTypeInfo.PgTypeId.DataTypeName;

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -82,9 +82,10 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
             var typeInfo = TypeMappingOptions.GetTypeInfoInternal(type, null);
             if (typeInfo is PgProviderTypeInfo providerInfo)
             {
-                dataTypeName = providerInfo.GetObjectConcreteTypeInfo(value, out var state).PgTypeId.DataTypeName;
+                var concreteTypeInfo = providerInfo.GetObjectConcreteTypeInfo(value, out var state);
                 if (state is not null)
-                    providerInfo.DisposeWriteState(state);
+                    concreteTypeInfo.DisposeWriteState(state);
+                dataTypeName = concreteTypeInfo.PgTypeId.DataTypeName;
             }
             else
             {

--- a/src/Npgsql/Util/TypeExtensions.cs
+++ b/src/Npgsql/Util/TypeExtensions.cs
@@ -12,7 +12,7 @@ static class TypeExtensions
         /// </summary>
         /// <remarks>
         /// Returns <see langword="true"/> when the types are identical, when one inherits from or implements the other,
-        /// or more generally when a reference conversion exists between them.
+        /// or more generally when an implicit reference or boxing conversion exists between them.
         /// </remarks>
         /// <param name="other">The type to check the relationship with.</param>
         /// <returns><see langword="true"/> if either type is assignable to the other; otherwise, <see langword="false"/>.</returns>

--- a/src/Npgsql/Util/TypeExtensions.cs
+++ b/src/Npgsql/Util/TypeExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Npgsql.Util;
+
+static class TypeExtensions
+{
+    extension(Type type)
+    {
+        /// <summary>
+        /// Determines whether this type and <paramref name="other"/> are in a subtype relationship,
+        /// i.e. whether one is assignable to the other in either direction.
+        /// </summary>
+        /// <remarks>
+        /// Returns <see langword="true"/> when the types are identical, when one inherits from or implements the other,
+        /// or more generally when a reference conversion exists between them.
+        /// </remarks>
+        /// <param name="other">The type to check the relationship with.</param>
+        /// <returns><see langword="true"/> if either type is assignable to the other; otherwise, <see langword="false"/>.</returns>
+        public bool IsInSubtypeRelationshipWith(Type other) =>
+            type.IsAssignableTo(other) || other.IsAssignableTo(type);
+    }
+}

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -44,7 +44,8 @@ public abstract class TypeHandlerBenchmarks<T>
     readonly BufferRequirements _binaryRequirements;
 
     T? _value;
-    PgValueBinding _binding;
+    PgValueBinding _valueBinding;
+    PgFieldBinding _fieldBinding;
 
     protected TypeHandlerBenchmarks(PgConverter<T> handler)
     {
@@ -81,32 +82,33 @@ public abstract class TypeHandlerBenchmarks<T>
             _value = value;
             object? writeState = null;
             var size = _converter.GetSizeOrDbNull(DataFormat.Binary, _binaryRequirements.Write, value, ref writeState);
-            _binding = new PgValueBinding(DataFormat.Binary, _binaryRequirements.Write, size, writeState);
+            _valueBinding = new PgValueBinding(DataFormat.Binary, _binaryRequirements.Write, size, writeState);
 
-            if (!_binding.IsDbNullBinding)
+            if (!_valueBinding.IsDbNullBinding)
             {
-                _writer.StartWrite(async: false, _binding, CancellationToken.None).GetAwaiter().GetResult();
+                _writer.StartWrite(async: false, _valueBinding, CancellationToken.None).GetAwaiter().GetResult();
                 _converter.Write(_writer, value!);
-                _writer.EndWrite(_binding.Size.Value);
+                _writer.EndWrite(_valueBinding.Size.Value);
+
+                Buffer.BlockCopy(_writeBuffer.Buffer, 0, _readBuffer.Buffer, 0, _writeBuffer.WritePosition);
+                _readBuffer.AddBytesToRead(_writeBuffer.WritePosition);
+                _readBuffer.ReadPosition = 0;
+                _writeBuffer.WritePosition = 0;
+
+                _reader.Init(_valueBinding.DataFormat, _valueBinding.Size.Value.GetValueOrDefault());
+                _fieldBinding = new PgFieldBinding(DataFormat.Binary, _binaryRequirements.Read);
             }
-
-            Buffer.BlockCopy(_writeBuffer.Buffer, 0, _readBuffer.Buffer, 0, _writeBuffer.WritePosition);
-            _readBuffer.AddBytesToRead(_writeBuffer.WritePosition);
-            _readBuffer.ReadPosition = 0;
-            _writeBuffer.WritePosition = 0;
-
-            _reader.Init((size ?? -1).Value);
         }
     }
 
     [Benchmark]
     public T Read()
     {
-        if (_binding.IsDbNullBinding)
+        if (_valueBinding.IsDbNullBinding)
             return default!;
 
         _readBuffer.ReadPosition = 0;
-        _reader.StartRead(DataFormat.Binary, _binaryRequirements.Read);
+        _reader.StartRead(_fieldBinding);
         var value = _converter.Read(_reader);
         _reader.EndRead();
         return value;
@@ -115,12 +117,12 @@ public abstract class TypeHandlerBenchmarks<T>
     [Benchmark]
     public void Write()
     {
-        if (_binding.IsDbNullBinding)
+        if (_valueBinding.IsDbNullBinding)
             return;
 
         _writer.RefreshBuffer();
-        _writer.StartWrite(async: false, _binding, CancellationToken.None).GetAwaiter().GetResult();
+        _writer.StartWrite(async: false, _valueBinding, CancellationToken.None).GetAwaiter().GetResult();
         _converter.Write(_writer, Value!);
-        _writer.EndWrite(_binding.Size.GetValueOrDefault());
+        _writer.EndWrite(_valueBinding.Size.GetValueOrDefault());
     }
 }

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -4,11 +4,10 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using Npgsql.Internal;
-
-#nullable disable
 
 namespace Npgsql.Benchmarks.TypeHandlers;
 
@@ -44,10 +43,10 @@ public abstract class TypeHandlerBenchmarks<T>
     readonly NpgsqlReadBuffer _readBuffer;
     readonly BufferRequirements _binaryRequirements;
 
-    T _value;
-    Size _elementSize;
+    T? _value;
+    PgValueBinding _binding;
 
-    protected TypeHandlerBenchmarks(PgConverter handler)
+    protected TypeHandlerBenchmarks(PgConverter<T> handler)
     {
         var stream = new EndlessStream();
         _converter = (PgConverter<T>)handler ?? throw new ArgumentNullException(nameof(handler));
@@ -58,11 +57,11 @@ public abstract class TypeHandlerBenchmarks<T>
         _converter.CanConvert(DataFormat.Binary, out _binaryRequirements);
     }
 
-    public IEnumerable<T> Values() => ValuesOverride();
+    public IEnumerable<T?> Values() => ValuesOverride();
 
-    protected virtual IEnumerable<T> ValuesOverride() => [default(T)];
+    protected virtual IEnumerable<T?> ValuesOverride() => [default];
 
-    [ParamsSource(nameof(Values))]
+    [ParamsSource(nameof(Values)), MaybeNull]
     public T Value
     {
         get => _value;
@@ -80,26 +79,32 @@ public abstract class TypeHandlerBenchmarks<T>
             }
 
             _value = value;
-            object state = null;
-            var size = _elementSize = _converter.GetSizeOrDbNullAsObject(DataFormat.Binary, _binaryRequirements.Write, value, ref state)!.Value;
-            var current = new ValueMetadata { Format = DataFormat.Binary, BufferRequirement = _binaryRequirements.Write, Size = size, WriteState = state };
+            object? writeState = null;
+            var size = _converter.GetSizeOrDbNull(DataFormat.Binary, _binaryRequirements.Write, value, ref writeState);
+            _binding = new PgValueBinding(DataFormat.Binary, _binaryRequirements.Write, size, writeState);
 
-            _writer.BeginWrite(async: false, current, CancellationToken.None).GetAwaiter().GetResult();
-            _converter.WriteAsObject(_writer, value);
-            _writer.Commit(size.Value);
+            if (!_binding.IsDbNullBinding)
+            {
+                _writer.StartWrite(async: false, _binding, CancellationToken.None).GetAwaiter().GetResult();
+                _converter.Write(_writer, value!);
+                _writer.EndWrite(_binding.Size.Value);
+            }
 
             Buffer.BlockCopy(_writeBuffer.Buffer, 0, _readBuffer.Buffer, 0, _writeBuffer.WritePosition);
             _readBuffer.AddBytesToRead(_writeBuffer.WritePosition);
             _readBuffer.ReadPosition = 0;
             _writeBuffer.WritePosition = 0;
 
-            _reader.Init(size.Value, DataFormat.Binary);
+            _reader.Init((size ?? -1).Value, DataFormat.Binary);
         }
     }
 
     [Benchmark]
     public T Read()
     {
+        if (_binding.IsDbNullBinding)
+            return default!;
+
         _readBuffer.ReadPosition = 0;
         _reader.StartRead(_binaryRequirements.Read);
         var value = _converter.Read(_reader);
@@ -110,9 +115,12 @@ public abstract class TypeHandlerBenchmarks<T>
     [Benchmark]
     public void Write()
     {
+        if (_binding.IsDbNullBinding)
+            return;
+
         _writer.RefreshBuffer();
-        var current = new ValueMetadata { Format = DataFormat.Binary, BufferRequirement = _binaryRequirements.Write, Size = _elementSize, WriteState = null };
-        _writer.BeginWrite(async: false, current, CancellationToken.None).GetAwaiter().GetResult();
-        _converter.Write(_writer, _value);
+        _writer.StartWrite(async: false, _binding, CancellationToken.None).GetAwaiter().GetResult();
+        _converter.Write(_writer, Value!);
+        _writer.EndWrite(_binding.Size.GetValueOrDefault());
     }
 }

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -81,7 +81,7 @@ public abstract class TypeHandlerBenchmarks<T>
 
             _value = value;
             object? writeState = null;
-            var size = _converter.GetSizeOrDbNull(DataFormat.Binary, _binaryRequirements.Write, value, ref writeState);
+            var size = _converter.IsDbNullOrGetSize(DataFormat.Binary, _binaryRequirements.Write, value, ref writeState);
             _valueBinding = new PgValueBinding(DataFormat.Binary, _binaryRequirements.Write, size, writeState);
 
             if (!_valueBinding.IsDbNullBinding)

--- a/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
+++ b/test/Npgsql.Benchmarks/TypeHandlers/TypeHandlerBenchmarks.cs
@@ -95,7 +95,7 @@ public abstract class TypeHandlerBenchmarks<T>
             _readBuffer.ReadPosition = 0;
             _writeBuffer.WritePosition = 0;
 
-            _reader.Init((size ?? -1).Value, DataFormat.Binary);
+            _reader.Init((size ?? -1).Value);
         }
     }
 
@@ -106,7 +106,7 @@ public abstract class TypeHandlerBenchmarks<T>
             return default!;
 
         _readBuffer.ReadPosition = 0;
-        _reader.StartRead(_binaryRequirements.Read);
+        _reader.StartRead(DataFormat.Binary, _binaryRequirements.Read);
         var value = _converter.Read(_reader);
         _reader.EndRead();
         return value;

--- a/test/Npgsql.Tests/NpgsqlParameterTests.cs
+++ b/test/Npgsql.Tests/NpgsqlParameterTests.cs
@@ -657,17 +657,17 @@ public class NpgsqlParameterTest : TestBase
     {
         var param = generic ? new NpgsqlParameter<object> { Value = "value" } : new NpgsqlParameter { Value = "value" };
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var typeInfo, out _, out _);
+        param.GetResolutionInfo(out var typeInfo, out _);
         Assert.That(typeInfo, Is.Not.Null);
 
         // Make sure we don't reset the type info when setting DBNull.
         param.Value = DBNull.Value;
-        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var secondTypeInfo, out _);
         Assert.That(secondTypeInfo, Is.SameAs(typeInfo));
 
         // Make sure we don't resolve a different type info either.
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _);
         Assert.That(thirdTypeInfo, Is.SameAs(secondTypeInfo));
     }
 
@@ -676,17 +676,16 @@ public class NpgsqlParameterTest : TestBase
     {
         var param = generic ? new NpgsqlParameter<object> { Value = DBNull.Value } : new NpgsqlParameter { Value = DBNull.Value };
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var typeInfo, out _, out var pgTypeId);
+        param.GetResolutionInfo(out var typeInfo, out _);
         Assert.That(typeInfo, Is.Not.Null);
-        Assert.That(pgTypeId.IsUnspecified, Is.True);
 
         param.Value = "value";
-        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var secondTypeInfo, out _);
         Assert.That(secondTypeInfo, Is.Null);
 
         // Make sure we don't resolve the same type info either.
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _);
         Assert.That(thirdTypeInfo, Is.Not.SameAs(typeInfo));
     }
 
@@ -695,16 +694,16 @@ public class NpgsqlParameterTest : TestBase
     {
         var param = generic ? new NpgsqlParameter<object> { Value = "value" } : new NpgsqlParameter { Value = "value" };
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var typeInfo, out _, out _);
+        param.GetResolutionInfo(out var typeInfo, out _);
         Assert.That(typeInfo, Is.Not.Null);
 
         param.Value = 1;
-        param.GetResolutionInfo(out var secondTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var secondTypeInfo, out _);
         Assert.That(secondTypeInfo, Is.Null);
 
         // Make sure we don't resolve a different type info either.
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var thirdTypeInfo, out _, out _);
+        param.GetResolutionInfo(out var thirdTypeInfo, out _);
         Assert.That(thirdTypeInfo, Is.Not.SameAs(typeInfo));
     }
 
@@ -723,7 +722,7 @@ public class NpgsqlParameterTest : TestBase
             Value = "value"
         };
         param.ResolveTypeInfo(DataSource.CurrentReloadableState.SerializerOptions, null);
-        param.GetResolutionInfo(out var typeInfo, out _, out _);
+        param.GetResolutionInfo(out var typeInfo, out _);
         Assert.That(typeInfo, Is.Not.Null);
         Assert.That(typeInfo.PgTypeId, Is.EqualTo(DataSource.CurrentReloadableState.SerializerOptions.TextPgTypeId));
     }

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2102,11 +2102,11 @@ LANGUAGE plpgsql VOLATILE";
         var buffer = conn.Connector!.ReadBuffer;
         buffer.AddBytesToRead(columnLength);
         var reader = buffer.PgReader;
-        reader.Init(columnLength, DataFormat.Binary, resumable: false);
+        reader.Init(columnLength, resumable: false);
         if (async)
-            await reader.StartReadAsync(Size.Unknown, CancellationToken.None);
+            await reader.StartReadAsync(DataFormat.Binary, Size.Unknown, CancellationToken.None);
         else
-            reader.StartRead(Size.Unknown);
+            reader.StartRead(DataFormat.Binary, Size.Unknown);
 
         await using (var _ = reader.GetStream())
         {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2102,11 +2102,11 @@ LANGUAGE plpgsql VOLATILE";
         var buffer = conn.Connector!.ReadBuffer;
         buffer.AddBytesToRead(columnLength);
         var reader = buffer.PgReader;
-        reader.Init(columnLength, resumable: false);
+        reader.Init(DataFormat.Binary, columnLength, resumable: false);
         if (async)
-            await reader.StartReadAsync(DataFormat.Binary, Size.Unknown, CancellationToken.None);
+            await reader.StartReadAsync(new(DataFormat.Binary, Size.Unknown), CancellationToken.None);
         else
-            reader.StartRead(DataFormat.Binary, Size.Unknown);
+            reader.StartRead(new(DataFormat.Binary, Size.Unknown));
 
         await using (var _ = reader.GetStream())
         {


### PR DESCRIPTION
Pulled out of #6317. Lands the first set of changes on top of the new provider/concrete split. Centralizes the resolution and binding-at-the-edge logic (parameters/fields) across providers and concretes + any related cleanup. Most of this is internal surface changes, some of it is PgTypeInfo related. None of it is used by plugin authors.