### PR TITLE
Rework converter db null and CLR null handling

### DIFF
--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -121,7 +121,7 @@ abstract class CompositeFieldInfo
         return new();
 
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
-        async ValueTask Core(CompositeBuilder builder, ValueTask<object> task)
+        async ValueTask Core(CompositeBuilder builder, ValueTask<object?> task)
         {
             builder.AddValue(await task.ConfigureAwait(false));
         }
@@ -148,7 +148,7 @@ abstract class CompositeFieldInfo
     public abstract Type Type { get; }
 
     protected abstract PgConverter BindValue(object instance, out Size writeRequirement, out object? writeState);
-    protected abstract void AddValue(CompositeBuilder builder, object value);
+    protected abstract void AddValue(CompositeBuilder builder, object? value);
 
     public abstract StrongBox CreateBox();
     public abstract void Set(object instance, StrongBox value);
@@ -251,7 +251,7 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
         return concreteTypeInfo.Converter;
     }
 
-    protected override void AddValue(CompositeBuilder builder, object value) => builder.AddValue((T)value);
+    protected override void AddValue(CompositeBuilder builder, object? value) => builder.AddValue((T)value!);
 
     public override ValueTask Read(bool async, PgConverter converter, CompositeBuilder builder, PgReader reader, CancellationToken cancellationToken = default)
     {

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -127,7 +127,7 @@ abstract class CompositeFieldInfo
         }
     }
 
-    protected ValueTask WriteAsObject(bool async, PgConverter converter, PgWriter writer, object value, CancellationToken cancellationToken)
+    protected ValueTask WriteAsObject(bool async, PgConverter converter, PgWriter writer, object? value, CancellationToken cancellationToken)
     {
         if (async)
             return converter.WriteAsObjectAsync(writer, value, cancellationToken);
@@ -166,10 +166,10 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
 {
     readonly Action<object, T>? _setter;
     readonly int _parameterIndex;
-    readonly Func<object, T> _getter;
+    readonly Func<object?, T> _getter;
     readonly bool _asObject;
 
-    CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object, T> getter)
+    CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object?, T> getter)
         : base(name, typeInfo, nominalPgTypeId)
     {
         if (typeInfo.Type != typeof(T))
@@ -190,12 +190,12 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     }
 
     // Accessed through reflection (ReflectionCompositeInfoFactory)
-    public CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object, T> getter, int parameterIndex)
+    public CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object?, T> getter, int parameterIndex)
         : this(name, typeInfo, nominalPgTypeId, getter)
         => _parameterIndex = parameterIndex;
 
     // Accessed through reflection (ReflectionCompositeInfoFactory)
-    public CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object, T> getter, Action<object, T> setter)
+    public CompositeFieldInfo(string name, PgTypeInfo typeInfo, PgTypeId nominalPgTypeId, Func<object?, T> getter, Action<object, T> setter)
         : this(name, typeInfo, nominalPgTypeId, getter)
         => _setter = setter;
 
@@ -295,16 +295,16 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
             : ((PgConverter<T>)converter).IsDbNullOrGetSize(format, writeRequirement, value, ref writeState);
     }
 
-    public override ValueTask Write(bool async, PgConverter converter, PgWriter writer, object instance, CancellationToken cancellationToken)
+    public override ValueTask Write(bool async, PgConverter converter, PgWriter writer, object? instance, CancellationToken cancellationToken)
     {
         var value = _getter(instance);
         if (AsObject(converter))
-            return WriteAsObject(async, converter, writer, value!, cancellationToken);
+            return WriteAsObject(async, converter, writer, value, cancellationToken);
 
         if (async)
-            return ((PgConverter<T>)converter).WriteAsync(writer, value!, cancellationToken);
+            return ((PgConverter<T>)converter).WriteAsync(writer, value, cancellationToken);
 
-        ((PgConverter<T>)converter).Write(writer, value!);
+        ((PgConverter<T>)converter).Write(writer, value);
         return new();
     }
 }

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -288,8 +288,10 @@ sealed class CompositeFieldInfo<T> : CompositeFieldInfo
     public override Size? IsDbNullOrGetSize(PgConverter converter, DataFormat format, Size writeRequirement, object instance, ref object? writeState)
     {
         var value = _getter(instance);
+        // Composite fields cross the POCO boundary: ADO sentinel vocabulary does not flow in, so the field's converter
+        // is invoked under Default regardless of how the composite itself was reached (e.g. an Extended parameter).
         return AsObject(converter)
-            ? converter.IsDbNullOrGetSizeAsObject(format, writeRequirement, value, ref writeState)
+            ? converter.IsDbNullOrGetSizeAsObject(format, writeRequirement, value, ref writeState, NestedObjectDbNullHandling.Default)
             : ((PgConverter<T>)converter).IsDbNullOrGetSize(format, writeRequirement, value, ref writeState);
     }
 

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -15,8 +15,11 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
 {
     readonly ArrayConverterCore _arrayConverterCore;
 
+    protected PgConcreteTypeInfo ElementTypeInfo { get; }
+
     private protected ArrayConverter(int? expectedDimensions, PgConcreteTypeInfo elementTypeInfo, int pgLowerBound = 1)
     {
+        ElementTypeInfo = elementTypeInfo;
         if (!elementTypeInfo.Converter.CanConvert(DataFormat.Binary, out var bufferRequirements))
             throw new NotSupportedException("Element converter has to support the binary format to be compatible.");
 
@@ -138,7 +141,12 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
             => ArrayConverterCore.GetArrayLengths((Array)collection, out lengths);
 
         Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
-            => _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, GetValue(collection, indices), ref writeState);
+        {
+            var value = GetValue(collection, indices);
+            return typeof(TElement) == typeof(object)
+                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value!, ref writeState)
+                : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
+        }
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)
         {
@@ -208,7 +216,12 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         }
 
         Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
-            => _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, GetValue(collection, indices.One), ref writeState);
+        {
+            var value = GetValue(collection, indices.One);
+            return typeof(TElement) == typeof(object)
+                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value!, ref writeState)
+                : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
+        }
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)
         {
@@ -291,7 +304,9 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out _), null);
             foreach (var value in array)
             {
-                var result = GetEffectiveForValue(effectiveContext, value, out var state);
+                var result = typeof(TElement) == typeof(object)
+                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -322,7 +337,9 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = GetEffectiveForValue(effectiveContext, value, out var state);
+                var result = typeof(TElement) == typeof(object)
+                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -353,7 +370,9 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(list.Count, null);
             foreach (var value in list)
             {
-                var result = GetEffectiveForValue(effectiveContext, value, out var state);
+                var result = typeof(TElement) == typeof(object)
+                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -384,7 +403,9 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             metadata = PgArrayMetadata.Create(ArrayConverterCore.GetArrayLengths(array, out var dimensionLengths), dimensionLengths);
             foreach (var value in array)
             {
-                var result = GetEffectiveForValue(effectiveContext, value, out var state);
+                var result = typeof(TElement) == typeof(object)
+                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    : GetEffectiveForValueAsObject(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
                     elemDataArrayPool = ArrayPool<(Size, object?)>.Shared;
@@ -423,6 +444,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             {
                 Metadata = metadata,
                 IterationIndices = metadata.CreateIndices(),
+                NestedObjectDbNullHandling = effectiveContext.NestedObjectDbNullHandling,
                 ArrayPool = elemDataArrayPool,
                 Data = new(elemData, 0, index),
                 AnyWriteState = true

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -144,7 +144,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         {
             var value = GetValue(collection, indices);
             return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value!, ref writeState)
+                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
                 : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 
@@ -219,7 +219,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         {
             var value = GetValue(collection, indices.One);
             return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value!, ref writeState)
+                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
                 : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -144,7 +144,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         {
             var value = GetValue(collection, indices);
             return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
+                ? _elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
                 : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 
@@ -219,7 +219,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         {
             var value = GetValue(collection, indices.One);
             return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsNestedObjectDbNull(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
+                ? _elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
                 : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 
@@ -305,7 +305,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in array)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
                     : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
@@ -338,7 +338,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in list)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
                     : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
@@ -371,7 +371,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in list)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
                     : GetEffectiveForValue(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {
@@ -404,7 +404,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in array)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForNestedObjectValue(effectiveContext, value, out var state)
+                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
                     : GetEffectiveForValueAsObject(effectiveContext, value, out state);
                 if (state is not null && elemData is null)
                 {

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -143,9 +143,15 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
         {
             var value = GetValue(collection, indices);
-            return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
-                : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
+            if (typeof(TElement) == typeof(object))
+            {
+                if (_elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling))
+                    return null;
+                if (context.BufferRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
+                    return byteCount;
+                return _elemConverter.GetSizeAsObject(context, value, ref writeState);
+            }
+            return _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)
@@ -218,9 +224,15 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         Size? IElementOperations.IsDbNullOrGetSize(SizeContext context, object collection, IterationIndices indices, ref object? writeState)
         {
             var value = GetValue(collection, indices.One);
-            return typeof(TElement) == typeof(object)
-                ? _elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling) ? null : _elemConverter.GetSizeAsObject(context, value, ref writeState)
-                : _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
+            if (typeof(TElement) == typeof(object))
+            {
+                if (_elemConverter.IsDbNullAsNestedObject(value, writeState, context.NestedObjectDbNullHandling))
+                    return null;
+                if (context.BufferRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
+                    return byteCount;
+                return _elemConverter.GetSizeAsObject(context, value, ref writeState);
+            }
+            return _elemConverter.IsDbNullOrGetSize(context.Format, context.BufferRequirement, value, ref writeState);
         }
 
         ValueTask IElementOperations.Read(bool async, PgReader reader, bool isDbNull, object collection, IterationIndices indices, CancellationToken cancellationToken)

--- a/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
@@ -35,14 +35,14 @@ readonly struct ArrayConverterCore(
     PgTypeInfo ElementTypeInfo { get; } = elementTypeInfo;
     bool ElemTypeDbNullable { get; } = elemTypeDbNullable;
 
-    bool IsDbNull(object values, IterationIndices arrayIndices, object? writeState)
+    bool IsDbNull(SizeContext context, object values, IterationIndices arrayIndices, object? writeState)
     {
         // This call will only skip GetSize if we are dealing with fixed size elements, otherwise we'll repeat sizing costs.
         // Fixed-size element converters cannot produce per-value write state, so IsDbNullOrGetSize must
         // leave writeState alone — any mutation is a contract violation in the element converter.
         Debug.Assert(binaryRequirements.Write.Kind is SizeKind.Exact);
         var originalWriteState = writeState;
-        var isDbNull = elemOps.IsDbNullOrGetSize(new(DataFormat.Binary, binaryRequirements.Write), values, arrayIndices, ref writeState) is null;
+        var isDbNull = elemOps.IsDbNullOrGetSize(context, values, arrayIndices, ref writeState) is null;
         Debug.Assert(ReferenceEquals(writeState, originalWriteState), "Fixed-size element converter mutated writeState during a null probe.");
         return isDbNull;
     }
@@ -88,9 +88,10 @@ readonly struct ArrayConverterCore(
             var lastLength = metadata.LastDimension;
             if (ElemTypeDbNullable)
             {
+                var elemContext = new SizeContext(context.Format, binaryRequirements.Write) { NestedObjectDbNullHandling = context.NestedObjectDbNullHandling };
                 do
                 {
-                    if (IsDbNull(values, indices, elemData?[indices.IndicesSum].WriteState))
+                    if (IsDbNull(elemContext, values, indices, elemData?[indices.IndicesSum].WriteState))
                         nulls++;
                 }
                 while (indices.TryAdvance(lastLength, metadata.DimensionLengths));
@@ -129,7 +130,8 @@ readonly struct ArrayConverterCore(
         var result = providerState ?? new()
         {
             Metadata = metadata,
-            IterationIndices = indices
+            IterationIndices = indices,
+            NestedObjectDbNullHandling = context.NestedObjectDbNullHandling
         };
         if (elemData is not null)
         {
@@ -269,6 +271,7 @@ readonly struct ArrayConverterCore(
         var lastCount = metadata.LastDimension;
         var offset = state.Data.Offset;
         var fixedSizeElements = state.FixedSizeElements;
+        var elemContext = new SizeContext(writer.Current.Format, binaryRequirements.Write) { NestedObjectDbNullHandling = state.NestedObjectDbNullHandling };
         do
         {
             if (writer.ShouldFlush(sizeof(int)))
@@ -276,7 +279,7 @@ readonly struct ArrayConverterCore(
 
             var elem = elemData?[offset + indices.IndicesSum] ?? default;
             var length = fixedSizeElements
-                ? ElemTypeDbNullable && IsDbNull(values, indices, elem.WriteState) ? -1 : binaryRequirements.Write.Value
+                ? ElemTypeDbNullable && IsDbNull(elemContext, values, indices, elem.WriteState) ? -1 : binaryRequirements.Write.Value
                 : elem.Size.Value;
 
             writer.WriteInt32(length);
@@ -345,6 +348,7 @@ sealed class ArrayConverterWriteState : MultiWriteState
 {
     public required PgArrayMetadata Metadata { get; init; }
     public required IterationIndices IterationIndices { get; init; }
+    public required NestedObjectDbNullHandling NestedObjectDbNullHandling { get; init; }
 
     /// When true, all non-null elements have a fixed binary size and Data is not populated with per-element sizes.
     public bool FixedSizeElements { get; set; }

--- a/src/Npgsql/Internal/Converters/AsyncHelpers.cs
+++ b/src/Npgsql/Internal/Converters/AsyncHelpers.cs
@@ -125,7 +125,7 @@ static class AsyncHelpers
         // Cheap if we have all the data.
         var task = effectiveConverter.ReadAsObjectAsync(reader, cancellationToken);
         if (task.IsCompletedSuccessfully)
-            return new((T)task.Result);
+            return new((T)task.Result!);
 
         // Otherwise we do one additional allocation, this allows us to share state machine codegen for all Ts.
         var source = new PoolingCompletionSource<T>();

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -40,26 +40,26 @@ public sealed class CastingConverter<T> : PgConverter<T>
         => this.ReadAsObjectAsyncAsT(_effectiveConverter, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, T value, ref object? writeState)
-        => _effectiveConverter.GetSizeAsObject(context, value!, ref writeState);
+        => _effectiveConverter.GetSizeAsObject(context, value, ref writeState);
 
     public override void Write(PgWriter writer, T value)
-        => _effectiveConverter.WriteAsObject(writer, value!);
+        => _effectiveConverter.WriteAsObject(writer, value);
 
     public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
-        => _effectiveConverter.WriteAsObjectAsync(writer, value!, cancellationToken);
+        => _effectiveConverter.WriteAsObjectAsync(writer, value, cancellationToken);
 
     internal override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => async
             ? _effectiveConverter.ReadAsObjectAsync(reader, cancellationToken)
             : new(_effectiveConverter.ReadAsObject(reader));
 
-    internal override ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken)
+    internal override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
     {
         // Cast here to keep our T contract, and otherwise return more accurate invalid cast exceptions (as the effective converter will cast as well).
         if (async)
-            return _effectiveConverter.WriteAsObjectAsync(writer, (T)value, cancellationToken);
+            return _effectiveConverter.WriteAsObjectAsync(writer, (T)value!, cancellationToken);
 
-        _effectiveConverter.WriteAsObject(writer, (T)value);
+        _effectiveConverter.WriteAsObject(writer, (T)value!);
         return new();
     }
 }

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -34,7 +34,7 @@ public sealed class CastingConverter<T> : PgConverter<T>
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
         => _effectiveConverter.CanConvert(format, out bufferRequirements);
 
-    public override T Read(PgReader reader) => (T)_effectiveConverter.ReadAsObject(reader);
+    public override T Read(PgReader reader) => (T)_effectiveConverter.ReadAsObject(reader)!;
 
     public override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => this.ReadAsObjectAsyncAsT(_effectiveConverter, reader, cancellationToken);
@@ -48,7 +48,7 @@ public sealed class CastingConverter<T> : PgConverter<T>
     public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
         => _effectiveConverter.WriteAsObjectAsync(writer, value, cancellationToken);
 
-    internal override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+    internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => async
             ? _effectiveConverter.ReadAsObjectAsync(reader, cancellationToken)
             : new(_effectiveConverter.ReadAsObject(reader));

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -9,13 +9,17 @@ using Npgsql.Util;
 namespace Npgsql.Internal.Converters;
 
 /// A converter that adapts a boxed converter's results to an exact-type converter over T, wrapping the read/write
-/// paths through object to present a typed surface for a converter whose TypeToConvert is only a base of T.
+/// paths through object to present a typed surface for a converter whose TypeToConvert is in a subtype relationship
+/// with T — a base, a subtype, or a boxing target (e.g. an int? converter backing a CastingConverter for object).
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class CastingConverter<T> : PgConverter<T>
 {
     readonly PgConverter _effectiveConverter;
 
-    public CastingConverter(PgConverter effectiveConverter) : base(effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+    public CastingConverter(PgConverter effectiveConverter)
+        : base(
+            effectiveType: effectiveConverter.TypeToConvert,
+            customDbNullPredicate: effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
     {
         if (!typeof(T).IsInSubtypeRelationshipWith(effectiveConverter.TypeToConvert))
             throw new ArgumentException(

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -17,9 +17,7 @@ public sealed class CastingConverter<T> : PgConverter<T>
     readonly PgConverter _effectiveConverter;
 
     public CastingConverter(PgConverter effectiveConverter)
-        : base(
-            effectiveType: effectiveConverter.TypeToConvert,
-            customDbNullPredicate: effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+        : base(effectiveType: effectiveConverter.TypeToConvert)
     {
         if (!typeof(T).IsInSubtypeRelationshipWith(effectiveConverter.TypeToConvert))
             throw new ArgumentException(
@@ -27,6 +25,7 @@ public sealed class CastingConverter<T> : PgConverter<T>
                 nameof(effectiveConverter));
 
         _effectiveConverter = effectiveConverter;
+        HandleDbNull = effectiveConverter.HandleDbNull;
     }
 
     protected override bool IsDbNullValue(T? value, object? writeState) => _effectiveConverter.IsDbNullAsObject(value, writeState);

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -32,7 +32,7 @@ sealed class NullableConverter<T>(PgConverter<T> effectiveConverter)
     public override ValueTask WriteAsync(PgWriter writer, T? value, CancellationToken cancellationToken = default)
         => effectiveConverter.WriteAsync(writer, value.GetValueOrDefault(), cancellationToken);
 
-    internal override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+    internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => effectiveConverter.ReadAsObject(async, reader, cancellationToken);
 
     internal override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -7,36 +7,43 @@ namespace Npgsql.Internal.Converters;
 
 // NULL writing is always responsibility of the caller writing the length, so there is not much we do here.
 /// Special value converter to be able to use struct converters as System.Nullable converters, it delegates all behavior to the effective converter.
-sealed class NullableConverter<T>(PgConverter<T> effectiveConverter)
-    : PgConverter<T?>(effectiveConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+sealed class NullableConverter<T> : PgConverter<T?>
     where T : struct
 {
+    readonly PgConverter<T> _effectiveConverter;
+
+    public NullableConverter(PgConverter<T> effectiveConverter)
+    {
+        _effectiveConverter = effectiveConverter;
+        HandleDbNull = effectiveConverter.HandleDbNull;
+    }
+
     protected override bool IsDbNullValue(T? value, object? writeState)
-        => value is null || effectiveConverter.IsDbNull(value.GetValueOrDefault(), writeState);
+        => value is null || _effectiveConverter.IsDbNull(value.GetValueOrDefault(), writeState);
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
-        => effectiveConverter.CanConvert(format, out bufferRequirements);
+        => _effectiveConverter.CanConvert(format, out bufferRequirements);
 
     public override T? Read(PgReader reader)
-        => effectiveConverter.Read(reader);
+        => _effectiveConverter.Read(reader);
 
     public override ValueTask<T?> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
-        => this.ReadAsyncAsNullable(effectiveConverter, reader, cancellationToken);
+        => this.ReadAsyncAsNullable(_effectiveConverter, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, T? value, ref object? writeState)
-        => effectiveConverter.GetSize(context, value.GetValueOrDefault(), ref writeState);
+        => _effectiveConverter.GetSize(context, value.GetValueOrDefault(), ref writeState);
 
     public override void Write(PgWriter writer, T? value)
-        => effectiveConverter.Write(writer, value.GetValueOrDefault());
+        => _effectiveConverter.Write(writer, value.GetValueOrDefault());
 
     public override ValueTask WriteAsync(PgWriter writer, T? value, CancellationToken cancellationToken = default)
-        => effectiveConverter.WriteAsync(writer, value.GetValueOrDefault(), cancellationToken);
+        => _effectiveConverter.WriteAsync(writer, value.GetValueOrDefault(), cancellationToken);
 
     internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
-        => effectiveConverter.ReadAsObject(async, reader, cancellationToken);
+        => _effectiveConverter.ReadAsObject(async, reader, cancellationToken);
 
     internal override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
-        => effectiveConverter.WriteAsObject(async, writer, value, cancellationToken);
+        => _effectiveConverter.WriteAsObject(async, writer, value, cancellationToken);
 }
 
 sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
@@ -24,7 +23,7 @@ sealed class NullableConverter<T>(PgConverter<T> effectiveConverter)
     public override ValueTask<T?> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => this.ReadAsyncAsNullable(effectiveConverter, reader, cancellationToken);
 
-    public override Size GetSize(SizeContext context, [DisallowNull]T? value, ref object? writeState)
+    public override Size GetSize(SizeContext context, T? value, ref object? writeState)
         => effectiveConverter.GetSize(context, value.GetValueOrDefault(), ref writeState);
 
     public override void Write(PgWriter writer, T? value)
@@ -36,7 +35,7 @@ sealed class NullableConverter<T>(PgConverter<T> effectiveConverter)
     internal override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => effectiveConverter.ReadAsObject(async, reader, cancellationToken);
 
-    internal override ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken)
+    internal override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
         => effectiveConverter.WriteAsObject(async, writer, value, cancellationToken);
 }
 

--- a/src/Npgsql/Internal/Converters/ObjectConverter.cs
+++ b/src/Npgsql/Internal/Converters/ObjectConverter.cs
@@ -6,8 +6,10 @@ using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
 
-sealed class ObjectConverter() : PgStreamingConverter<object>(customDbNullPredicate: true)
+sealed class ObjectConverter : PgStreamingConverter<object>
 {
+    public ObjectConverter() => HandleDbNull = true;
+
     protected override bool IsDbNullValue(object? value, object? writeState)
     {
         var (concreteTypeInfo, effectiveState) = writeState switch

--- a/src/Npgsql/Internal/Converters/RangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/RangeConverter.cs
@@ -106,7 +106,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         {
             totalSize = totalSize.Combine(sizeof(int));
             var subTypeState = (object?)null;
-            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.LowerBound, ref subTypeState) is { } size)
+            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.LowerBound!, ref subTypeState) is { } size)
             {
                 totalSize = totalSize.Combine(size);
                 (state ??= new WriteState()).LowerBoundSize = size;
@@ -120,7 +120,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         {
             totalSize = totalSize.Combine(sizeof(int));
             var subTypeState = (object?)null;
-            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.UpperBound, ref subTypeState) is { } size)
+            if (_subtypeConverter.IsDbNullOrGetSize(context.Format, _subtypeRequirements.Write, value.UpperBound!, ref subTypeState) is { } size)
             {
                 totalSize = totalSize.Combine(size);
                 (state ??= new WriteState()).UpperBoundSize = size;

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -51,7 +51,7 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
             var scope = await reader.BeginNestedRead(async, length, binding.BufferRequirement, cancellationToken).ConfigureAwait(false);
             try
             {
-                result[i] = await concreteTypeInfo.Converter.ReadAsObject(async, reader, cancellationToken).ConfigureAwait(false);
+                result[i] = (await concreteTypeInfo.Converter.ReadAsObject(async, reader, cancellationToken).ConfigureAwait(false))!;
             }
             finally
             {

--- a/src/Npgsql/Internal/Converters/VersionPrefixedTextConverter.cs
+++ b/src/Npgsql/Internal/Converters/VersionPrefixedTextConverter.cs
@@ -4,15 +4,23 @@ using System.Threading.Tasks;
 
 namespace Npgsql.Internal.Converters;
 
-sealed class VersionPrefixedTextConverter<T>(byte versionPrefix, PgConverter<T> textConverter)
-    : PgStreamingConverter<T>(textConverter.DbNullPredicateKind is DbNullPredicate.Custom)
+sealed class VersionPrefixedTextConverter<T> : PgStreamingConverter<T>
 {
     BufferRequirements _innerRequirements;
+    readonly byte _versionPrefix;
+    readonly PgConverter<T> _textConverter;
 
-    protected override bool IsDbNullValue(T? value, object? writeState) => textConverter.IsDbNull(value, writeState);
+    public VersionPrefixedTextConverter(byte versionPrefix, PgConverter<T> textConverter)
+    {
+        _versionPrefix = versionPrefix;
+        _textConverter = textConverter;
+        HandleDbNull = textConverter.HandleDbNull;
+    }
+
+    protected override bool IsDbNullValue(T? value, object? writeState) => _textConverter.IsDbNull(value, writeState);
 
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
-        => VersionPrefixedTextConverter.CanConvert(textConverter, format, out _innerRequirements, out bufferRequirements);
+        => VersionPrefixedTextConverter.CanConvert(_textConverter, format, out _innerRequirements, out bufferRequirements);
 
     public override T Read(PgReader reader)
         => Read(async: false, reader, CancellationToken.None).Result;
@@ -21,7 +29,7 @@ sealed class VersionPrefixedTextConverter<T>(byte versionPrefix, PgConverter<T> 
         => Read(async: true, reader, cancellationToken);
 
     public override Size GetSize(SizeContext context, T value, ref object? writeState)
-        => textConverter.GetSize(context, value, ref writeState).Combine(context.Format is DataFormat.Binary ? sizeof(byte) : 0);
+        => _textConverter.GetSize(context, value, ref writeState).Combine(context.Format is DataFormat.Binary ? sizeof(byte) : 0);
 
     public override void Write(PgWriter writer, T value)
         => Write(async: false, writer, value, CancellationToken.None).GetAwaiter().GetResult();
@@ -31,17 +39,17 @@ sealed class VersionPrefixedTextConverter<T>(byte versionPrefix, PgConverter<T> 
 
     async ValueTask<T> Read(bool async, PgReader reader, CancellationToken cancellationToken)
     {
-        await VersionPrefixedTextConverter.ReadVersion(async, versionPrefix, reader, _innerRequirements.Read, cancellationToken).ConfigureAwait(false);
-        return async ? await textConverter.ReadAsync(reader, cancellationToken).ConfigureAwait(false) : textConverter.Read(reader);
+        await VersionPrefixedTextConverter.ReadVersion(async, _versionPrefix, reader, _innerRequirements.Read, cancellationToken).ConfigureAwait(false);
+        return async ? await _textConverter.ReadAsync(reader, cancellationToken).ConfigureAwait(false) : _textConverter.Read(reader);
     }
 
     async ValueTask Write(bool async, PgWriter writer, T value, CancellationToken cancellationToken)
     {
-        await VersionPrefixedTextConverter.WriteVersion(async, versionPrefix, writer, cancellationToken).ConfigureAwait(false);
+        await VersionPrefixedTextConverter.WriteVersion(async, _versionPrefix, writer, cancellationToken).ConfigureAwait(false);
         if (async)
-            await textConverter.WriteAsync(writer, value, cancellationToken).ConfigureAwait(false);
+            await _textConverter.WriteAsync(writer, value, cancellationToken).ConfigureAwait(false);
         else
-            textConverter.Write(writer, value);
+            _textConverter.Write(writer, value);
     }
 }
 

--- a/src/Npgsql/Internal/Converters/VersionPrefixedTextConverter.cs
+++ b/src/Npgsql/Internal/Converters/VersionPrefixedTextConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,13 +20,13 @@ sealed class VersionPrefixedTextConverter<T>(byte versionPrefix, PgConverter<T> 
     public override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => Read(async: true, reader, cancellationToken);
 
-    public override Size GetSize(SizeContext context, [DisallowNull]T value, ref object? writeState)
+    public override Size GetSize(SizeContext context, T value, ref object? writeState)
         => textConverter.GetSize(context, value, ref writeState).Combine(context.Format is DataFormat.Binary ? sizeof(byte) : 0);
 
-    public override void Write(PgWriter writer, [DisallowNull]T value)
+    public override void Write(PgWriter writer, T value)
         => Write(async: false, writer, value, CancellationToken.None).GetAwaiter().GetResult();
 
-    public override ValueTask WriteAsync(PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken = default)
+    public override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
         => Write(async: true, writer, value, cancellationToken);
 
     async ValueTask<T> Read(bool async, PgReader reader, CancellationToken cancellationToken)
@@ -36,7 +35,7 @@ sealed class VersionPrefixedTextConverter<T>(byte versionPrefix, PgConverter<T> 
         return async ? await textConverter.ReadAsync(reader, cancellationToken).ConfigureAwait(false) : textConverter.Read(reader);
     }
 
-    async ValueTask Write(bool async, PgWriter writer, [DisallowNull]T value, CancellationToken cancellationToken)
+    async ValueTask Write(bool async, PgWriter writer, T value, CancellationToken cancellationToken)
     {
         await VersionPrefixedTextConverter.WriteVersion(async, versionPrefix, writer, cancellationToken).ConfigureAwait(false);
         if (async)

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -24,15 +24,15 @@ public abstract class PgBufferedConverter<T>(bool customDbNullPredicate = false)
 
     public sealed override void Write(PgWriter writer, T value) => WriteCore(writer, value);
 
-    public sealed override ValueTask WriteAsync(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default)
+    public sealed override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
     {
         Write(writer, value);
         return new();
     }
 
-    internal sealed override ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken)
+    internal sealed override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
     {
-        Write(writer, (T)value);
+        Write(writer, (T)value!);
         return new();
     }
 }

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -19,8 +19,8 @@ public abstract class PgBufferedConverter<T>(bool customDbNullPredicate = false)
     public sealed override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => new(Read(reader));
 
-    internal sealed override ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
-        => new(Read(reader)!);
+    internal sealed override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+        => new(Read(reader));
 
     public sealed override void Write(PgWriter writer, T value) => WriteCore(writer, value);
 

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -6,8 +6,15 @@ using System.Threading.Tasks;
 namespace Npgsql.Internal;
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
-public abstract class PgBufferedConverter<T>(bool customDbNullPredicate = false) : PgConverter<T>(customDbNullPredicate)
+public abstract class PgBufferedConverter<T> : PgConverter<T>
 {
+    protected PgBufferedConverter()
+    {
+    }
+
+    [Obsolete("Call the parameterless constructor and set HandleDbNull directly.")]
+    protected PgBufferedConverter(bool customDbNullPredicate) => HandleDbNull = customDbNullPredicate;
+
     protected abstract T ReadCore(PgReader reader);
     protected abstract void WriteCore(PgWriter writer, T value);
 

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -65,6 +65,12 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
             ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsObject(context, value, out writeState)
             : EffectiveTypeInfo.GetForValueAsObject(context, value, out writeState);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected PgConcreteTypeInfo? GetEffectiveForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+        => IsCompositionalUnit
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForNestedObjectValue(context, value, out writeState)
+            : EffectiveTypeInfo.GetForNestedObjectValue(context, value, out writeState);
+
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
     protected abstract PgConverter<T> CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo, out Type? requestedType);

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -66,10 +66,10 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
             : EffectiveTypeInfo.GetForValueAsObject(context, value, out writeState);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetEffectiveForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForNestedObjectValue(context, value, out writeState)
-            : EffectiveTypeInfo.GetForNestedObjectValue(context, value, out writeState);
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsNestedObject(context, value, out writeState)
+            : EffectiveTypeInfo.GetForValueAsNestedObject(context, value, out writeState);
 
     protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
     protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -143,8 +143,7 @@ static class PgConcreteTypeInfoProviderExtensions
             {
             case NestedObjectDbNullHandling.ExtendedThrowOnNull:
                 if (value is null)
-                    ThrowHelper.ThrowArgumentNullException(nameof(value),
-                        "Object-typed value cannot be null, a db null value must be used instead.");
+                    ThrowHelper.ThrowArgumentNullException("Object-typed value cannot be null, a db null value must be used instead.", nameof(value));
                 goto case NestedObjectDbNullHandling.Extended;
             case NestedObjectDbNullHandling.Extended:
                 if (value is DBNull)

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -136,7 +136,7 @@ static class PgConcreteTypeInfoProviderExtensions
 {
     extension(PgConcreteTypeInfoProvider provider)
     {
-        internal PgConcreteTypeInfo? GetForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+        internal PgConcreteTypeInfo? GetForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
         {
             writeState = null;
             switch (context.NestedObjectDbNullHandling)

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -92,6 +91,7 @@ public abstract class PgConcreteTypeInfoProvider
             $"'{methodName}' incorrectly returned a different {nameof(PgTypeId)} in its concrete type info than the caller passed in.");
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
 {
     /// <summary>
@@ -124,7 +124,38 @@ public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
         => default(T) is null || value is not null ? GetForValueCore(context, (T?)value, ref writeState) : null;
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct ProviderValueContext
 {
     public PgTypeId? ExpectedPgTypeId { get; init; }
+    public NestedObjectDbNullHandling NestedObjectDbNullHandling { get; init; }
+}
+
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
+static class PgConcreteTypeInfoProviderExtensions
+{
+    extension(PgConcreteTypeInfoProvider provider)
+    {
+        internal PgConcreteTypeInfo? GetForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+        {
+            writeState = null;
+            switch (context.NestedObjectDbNullHandling)
+            {
+            case NestedObjectDbNullHandling.ExtendedThrowOnNull:
+                if (value is null)
+                    ThrowHelper.ThrowArgumentNullException(nameof(value),
+                        "Object-typed value cannot be null, a db null value must be used instead.");
+                goto case NestedObjectDbNullHandling.Extended;
+            case NestedObjectDbNullHandling.Extended:
+                if (value is DBNull)
+                    return null;
+                goto case NestedObjectDbNullHandling.Default;
+            case NestedObjectDbNullHandling.Default:
+                return value is null ? null : provider.GetForValueAsObject(context, value, out writeState);
+            default:
+                ThrowHelper.ThrowUnreachableException();
+                return default;
+            }
+        }
+    }
 }

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -263,7 +263,7 @@ static class PgConverterExtensions
         {
         case NestedObjectDbNullHandling.ExtendedThrowOnNull:
             if (value is null)
-                ThrowHelper.ThrowArgumentNullException(nameof(value), "Object-typed value cannot be null, a db null value must be used instead.");
+                ThrowHelper.ThrowArgumentNullException("Object-typed value cannot be null, a db null value must be used instead.", nameof(value));
             goto case NestedObjectDbNullHandling.Extended;
         case NestedObjectDbNullHandling.Extended:
             if (value is DBNull)

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -92,7 +92,7 @@ public abstract class PgConverter
         => DbNullPredicateKind switch
         {
             DbNullPredicate.Null => value is null,
-            DbNullPredicate.None => false,
+            DbNullPredicate.None => value is null && ThrowInvalidNullValue(),
             DbNullPredicate.PolymorphicNull => value is null or DBNull,
             // We do the null check to keep the NotNullWhen(false) invariant.
             DbNullPredicate.Custom => IsDbNullValueAsObject(value, writeState) || (value is null && ThrowInvalidNullValue()),
@@ -213,8 +213,30 @@ public abstract class PgConverter<T> : PgConverter
         => GetSize(context, (T)value, ref writeState);
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 static class PgConverterExtensions
 {
+    /// Checks whether <paramref name="value"/> is considered a database null under the given <paramref name="handling"/> policy.
+    public static bool IsNestedObjectDbNull(this PgConverter converter, object? value, object? writeState, NestedObjectDbNullHandling handling)
+    {
+        switch (handling)
+        {
+        case NestedObjectDbNullHandling.ExtendedThrowOnNull:
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(nameof(value), "Object-typed value cannot be null, a db null value must be used instead.");
+            goto case NestedObjectDbNullHandling.Extended;
+        case NestedObjectDbNullHandling.Extended:
+            if (value is DBNull)
+                return true;
+            goto case NestedObjectDbNullHandling.Default;
+        case NestedObjectDbNullHandling.Default:
+            return value is null || converter.IsDbNullAsObject(value, writeState);
+        default:
+            ThrowHelper.ThrowUnreachableException();
+            return default;
+        }
+    }
+
     public static Size? IsDbNullOrGetSize<T>(this PgConverter<T> converter, DataFormat format, Size writeRequirement, T? value, ref object? writeState)
     {
         if (converter.IsDbNull(value, writeState))
@@ -238,14 +260,14 @@ static class PgConverterExtensions
         return size;
     }
 
-    public static Size? IsDbNullOrGetSizeAsObject(this PgConverter converter, DataFormat format, Size writeRequirement, object? value, ref object? writeState)
+    public static Size? IsDbNullOrGetSizeAsObject(this PgConverter converter, DataFormat format, Size writeRequirement, object? value, ref object? writeState, NestedObjectDbNullHandling nestedObjectDbNullHandling = NestedObjectDbNullHandling.Default)
     {
         if (converter.IsDbNullAsObject(value, writeState))
             return null;
 
         if (writeRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
             return byteCount;
-        var size = converter.GetSizeAsObject(new(format, writeRequirement), value, ref writeState);
+        var size = converter.GetSizeAsObject(new(format, writeRequirement) { NestedObjectDbNullHandling = nestedObjectDbNullHandling }, value, ref writeState);
 
         switch (size.Kind)
         {
@@ -262,11 +284,35 @@ static class PgConverterExtensions
     }
 }
 
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 [method: SetsRequiredMembers]
 public readonly struct SizeContext(DataFormat format, Size bufferRequirement)
 {
     public required Size BufferRequirement { get; init; } = bufferRequirement;
     public DataFormat Format { get; } = format;
+
+    public NestedObjectDbNullHandling NestedObjectDbNullHandling { get; init; }
+}
+
+/// <summary>
+/// How null-shaped values are pre-filtered when a container's element or field slot is erased to <see cref="object"/>.
+/// CLR semantics are the floor (<see cref="Default"/>), extended modes layer database null sentinel recognition on top.
+/// Strongly-typed slots resolve nulls through the nested converter directly and don't consult this knob.
+/// </summary>
+/// <remarks>
+/// Parameter-shaped containers (e.g. an <c>object[]</c> parameter) use <see cref="Extended"/> because the
+/// parameter layer treats database null sentinels as a first-class null expression alongside CLR null.
+/// Typed composites generally use <see cref="Default"/>. These create a new serialization scope where database null sentinels are not recognized.
+/// </remarks>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
+public enum NestedObjectDbNullHandling
+{
+    /// <summary>CLR null becomes a database null. Database null sentinels are passed through to the nested converter.</summary>
+    Default = 0,
+    /// <summary>CLR null and database null sentinels both become a database null.</summary>
+    Extended,
+    /// <summary>CLR null throws. Database null sentinels become a database null.</summary>
+    ExtendedThrowOnNull
 }
 
 class MultiWriteState : IDisposable

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -12,13 +12,25 @@ namespace Npgsql.Internal;
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgConverter
 {
-    internal DbNullPredicate DbNullPredicateKind { get; }
+    bool CustomDbNullPredicate { get; }
+    /// <summary>
+    /// True when CLR null can reach this converter's API surface.
+    /// Auto-derived from <see cref="TypeToConvert"/> (or from an internal wrapper's effective type if passed).
+    /// Orthogonal to <see cref="HandleDbNull"/>: the two combine into <see cref="DbNullPredicateKind"/> as Custom (HandleDbNull true),
+    /// Null (HandleDbNull false, TypeAcceptsNull true), or None (both false).
+    /// </summary>
+    internal bool TypeAcceptsNull { get; }
+    internal DbNullPredicate DbNullPredicateKind
+        => CustomDbNullPredicate ? DbNullPredicate.Custom
+            : TypeAcceptsNull ? DbNullPredicate.Null
+            : DbNullPredicate.None;
     public bool IsDbNullable => DbNullPredicateKind is not DbNullPredicate.None;
 
-    private protected PgConverter(Type type, bool isNullDefaultValue, bool customDbNullPredicate = false)
+    private protected PgConverter(Type type, bool typeAcceptsNull, bool customDbNullPredicate)
     {
         TypeToConvert = type;
-        DbNullPredicateKind = customDbNullPredicate ? DbNullPredicate.Custom : InferDbNullPredicate(type, isNullDefaultValue);
+        TypeAcceptsNull = typeAcceptsNull;
+        CustomDbNullPredicate = customDbNullPredicate;
     }
 
     /// <summary>
@@ -89,14 +101,17 @@ public abstract class PgConverter
             : UnsafeAs<T>().WriteAsync(writer, value, cancellationToken);
 
     internal bool IsDbNullAsObject([NotNullWhen(false)] object? value, object? writeState)
-        => DbNullPredicateKind switch
+    {
+        if (value is null && !TypeAcceptsNull)
+            ThrowInvalidNullValue();
+        return DbNullPredicateKind switch
         {
             DbNullPredicate.Null => value is null,
-            DbNullPredicate.None => value is null && ThrowInvalidNullValue(),
-            // We do the null check to keep the NotNullWhen(false) invariant.
-            DbNullPredicate.Custom => IsDbNullValueAsObject(value, writeState) || (value is null && ThrowInvalidNullValue()),
+            DbNullPredicate.None => false,
+            DbNullPredicate.Custom => IsDbNullValueAsObject(value, writeState),
             _ => ThrowDbNullPredicateOutOfRange()
         };
+    }
 
     private protected abstract bool IsDbNullValueAsObject(object? value, object? writeState);
 
@@ -144,6 +159,9 @@ public abstract class PgConverter<T> : PgConverter
     private protected PgConverter(bool customDbNullPredicate)
         : base(typeof(T), default(T) is null, customDbNullPredicate) { }
 
+    private protected PgConverter(Type effectiveType, bool customDbNullPredicate)
+        : base(typeof(T), !effectiveType.IsValueType || Nullable.GetUnderlyingType(effectiveType) is not null, customDbNullPredicate) { }
+
 #pragma warning disable CS0618 // Obsolete - delegates to ref overload for binary compat with existing overrides
     protected virtual bool IsDbNullValue(T? value, object? writeState)
     {
@@ -164,21 +182,21 @@ public abstract class PgConverter<T> : PgConverter
     [EditorBrowsable(EditorBrowsableState.Never)]
     protected virtual bool IsDbNullValue(T? value, ref object? writeState) => throw new NotSupportedException();
 
-    // Object null semantics as follows, if T is a struct (so excluding nullable) report false for null values, don't throw on the cast.
-    // As a result this creates symmetry with IsDbNull when we're dealing with a struct T, as it cannot be passed null at all.
     private protected override bool IsDbNullValueAsObject(object? value, object? writeState)
-        => (default(T) is null || value is not null) && IsDbNullValue((T?)value, writeState);
+        => IsDbNullValue((T?)value, writeState);
 
     /// Checks whether <paramref name="value"/> is considered a database null by this converter.
     public bool IsDbNull([NotNullWhen(false)] T? value, object? writeState)
-        => DbNullPredicateKind switch
+    {
+        Debug.Assert(value is not null || TypeAcceptsNull, "TypeAcceptsNull issue, null reached the typed IsDbNull on a converter whose T does not accept null.");
+        return DbNullPredicateKind switch
         {
             DbNullPredicate.Null => value is null,
             DbNullPredicate.None => false,
-            // We do the null check to keep the NotNullWhen(false) invariant.
-            DbNullPredicate.Custom => IsDbNullValue(value, writeState) || (value is null && ThrowInvalidNullValue()),
+            DbNullPredicate.Custom => IsDbNullValue(value, writeState),
             _ => ThrowDbNullPredicateOutOfRange()
         };
+    }
 
     [Obsolete("Use the overload without ref.")]
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -12,7 +12,6 @@ namespace Npgsql.Internal;
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public abstract class PgConverter
 {
-    bool CustomDbNullPredicate { get; }
     /// <summary>
     /// True when CLR null can reach this converter's API surface.
     /// Auto-derived from <see cref="TypeToConvert"/> (or from an internal wrapper's effective type if passed).
@@ -21,17 +20,22 @@ public abstract class PgConverter
     /// </summary>
     internal bool TypeAcceptsNull { get; }
     internal DbNullPredicate DbNullPredicateKind
-        => CustomDbNullPredicate ? DbNullPredicate.Custom
+        => HandleDbNull ? DbNullPredicate.Custom
             : TypeAcceptsNull ? DbNullPredicate.Null
             : DbNullPredicate.None;
     public bool IsDbNullable => DbNullPredicateKind is not DbNullPredicate.None;
 
-    private protected PgConverter(Type type, bool typeAcceptsNull, bool customDbNullPredicate)
+    private protected PgConverter(Type type, bool typeAcceptsNull)
     {
         TypeToConvert = type;
         TypeAcceptsNull = typeAcceptsNull;
-        CustomDbNullPredicate = customDbNullPredicate;
     }
+
+    /// <summary>
+    /// True when the converter has a custom IsDbNullValue override that should be consulted to determine db-nullness.
+    /// When false, db-nullness is decided purely based on whether the <see cref="TypeToConvert"/> accepts nulls naturally.
+    /// </summary>
+    protected internal bool HandleDbNull { get; init; }
 
     /// <summary>
     /// Whether this converter can handle the given format and with which buffer requirements.
@@ -164,11 +168,10 @@ public abstract class PgConverter
 
 public abstract class PgConverter<T> : PgConverter
 {
-    private protected PgConverter(bool customDbNullPredicate)
-        : base(typeof(T), default(T) is null, customDbNullPredicate) { }
+    private protected PgConverter() : base(typeof(T), default(T) is null) { }
 
-    private protected PgConverter(Type effectiveType, bool customDbNullPredicate)
-        : base(typeof(T), !effectiveType.IsValueType || Nullable.GetUnderlyingType(effectiveType) is not null, customDbNullPredicate) { }
+    private protected PgConverter(Type effectiveType)
+        : base(typeof(T), !effectiveType.IsValueType || Nullable.GetUnderlyingType(effectiveType) is not null) { }
 
 #pragma warning disable CS0618 // Obsolete - delegates to ref overload for binary compat with existing overrides
     protected virtual bool IsDbNullValue(T? value, object? writeState)

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -56,27 +56,35 @@ public abstract class PgConverter
     /// <summary>Reads a value from the reader as <typeparamref name="T"/>.</summary>
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public T Read<T>(PgReader reader)
+    public
+#nullable disable // T may or may not be nullable depending on the converter's read behavior.
+    T
+#nullable restore
+    Read<T>(PgReader reader)
         => typeof(T) != TypeToConvert
-            ? (T)ReadAsObject(reader)
+            ? (T)ReadAsObject(reader)!
             : UnsafeAs<T>().Read(reader);
 
     /// <summary>Asynchronously reads a value from the reader as <typeparamref name="T"/>.</summary>
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask<T> ReadAsync<T>(PgReader reader, CancellationToken cancellationToken = default)
+    public ValueTask<
+#nullable disable // T may or may not be nullable depending on the converter's read behavior.
+    T
+#nullable restore
+    > ReadAsync<T>(PgReader reader, CancellationToken cancellationToken = default)
     {
         if (typeof(T) != TypeToConvert)
         {
             var task = ReadAsObjectAsync(reader, cancellationToken);
-            return task.IsCompletedSuccessfully ? new((T)task.Result) : ReadAndUnboxAsync(task);
+            return task.IsCompletedSuccessfully ? new((T)task.Result!) : ReadAndUnboxAsync(task);
         }
 
         return UnsafeAs<T>().ReadAsync(reader, cancellationToken);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static async ValueTask<T> ReadAndUnboxAsync(ValueTask<object> task)
-            => (T)await task.ConfigureAwait(false);
+        static async ValueTask<T> ReadAndUnboxAsync(ValueTask<object?> task)
+            => (T)(await task.ConfigureAwait(false))!;
     }
 
     /// <summary>Writes a <typeparamref name="T"/> value to the writer.</summary>
@@ -117,13 +125,13 @@ public abstract class PgConverter
 
     internal abstract Size GetSizeAsObject(SizeContext context, object? value, ref object? writeState);
 
-    internal object ReadAsObject(PgReader reader)
+    internal object? ReadAsObject(PgReader reader)
         => ReadAsObject(async: false, reader, CancellationToken.None).GetAwaiter().GetResult();
-    internal ValueTask<object> ReadAsObjectAsync(PgReader reader, CancellationToken cancellationToken = default)
+    internal ValueTask<object?> ReadAsObjectAsync(PgReader reader, CancellationToken cancellationToken = default)
         => ReadAsObject(async: true, reader, cancellationToken);
 
     // Shared sync/async abstract to reduce virtual method table size overhead and code size for each NpgsqlConverter<T> instantiation.
-    internal abstract ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken);
+    internal abstract ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken);
 
     internal void WriteAsObject(PgWriter writer, object? value)
         => WriteAsObject(async: false, writer, value, CancellationToken.None).GetAwaiter().GetResult();
@@ -204,9 +212,18 @@ public abstract class PgConverter<T> : PgConverter
         => IsDbNull(value, writeState);
 
     /// Reads a <typeparamref name="T"/> value from the reader.
-    public abstract T Read(PgReader reader);
+    public abstract
+#nullable disable // T may or may not be nullable depending on the derived converter's read behavior.
+    T
+#nullable restore
+    Read(PgReader reader);
+
     /// Asynchronously reads a <typeparamref name="T"/> value from the reader.
-    public abstract ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default);
+    public abstract ValueTask<
+#nullable disable // T may or may not be nullable depending on the derived converter's read behavior.
+    T
+#nullable restore
+    > ReadAsync(PgReader reader, CancellationToken cancellationToken = default);
 
     /// Computes the serialized size for <paramref name="value"/>, producing any required <paramref name="writeState"/>.
     public abstract Size GetSize(SizeContext context,

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -257,7 +257,7 @@ public abstract class PgConverter<T> : PgConverter
 static class PgConverterExtensions
 {
     /// Checks whether <paramref name="value"/> is considered a database null under the given <paramref name="handling"/> policy.
-    public static bool IsNestedObjectDbNull(this PgConverter converter, object? value, object? writeState, NestedObjectDbNullHandling handling)
+    public static bool IsDbNullAsNestedObject(this PgConverter converter, object? value, object? writeState, NestedObjectDbNullHandling handling)
     {
         switch (handling)
         {

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -93,7 +93,6 @@ public abstract class PgConverter
         {
             DbNullPredicate.Null => value is null,
             DbNullPredicate.None => value is null && ThrowInvalidNullValue(),
-            DbNullPredicate.PolymorphicNull => value is null or DBNull,
             // We do the null check to keep the NotNullWhen(false) invariant.
             DbNullPredicate.Custom => IsDbNullValueAsObject(value, writeState) || (value is null && ThrowInvalidNullValue()),
             _ => ThrowDbNullPredicateOutOfRange()
@@ -119,13 +118,6 @@ public abstract class PgConverter
     // Shared sync/async abstract to reduce virtual method table size overhead and code size for each NpgsqlConverter<T> instantiation.
     internal abstract ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken);
 
-    static DbNullPredicate InferDbNullPredicate(Type type, bool isNullDefaultValue)
-        => type == typeof(object) || type == typeof(DBNull)
-            ? DbNullPredicate.PolymorphicNull
-            : isNullDefaultValue
-                ? DbNullPredicate.Null
-                : DbNullPredicate.None;
-
     internal enum DbNullPredicate : byte
     {
         /// Never DbNull (struct types)
@@ -133,9 +125,7 @@ public abstract class PgConverter
         /// DbNull when *user code*
         Custom,
         /// DbNull when value is null
-        Null,
-        /// DbNull when value is null or DBNull
-        PolymorphicNull
+        Null
     }
 
     [DoesNotReturn]
@@ -185,7 +175,6 @@ public abstract class PgConverter<T> : PgConverter
         {
             DbNullPredicate.Null => value is null,
             DbNullPredicate.None => false,
-            DbNullPredicate.PolymorphicNull => value is null or DBNull,
             // We do the null check to keep the NotNullWhen(false) invariant.
             DbNullPredicate.Custom => IsDbNullValue(value, writeState) || (value is null && ThrowInvalidNullValue()),
             _ => ThrowDbNullPredicateOutOfRange()

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -82,7 +82,7 @@ public abstract class PgConverter
     /// <summary>Writes a <typeparamref name="T"/> value to the writer.</summary>
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Write<T>(PgWriter writer, [DisallowNull] T value)
+    public void Write<T>(PgWriter writer, T value)
     {
         if (typeof(T) != TypeToConvert)
         {
@@ -95,12 +95,12 @@ public abstract class PgConverter
     /// <summary>Asynchronously writes a <typeparamref name="T"/> value to the writer.</summary>
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask WriteAsync<T>(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default)
+    public ValueTask WriteAsync<T>(PgWriter writer, T value, CancellationToken cancellationToken = default)
         => typeof(T) != TypeToConvert
             ? WriteAsObjectAsync(writer, value, cancellationToken)
             : UnsafeAs<T>().WriteAsync(writer, value, cancellationToken);
 
-    internal bool IsDbNullAsObject([NotNullWhen(false)] object? value, object? writeState)
+    internal bool IsDbNullAsObject(object? value, object? writeState)
     {
         if (value is null && !TypeAcceptsNull)
             ThrowInvalidNullValue();
@@ -115,7 +115,7 @@ public abstract class PgConverter
 
     private protected abstract bool IsDbNullValueAsObject(object? value, object? writeState);
 
-    internal abstract Size GetSizeAsObject(SizeContext context, object value, ref object? writeState);
+    internal abstract Size GetSizeAsObject(SizeContext context, object? value, ref object? writeState);
 
     internal object ReadAsObject(PgReader reader)
         => ReadAsObject(async: false, reader, CancellationToken.None).GetAwaiter().GetResult();
@@ -125,13 +125,13 @@ public abstract class PgConverter
     // Shared sync/async abstract to reduce virtual method table size overhead and code size for each NpgsqlConverter<T> instantiation.
     internal abstract ValueTask<object> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken);
 
-    internal void WriteAsObject(PgWriter writer, object value)
+    internal void WriteAsObject(PgWriter writer, object? value)
         => WriteAsObject(async: false, writer, value, CancellationToken.None).GetAwaiter().GetResult();
-    internal ValueTask WriteAsObjectAsync(PgWriter writer, object value, CancellationToken cancellationToken = default)
+    internal ValueTask WriteAsObjectAsync(PgWriter writer, object? value, CancellationToken cancellationToken = default)
         => WriteAsObject(async: true, writer, value, cancellationToken);
 
     // Shared sync/async abstract to reduce virtual method table size overhead and code size for each NpgsqlConverter<T> instantiation.
-    internal abstract ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken);
+    internal abstract ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken);
 
     internal enum DbNullPredicate : byte
     {
@@ -186,7 +186,7 @@ public abstract class PgConverter<T> : PgConverter
         => IsDbNullValue((T?)value, writeState);
 
     /// Checks whether <paramref name="value"/> is considered a database null by this converter.
-    public bool IsDbNull([NotNullWhen(false)] T? value, object? writeState)
+    public bool IsDbNull(T? value, object? writeState)
     {
         Debug.Assert(value is not null || TypeAcceptsNull, "TypeAcceptsNull issue, null reached the typed IsDbNull on a converter whose T does not accept null.");
         return DbNullPredicateKind switch
@@ -200,7 +200,7 @@ public abstract class PgConverter<T> : PgConverter
 
     [Obsolete("Use the overload without ref.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool IsDbNull([NotNullWhen(false)] T? value, ref object? writeState)
+    public bool IsDbNull(T? value, ref object? writeState)
         => IsDbNull(value, writeState);
 
     /// Reads a <typeparamref name="T"/> value from the reader.
@@ -209,15 +209,28 @@ public abstract class PgConverter<T> : PgConverter
     public abstract ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default);
 
     /// Computes the serialized size for <paramref name="value"/>, producing any required <paramref name="writeState"/>.
-    public abstract Size GetSize(SizeContext context, [DisallowNull]T value, ref object? writeState);
+    public abstract Size GetSize(SizeContext context,
+#nullable disable // T may or may not be nullable depending on the derived converter's IsDbNullValue override.
+        T value,
+#nullable restore
+        ref object? writeState);
 
     /// Writes a <typeparamref name="T"/> value to the writer.
-    public abstract void Write(PgWriter writer, [DisallowNull] T value);
-    /// Asynchronously writes a <typeparamref name="T"/> value to the writer.
-    public abstract ValueTask WriteAsync(PgWriter writer, [DisallowNull] T value, CancellationToken cancellationToken = default);
+    public abstract void Write(PgWriter writer,
+#nullable disable // T may or may not be nullable depending on the derived converter's IsDbNullValue override.
+        T value
+#nullable restore
+        );
 
-    internal sealed override Size GetSizeAsObject(SizeContext context, object value, ref object? writeState)
-        => GetSize(context, (T)value, ref writeState);
+    /// Asynchronously writes a <typeparamref name="T"/> value to the writer.
+    public abstract ValueTask WriteAsync(PgWriter writer,
+#nullable disable // T may or may not be nullable depending on the derived converter's IsDbNullValue override.
+        T value,
+#nullable restore
+        CancellationToken cancellationToken = default);
+
+    internal sealed override Size GetSizeAsObject(SizeContext context, object? value, ref object? writeState)
+        => GetSize(context, (T)value!, ref writeState);
 }
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
@@ -251,7 +264,10 @@ static class PgConverterExtensions
 
         if (writeRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
             return byteCount;
-        var size = converter.GetSize(new(format, writeRequirement), value, ref writeState);
+        // Value may legitimately be null when a Custom predicate opts into null-writing (IsDbNullValue returning false for null).
+        // GetSize's oblivious T parameter accepts it, but we are in a nullability aware context so we must null forgive.
+        Debug.Assert(converter.TypeAcceptsNull || value is not null);
+        var size = converter.GetSize(new(format, writeRequirement), value!, ref writeState);
 
         switch (size.Kind)
         {

--- a/src/Npgsql/Internal/PgStreamingConverter.cs
+++ b/src/Npgsql/Internal/PgStreamingConverter.cs
@@ -8,8 +8,15 @@ using System.Threading.Tasks;
 namespace Npgsql.Internal;
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
-public abstract class PgStreamingConverter<T>(bool customDbNullPredicate = false) : PgConverter<T>(customDbNullPredicate)
+public abstract class PgStreamingConverter<T> : PgConverter<T>
 {
+    protected PgStreamingConverter()
+    {
+    }
+
+    [Obsolete("Call the parameterless constructor and set HandleDbNull directly.")]
+    protected PgStreamingConverter(bool customDbNullPredicate) => HandleDbNull = customDbNullPredicate;
+
     public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
     {
         bufferRequirements = BufferRequirements.None;

--- a/src/Npgsql/Internal/PgStreamingConverter.cs
+++ b/src/Npgsql/Internal/PgStreamingConverter.cs
@@ -49,12 +49,12 @@ public abstract class PgStreamingConverter<T>(bool customDbNullPredicate = false
         }
     }
 
-    internal sealed override ValueTask WriteAsObject(bool async, PgWriter writer, object value, CancellationToken cancellationToken)
+    internal sealed override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
     {
         if (async)
-            return WriteAsync(writer, (T)value, cancellationToken);
+            return WriteAsync(writer, (T)value!, cancellationToken);
 
-        Write(writer, (T)value);
+        Write(writer, (T)value!);
         return new();
     }
 }

--- a/src/Npgsql/Internal/PgStreamingConverter.cs
+++ b/src/Npgsql/Internal/PgStreamingConverter.cs
@@ -29,23 +29,23 @@ public abstract class PgStreamingConverter<T>(bool customDbNullPredicate = false
         return task.AsTask();
     }
 
-    internal sealed override unsafe ValueTask<object> ReadAsObject(
+    internal sealed override unsafe ValueTask<object?> ReadAsObject(
         bool async, PgReader reader, CancellationToken cancellationToken)
     {
         if (!async)
-            return new(Read(reader)!);
+            return new(Read(reader));
 
         var task = ReadAsync(reader, cancellationToken);
         return task.IsCompletedSuccessfully
-            ? new(task.Result!)
+            ? new(task.Result)
             : PgStreamingConverterHelpers.AwaitTask(task.AsTask(), new(this, &BoxResult));
 
-        static object BoxResult(Task task)
+        static object? BoxResult(Task task)
         {
             // Justification: exact type Unsafe.As used to reduce generic duplication cost.
             Debug.Assert(task is Task<T>);
             // Using .Result on ValueTask is equivalent to GetAwaiter().GetResult(), this removes TaskAwaiter<T> rooting.
-            return new ValueTask<T>(task: Unsafe.As<Task<T>>(task)).Result!;
+            return new ValueTask<T>(task: Unsafe.As<Task<T>>(task)).Result;
         }
     }
 
@@ -71,7 +71,7 @@ static class PgStreamingConverterHelpers
     // Split out from the generic class to amortize the huge size penalty per async state machine, which would otherwise be per
     // instantiation.
     [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-    public static async ValueTask<object> AwaitTask(Task task, Continuation continuation)
+    public static async ValueTask<object?> AwaitTask(Task task, Continuation continuation)
     {
         await task.ConfigureAwait(false);
         var result = continuation.Invoke(task);
@@ -85,16 +85,16 @@ static class PgStreamingConverterHelpers
     public readonly unsafe struct Continuation
     {
         public object Handle { get; }
-        readonly delegate*<Task, object> _continuation;
+        readonly delegate*<Task, object?> _continuation;
 
         /// <param name="handle">A reference to the type that houses the static method <see ref="continuation"/> points to.</param>
         /// <param name="continuation">The continuation</param>
-        public Continuation(object handle, delegate*<Task, object> continuation)
+        public Continuation(object handle, delegate*<Task, object?> continuation)
         {
             Handle = handle;
             _continuation = continuation;
         }
 
-        public object Invoke(Task task) => _continuation(task);
+        public object? Invoke(Task task) => _continuation(task);
     }
 }

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -298,7 +298,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
-    internal PgConcreteTypeInfo? GetForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+    internal PgConcreteTypeInfo? GetForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
     {
         if (PgTypeId is { } pgTypeId)
         {
@@ -310,7 +310,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
         }
 
-        return _typeInfoProvider.GetForNestedObjectValue(context, value, out writeState);
+        return _typeInfoProvider.GetForValueAsNestedObject(context, value, out writeState);
     }
 
     public static PgConcreteTypeInfoProvider GetProvider(PgProviderTypeInfo instance) => instance._typeInfoProvider;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -456,6 +456,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
+        // Db nulls are format agnostic, any format will do here, bind can decide to ignore these based on size for overall format handling.
         if (Unsafe.As<PgConverter<T>>(Converter).IsDbNull(value, writeState))
             return new(DataFormat.Binary, Size.Zero, null, writeState);
 
@@ -492,6 +493,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
+        // Db nulls are format agnostic, any format will do here, bind can decide to ignore these based on size for overall format handling.
         if (Converter.IsDbNullAsObject(value, writeState))
             return new(DataFormat.Binary, Size.Zero, null, writeState);
 

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
-using Npgsql.Util;
 
 namespace Npgsql.Internal;
 
@@ -299,6 +298,21 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
+    internal PgConcreteTypeInfo? GetForNestedObjectValue(ProviderValueContext context, object? value, out object? writeState)
+    {
+        if (PgTypeId is { } pgTypeId)
+        {
+            if (context.ExpectedPgTypeId is not { } expectedId)
+            {
+                context = context with { ExpectedPgTypeId = pgTypeId };
+            }
+            else if (pgTypeId != expectedId)
+                ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
+        }
+
+        return _typeInfoProvider.GetForNestedObjectValue(context, value, out writeState);
+    }
+
     public static PgConcreteTypeInfoProvider GetProvider(PgProviderTypeInfo instance) => instance._typeInfoProvider;
 
     static void ThrowUnexpectedPgTypeId(string parameterName)
@@ -433,41 +447,75 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         return info;
     }
 
-    // Bind for writing.
-    /// When result is null, the value was interpreted to be a SQL NULL.
-    internal PgValueBinding BindParameterValue<T>(T? value, object? writeState, DataFormat? formatPreference = null)
+    internal PgValueBinding BindParameterValue<T>(T? value, object? writeState, NestedObjectDbNullHandling nestedObjectDbNullHandling, DataFormat? formatPreference = null)
     {
         if (typeof(T) != Converter.TypeToConvert)
-            return BindParameterObjectValue(value, writeState, formatPreference);
+            return BindParameterValueAsObject(value, writeState, nestedObjectDbNullHandling, formatPreference);
 
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
+        if (Unsafe.As<PgConverter<T>>(Converter).IsDbNull(value, writeState))
+            return new(DataFormat.Binary, Size.Zero, null, writeState);
 
-        Debug.Assert(Converter is PgConverter<T>);
-        if (Unsafe.As<PgConverter<T>>(Converter).IsDbNullOrGetSize(format, bufferRequirements.Write, value, ref writeState) is not { } size)
-            return new(format, bufferRequirements.Write, null, null);
+        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var context = new SizeContext(format, bufferRequirements.Write) { NestedObjectDbNullHandling = nestedObjectDbNullHandling };
+
+        Size size;
+        if (context.BufferRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
+        {
+            size = byteCount;
+        }
+        else
+        {
+            size = Unsafe.As<PgConverter<T>>(Converter).GetSize(context, value!, ref writeState);
+
+            switch (size.Kind)
+            {
+            case SizeKind.UpperBound:
+                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.UpperBound)} is not a valid return value for GetSize.");
+                break;
+            case SizeKind.Unknown:
+                // Not valid yet.
+                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.Unknown)} is not a valid return value for GetSize.");
+                break;
+            }
+        }
 
         return new(format, bufferRequirements.Write, size, writeState);
     }
 
-    // Bind for writing.
-    // Note: this api is not called BindAsObject as the semantics are extended, DBNull is a NULL value for all object values.
-    /// When result is null or DBNull, the value was interpreted to be a SQL NULL.
-    internal PgValueBinding BindParameterObjectValue(object? value, object? writeState, DataFormat? formatPreference = null)
+    internal PgValueBinding BindParameterValueAsObject(object? value, object? writeState, NestedObjectDbNullHandling nestedObjectDbNullHandling, DataFormat? formatPreference = null)
     {
         // Basically exists to catch cases like object[] resolving a polymorphic read converter, better to fail during binding than writing.
         if (!SupportsWriting)
             ThrowHelper.ThrowNotSupportedException($"Writing {Type} is not supported for this type info.");
 
-        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
+        if (Converter.IsDbNullAsObject(value, writeState))
+            return new(DataFormat.Binary, Size.Zero, null, writeState);
 
-        // Given SQL values are effectively a union of T | NULL we support DBNull.Value to signify a NULL value for all types except DBNull in this api.
-        if (value is DBNull && Type != typeof(DBNull) || Converter.IsDbNullOrGetSizeAsObject(format, bufferRequirements.Write, value, ref writeState) is not { } size)
+        var format = ResolveFormat(out var bufferRequirements, formatPreference ?? PreferredFormat);
+        var context = new SizeContext(format, bufferRequirements.Write) { NestedObjectDbNullHandling = nestedObjectDbNullHandling };
+
+        Size size;
+        if (context.BufferRequirement is { Kind: SizeKind.Exact, Value: var byteCount })
         {
-            return new(format, bufferRequirements.Write, null, null);
+            size = byteCount;
+        }
+        else
+        {
+            size = Converter.GetSizeAsObject(context, value, ref writeState);
+
+            switch (size.Kind)
+            {
+            case SizeKind.UpperBound:
+                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.UpperBound)} is not a valid return value for GetSize.");
+                break;
+            case SizeKind.Unknown:
+                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.Unknown)} is not a valid return value for GetSize.");
+                break;
+            }
         }
 
         return new(format, bufferRequirements.Write, size, writeState);

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -419,7 +419,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
 
         // Inline copy of Converter.ReadAsync<T> to keep everything in one async frame.
         var result = typeof(T) != Converter.TypeToConvert
-            ? (T)await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false)
+            ? (T)(await Converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false))!
             : await Unsafe.As<PgConverter<T>>(Converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false);
 
         await reader.EndReadAsync().ConfigureAwait(false);

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -320,6 +320,8 @@ public sealed class NpgsqlBinaryExporter : ICancelable
         // When T is a Nullable<T>, we support returning null
         if (default(T) is null && typeof(T).IsValueType)
             return default!;
+        if (typeof(T) == typeof(object))
+            return (T)(object)DBNull.Value;
         throw new InvalidCastException("Column is null");
     }
 

--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -1562,9 +1562,10 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
             using var registration = Connector.StartNestedCancellableOperation(cancellationToken, attemptPgCancellation: false);
 
             var reader = PgReader;
-            return await SeekToColumnAsync(ordinal, context.Binding.DataFormat).ConfigureAwait(false) is DbNullSentinel
-                ? DbNullValueOrThrow<T>(ordinal)
-                : await context.TypeInfo.ReadFieldValueAsync<T>(reader, context.Binding, cancellationToken).ConfigureAwait(false);
+            if (await SeekToColumnAsync(ordinal, context.Binding.DataFormat).ConfigureAwait(false) is DbNullSentinel)
+                return DbNullValueOrThrow<T>(ordinal);
+
+            return await context.TypeInfo.ReadFieldValueAsync<T>(reader, context.Binding, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -1581,9 +1582,10 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         ThrowIfNotInResult();
         var context = GetConversionContext(ordinal, type: typeof(T) == typeof(object) ? null : typeof(T));
 
-        return SeekToColumn(ordinal, context.Binding.DataFormat) is DbNullSentinel
-            ? DbNullValueOrThrow<T>(ordinal)
-            : context.TypeInfo.ReadFieldValue<T>(PgReader, context.Binding);
+        if (SeekToColumn(ordinal, context.Binding.DataFormat) is DbNullSentinel)
+            return DbNullValueOrThrow<T>(ordinal);
+
+        return context.TypeInfo.ReadFieldValue<T>(PgReader, context.Binding);
     }
 
     #endregion

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -304,7 +304,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
             return DBNull.Value;
 
         using var _ = PgReader.BeginNestedRead(columnLength, column.ObjectBinding.BufferRequirement);
-        return column.ObjectTypeInfo.Converter.ReadAsObject(PgReader);
+        return column.ObjectTypeInfo.Converter.ReadAsObject(PgReader)!;
     }
 
     /// <inheritdoc />
@@ -336,19 +336,21 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         var info = GetOrAddConverterInfo(typeof(T), column, ordinal);
 
         if (columnLength == -1)
-        {
-            // When T is a Nullable<T> (and only in that case), we support returning null
-            if (default(T) is null && typeof(T).IsValueType)
-                return default!;
-
-            if (typeof(T) == typeof(object))
-                return (T)(object)DBNull.Value;
-
-            ThrowHelper.ThrowInvalidCastException_NoValue();
-        }
+            return DbNullOrThrow<T>();
 
         using var _ = PgReader.BeginNestedRead(columnLength, info.Binding.BufferRequirement);
         return info.TypeInfo.Converter.Read<T>(PgReader);
+    }
+
+    static T DbNullOrThrow<T>()
+    {
+        // When T is a Nullable<T> (and only in that case), we support returning null
+        if (default(T) is null && typeof(T).IsValueType)
+            return default!;
+        if (typeof(T) == typeof(object))
+            return (T)(object)DBNull.Value;
+        ThrowHelper.ThrowInvalidCastException_NoValue();
+        return default!;
     }
 
     /// <inheritdoc />

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -766,7 +766,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                     if (value is null)
                         ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
 
-                    binding = ConcreteTypeInfo.Converter.IsNestedObjectDbNull(value, _writeState, ParameterDbNullHandling)
+                    binding = ConcreteTypeInfo.Converter.IsDbNullAsNestedObject(value, _writeState, ParameterDbNullHandling)
                         ? new PgValueBinding(DataFormat.Binary, 0, null, _writeState)
                         : ConcreteTypeInfo.BindParameterValueAsObject(value, _writeState, ParameterDbNullHandling, requiredFormat);
                 }

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -334,7 +334,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             // Infer from value but don't cache
             // We pass ValueType here for the generic derived type, where we should respect T and not the runtime type.
             if (GetValueType(StaticValueType) is { } valueType)
-                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, Value)?.ToNpgsqlDbType()?.ToDbType() ?? DbType.Object;
+                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, ValueAsObject)?.ToNpgsqlDbType()?.ToDbType() ?? DbType.Object;
 
             return DbType.Object;
         }
@@ -374,7 +374,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             // Infer from value but don't cache
             // We pass ValueType here for the generic derived type, where we should respect T and not the runtime type.
             if (valueType is not null)
-                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, Value)?.ToNpgsqlDbType() ?? NpgsqlDbType.Unknown;
+                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, ValueAsObject)?.ToNpgsqlDbType() ?? NpgsqlDbType.Unknown;
 
             return NpgsqlDbType.Unknown;
         }
@@ -422,7 +422,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             // Infer from value but don't cache
             // We pass ValueType here for the generic derived type, where we should respect T and not the runtime type.
             if (valueType is not null)
-                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, Value)?.DisplayName;
+                return GlobalTypeMapper.Instance.FindDataTypeName(valueType, ValueAsObject)?.DisplayName;
 
             return null;
         }
@@ -430,6 +430,16 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         {
             ResetTypeInfo();
             _dataTypeName = value;
+        }
+    }
+
+    // Value without DBNull to pass onto FindDataTypeName.
+    object? ValueAsObject
+    {
+        get
+        {
+            var value = Value;
+            return value is DBNull ? null : value;
         }
     }
 
@@ -519,6 +529,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     #endregion Other Properties
 
     #region Internals
+
+    /// The DBNull handling mode parameters apply at their own ADO.NET boundary.
+    /// Compositional converters inherit this from SizeContext / ProviderValueContext.
+    internal const NestedObjectDbNullHandling ParameterDbNullHandling = NestedObjectDbNullHandling.Extended;
 
     private protected virtual Type StaticValueType => typeof(object);
 
@@ -687,7 +701,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             {
                 // Pull from Value (not _value) so we also support object typed generic params.
                 var value = Value;
-                ConcreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(value is DBNull ? null : value, out _writeState);
+                ConcreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(
+                    new() { NestedObjectDbNullHandling = ParameterDbNullHandling },
+                    value is DBNull ? null : value,
+                    out _writeState);
             }
             else
             {
@@ -749,7 +766,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
                     if (value is null)
                         ThrowHelper.ThrowInvalidOperationException($"Parameter '{ParameterName}' cannot be null, DBNull.Value should be used instead.");
 
-                    binding = ConcreteTypeInfo.BindParameterObjectValue(value, _writeState, requiredFormat);
+                    binding = ConcreteTypeInfo.Converter.IsNestedObjectDbNull(value, _writeState, ParameterDbNullHandling)
+                        ? new PgValueBinding(DataFormat.Binary, 0, null, _writeState)
+                        : ConcreteTypeInfo.BindParameterValueAsObject(value, _writeState, ParameterDbNullHandling, requiredFormat);
                 }
                 else
                 {

--- a/src/Npgsql/NpgsqlParameter`.cs
+++ b/src/Npgsql/NpgsqlParameter`.cs
@@ -79,10 +79,13 @@ public sealed class NpgsqlParameter<T> : NpgsqlParameter
     #endregion Constructors
 
     private protected override PgConcreteTypeInfo MakeConcreteTypeInfoForTypedValue(PgTypeInfo typeInfo)
-        => typeInfo.MakeConcreteForValue(TypedValue, out _writeState);
+        => typeInfo.MakeConcreteForValue(
+            new() { NestedObjectDbNullHandling = ParameterDbNullHandling },
+            TypedValue,
+            out _writeState);
 
     private protected override PgValueBinding BindTypedValue(PgConcreteTypeInfo typeInfo, DataFormat? formatPreference)
-        => typeInfo.BindParameterValue(TypedValue, _writeState, formatPreference);
+        => typeInfo.BindParameterValue(TypedValue, _writeState, ParameterDbNullHandling, formatPreference);
 
     private protected override ValueTask WriteTypedValue(bool async, PgConcreteTypeInfo typeInfo, PgWriter writer, CancellationToken cancellationToken)
     {

--- a/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
+++ b/src/Npgsql/Replication/PgOutput/ReplicationValue.cs
@@ -135,15 +135,7 @@ public class ReplicationValue
         switch (Kind)
         {
         case TupleDataKind.Null:
-            // When T is a Nullable<T> (and only in that case), we support returning null
-            if (default(T) is null && typeof(T).IsValueType)
-                return default!;
-
-            if (typeof(T) == typeof(object))
-                return (T)(object)DBNull.Value;
-
-            ThrowHelper.ThrowInvalidCastException_NoValue(_fieldDescription);
-            break;
+            return DbNullOrThrow<T>();
 
         case TupleDataKind.UnchangedToastedValue:
             throw new InvalidCastException(
@@ -165,15 +157,7 @@ public class ReplicationValue
         switch (Kind)
         {
         case TupleDataKind.Null:
-            // When T is a Nullable<T> (and only in that case), we support returning null
-            if (default(T) is null && typeof(T).IsValueType)
-                return default!;
-
-            if (typeof(T) == typeof(object))
-                return (T)(object)DBNull.Value;
-
-            ThrowHelper.ThrowInvalidCastException_NoValue(_fieldDescription);
-            break;
+            return DbNullOrThrow<T>();
 
         case TupleDataKind.UnchangedToastedValue:
             throw new InvalidCastException(
@@ -185,6 +169,17 @@ public class ReplicationValue
         var reader = PgReader;
         reader.Init(conversionContext.Binding.DataFormat, Length);
         return await conversionContext.TypeInfo.ReadFieldValueAsync<T>(PgReader, conversionContext.Binding, cancellationToken).ConfigureAwait(false);
+    }
+
+    T DbNullOrThrow<T>()
+    {
+        // When T is a Nullable<T> (and only in that case), we support returning null
+        if (default(T) is null && typeof(T).IsValueType)
+            return default!;
+        if (typeof(T) == typeof(object))
+            return (T)(object)DBNull.Value;
+        ThrowHelper.ThrowInvalidCastException_NoValue(_fieldDescription);
+        return default!;
     }
 
     void ThrowIfInitialized()

--- a/src/Npgsql/ThrowHelper.cs
+++ b/src/Npgsql/ThrowHelper.cs
@@ -21,6 +21,10 @@ static class ThrowHelper
         => throw new ArgumentOutOfRangeException(paramName, string.Format(message, argument));
 
     [DoesNotReturn]
+    internal static void ThrowUnreachableException(string? message = null)
+        => throw new UnreachableException(message);
+
+    [DoesNotReturn]
     internal static void ThrowUnreachableException(string message, object argument)
         => throw new UnreachableException(string.Format(message, argument));
 

--- a/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/GlobalTypeMapper.cs
@@ -76,27 +76,20 @@ sealed class GlobalTypeMapper : INpgsqlTypeMapper
 
     internal DataTypeName? FindDataTypeName(Type type, object? value)
     {
-        DataTypeName? dataTypeName;
         try
         {
             var typeInfo = TypeMappingOptions.GetTypeInfoInternal(type, null);
-            if (typeInfo is PgProviderTypeInfo providerInfo)
-            {
-                var concreteTypeInfo = providerInfo.MakeConcreteForValueAsObject(value is DBNull ? null : value, out var state);
-                if (state is not null)
-                    concreteTypeInfo.DisposeWriteState(state);
-                dataTypeName = concreteTypeInfo.PgTypeId.DataTypeName;
-            }
-            else
-            {
-                dataTypeName = ((PgConcreteTypeInfo?)typeInfo)?.PgTypeId.DataTypeName;
-            }
+            if (typeInfo is null)
+                return null;
+            var concreteTypeInfo = typeInfo.MakeConcreteForValueAsObject(value, out var writeState);
+            if (writeState is not null)
+                concreteTypeInfo.DisposeWriteState(writeState);
+            return concreteTypeInfo.PgTypeId.DataTypeName;
         }
         catch
         {
-            dataTypeName = null;
+            return null;
         }
-        return dataTypeName;
     }
 
     internal static GlobalTypeMapper Instance { get; }

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -248,19 +248,30 @@ public class WriteStateTests : TestBase
         public bool WriteWriteStateReceived;
     }
 
-    sealed class WriteStateTrackingConverter(bool fixedSize, WriteStateTracker tracker, bool generatesWriteState = false)
-        : PgBufferedConverter<int>(customDbNullPredicate: true)
+    sealed class WriteStateTrackingConverter : PgBufferedConverter<int>
     {
+        readonly bool _fixedSize;
+        readonly WriteStateTracker _tracker;
+        readonly bool _generatesWriteState;
+
+        public WriteStateTrackingConverter(bool fixedSize, WriteStateTracker tracker, bool generatesWriteState = false)
+        {
+            _fixedSize = fixedSize;
+            _tracker = tracker;
+            _generatesWriteState = generatesWriteState;
+            HandleDbNull = true;
+        }
+
         public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
         {
-            bufferRequirements = fixedSize ? BufferRequirements.CreateFixedSize(sizeof(int)) : BufferRequirements.Create(Size.CreateUpperBound(sizeof(int)));
+            bufferRequirements = _fixedSize ? BufferRequirements.CreateFixedSize(sizeof(int)) : BufferRequirements.Create(Size.CreateUpperBound(sizeof(int)));
             return format is DataFormat.Binary;
         }
 
         protected override bool IsDbNullValue(int value, object? writeState)
         {
             if (writeState is not null)
-                tracker.IsDbNullWriteStateReceived = true;
+                _tracker.IsDbNullWriteStateReceived = true;
             return false;
         }
 
@@ -269,7 +280,7 @@ public class WriteStateTests : TestBase
         protected override void WriteCore(PgWriter writer, int value)
         {
             if (writer.Current.WriteState is not null)
-                tracker.WriteWriteStateReceived = true;
+                _tracker.WriteWriteStateReceived = true;
             writer.WriteInt32(value);
         }
 
@@ -278,7 +289,7 @@ public class WriteStateTests : TestBase
             // Range/Multirange call the subtype converter directly with a fresh null writeState, so for those tests the
             // subtype must produce state from GetSize. For the array tests the provider has already populated non-null
             // state and the ??= is a no-op, preserving existing behavior.
-            if (generatesWriteState)
+            if (_generatesWriteState)
                 writeState ??= "provider-state";
             return sizeof(int);
         }


### PR DESCRIPTION
Splits two concerns the prior `DbNullPredicate` enum was conflating:

1. **The converter's intrinsic null contract** — does the converter's `T` accept CLR null at all, and does the converter treat values it understands as database nulls? Owned by the converter because only the converter can answer it for `T`.
2. **The erasure-layer's null-sentinel policy** — when a slot erases values to `object`, what do CLR null and `DBNull.Value` mean *before* the converter is consulted? Owned by the erasure performer (parameter binder, array element op when `TElement == object`, composite field) because it varies per call site sharing one converter.

The four-state `DbNullPredicate` (with `PolymorphicNull` baked into the converter at construction time) handled both as a single static flag, which couldn't express call-site variance and forced converters to know whether they'd been boxed. The rework keeps the intrinsic story on the converter (`TypeAcceptsNull` + `HandleDbNull`) and moves the erasure-layer policy onto the erasure performer's context (`NestedObjectDbNullHandling`).

## What changed, by layer

### `PgConverter` substrate — `src/Npgsql/Internal/PgConverter.cs`

- Replaces the four-state `DbNullPredicate` enum (`None` / `Custom` / `Null` / **`PolymorphicNull`**) with two orthogonal flags producing three states:
  - `TypeAcceptsNull` (auto-derived from `T` / effective type — does CLR null even reach this converter's API?)
  - `HandleDbNull` (init property — does the converter override `IsDbNullValue`?)
  - `DbNullPredicateKind` is now derived: `Custom` ↔ `Null` ↔ `None`.
- `PolymorphicNull` is gone. `DBNull` is no longer special at the converter layer.
- Constructor surface change: typed `PgConverter<T>(bool customDbNullPredicate)` → `PgConverter<T>()` or `PgConverter<T>(Type effectiveType)`; `customDbNullPredicate` ctor arg replaced by `HandleDbNull { get; init; }`.
- AsObject paths now legitimately accept null — `WriteAsObject(object? value)`, `ReadAsObject` returns `object?`, `GetSizeAsObject(... object? value, ...)`. Throw at the AsObject boundary when null reaches a `!TypeAcceptsNull` converter; `Debug.Assert` on the typed path.
- New extension `IsNestedObjectDbNull(converter, value, writeState, NestedObjectDbNullHandling)` — extension form is deliberate: it's an erasure-performer helper, not a converter responsibility, and stays out of `PgConverter`'s public vocabulary.

### New context property — `NestedObjectDbNullHandling`

Three modes:

- `Default` — CLR null → SQL null; DBNull sentinel passes through to the converter.
- `Extended` — CLR null AND DBNull both → SQL null. Pushed to the edge converter at the ADO.NET parameter boundary.
- `ExtendedThrowOnNull` — CLR null throws; DBNull → SQL null. Semantically used by the ADO.NET parameter boundary before calling into the converter.

Threaded as init properties on:

- `SizeContext.NestedObjectDbNullHandling`
- `ProviderValueContext.NestedObjectDbNullHandling`

### `PgTypeInfo` / providers

- New `GetForNestedObjectValue(ProviderValueContext, value, out writeState)` on both `PgTypeInfo` and `PgConcreteTypeInfoProvider` — the chokepoint where the three-mode null pre-filter runs *before* dispatch into the value-targeted resolver.
- `BindParameterValue<T>` / `BindParameterValueAsObject` get a `NestedObjectDbNullHandling` parameter; old `IsDbNullOrGetSize` rolled into `IsDbNull` + `GetSize` directly inside the binder, with explicit `Exact`-buffer fast path and explicit rejection of `UpperBound` / `Unknown` size kinds.
- `ResolveTypeInfo` / `Bind` on `NpgsqlParameter` now thread a single `internal const NestedObjectDbNullHandling ParameterDbNullHandling = Extended` through the path. Generic `NpgsqlParameter<T>` does the same in its overrides.

### Compositional consumers

- **Array converters**: when `TElement == typeof(object)`, use the nested-object-null path (`IsNestedObjectDbNull` + `GetSizeAsObject`) and propagate `context.NestedObjectDbNullHandling` into per-element `SizeContext` and through the `ArrayConverterCore.WriteState`.
- **Composites** (`CompositeFieldInfo`): bind through the typed dispatcher, hardcoded to `NestedObjectDbNullHandling.Default` — composite fields create a new serialization scope where DBNull is not a sentinel.
- **`CastingConverter<T>`**: now constructed with the effective type to derive `TypeAcceptsNull` correctly; copies `HandleDbNull` from inner.
- **`NullableConverter<T>`**: rewritten from primary-ctor record shape to explicit fields so `HandleDbNull` can be init-assigned from inner.
- **`VersionPrefixedTextConverter`**, **`RangeConverter`**, **`RecordConverter`**, **`ObjectConverter`**, **`PgBufferedConverter`**, **`PgStreamingConverter`**: ctor-signature updates to drop `customDbNullPredicate` and add `HandleDbNull = true` where they previously asserted custom DB-null logic.

### Reader/writer surface

- `NpgsqlDataReader`, `NpgsqlNestedDataReader`, `NpgsqlBinaryExporter`, `Replication.PgOutput.ReplicationValue`: no behavioral changes; just ride the new `object?`-typed AsObject signatures.
- `NpgsqlParameter.ValueAsObject` helper added to filter `DBNull` → `null` at type-inference sites (`DbType` / `NpgsqlDbType` / `DataTypeName` getters).

### Tests — `WriteStateTests.cs`

- `WriteStateTrackingConverter` migrated from `customDbNullPredicate: true` ctor arg to explicit `HandleDbNull = true` init.

## What this enables

- The ADO.NET boundary (parameter) explicitly opts into DBNull-as-sentinel via `Extended`.
- Composite fields explicitly opt out via `Default`.
- CLR null can now legitimately flow into typed converter APIs when `TypeAcceptsNull` is true (e.g., `string`, `Nullable<T>`); previously gated by `[DisallowNull]`.
- The `DbNullPredicate.PolymorphicNull` static-flag escape hatch is gone — null-sentinel handling is now a parent concern of whoever erases to `object`, not a static fact baked into the converter at construction time.
- Provider chokepoint (`GetForNestedObjectValue`) unblocks `LateBoundTypeInfoProvider` and similar value-targeted resolvers that need to short-circuit on null before dispatching.