### PR TITLE
PgTypeInfo CLR type variance and perf improvements

### DIFF
--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -291,7 +291,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out _), null);
             foreach (var value in array)
             {
-                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
+                var result = GetEffectiveForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -322,7 +322,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
+                var result = GetEffectiveForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -353,7 +353,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
+                var result = GetEffectiveForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -384,7 +384,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out var dimensionLengths), dimensionLengths);
             foreach (var value in array)
             {
-                var result = EffectiveTypeInfo.GetForValue(effectiveContext, value, out var state);
+                var result = GetEffectiveForValue(effectiveContext, value, out var state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -479,9 +479,10 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
 {
     readonly PgProviderTypeInfo _effectiveTypeInfo;
     readonly PgProviderTypeInfo _effectiveNullableTypeInfo;
+    readonly bool _isCompositionalUnit;
     readonly ConcurrentDictionary<PgConcreteTypeInfo, PgConcreteTypeInfo> _concreteInfoCache = new(ReferenceEqualityComparer.Instance);
 
-    public PolymorphicArrayTypeInfoProvider(PgProviderTypeInfo effectiveTypeInfo, PgProviderTypeInfo effectiveNullableTypeInfo)
+    public PolymorphicArrayTypeInfoProvider(PgProviderTypeInfo effectiveTypeInfo, PgProviderTypeInfo effectiveNullableTypeInfo, bool isCompositionalUnit = false)
     {
         if (effectiveTypeInfo.PgTypeId is null || effectiveNullableTypeInfo.PgTypeId is null)
             throw new ArgumentException("Type info cannot have an undecided PgTypeId.",
@@ -489,18 +490,31 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
 
         _effectiveTypeInfo = effectiveTypeInfo;
         _effectiveNullableTypeInfo = effectiveNullableTypeInfo;
+        _isCompositionalUnit = isCompositionalUnit;
     }
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
-        => GetOrAdd(_effectiveTypeInfo.GetDefault(pgTypeId), _effectiveNullableTypeInfo.GetDefault(pgTypeId));
+        => GetOrAdd(
+            _isCompositionalUnit
+                ? PgProviderTypeInfo.GetProvider(_effectiveTypeInfo).GetDefault(pgTypeId)
+                : _effectiveTypeInfo.GetDefault(pgTypeId),
+            _isCompositionalUnit
+                ? PgProviderTypeInfo.GetProvider(_effectiveNullableTypeInfo).GetDefault(pgTypeId)
+                : _effectiveNullableTypeInfo.GetDefault(pgTypeId));
 
     protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, TBase? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        var concreteTypeInfo = _effectiveTypeInfo.GetForField(field);
-        var concreteNullableTypeInfo = _effectiveNullableTypeInfo.GetForField(field);
+        // When constructed as a same-authoring-unit composition, route directly to inner providers, skipping their
+        // wrapping ValidateConcrete on each call.
+        var concreteTypeInfo = _isCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(_effectiveTypeInfo).GetForField(field)
+            : _effectiveTypeInfo.GetForField(field);
+        var concreteNullableTypeInfo = _isCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(_effectiveNullableTypeInfo).GetForField(field)
+            : _effectiveNullableTypeInfo.GetForField(field);
 
         return concreteTypeInfo is not null && concreteNullableTypeInfo is not null
             ? GetOrAdd(concreteTypeInfo, concreteNullableTypeInfo)

--- a/src/Npgsql/Internal/Converters/BitStringConverters.cs
+++ b/src/Npgsql/Internal/Converters/BitStringConverters.cs
@@ -233,6 +233,9 @@ sealed class PolymorphicBitStringTypeInfoProvider(PgSerializerOptions options, P
     readonly PgConcreteTypeInfo _boolConcreteTypeInfo = new(options, new BoolBitStringConverter(), bitString) { SupportsWriting = false };
     readonly PgConcreteTypeInfo _bitArrayConcreteTypeInfo = new(options, new BitArrayBitStringConverter(), bitString) { SupportsWriting = false };
 
+    // Dispatched concretes vary in advertised Type (bool vs BitArray) per field's TypeModifier.
+    internal override bool AllowConcreteVariance => true;
+
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
         => GetConcreteInfo(field: null);
 

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -69,6 +69,10 @@ sealed class CastingTypeInfoProvider<T> : PgComposingTypeInfoProvider<T>
         Debug.Assert(!effectiveProviderTypeInfo.HasExactType, "CastingTypeInfoProvider is for wrapping non-exact providers; an exact provider doesn't need the cast.");
     }
 
+    // Wraps a dynamically-obtained inner — not a same-authoring-unit composition. The inner's contract must still be
+    // verified per dispatch.
+    protected override bool IsCompositionalUnit => false;
+
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -83,7 +83,7 @@ sealed class CastingTypeInfoProvider<T> : PgComposingTypeInfoProvider<T>
     }
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
-        => EffectiveTypeInfo.GetForValueAsObject(effectiveContext, value, out writeState);
+        => GetEffectiveForValueAsObject(effectiveContext, value, out writeState);
 }
 
 static class CastingTypeInfoExtensions

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,9 +61,14 @@ public sealed class CastingConverter<T> : PgConverter<T>
 }
 
 // Given there aren't many instantiations of providers (and it's fairly involved to write a fast one) we use the composing base class.
-sealed class CastingTypeInfoProvider<T>(PgProviderTypeInfo effectiveProviderTypeInfo)
-    : PgComposingTypeInfoProvider<T>(effectiveProviderTypeInfo.PgTypeId, effectiveProviderTypeInfo)
+sealed class CastingTypeInfoProvider<T> : PgComposingTypeInfoProvider<T>
 {
+    public CastingTypeInfoProvider(PgProviderTypeInfo effectiveProviderTypeInfo)
+        : base(effectiveProviderTypeInfo.PgTypeId, effectiveProviderTypeInfo)
+    {
+        Debug.Assert(!effectiveProviderTypeInfo.HasExactType, "CastingTypeInfoProvider is for wrapping non-exact providers; an exact provider doesn't need the cast.");
+    }
+
     protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
     protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
 

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -55,6 +55,6 @@ sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
 
     protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => value is not null
-            ? EffectiveTypeInfo.GetForValue(effectiveContext, value.GetValueOrDefault(), out writeState)
+            ? GetEffectiveForValue(effectiveContext, value.GetValueOrDefault(), out writeState)
             : null;
 }

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -17,6 +17,9 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
     readonly PgTypeId _elementPgTypeId;
     readonly ConcurrentDictionary<PgConcreteTypeInfo, PgConcreteTypeInfo> _concreteInfoCache = new(ReferenceEqualityComparer.Instance);
 
+    // Dispatched concretes always advertise Type=Array, narrower than this provider's TypeToConvert=object.
+    internal override bool AllowConcreteVariance => true;
+
     public PolymorphicArrayTypeInfoProvider(PgTypeId pgTypeId, PgProviderTypeInfo elementTypeInfo, Func<PgConcreteTypeInfo, PgConverter> elementToArrayConverterFactory)
     {
         if (elementTypeInfo.PgTypeId is null)

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -15,12 +15,13 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
     readonly PgProviderTypeInfo _elementTypeInfo;
     readonly Func<PgConcreteTypeInfo, PgConverter> _elementToArrayConverterFactory;
     readonly PgTypeId _elementPgTypeId;
+    readonly bool _isCompositionalUnit;
     readonly ConcurrentDictionary<PgConcreteTypeInfo, PgConcreteTypeInfo> _concreteInfoCache = new(ReferenceEqualityComparer.Instance);
 
     // Dispatched concretes always advertise Type=Array, narrower than this provider's TypeToConvert=object.
     internal override bool AllowConcreteVariance => true;
 
-    public PolymorphicArrayTypeInfoProvider(PgTypeId pgTypeId, PgProviderTypeInfo elementTypeInfo, Func<PgConcreteTypeInfo, PgConverter> elementToArrayConverterFactory)
+    public PolymorphicArrayTypeInfoProvider(PgTypeId pgTypeId, PgProviderTypeInfo elementTypeInfo, Func<PgConcreteTypeInfo, PgConverter> elementToArrayConverterFactory, bool isCompositionalUnit = false)
     {
         if (elementTypeInfo.PgTypeId is null)
             throw new ArgumentException("Type info cannot have an undecided PgTypeId.", nameof(elementTypeInfo));
@@ -29,17 +30,24 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
         _elementTypeInfo = elementTypeInfo;
         _elementToArrayConverterFactory = elementToArrayConverterFactory;
         _elementPgTypeId = elementTypeInfo.PgTypeId!.Value;
+        _isCompositionalUnit = isCompositionalUnit;
     }
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
-        => GetOrAdd(_elementTypeInfo.GetDefault(_elementPgTypeId));
+        => GetOrAdd(_isCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(_elementTypeInfo).GetDefault(_elementPgTypeId)
+            : _elementTypeInfo.GetDefault(_elementPgTypeId));
 
     protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        var elementConcreteTypeInfo = _elementTypeInfo.GetForField(field with { PgTypeId = _elementPgTypeId });
+        // When constructed as a same-authoring-unit composition, route directly to the inner provider, skipping the
+        // inner's wrapping ValidateConcrete on each call.
+        var elementConcreteTypeInfo = _isCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(_elementTypeInfo).GetForField(field with { PgTypeId = _elementPgTypeId })
+            : _elementTypeInfo.GetForField(field with { PgTypeId = _elementPgTypeId });
         return elementConcreteTypeInfo is not null ? GetOrAdd(elementConcreteTypeInfo) : null;
     }
 

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -22,6 +22,19 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
         IsInternalProvider = true;
     }
 
+    /// <summary>
+    /// Whether this composer and its inner provider are part of the same compositional unit — both authored together
+    /// by the same factory (e.g. a plugin or framework resolver via TypeInfoMapping) and tested as one whole. When
+    /// true, the framework can dispatch to the inner directly, skipping the inner's wrapping validation; when false,
+    /// the inner is treated as dynamically obtained and validated per call.
+    /// </summary>
+    /// <remarks>
+    /// Default true reflects the typical case: composers built via TypeInfoMapping helpers (e.g. <c>AddArrayType</c>)
+    /// where one authoring unit produces both layers. Composers wrapping arbitrary dynamically-obtained inners (e.g.
+    /// <c>CastingTypeInfoProvider</c>) opt out so the inner's contract is verified per dispatch.
+    /// </remarks>
+    protected virtual bool IsCompositionalUnit => true;
+
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
     protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType);

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -19,6 +19,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
         _pgTypeId = pgTypeId;
         EffectiveTypeInfo = effectiveTypeInfo;
+        IsInternalProvider = true;
     }
 
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -35,6 +36,35 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
     /// </remarks>
     protected virtual bool IsCompositionalUnit => true;
 
+    // Dispatch helpers route to the inner provider directly when this composer is a compositional unit (skipping the
+    // inner's wrapping ValidateConcrete) or through the wrapping info otherwise (validated). Composers should call
+    // these instead of EffectiveTypeInfo.GetFor* directly to honor the IsCompositionalUnit contract.
+    // AggressiveInlining ensures the virtual IsCompositionalUnit access devirtualizes when called from sealed derived
+    // composers, collapsing the branch to a constant at JIT time.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected PgConcreteTypeInfo GetEffectiveDefault(PgTypeId? pgTypeId)
+        => IsCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetDefault(pgTypeId)
+            : EffectiveTypeInfo.GetDefault(pgTypeId);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected PgConcreteTypeInfo? GetEffectiveForField(Field field)
+        => IsCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForField(field)
+            : EffectiveTypeInfo.GetForField(field);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected PgConcreteTypeInfo? GetEffectiveForValue<TInner>(ProviderValueContext context, TInner? value, out object? writeState)
+        => IsCompositionalUnit
+            ? ((PgConcreteTypeInfoProvider<TInner>)PgProviderTypeInfo.GetProvider(EffectiveTypeInfo)).GetForValue(context, value, out writeState)
+            : EffectiveTypeInfo.GetForValue(context, value, out writeState);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected PgConcreteTypeInfo? GetEffectiveForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
+        => IsCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsObject(context, value, out writeState)
+            : EffectiveTypeInfo.GetForValueAsObject(context, value, out writeState);
+
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
     protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType);
@@ -43,7 +73,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
     {
         PgTypeId? effectiveTypeId = pgTypeId is { } id ? GetEffectiveTypeId(id) : null;
-        var concreteTypeInfo = EffectiveTypeInfo.GetDefault(effectiveTypeId);
+        var concreteTypeInfo = GetEffectiveDefault(effectiveTypeId);
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);
         return GetOrAdd(concreteTypeInfo, composingPgTypeId);
     }
@@ -60,7 +90,8 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
     {
-        if (EffectiveTypeInfo.GetForField(field with { PgTypeId = GetEffectivePgTypeId(field.PgTypeId)}) is not { } concreteTypeInfo)
+        var effectiveField = field with { PgTypeId = GetEffectivePgTypeId(field.PgTypeId) };
+        if (GetEffectiveForField(effectiveField) is not { } concreteTypeInfo)
             return null;
 
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -70,6 +70,18 @@ public abstract class PgConcreteTypeInfoProvider
     /// </summary>
     internal virtual bool AllowConcreteVariance => false;
 
+    /// <summary>
+    /// Whether this provider is part of the framework's own resolution mechanism rather than plugin-authored code.
+    /// Providers are dual-natured — extensible surface plus tier-2 resolution mechanism — and this flag lets the
+    /// framework label its own composing infrastructure to skip self-validation without affecting the surface that
+    /// plugins extend.
+    /// </summary>
+    /// <remarks>
+    /// Compare to the cache layer (tier-1): the cache is purely mechanism, not extensible surface, so it doesn't need
+    /// an analogous flag — the whole class is framework-only by construction.
+    /// </remarks>
+    internal bool IsInternalProvider { get; private protected init; }
+
     private protected abstract PgConcreteTypeInfo? GetForValueAsObjectCore(ProviderValueContext context, object? value, ref object? writeState);
 
     private protected static void ThrowPgTypeIdMismatch(string methodName)

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -35,8 +35,9 @@ public abstract class PgConcreteTypeInfoProvider
     /// <summary>
     /// Gets the appropriate type info based on the given value and expected type id.
     /// </summary>
-    public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, ref object? writeState)
+    public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
     {
+        writeState = null;
         var result = GetForValueAsObjectCore(context, value, ref writeState);
         var expected = context.ExpectedPgTypeId;
         if (result is not null && expected.HasValue && result.PgTypeId != Nullable.GetValueRefOrDefaultRef(in expected))
@@ -96,8 +97,9 @@ public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
     /// <summary>
     /// Gets the appropriate type info based on the given value and expected type id.
     /// </summary>
-    public PgConcreteTypeInfo? GetForValue(ProviderValueContext context, T? value, ref object? writeState)
+    public PgConcreteTypeInfo? GetForValue(ProviderValueContext context, T? value, out object? writeState)
     {
+        writeState = null;
         var result = GetForValueCore(context, value, ref writeState);
         var expected = context.ExpectedPgTypeId;
         if (result is not null && expected.HasValue && result.PgTypeId != Nullable.GetValueRefOrDefaultRef(in expected))

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -15,7 +16,7 @@ public abstract class PgConcreteTypeInfoProvider
     public PgConcreteTypeInfo GetDefault(PgTypeId? pgTypeId)
     {
         var result = GetDefaultCore(pgTypeId);
-        if (pgTypeId is { } id && result.PgTypeId != id)
+        if (pgTypeId.HasValue && result.PgTypeId != Nullable.GetValueRefOrDefaultRef(in pgTypeId))
             ThrowPgTypeIdMismatch(nameof(GetDefaultCore));
         return result;
     }
@@ -37,7 +38,8 @@ public abstract class PgConcreteTypeInfoProvider
     public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, ref object? writeState)
     {
         var result = GetForValueAsObjectCore(context, value, ref writeState);
-        if (context.ExpectedPgTypeId is { } id && result is not null && result.PgTypeId != id)
+        var expected = context.ExpectedPgTypeId;
+        if (result is not null && expected.HasValue && result.PgTypeId != Nullable.GetValueRefOrDefaultRef(in expected))
             ThrowPgTypeIdMismatch(nameof(GetForValueAsObjectCore));
         return result;
     }
@@ -97,7 +99,8 @@ public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
     public PgConcreteTypeInfo? GetForValue(ProviderValueContext context, T? value, ref object? writeState)
     {
         var result = GetForValueCore(context, value, ref writeState);
-        if (context.ExpectedPgTypeId is { } id && result is not null && result.PgTypeId != id)
+        var expected = context.ExpectedPgTypeId;
+        if (result is not null && expected.HasValue && result.PgTypeId != Nullable.GetValueRefOrDefaultRef(in expected))
             ThrowPgTypeIdMismatch(nameof(GetForValueCore));
         return result;
     }

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -62,6 +62,14 @@ public abstract class PgConcreteTypeInfoProvider
 
     internal abstract Type TypeToConvert { get; }
 
+    /// <summary>
+    /// Whether dispatched concretes from this provider may have a <see cref="PgTypeInfo.Type"/> that varies along the
+    /// <see cref="TypeToConvert"/> subtype chain. Defaults to <see langword="false"/>: providers are canonical unless
+    /// they explicitly opt in. Polymorphic providers that dispatch to varied concretes per call must override to
+    /// <see langword="true"/>.
+    /// </summary>
+    internal virtual bool AllowConcreteVariance => false;
+
     private protected abstract PgConcreteTypeInfo? GetForValueAsObjectCore(ProviderValueContext context, object? value, ref object? writeState);
 
     private protected static void ThrowPgTypeIdMismatch(string methodName)

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
@@ -76,21 +77,26 @@ public sealed class PgSerializerOptions
     internal bool MultirangesEnabled => _resolverChain.MultirangesEnabled;
     internal bool ArraysEnabled => _resolverChain.ArraysEnabled;
 
-    // We don't verify the kind of pgTypeId we get, it'll throw if it's incorrect.
-    // It's up to the caller to call GetCanonicalTypeId if they want to use an oid instead of a DataTypeName.
-    // This also makes it easier to realize it should be a cached value if infos for different CLR types are requested for the same
-    // pgTypeId. Effectively it should be 'impossible' to get the wrong kind via any PgConverterOptions api which is what this is mainly
-    // for.
+    // GetTypeInfoCore consumes the canonical pair: only the side matching PortableTypeIds is read, the other is
+    // expected to be default. Callers must canonicalize before calling — public entries (GetDefaultTypeInfo/GetTypeInfo)
+    // do this via GetCanonicalTypeId, which routes through DatabaseInfo.GetDataTypeName/GetOid (form-tolerant). The
+    // internal entry trusts callers to have canonicalized; passing a non-matching kind silently dispatches with a
+    // default opposite-side value.
     PgTypeInfo? GetTypeInfoCore(Type? type, Oid? oid, DataTypeName? dataTypeName)
         => PortableTypeIds
             ? (_dataTypeNameCache ??= new TypeInfoCache<DataTypeName>(this)).GetOrAddInfo(type, dataTypeName)
             : (_oidCache ??= new TypeInfoCache<Oid>(this)).GetOrAddInfo(type, oid);
 
     internal PgTypeInfo? GetTypeInfoInternal(Type? type, PgTypeId? pgTypeId)
+        => !pgTypeId.HasValue
+            ? GetTypeInfoCore(type, null, null)
+            : GetTypeInfoInternal(type, Nullable.GetValueRefOrDefaultRef(in pgTypeId));
+
+    internal PgTypeInfo? GetTypeInfoInternal(Type? type, PgTypeId pgTypeId)
     {
-        if (!pgTypeId.HasValue)
-            return GetTypeInfoCore(type, null, null);
-        var (oid, dataTypeName) = Nullable.GetValueRefOrDefaultRef(in pgTypeId);
+        var (oid, dataTypeName) = pgTypeId;
+        Debug.Assert(PortableTypeIds ? oid == default : dataTypeName == default,
+            "PgTypeId form does not match PortableTypeIds; caller must canonicalize.");
         return GetTypeInfoCore(type, oid, dataTypeName);
     }
 

--- a/src/Npgsql/Internal/PgSerializerOptions.cs
+++ b/src/Npgsql/Internal/PgSerializerOptions.cs
@@ -22,7 +22,8 @@ public sealed class PgSerializerOptions
     readonly PgTypeInfoResolverChain _resolverChain;
     readonly Func<string>? _timeZoneProvider;
     IPgTypeInfoResolver? _typeInfoResolver;
-    object? _typeInfoCache;
+    TypeInfoCache<Oid>? _oidCache;
+    TypeInfoCache<DataTypeName>? _dataTypeNameCache;
 
     internal PgSerializerOptions(NpgsqlDatabaseInfo databaseInfo, PgTypeInfoResolverChain? resolverChain = null, Func<string>? timeZoneProvider = null)
     {
@@ -80,22 +81,33 @@ public sealed class PgSerializerOptions
     // This also makes it easier to realize it should be a cached value if infos for different CLR types are requested for the same
     // pgTypeId. Effectively it should be 'impossible' to get the wrong kind via any PgConverterOptions api which is what this is mainly
     // for.
-    PgTypeInfo? GetTypeInfoCore(Type? type, PgTypeId? pgTypeId)
+    PgTypeInfo? GetTypeInfoCore(Type? type, Oid? oid, DataTypeName? dataTypeName)
         => PortableTypeIds
-            ? ((TypeInfoCache<DataTypeName>)(_typeInfoCache ??= new TypeInfoCache<DataTypeName>(this))).GetOrAddInfo(type, pgTypeId?.DataTypeName)
-            : ((TypeInfoCache<Oid>)(_typeInfoCache ??= new TypeInfoCache<Oid>(this))).GetOrAddInfo(type, pgTypeId?.Oid);
+            ? (_dataTypeNameCache ??= new TypeInfoCache<DataTypeName>(this)).GetOrAddInfo(type, dataTypeName)
+            : (_oidCache ??= new TypeInfoCache<Oid>(this)).GetOrAddInfo(type, oid);
 
     internal PgTypeInfo? GetTypeInfoInternal(Type? type, PgTypeId? pgTypeId)
-        => GetTypeInfoCore(type, pgTypeId);
+    {
+        if (!pgTypeId.HasValue)
+            return GetTypeInfoCore(type, null, null);
+        var (oid, dataTypeName) = Nullable.GetValueRefOrDefaultRef(in pgTypeId);
+        return GetTypeInfoCore(type, oid, dataTypeName);
+    }
 
     public PgTypeInfo? GetDefaultTypeInfo(Type type)
-        => GetTypeInfoCore(type, null);
+        => GetTypeInfoCore(type, null, null);
 
     public PgTypeInfo? GetDefaultTypeInfo(PgTypeId pgTypeId)
-        => GetTypeInfoCore(null, GetCanonicalTypeId(pgTypeId));
+    {
+        var (oid, dataTypeName) = GetCanonicalTypeId(pgTypeId);
+        return GetTypeInfoCore(null, oid, dataTypeName);
+    }
 
     public PgTypeInfo? GetTypeInfo(Type type, PgTypeId pgTypeId)
-        => GetTypeInfoCore(type, GetCanonicalTypeId(pgTypeId));
+    {
+        var (oid, dataTypeName) = GetCanonicalTypeId(pgTypeId);
+        return GetTypeInfoCore(type, oid, dataTypeName);
+    }
 
     // If a given type id is in the opposite form than what was expected it will be mapped according to the requirement.
     internal PgTypeId GetCanonicalTypeId(PgTypeId pgTypeId)

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -48,14 +48,14 @@ public abstract class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
-    // Invariance bit on the (Converter.TypeToConvert, Type) pair: true when no requestedType was given or it equalled
-    // the converter type, false when Type and the converter type differ (in either direction along their shared
-    // subtype chain). False covers two construction cases that are indistinguishable downstream:
-    //   - Under-reporting: Type is narrower than the converter type (e.g. ArrayConverter<Array> answering as int[]).
-    //   - Polymorphic alias: Type is the converter type returned to a wider query (e.g. typeof(object)).
-    // When false the typed fast path is unsafe and dispatch routes through the AsObject APIs with a runtime cast,
-    // letting one converter cover multiple advertised types.
-    internal bool HasExactType { get; }
+    // Forward-looking contract bit about the converter consumers will ultimately use through this info: true when the
+    // converter's type matches Type canonically, false when consumers should expect variation (the typed fast path is
+    // unsafe; dispatch routes through the AsObject APIs with a runtime cast).
+    //   - Concrete: false when (Converter.TypeToConvert, Type) differ in either direction along their shared subtype
+    //     chain (under-reporting or polymorphic alias).
+    //   - Provider: false when the underlying provider is polymorphic and will dispatch to varied concretes per call;
+    //     even though the wrapping pair (TypeToConvert, Type) is invariant, what flows out is not.
+    internal bool HasExactType { get; private protected init; }
 
     public PgTypeId? PgTypeId { get; }
 
@@ -66,6 +66,12 @@ public abstract class PgTypeInfo
     // requestedType on the chain, covers polymorphic-alias and under-reporting in one branch.
     internal bool ResolvesAs(Type? requestedType)
         => requestedType is null || requestedType == Type || (!HasExactType && Type.IsAssignableTo(requestedType));
+
+    // On the outer info (this), check whether a concrete result is admissible per the outer's contract.
+    // HasExactType=true requires canonical match (result.Type == Type); HasExactType=false admits narrower-or-equal
+    // results on the subtype chain. Used at provider boundaries to validate that concretes flowing out fit.
+    internal bool AcceptsResult(PgConcreteTypeInfo result)
+        => result.Type == Type || (!HasExactType && result.Type.IsAssignableTo(Type));
 
     /// <summary>
     /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field.
@@ -196,9 +202,17 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
     {
         _typeInfoProvider = typeInfoProvider;
 
+        // When the underlying provider permits concrete variance and the resolved Type isn't a leaf (sealed / value
+        // type), dispatched concretes may vary along Type's subtype chain — HasExactType=false honestly previews that.
+        // requestedType narrowing flows through Type: a variant provider narrowed via requestedType to a sealed
+        // wrapper Type is canonical at that leaf, regardless of the underlying floor. Canonical providers over
+        // non-sealed floors can opt out via AllowConcreteVariance=false.
+        if (typeInfoProvider.AllowConcreteVariance && !Type.IsSealed)
+            HasExactType = false;
+
         // Always validate the default provider result, the info will be re-used so there is no real downside.
         var result = typeInfoProvider.GetDefault(pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null);
-        ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result, typeInfoProvider.TypeToConvert, options.PortableTypeIds);
+        ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
         _defaultConcrete = result;
     }
 
@@ -283,12 +297,17 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         => throw new ArgumentException($"PgTypeId does not match the decided value on this {nameof(PgProviderTypeInfo)}.", parameterName);
 
     void ValidateResult(string methodName, PgConcreteTypeInfo result)
-        => ValidateResult(methodName, result, _typeInfoProvider.TypeToConvert, Options.PortableTypeIds);
+        => ValidateResult(methodName, result, _typeInfoProvider.TypeToConvert, this, Options.PortableTypeIds);
 
-    static void ValidateResult(string methodName, PgConcreteTypeInfo result, Type expectedTypeToConvert, bool expectPortableTypeIds)
+    static void ValidateResult(string methodName, PgConcreteTypeInfo result, Type expectedTypeToConvert, PgTypeInfo expected, bool expectPortableTypeIds)
     {
         if (expectedTypeToConvert != typeof(object) && result.Converter.TypeToConvert != expectedTypeToConvert)
             throw new InvalidOperationException($"'{methodName}' returned a {nameof(result.Converter)} of type {result.Converter.TypeToConvert} instead of {expectedTypeToConvert} unexpectedly.");
+
+        // Plugins ship in-tree, so this fires in release. The result must fit the outer info's contract:
+        // canonical when the outer is HasExactType=true, otherwise narrower-or-equal on the chain.
+        if (!expected.AcceptsResult(result))
+            throw new InvalidOperationException($"'{methodName}' returned a concrete type info advertising type {result.Type} which is incompatible with this info's contract (Type={expected.Type}, HasExactType={expected.HasExactType}).");
 
         if (expectPortableTypeIds && result.PgTypeId.IsOid || !expectPortableTypeIds && result.PgTypeId.IsDataTypeName)
             throw new InvalidOperationException($"'{methodName}' returned a concrete type info with a {nameof(result.PgTypeId)} that was not in canonical form.");

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -189,18 +189,20 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
     public PgConcreteTypeInfo GetDefault(PgTypeId? pgTypeId)
     {
-        if (pgTypeId is { } id && PgTypeId is { } decidedId)
+        if (PgTypeId is { } decidedId)
         {
-            if (id != decidedId)
+            if (pgTypeId is { } id && id != decidedId)
                 ThrowUnexpectedPgTypeId(nameof(pgTypeId));
-
-            Debug.Assert(_defaultConcrete is not null);
-            return _defaultConcrete;
+        }
+        else if (pgTypeId is not null)
+        {
+            var result = _typeInfoProvider.GetDefault(pgTypeId);
+            ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
+            return result;
         }
 
-        var result = _typeInfoProvider.GetDefault(pgTypeId ?? PgTypeId);
-        ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
-        return result;
+        Debug.Assert(_defaultConcrete is not null);
+        return _defaultConcrete;
     }
 
     public PgConcreteTypeInfo? GetForField(Field field)

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -15,9 +15,27 @@ public abstract class PgTypeInfo
     PgTypeInfo(PgSerializerOptions options, Type type, Type? requestedType)
     {
         Options = options;
-
         HasExactType = requestedType is null || requestedType == type;
-        Type = requestedType is null ? type : GetReportedType(type, requestedType) ?? type;
+        Type = ResolveType(type, requestedType);
+    }
+
+    /// <summary>
+    /// Resolves the type the info should advertise. <paramref name="requestedType"/> must be on the same subtype
+    /// chain as <paramref name="type"/>: when narrower (or equal) it is returned as-is (the under-reporting case);
+    /// when wider <paramref name="type"/> is returned (the polymorphic-alias case, the info advertises the
+    /// converter's type back to a wider query). Throws when the two types are not in any subtype relationship.
+    /// </summary>
+    private protected static Type ResolveType(Type type, Type? requestedType)
+    {
+        if (requestedType is null || requestedType == type)
+            return type;
+        if (requestedType.IsAssignableTo(type))
+            return requestedType;
+        if (type.IsAssignableTo(requestedType))
+            return type;
+        throw new ArgumentException(
+            $"The requested type {requestedType} is not in a subtype relationship with the converter's type {type}.",
+            nameof(requestedType));
     }
 
     private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? requestedType = null)
@@ -30,16 +48,24 @@ public abstract class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
-    // True when the reported type matches the converter's type exactly (no reported type given at construction, or
-    // the given reported type equals the converter type). When false, the reported type is a widening of the converter
-    // type (e.g. Array/Stream base-type reporting, enum-underlying widening) and the caller must dispatch through the
-    // info — the info routes reference-variance cases through the object APIs and layout-identity cases (enum) through
-    // the typed path with Unsafe.As, as appropriate for the widening kind.
-    // Having a single converter cover multiple reported types (Arrays, Streams) reduces the number of generic
-    // instantiations that need to be compiled for AOT.
+    // Invariance bit on the (Converter.TypeToConvert, Type) pair: true when no requestedType was given or it equalled
+    // the converter type, false when Type and the converter type differ (in either direction along their shared
+    // subtype chain). False covers two construction cases that are indistinguishable downstream:
+    //   - Under-reporting: Type is narrower than the converter type (e.g. ArrayConverter<Array> answering as int[]).
+    //   - Polymorphic alias: Type is the converter type returned to a wider query (e.g. typeof(object)).
+    // When false the typed fast path is unsafe and dispatch routes through the AsObject APIs with a runtime cast,
+    // letting one converter cover multiple advertised types.
     internal bool HasExactType { get; }
 
     public PgTypeId? PgTypeId { get; }
+
+    // Same predicate used at construction (ResolveType) and at the cache to validate that an info answers a given query.
+    // Null requestedType: any info fits (PgTypeId-only queries).
+    // requestedType == Type: trivial match.
+    // Otherwise: only when this info acknowledges it isn't the exact answer (HasExactType=false) and Type sits below
+    // requestedType on the chain, covers polymorphic-alias and under-reporting in one branch.
+    internal bool ResolvesAs(Type? requestedType)
+        => requestedType is null || requestedType == Type || (!HasExactType && Type.IsAssignableTo(requestedType));
 
     /// <summary>
     /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field.
@@ -154,17 +180,6 @@ public abstract class PgTypeInfo
             disposable.Dispose();
     }
 
-    /// <summary>
-    /// Returns <paramref name="requestedType"/> when it is a strict subtype of <paramref name="converterType"/>, otherwise null.
-    /// Throws when the two are not in a subtype relationship.
-    /// </summary>
-    protected static Type? GetReportedType(Type converterType, Type requestedType)
-    {
-        if (!requestedType.IsInSubtypeRelationshipWith(converterType))
-            throw new ArgumentException($"The requested type {requestedType} is not in a subtype relationship with the converter's type {converterType}.", nameof(requestedType));
-
-        return requestedType != converterType && requestedType.IsAssignableTo(converterType) ? requestedType : null;
-    }
 }
 
 public sealed class PgProviderTypeInfo : PgTypeInfo
@@ -303,26 +318,22 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         SupportsWriting = true;
     }
 
-    Type TypeToConvert
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Converter.TypeToConvert;
-    }
-
     public PgConverter Converter { get; }
 
     public bool SupportsReading { get; init; }
     public bool SupportsWriting { get; init; }
 
-    // We assume a non-exact typed info does not support reading as the converter won't be able to produce the derived type statically.
-    // Cases like Array converters reading int[], int[,] etc. are the exception and the reason why SupportsReading is a settable property.
+    // Default reads false only when the resolved Type is narrower than the converter type (under-reporting case);
+    // caller can opt in to true via the init setter when they know the converter actually produces the narrower type.
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
-        => requestedType is null || GetReportedType(type, requestedType) is not { } reportedType || reportedType == type;
+        => type.IsAssignableTo(ResolveType(type, requestedType));
 
     public DataFormat? PreferredFormat { get; init; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();
 
-    internal bool CanReadTo(Type type) => Type == type || (!HasExactType && Type.IsAssignableTo(type));
+    // Cache hits are invariant in advertised type vs requested read type.
+    // A different request type means a different cache key, no matter how compatible the type chains are.
+    internal bool CanReadTo(Type type) => Type == type;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal T ReadFieldValue<T>(PgReader reader, in PgFieldBinding binding)
@@ -338,7 +349,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         await reader.StartReadAsync(binding, cancellationToken).ConfigureAwait(false);
 
         // Inline copy of Converter.ReadAsync<T> to keep everything in one async frame.
-        var result = typeof(T) != TypeToConvert
+        var result = typeof(T) != Converter.TypeToConvert
             ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
             : await Unsafe.As<PgConverter<T>>(Converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false);
 
@@ -371,7 +382,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     /// When result is null, the value was interpreted to be a SQL NULL.
     internal PgValueBinding BindParameterValue<T>(T? value, object? writeState, DataFormat? formatPreference = null)
     {
-        if (typeof(T) != TypeToConvert)
+        if (typeof(T) != Converter.TypeToConvert)
             return BindParameterObjectValue(value, writeState, formatPreference);
 
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -259,7 +259,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
         writeState = null;
         var result = _typeInfoProvider is PgConcreteTypeInfoProvider<T> providerT
-            ? providerT.GetForValue(context, value, ref writeState)
+            ? providerT.GetForValue(context, value, out writeState)
             : ThrowNotSupportedType(typeof(T));
 
         if (result is not null)
@@ -284,8 +284,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
         }
 
-        writeState = null;
-        var result = _typeInfoProvider.GetForValueAsObject(context, value, ref writeState);
+        var result = _typeInfoProvider.GetForValueAsObject(context, value, out writeState);
         if (result is not null)
             ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetForValueAsObject), result);
         return result;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -212,7 +212,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
         // Always validate the default provider result, the info will be re-used so there is no real downside.
         var result = typeInfoProvider.GetDefault(pgTypeId is { } id ? options.GetCanonicalTypeId(id) : null);
-        ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
+        ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
         _defaultConcrete = result;
     }
 
@@ -226,7 +226,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         else if (pgTypeId is not null)
         {
             var result = _typeInfoProvider.GetDefault(pgTypeId);
-            ValidateResult(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
+            ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetDefault), result);
             return result;
         }
 
@@ -241,7 +241,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
         var result = _typeInfoProvider.GetForField(field);
         if (result is not null)
-            ValidateResult(nameof(PgConcreteTypeInfoProvider.GetForField), result);
+            ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetForField), result);
         return result;
     }
 
@@ -263,7 +263,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
             : ThrowNotSupportedType(typeof(T));
 
         if (result is not null)
-            ValidateResult(nameof(PgConcreteTypeInfoProvider<>.GetForValue), result);
+            ValidateConcrete(nameof(PgConcreteTypeInfoProvider<>.GetForValue), result);
         return result;
 
         PgConcreteTypeInfo ThrowNotSupportedType(Type? type)
@@ -287,7 +287,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         writeState = null;
         var result = _typeInfoProvider.GetForValueAsObject(context, value, ref writeState);
         if (result is not null)
-            ValidateResult(nameof(PgConcreteTypeInfoProvider.GetForValueAsObject), result);
+            ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetForValueAsObject), result);
         return result;
     }
 
@@ -296,18 +296,22 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
     static void ThrowUnexpectedPgTypeId(string parameterName)
         => throw new ArgumentException($"PgTypeId does not match the decided value on this {nameof(PgProviderTypeInfo)}.", parameterName);
 
-    void ValidateResult(string methodName, PgConcreteTypeInfo result)
-        => ValidateResult(methodName, result, _typeInfoProvider.TypeToConvert, this, Options.PortableTypeIds);
-
-    static void ValidateResult(string methodName, PgConcreteTypeInfo result, Type expectedTypeToConvert, PgTypeInfo expected, bool expectPortableTypeIds)
+    void ValidateConcrete(string methodName, PgConcreteTypeInfo result)
     {
+        // Skip self-validation for framework-internal providers (e.g. composing infrastructure); see PgConcreteTypeInfoProvider.IsInternalProvider.
+        if (_typeInfoProvider.IsInternalProvider)
+            return;
+
+        var expectedTypeToConvert = _typeInfoProvider.TypeToConvert;
         if (expectedTypeToConvert != typeof(object) && result.Converter.TypeToConvert != expectedTypeToConvert)
             throw new InvalidOperationException($"'{methodName}' returned a {nameof(result.Converter)} of type {result.Converter.TypeToConvert} instead of {expectedTypeToConvert} unexpectedly.");
 
         // Plugins ship in-tree, so this fires in release. The result must fit the outer info's contract:
         // canonical when the outer is HasExactType=true, otherwise narrower-or-equal on the chain.
-        if (!expected.AcceptsResult(result))
-            throw new InvalidOperationException($"'{methodName}' returned a concrete type info advertising type {result.Type} which is incompatible with this info's contract (Type={expected.Type}, HasExactType={expected.HasExactType}).");
+        if (!AcceptsResult(result))
+            throw new InvalidOperationException($"'{methodName}' returned a concrete type info advertising type {result.Type} which is incompatible with this info's contract (Type={Type}, HasExactType={HasExactType}).");
+
+        var expectPortableTypeIds = Options.PortableTypeIds;
 
         if (expectPortableTypeIds && result.PgTypeId.IsOid || !expectPortableTypeIds && result.PgTypeId.IsDataTypeName)
             throw new InvalidOperationException($"'{methodName}' returned a concrete type info with a {nameof(result.PgTypeId)} that was not in canonical form.");

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -307,6 +307,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         : this(options, converter, pgTypeId, requestedType: null)
     {}
 
+    bool _supportsReading;
+    bool _supportsWriting;
+
     internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter converter, PgTypeId pgTypeId, Type? requestedType)
         : base(options, converter, pgTypeId, requestedType)
     {
@@ -314,19 +317,53 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         _canBinaryConvert = converter.CanConvert(DataFormat.Binary, out _binaryBufferRequirements);
         _canTextConvert = converter.CanConvert(DataFormat.Text, out _textBufferRequirements);
 
-        SupportsReading = GetDefaultSupportsReading(converter.TypeToConvert, requestedType);
-        SupportsWriting = true;
+        // Set fields directly to bypass init guards on default values; init props enforce directional widen-to-true.
+        _supportsReading = GetDefaultSupportsReading(converter.TypeToConvert, requestedType);
+        _supportsWriting = GetDefaultSupportsWriting(converter.TypeToConvert, requestedType);
     }
 
     public PgConverter Converter { get; }
 
-    public bool SupportsReading { get; init; }
-    public bool SupportsWriting { get; init; }
+    // Author widen-to-true is only meaningful in the under-reporting direction (Type narrower than the converter's
+    // type): the converter actually returns instances assignable to Type at runtime via author contract.
+    public bool SupportsReading
+    {
+        get => _supportsReading;
+        init
+        {
+            if (value && !_supportsReading && !Type.IsAssignableTo(Converter.TypeToConvert))
+                ThrowHelper.ThrowInvalidOperationException(
+                    $"Cannot widen {nameof(SupportsReading)} to true; reported type {Type} is not narrower-or-equal to converter type {Converter.TypeToConvert} (under-reporting direction).");
+            _supportsReading = value;
+        }
+    }
 
-    // Default reads false only when the resolved Type is narrower than the converter type (under-reporting case);
-    // caller can opt in to true via the init setter when they know the converter actually produces the narrower type.
+    // Author widen-to-true is only meaningful in the polymorphic-alias direction (Type wider than the converter's
+    // type), where the AsObject write path can route the wider inbound value through the narrower converter via cast.
+    public bool SupportsWriting
+    {
+        get => _supportsWriting;
+        init
+        {
+            if (value && !_supportsWriting && !Converter.TypeToConvert.IsAssignableTo(Type))
+                ThrowHelper.ThrowInvalidOperationException(
+                    $"Cannot widen {nameof(SupportsWriting)} to true; converter type {Converter.TypeToConvert} is not narrower-or-equal to reported type {Type} (polymorphic-alias direction).");
+            _supportsWriting = value;
+        }
+    }
+
+    // Defaults compute over the resolved Type (what the info will advertise), not the raw requestedType, so the
+    // wider-than-converter case naturally collapses to self-comparison.
+    //   - Exact (Type == converter type): both checks are self-comparisons → true.
+    //   - Under-reporting (Type narrower than converter type): read true (info.Type fits in caller's slot of the same
+    //     type), write false-ish (writing the narrower advertised type into the wider converter is safe via cast,
+    //     so this also returns true via assignability).
+    //   - Polymorphic alias (Type == converter type, requestedType wider): self-comparison → true.
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
         => type.IsAssignableTo(ResolveType(type, requestedType));
+
+    internal static bool GetDefaultSupportsWriting(Type type, Type? requestedType)
+        => ResolveType(type, requestedType).IsAssignableTo(type);
 
     public DataFormat? PreferredFormat { get; init; }
     public new PgTypeId PgTypeId => base.PgTypeId.GetValueOrDefault();

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -48,30 +48,39 @@ public abstract class PgTypeInfo
     public Type Type { get; }
     public PgSerializerOptions Options { get; }
 
-    // Forward-looking contract bit about the converter consumers will ultimately use through this info: true when the
-    // converter's type matches Type canonically, false when consumers should expect variation (the typed fast path is
-    // unsafe; dispatch routes through the AsObject APIs with a runtime cast).
-    //   - Concrete: false when (Converter.TypeToConvert, Type) differ in either direction along their shared subtype
-    //     chain (under-reporting or polymorphic alias).
-    //   - Provider: false when the underlying provider is polymorphic and will dispatch to varied concretes per call;
-    //     even though the wrapping pair (TypeToConvert, Type) is invariant, what flows out is not.
+    // Whether the eventual converter's type is exactly Type. False when what flows out can vary along the shared
+    // subtype chain (under-report, polymorphic alias).
+    //   - Concrete: false when (Converter.TypeToConvert, Type) differ.
+    //   - Provider: false when the underlying provider is polymorphic and dispatches to varied concretes per call,
+    //     even though the wrapping pair (Provider.TypeToConvert, Type) is invariant.
     internal bool HasExactType { get; private protected init; }
 
     public PgTypeId? PgTypeId { get; }
 
-    // Same predicate used at construction (ResolveType) and at the cache to validate that an info answers a given query.
-    // Null requestedType: any info fits (PgTypeId-only queries).
-    // requestedType == Type: trivial match.
-    // Otherwise: only when this info acknowledges it isn't the exact answer (HasExactType=false) and Type sits below
-    // requestedType on the chain, covers polymorphic-alias and under-reporting in one branch.
-    internal bool ResolvesAs(Type? requestedType)
-        => requestedType is null || requestedType == Type || (!HasExactType && Type.IsAssignableTo(requestedType));
+    // Shared validation. Throws if info doesn't belong to options or its Type isn't compatible with expectedType
+    // (when allowSubtypes is true, subtypes are accepted). Plugins ship in-tree, so this fires in release. Hot success
+    // path is the inlinable predicate. The cold throw path is factored out so callers only pay for the predicate when
+    // valid.
+    internal static void ValidateInfo(string contextName, PgTypeInfo info, PgSerializerOptions options, Type? expectedType, bool allowSubtypes)
+    {
+        if (info.Options != options || !IsCompatibleResolution(info.Type, expectedType, allowSubtypes))
+            Throw(contextName, info, options, expectedType, allowSubtypes);
 
-    // On the outer info (this), check whether a concrete result is admissible per the outer's contract.
-    // HasExactType=true requires canonical match (result.Type == Type); HasExactType=false admits narrower-or-equal
-    // results on the subtype chain. Used at provider boundaries to validate that concretes flowing out fit.
-    internal bool AcceptsResult(PgConcreteTypeInfo result)
-        => result.Type == Type || (!HasExactType && result.Type.IsAssignableTo(Type));
+        // Strict equality when allowSubtypes is false. Otherwise also admits subtypes of expectedType (covers polymorphic-alias
+        // and under-reporting). Null expectedType means "any", used by callers that care only about ownership.
+        static bool IsCompatibleResolution(Type? resolvedType, Type? expectedType, bool allowSubtypes)
+            => expectedType is null
+                || resolvedType is not null && (resolvedType == expectedType || (allowSubtypes && resolvedType.IsAssignableTo(expectedType)));
+
+        static void Throw(string contextName, PgTypeInfo info, PgSerializerOptions options, Type? expectedType, bool allowSubtypes)
+        {
+            if (info.Options != options)
+                throw new InvalidOperationException($"'{contextName}' returned a {nameof(PgTypeInfo)} from a different {nameof(PgSerializerOptions)} instance.");
+
+            if (!IsCompatibleResolution(info.Type, expectedType, allowSubtypes))
+                throw new InvalidOperationException($"'{contextName}' returned a {nameof(PgTypeInfo)} advertising type {info.Type} which is incompatible with expected type {expectedType}.");
+        }
+    }
 
     /// <summary>
     /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field.
@@ -301,19 +310,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         if (_typeInfoProvider.IsInternalProvider)
             return;
 
-        var expectedTypeToConvert = _typeInfoProvider.TypeToConvert;
-        if (expectedTypeToConvert != typeof(object) && result.Converter.TypeToConvert != expectedTypeToConvert)
-            throw new InvalidOperationException($"'{methodName}' returned a {nameof(result.Converter)} of type {result.Converter.TypeToConvert} instead of {expectedTypeToConvert} unexpectedly.");
-
-        // Plugins ship in-tree, so this fires in release. The result must fit the outer info's contract:
-        // canonical when the outer is HasExactType=true, otherwise narrower-or-equal on the chain.
-        if (!AcceptsResult(result))
-            throw new InvalidOperationException($"'{methodName}' returned a concrete type info advertising type {result.Type} which is incompatible with this info's contract (Type={Type}, HasExactType={HasExactType}).");
-
-        var expectPortableTypeIds = Options.PortableTypeIds;
-
-        if (expectPortableTypeIds && result.PgTypeId.IsOid || !expectPortableTypeIds && result.PgTypeId.IsDataTypeName)
-            throw new InvalidOperationException($"'{methodName}' returned a concrete type info with a {nameof(result.PgTypeId)} that was not in canonical form.");
+        ValidateInfo(methodName, result, Options, Type, allowSubtypes: !HasExactType);
     }
 }
 

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -372,12 +372,11 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     }
 
     // Defaults compute over the resolved Type (what the info will advertise), not the raw requestedType, so the
-    // wider-than-converter case naturally collapses to self-comparison.
-    //   - Exact (Type == converter type): both checks are self-comparisons → true.
-    //   - Under-reporting (Type narrower than converter type): read true (info.Type fits in caller's slot of the same
-    //     type), write false-ish (writing the narrower advertised type into the wider converter is safe via cast,
-    //     so this also returns true via assignability).
-    //   - Polymorphic alias (Type == converter type, requestedType wider): self-comparison → true.
+    // wider-than-converter case (polymorphic alias) collapses to self-comparison and yields reading=true, writing=true.
+    // The exact-type case (Type == converter type) does the same. Under-reporting (Type narrower than converter type)
+    // is asymmetric: the converter type is wider so it isn't assignable to Type, yielding reading=false (authors opt
+    // in via SupportsReading=true to assert their converter actually returns runtime instances of Type), while Type is
+    // narrower than the converter type, which is assignable, yielding writing=true.
     internal static bool GetDefaultSupportsReading(Type type, Type? requestedType)
         => type.IsAssignableTo(ResolveType(type, requestedType));
 

--- a/src/Npgsql/Internal/Postgres/PgTypeId.cs
+++ b/src/Npgsql/Internal/Postgres/PgTypeId.cs
@@ -25,6 +25,12 @@ public readonly struct PgTypeId: IEquatable<PgTypeId>
     public Oid Oid
         => IsOid ? _oid : throw new InvalidOperationException("This value does not describe an Oid.");
 
+    internal void Deconstruct(out Oid oid, out DataTypeName dataTypeName)
+    {
+        oid = _oid;
+        dataTypeName = _dataTypeName;
+    }
+
     public static implicit operator PgTypeId(DataTypeName name) => new(name);
     public static implicit operator PgTypeId(Oid id) => new(id);
 

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -104,8 +104,7 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             if (pgTypeId is not null && info.PgTypeId != pgTypeId)
                 throw new InvalidOperationException("A Postgres type was passed but the resolved PgTypeInfo does not have an equal PgTypeId.");
 
-            if (!info.ResolvesAs(type))
-                throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have a compatible type: {info.Type}.");
+            PgTypeInfo.ValidateInfo("resolver chain", info, options, type, allowSubtypes: !info.HasExactType);
 
             return info;
         }

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -72,14 +72,9 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             if (CreateInfo(type, pgTypeId, options, validatePgTypeIds) is not { } info)
                 return null;
 
-            var isDefaultInfo = type is null;
             if (infos is null)
             {
-                // Also add defaults by their info type to save a future resolver lookup + resize.
-                infos = isDefaultInfo
-                    ? new [] { (type, info), (info.Type, info) }
-                    : new [] { (type, info) };
-
+                infos = new [] { (type, info) };
                 if (_cacheByPgTypeId.TryAdd(pgTypeId, infos))
                     return info;
             }
@@ -91,19 +86,9 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
                 if (FindMatch(type, infos) is { } racedInfo)
                     return racedInfo;
 
-                // Also add defaults by their info type to save a future resolver lookup + resize.
                 var oldInfos = infos;
-                var hasExactType = false;
-                if (isDefaultInfo)
-                {
-                    foreach (var oldInfo in oldInfos)
-                        if (oldInfo.Type == info.Type)
-                            hasExactType = true;
-                }
-                Array.Resize(ref infos, oldInfos.Length + (isDefaultInfo && !hasExactType ? 2 : 1));
+                Array.Resize(ref infos, oldInfos.Length + 1);
                 infos[oldInfos.Length] = (type, info);
-                if (isDefaultInfo && !hasExactType)
-                    infos[oldInfos.Length + 1] = (info.Type, info);
 
                 if (_cacheByPgTypeId.TryUpdate(pgTypeId, infos, oldInfos))
                     return info;

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -20,17 +21,11 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             throw new InvalidOperationException("Cannot use this type argument.");
     }
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="type"></param>
-    /// <param name="pgTypeId"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
     public PgTypeInfo? GetOrAddInfo(Type? type, TPgTypeId? pgTypeId)
     {
-        if (pgTypeId is { } id)
+        if (pgTypeId.HasValue)
         {
+            ref readonly var id = ref Nullable.GetValueRefOrDefaultRef(in pgTypeId);
             if (_cacheByPgTypeId.TryGetValue(id, out var infos))
                 if (FindMatch(type, infos) is { } info)
                     return info;
@@ -55,6 +50,7 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             return null;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         PgTypeInfo? AddByType(Type type)
         {
             // We don't pass PgTypeId as we're interested in default converters here.
@@ -67,6 +63,7 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
                     : _cacheByClrType[type];
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         PgTypeInfo? AddEntryById(Type? type, TPgTypeId pgTypeId, (Type? Type, PgTypeInfo Info)[]? infos)
         {
             if (CreateInfo(type, pgTypeId, options, validatePgTypeIds) is not { } info)
@@ -74,7 +71,7 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
 
             if (infos is null)
             {
-                infos = new [] { (type, info) };
+                infos = [(type, info)];
                 if (_cacheByPgTypeId.TryAdd(pgTypeId, infos))
                     return info;
             }

--- a/src/Npgsql/Internal/TypeInfoCache.cs
+++ b/src/Npgsql/Internal/TypeInfoCache.cs
@@ -107,12 +107,8 @@ sealed class TypeInfoCache<TPgTypeId>(PgSerializerOptions options, bool validate
             if (pgTypeId is not null && info.PgTypeId != pgTypeId)
                 throw new InvalidOperationException("A Postgres type was passed but the resolved PgTypeInfo does not have an equal PgTypeId.");
 
-            if (type is not null && info.Type != type)
-            {
-                // Types were not equal, throw for HasExactType = true, otherwise we throw when the returned type isn't assignable to the requested type.
-                if (info.HasExactType || !info.Type.IsAssignableTo(type))
-                    throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have a compatible type: {info.Type}.");
-            }
+            if (!info.ResolvesAs(type))
+                throw new InvalidOperationException($"A CLR type '{type}' was passed but the resolved PgTypeInfo does not have a compatible type: {info.Type}.");
 
             return info;
         }

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -272,13 +272,13 @@ public sealed class TypeInfoMappingCollection
     {
         var mapping = new TypeInfoMapping(typeof(T), dataTypeName, createInfo);
         mapping = configure?.Invoke(mapping) ?? mapping;
+        _items.Add(mapping);
         if (typeof(T) != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
             _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
                 CreateComposedFactory(typeof(T), mapping, static (_, info) => ((PgConcreteTypeInfo)info).Converter, copyPreferredFormat: true))
             {
                 MatchRequirement = mapping.MatchRequirement
             });
-        _items.Add(mapping);
     }
 
     public void AddProviderType<T>(string dataTypeName, TypeInfoFactory createInfo, bool isDefault = false) where T : class
@@ -399,13 +399,13 @@ public sealed class TypeInfoMappingCollection
     {
         var mapping = new TypeInfoMapping(type, dataTypeName, createInfo);
         mapping = configure?.Invoke(mapping) ?? mapping;
+        _items.Add(mapping);
         if (type != typeof(object) && mapping.MatchRequirement is MatchRequirement.DataTypeName or MatchRequirement.Single && !TryGetMapping(typeof(object), mapping.DataTypeName, out _))
             _items.Add(new TypeInfoMapping(typeof(object), dataTypeName,
                 CreateComposedFactory(type, mapping, static (_, info) => ((PgConcreteTypeInfo)info).Converter, copyPreferredFormat: true))
             {
                 MatchRequirement = mapping.MatchRequirement
             });
-        _items.Add(mapping);
         _items.Add(new TypeInfoMapping(nullableType, dataTypeName,
             CreateComposedFactory(nullableType, mapping, nullableConverter, copyPreferredFormat: true))
             {

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -606,21 +606,21 @@ public sealed class TypeInfoMappingCollection
             {
                 var provider =
                     new PolymorphicArrayTypeInfoProvider<Array>((PgProviderTypeInfo)innerInfo,
-                        (PgProviderTypeInfo)nullableInnerInfo);
+                        (PgProviderTypeInfo)nullableInnerInfo, isCompositionalUnit: true);
 
                 return new PgProviderTypeInfo(innerInfo.Options, provider,
                     innerInfo.Options.GetCanonicalTypeId(new DataTypeName(dataTypeName)), requestedType: typeof(object));
             }
         }
 
-    public void AddPolymorphicProviderArrayType(string elementDataTypeName, Func<PgSerializerOptions, Func<PgConcreteTypeInfo, PgConverter>> elementToArrayConverterFactory)
+    internal void AddPolymorphicProviderArrayType(string elementDataTypeName, Func<PgSerializerOptions, Func<PgConcreteTypeInfo, PgConverter>> elementToArrayConverterFactory)
         => AddPolymorphicProviderArrayType(GetMapping(typeof(object), elementDataTypeName), elementToArrayConverterFactory);
 
-    public void AddPolymorphicProviderArrayType(TypeInfoMapping elementMapping, Func<PgSerializerOptions, Func<PgConcreteTypeInfo, PgConverter>> elementToArrayConverterFactory)
+    internal void AddPolymorphicProviderArrayType(TypeInfoMapping elementMapping, Func<PgSerializerOptions, Func<PgConcreteTypeInfo, PgConverter>> elementToArrayConverterFactory)
     {
         AddPolymorphicProviderArrayType(elementMapping, typeof(object),
             (mapping, elementInfo) => new PolymorphicArrayTypeInfoProvider(
-                elementInfo.Options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), elementInfo, elementToArrayConverterFactory(elementInfo.Options))
+                elementInfo.Options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), elementInfo, elementToArrayConverterFactory(elementInfo.Options), isCompositionalUnit: true)
         , null);
 
         void AddPolymorphicProviderArrayType(TypeInfoMapping elementMapping, Type type, Func<TypeInfoMapping, PgProviderTypeInfo, PgConcreteTypeInfoProvider> converter, Func<Type?, bool>? typeMatchPredicate)

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -209,7 +209,8 @@ public sealed class TypeInfoMappingCollection
             var preferredFormat = copyPreferredFormat ? innerConcrete.PreferredFormat : null;
             var readingSupported = innerConcrete.SupportsReading
                                    && (supportsReading ?? PgConcreteTypeInfo.GetDefaultSupportsReading(converter.TypeToConvert, requestedType: mapping.Type));
-            var writingSupported = innerConcrete.SupportsWriting && (supportsWriting ?? true);
+            var writingSupported = innerConcrete.SupportsWriting
+                                   && (supportsWriting ?? PgConcreteTypeInfo.GetDefaultSupportsWriting(converter.TypeToConvert, requestedType: mapping.Type));
 
             return new PgConcreteTypeInfo(options, converter, options.GetCanonicalTypeId(new DataTypeName(mapping.DataTypeName)), requestedType: mapping.Type)
             {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2165,11 +2165,11 @@ LANGUAGE plpgsql VOLATILE";
         await using var reader = await cmd.ExecuteReaderAsync(Behavior);
 
         Assert.That(await reader.ReadAsync(), Is.True);
-        var custom = reader.GetFieldValue<CustomStream>(0);
+        using var custom = reader.GetFieldValue<CustomStream>(0);
         Assert.That(custom, Is.InstanceOf<CustomStream>());
 
         Assert.That(await reader.ReadAsync(), Is.True);
-        var general = reader.GetFieldValue<Stream>(0);
+        using var general = reader.GetFieldValue<Stream>(0);
         Assert.That(general, Is.Not.InstanceOf<CustomStream>(),
             "Reader cache aliased the CustomStream-specific info onto a Stream query — the resolver chain must be re-consulted on type change.");
     }
@@ -2680,16 +2680,18 @@ sealed class CustomStreamConverter : PgStreamingConverter<Stream>
 {
     public override Stream Read(PgReader reader)
     {
+        using var bytes = reader.GetStream();
         var ms = new CustomStream();
-        reader.GetStream().CopyTo(ms);
+        bytes.CopyTo(ms);
         ms.Position = 0;
         return ms;
     }
 
     public override async ValueTask<Stream> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
     {
+        await using var bytes = reader.GetStream();
         var ms = new CustomStream();
-        await reader.GetStream().CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        await bytes.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
         ms.Position = 0;
         return ms;
     }

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2153,6 +2153,27 @@ LANGUAGE plpgsql VOLATILE";
         Assert.That(connection.State, Is.EqualTo(ConnectionState.Closed));
     }
 
+    [Test, Description("Per-ordinal conversion cache must be invariant in advertised type vs requested read type — a chain-compatible cached entry from a prior typed read must not satisfy a query for a different type, the resolver chain has to be re-consulted.")]
+    public async Task ReaderCache_invariant_in_read_type()
+    {
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.AddTypeInfoResolverFactory(new CustomStreamResolverFactory());
+        await using var dataSource = dataSourceBuilder.Build();
+        await using var connection = await dataSource.OpenConnectionAsync();
+
+        await using var cmd = new NpgsqlCommand(@"SELECT '\x01'::bytea UNION ALL SELECT '\x02'::bytea", connection);
+        await using var reader = await cmd.ExecuteReaderAsync(Behavior);
+
+        Assert.That(await reader.ReadAsync(), Is.True);
+        var custom = reader.GetFieldValue<CustomStream>(0);
+        Assert.That(custom, Is.InstanceOf<CustomStream>());
+
+        Assert.That(await reader.ReadAsync(), Is.True);
+        var general = reader.GetFieldValue<Stream>(0);
+        Assert.That(general, Is.Not.InstanceOf<CustomStream>(),
+            "Reader cache aliased the CustomStream-specific info onto a Stream query — the resolver chain must be re-consulted on type change.");
+    }
+
     #region Cancellation
 
     [Test, Description("Cancels ReadAsync via the NpgsqlCommand.Cancel, with successful PG cancellation")]
@@ -2629,6 +2650,53 @@ sealed class ExplodingTypeHandlerResolverFactory(bool safe) : PgTypeInfoResolver
             return null;
         }
     }
+}
+
+sealed class CustomStream : MemoryStream;
+
+sealed class CustomStreamResolverFactory : PgTypeInfoResolverFactory
+{
+    public override IPgTypeInfoResolver CreateResolver() => new Resolver();
+    public override IPgTypeInfoResolver? CreateArrayResolver() => null;
+
+    sealed class Resolver : IPgTypeInfoResolver
+    {
+        // Converter handles Stream but the info advertises CustomStream — HasExactType=false (under-reporting), which is
+        // the construction shape that previously enabled the cache's variance-tolerant CanReadTo to alias this info onto
+        // a Stream query.
+        public PgTypeInfo? GetTypeInfo(Type? type, DataTypeName? dataTypeName, PgSerializerOptions options)
+            => type == typeof(CustomStream) && dataTypeName == DataTypeNames.Bytea
+                ? new PgConcreteTypeInfo(options, new CustomStreamConverter(), DataTypeNames.Bytea, requestedType: typeof(CustomStream))
+                {
+                    // Under-reporting: converter produces Stream values that are actually CustomStream instances.
+                    SupportsReading = true,
+                    SupportsWriting = false,
+                }
+                : null;
+    }
+}
+
+sealed class CustomStreamConverter : PgStreamingConverter<Stream>
+{
+    public override Stream Read(PgReader reader)
+    {
+        var ms = new CustomStream();
+        reader.GetStream().CopyTo(ms);
+        ms.Position = 0;
+        return ms;
+    }
+
+    public override async ValueTask<Stream> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
+    {
+        var ms = new CustomStream();
+        await reader.GetStream().CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+        ms.Position = 0;
+        return ms;
+    }
+
+    public override Size GetSize(SizeContext context, Stream value, ref object? writeState) => throw new NotSupportedException();
+    public override void Write(PgWriter writer, Stream value) => throw new NotSupportedException();
+    public override ValueTask WriteAsync(PgWriter writer, Stream value, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 }
 
 class ExplodingTypeHandler : PgBufferedConverter<int>


### PR DESCRIPTION
Generated summary:

**Correctness fixes**
  - Remove unprincipled cross caching optimization. Pre-populating _cacheByPgTypeId with (info.Type, info) from a default-by-type lookup violated the resolver chain's authority to answer info.Type differently when queried directly.

**Cache-hit enhancements**
  - Fix _defaultConcrete opt. Broadens the cached-default-concrete fast path on PgProviderTypeInfo. Previously only hit when both pgTypeId arg and decided PgTypeId were present; now hits whenever the cache answers the request (decided cases skip regardless of arg; undecided plus no-arg also skips).

**PgTypeInfo reshape**
  - Centralize chain-membership predicate. ResolvesAs / AcceptsResult on PgTypeInfo as the single chain-membership check, replacing scattered HasExactType + IsAssignableTo checks across cache validation and provider validation.
  - Default-derive SupportsReading/SupportsWriting. Variance-direction guards on SupportsReading/SupportsWriting to prevent 'upgrading' support past chain validity for the given variance direction.
 - Fully share validation between providers (tier2) and cache (tier1). Centralize PgTypeInfo.ValidateInfo static helper consumed by both TypeInfoCache.CreateInfo and PgProviderTypeInfo.ValidateConcrete. Options reference-equality replaces canonical-PgTypeId-form check. Per-call PgTypeId and Converter T-match checks moved out (layer-local enforcement / cast at use site).

**Provider validation reshape**
  - Refine checks for providers. Sharper validation in ValidateConcrete.
  - Add internal opt-out for provider concrete validation. IsInternalProvider flag lets framework composing infrastructure skip self-validation while plugins still get the contract enforced.
  - Optimize provider pg type id invariant checks.

**Composition + dispatch**
  - Add compositional unit flag. IsCompositionalUnit plus dispatch helpers (GetEffectiveDefault etc.) on PgComposingTypeInfoProvider, with AggressiveInlining to force late devirt and constant fold. Skips wrapping-info validation when composer and inner are authored together.
  - Remove per element overhead by honoring IsCompositionalUnit. Applies that flag to drop per-element wrapping validation in array/casting paths.
  - Move providers to return state by out. writeState out at public boundaries, ref on *Core. Cleaner write-state lifecycle contract.
  - More compositional unit opts. Add isCompositionalUnit ctor flag on the polymorphic array providers to skip wrapping ValidateConcrete when caller is same-authoring-unit. Internalize AddPolymorphicProviderArrayType and AllowConcreteVariance (framework-only).                                                                                         

**Resolver cache micro-opts**
  - Micro opts for resolver cache. Typed _oidCache / _dataTypeNameCache (drops CHKCASTCLASS guard), Deconstruct on PgTypeId, Nullable.GetValueRefOrDefaultRef plus deconstruct pattern at the cache boundary (drops the lift-from-Nullable stack copy). ~50% faster cache hit when cache contains one entry, ~5.6 to ~2.8ns.

**Tests**
  - 68 lines added to test/Npgsql.Tests/ReaderTests.cs: ReaderCache_invariant_in_read_type test for the per-ordinal reader cache. A chain-compatible cached entry from a prior typed read (HasExactType=false, e.g. CustomStream advertised by a Stream-producing converter) must not satisfy a query for a different type like Stream, even if it's type compatible. The resolver chain stays authoritative on type change. Brings in CustomStream and CustomStreamResolverFactory test helpers.