### PR TITLE
Move write state types out of generic converters and rename

### DIFF
--- a/src/Npgsql/Internal/Converters/CompositeConverter.cs
+++ b/src/Npgsql/Internal/Converters/CompositeConverter.cs
@@ -190,15 +190,15 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
 
         return totalSize;
 
-        static WriteState RentWrapper(object boxedInstance, int fieldCount, bool anyWriteState)
+        static CompositeWriteState RentWrapper(object boxedInstance, int fieldCount, bool anyWriteState)
         {
-            var data = ArrayPool<ElementState>.Shared.Rent(fieldCount);
-            // Stale slots from the previous pool user must read as default(ElementState) — Dispose iterates
+            var data = ArrayPool<CompositeFieldWriteState>.Shared.Rent(fieldCount);
+            // Stale slots from the previous pool user must read as default(CompositeFieldWriteState) — Dispose iterates
             // the full segment and relies on null WriteState in unfilled slots to skip them safely.
             Array.Clear(data, 0, fieldCount);
-            return new WriteState
+            return new CompositeWriteState
             {
-                ArrayPool = ArrayPool<ElementState>.Shared,
+                ArrayPool = ArrayPool<CompositeFieldWriteState>.Shared,
                 Data = new(data, 0, fieldCount),
                 AnyWriteState = anyWriteState,
                 BoxedInstance = boxedInstance,
@@ -221,10 +221,10 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
         // we can't recover per-field value-dependent sizes otherwise.
         var writeState = writer.Current.WriteState switch
         {
-            WriteState ws => ws,
+            CompositeWriteState ws => ws,
             null when _writeSizePrecomputed.Kind is SizeKind.Exact => null,
             null => throw new InvalidOperationException("Composite Write requires per-field data from BindValue when any field is variable-size."),
-            _ => throw new InvalidCastException($"Invalid write state, expected {typeof(WriteState).FullName}.")
+            _ => throw new InvalidCastException($"Invalid write state, expected {typeof(CompositeWriteState).FullName}.")
         };
         Debug.Assert(_bufferRequirements.Write.Kind is not SizeKind.Exact || writeState is null,
             "Exact-size composite must not carry write state — BindValue should have been skipped.");
@@ -249,7 +249,7 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
             // path for fixed-size fields). The cached default writes the same bytes a stateful slot would
             // have, with no per-slot disposal obligation. Variable-size composites must populate every
             // slot during BindValue, so data[i].Converter is never null on the slow path.
-            ElementState elementState;
+            CompositeFieldWriteState elementState;
             if (data?[i] is { Converter: not null } state)
                 elementState = state;
             else
@@ -273,42 +273,43 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
         }
     }
 
-    struct ElementState
-    {
-        public Size Size;
-        public object? WriteState;
-        public PgConverter? Converter;
-        public Size BufferRequirement;
-    }
+}
 
-    class WriteState : IDisposable
-    {
-        public required ArrayPool<ElementState>? ArrayPool { get; set; }
-        public required ArraySegment<ElementState> Data { get; set; }
-        public required bool AnyWriteState { get; set; }
-        public required object BoxedInstance { get; set; }
-        int _disposed;
+file struct CompositeFieldWriteState
+{
+    public Size Size;
+    public object? WriteState;
+    public PgConverter? Converter;
+    public Size BufferRequirement;
+}
 
-        public void Dispose()
+file sealed class CompositeWriteState : IDisposable
+{
+    public required ArrayPool<CompositeFieldWriteState>? ArrayPool { get; set; }
+    public required ArraySegment<CompositeFieldWriteState> Data { get; set; }
+    public required bool AnyWriteState { get; set; }
+    public required object BoxedInstance { get; set; }
+    int _disposed;
+
+    public void Dispose()
+    {
+        // Atomic idempotency guard — double-dispose returns the rented CompositeFieldWriteState[] to the pool
+        // twice. Atomic catches concurrent disposal too, important once states become reusable.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
-            // Atomic idempotency guard — double-dispose returns the rented ElementState[] to the pool
-            // twice. Atomic catches concurrent disposal too, important once states become reusable.
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                Debug.Assert(false, "CompositeConverter.WriteState double-dispose detected — caller violated lifecycle contract.");
-                return;
-            }
-
-            if (Data.Array is not { } array)
-                return;
-
-            if (AnyWriteState)
-                for (var i = Data.Offset; i < Data.Offset + Data.Count; i++)
-                    if (array[i].WriteState is IDisposable disposable)
-                        disposable.Dispose();
-
-            Array.Clear(array, Data.Offset, Data.Count);
-            ArrayPool?.Return(array);
+            Debug.Assert(false, $"{nameof(CompositeWriteState)} double-dispose detected — caller violated lifecycle contract.");
+            return;
         }
+
+        if (Data.Array is not { } array)
+            return;
+
+        if (AnyWriteState)
+            for (var i = Data.Offset; i < Data.Offset + Data.Count; i++)
+                if (array[i].WriteState is IDisposable disposable)
+                    disposable.Dispose();
+
+        Array.Clear(array, Data.Offset, Data.Count);
+        ArrayPool?.Return(array);
     }
 }

--- a/src/Npgsql/Internal/Converters/CompositeConverter.cs
+++ b/src/Npgsql/Internal/Converters/CompositeConverter.cs
@@ -192,13 +192,13 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
 
         static CompositeWriteState RentWrapper(object boxedInstance, int fieldCount, bool anyWriteState)
         {
-            var data = ArrayPool<CompositeFieldWriteState>.Shared.Rent(fieldCount);
-            // Stale slots from the previous pool user must read as default(CompositeFieldWriteState) — Dispose iterates
+            var data = ArrayPool<CompositeWriteState.FieldState>.Shared.Rent(fieldCount);
+            // Stale slots from the previous pool user must read as default(CompositeWriteState.FieldState) — Dispose iterates
             // the full segment and relies on null WriteState in unfilled slots to skip them safely.
             Array.Clear(data, 0, fieldCount);
             return new CompositeWriteState
             {
-                ArrayPool = ArrayPool<CompositeFieldWriteState>.Shared,
+                ArrayPool = ArrayPool<CompositeWriteState.FieldState>.Shared,
                 Data = new(data, 0, fieldCount),
                 AnyWriteState = anyWriteState,
                 BoxedInstance = boxedInstance,
@@ -249,7 +249,7 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
             // path for fixed-size fields). The cached default writes the same bytes a stateful slot would
             // have, with no per-slot disposal obligation. Variable-size composites must populate every
             // slot during BindValue, so data[i].Converter is never null on the slow path.
-            CompositeFieldWriteState elementState;
+            CompositeWriteState.FieldState elementState;
             if (data?[i] is { Converter: not null } state)
                 elementState = state;
             else
@@ -275,25 +275,17 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
 
 }
 
-file struct CompositeFieldWriteState
-{
-    public Size Size;
-    public object? WriteState;
-    public PgConverter? Converter;
-    public Size BufferRequirement;
-}
-
 file sealed class CompositeWriteState : IDisposable
 {
-    public required ArrayPool<CompositeFieldWriteState>? ArrayPool { get; set; }
-    public required ArraySegment<CompositeFieldWriteState> Data { get; set; }
+    public required ArrayPool<FieldState>? ArrayPool { get; set; }
+    public required ArraySegment<FieldState> Data { get; set; }
     public required bool AnyWriteState { get; set; }
     public required object BoxedInstance { get; set; }
     int _disposed;
 
     public void Dispose()
     {
-        // Atomic idempotency guard — double-dispose returns the rented CompositeFieldWriteState[] to the pool
+        // Atomic idempotency guard — double-dispose returns the rented FieldState[] to the pool
         // twice. Atomic catches concurrent disposal too, important once states become reusable.
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
@@ -311,5 +303,13 @@ file sealed class CompositeWriteState : IDisposable
 
         Array.Clear(array, Data.Offset, Data.Count);
         ArrayPool?.Return(array);
+    }
+
+    public struct FieldState
+    {
+        public Size Size;
+        public object? WriteState;
+        public PgConverter? Converter;
+        public Size BufferRequirement;
     }
 }

--- a/src/Npgsql/Internal/Converters/HstoreConverter.cs
+++ b/src/Npgsql/Internal/Converters/HstoreConverter.cs
@@ -29,7 +29,7 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
         var arrayPool = ArrayPool<(Size Size, object? WriteState)>.Shared;
         var data = arrayPool.Rent(value.Count * 2);
         Array.Clear(data, 0, value.Count * 2);
-        writeState = new WriteState
+        writeState = new HstoreWriteState
         {
             ArrayPool = arrayPool,
             Data = new(data, 0, value.Count * 2),
@@ -101,15 +101,15 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
 
     async ValueTask Write(bool async, PgWriter writer, T value, CancellationToken cancellationToken)
     {
-        if (writer.Current.WriteState is not WriteState && value.Count is not 0)
-            throw new InvalidCastException($"Invalid write state, expected {typeof(WriteState).FullName}.");
+        if (writer.Current.WriteState is not HstoreWriteState && value.Count is not 0)
+            throw new InvalidCastException($"Invalid write state, expected {typeof(HstoreWriteState).FullName}.");
 
         // Number of lengths (count, key length, value length).
         if (writer.ShouldFlush(sizeof(int)))
             await writer.Flush(async, cancellationToken).ConfigureAwait(false);
         writer.WriteInt32(value.Count);
 
-        if (value.Count is 0 || writer.Current.WriteState is not WriteState writeState)
+        if (value.Count is 0 || writer.Current.WriteState is not HstoreWriteState writeState)
             return;
 
         var data = writeState.Data;
@@ -150,7 +150,6 @@ sealed class HstoreConverter<T>(Encoding encoding, Func<ICollection<KeyValuePair
         }
     }
 
-    sealed class WriteState : MultiWriteState
-    {
-    }
 }
+
+file sealed class HstoreWriteState : MultiWriteState;

--- a/src/Npgsql/Internal/Converters/LateBindingConverter.cs
+++ b/src/Npgsql/Internal/Converters/LateBindingConverter.cs
@@ -6,17 +6,17 @@ using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
 
-sealed class ObjectConverter : PgStreamingConverter<object>
+sealed class LateBindingConverter : PgStreamingConverter<object>
 {
-    public ObjectConverter() => HandleDbNull = true;
+    public LateBindingConverter() => HandleDbNull = true;
 
     protected override bool IsDbNullValue(object? value, object? writeState)
     {
         var (concreteTypeInfo, effectiveState) = writeState switch
         {
             PgConcreteTypeInfo info => (info, (object?)null),
-            WriteState ws => (ws.ConcreteTypeInfo, ws.EffectiveState),
-            _ => throw new InvalidOperationException("writeState cannot be null, LateBoundTypeInfoProvider is expected to pre-populate it with concrete type info.")
+            LateBindingWriteState ws => (ws.ConcreteTypeInfo, ws.EffectiveState),
+            _ => throw new InvalidOperationException("writeState cannot be null, LateBindingTypeInfoProvider is expected to pre-populate it with concrete type info.")
         };
 
         return concreteTypeInfo.Converter.IsDbNullAsObject(value, effectiveState);
@@ -30,7 +30,7 @@ sealed class ObjectConverter : PgStreamingConverter<object>
         var (concreteTypeInfo, effectiveState) = writeState switch
         {
             PgConcreteTypeInfo info => (info, (object?)null),
-            WriteState state => (state.ConcreteTypeInfo, state.EffectiveState),
+            LateBindingWriteState state => (state.ConcreteTypeInfo, state.EffectiveState),
             _ => throw new InvalidOperationException("Invalid state")
         };
 
@@ -43,7 +43,7 @@ sealed class ObjectConverter : PgStreamingConverter<object>
         // Null the wrapper's EffectiveState before handoff. Inner BindAsObject's framework safety net
         // disposes via our local ref on throw and nulls the local; the wrapper would otherwise hold a
         // dangling reference to the same object, double-disposing through outer Bind's catch.
-        if (writeState is WriteState before)
+        if (writeState is LateBindingWriteState before)
             before.EffectiveState = null;
 
         var result = concreteTypeInfo.Converter.BindAsObject(
@@ -52,10 +52,10 @@ sealed class ObjectConverter : PgStreamingConverter<object>
             ref effectiveState);
         if (effectiveState is not null)
         {
-            if (writeState is WriteState s)
+            if (writeState is LateBindingWriteState s)
                 s.EffectiveState = effectiveState;
             else
-                writeState = new WriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState };
+                writeState = new LateBindingWriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState };
         }
 
         return result;
@@ -72,7 +72,7 @@ sealed class ObjectConverter : PgStreamingConverter<object>
         var (concreteTypeInfo, effectiveState) = writer.Current.WriteState switch
         {
             PgConcreteTypeInfo info => (info, (object?)null),
-            WriteState state => (state.ConcreteTypeInfo, state.EffectiveState),
+            LateBindingWriteState state => (state.ConcreteTypeInfo, state.EffectiveState),
             _ => throw new InvalidOperationException("Invalid state")
         };
 
@@ -82,37 +82,13 @@ sealed class ObjectConverter : PgStreamingConverter<object>
         using var _ = await writer.BeginNestedWrite(async, writeRequirement, writer.Current.Size.Value, effectiveState, cancellationToken).ConfigureAwait(false);
         await concreteTypeInfo.Converter.WriteAsObject(async, writer, value, cancellationToken).ConfigureAwait(false);
     }
-
-    internal sealed class WriteState : IDisposable
-    {
-        public required PgConcreteTypeInfo ConcreteTypeInfo { get; init; }
-        public required object? EffectiveState { get; set; }
-        int _disposed;
-
-        // EffectiveState may hold a pooled WriteState from the underlying concrete converter
-        // (composite, array, etc.). The outer DisposeWriteState on PgTypeInfo only sees this
-        // wrapper, so the wrapper is responsible for cascading disposal to the inner state.
-        public void Dispose()
-        {
-            // Atomic idempotency guard — EffectiveState may be pool-backed; cascading double-dispose
-            // corrupts downstream pools. Atomic catches concurrent disposal too.
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                Debug.Assert(false, "ObjectConverter.WriteState double-dispose detected — caller violated lifecycle contract.");
-                return;
-            }
-
-            if (EffectiveState is IDisposable disposable)
-                disposable.Dispose();
-        }
-    }
 }
 
 // TODO the goal is to allow this provider to return the underlying converter type info, but we're not there yet.
-// At that point we don't need the ObjectConverter any longer.
-sealed class LateBoundTypeInfoProvider(PgSerializerOptions options, PgTypeId typeId) : PgConcreteTypeInfoProvider<object>
+// At that point we don't need the LateBindingConverter any longer.
+sealed class LateBindingTypeInfoProvider(PgSerializerOptions options, PgTypeId typeId) : PgConcreteTypeInfoProvider<object>
 {
-    readonly PgConcreteTypeInfo _defaultConcreteTypeInfo = new(options, new ObjectConverter(), typeId);
+    readonly PgConcreteTypeInfo _defaultConcreteTypeInfo = new(options, new LateBindingConverter(), typeId);
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
     {
@@ -139,11 +115,35 @@ sealed class LateBoundTypeInfoProvider(PgSerializerOptions options, PgTypeId typ
         // cascades to EffectiveState; PgConcreteTypeInfo (non-IDisposable) is a long-lived cached
         // instance so the no-wrapper branch is naturally safe.
         writeState = effectiveState is not null
-            ? new ObjectConverter.WriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState }
+            ? new LateBindingWriteState { ConcreteTypeInfo = concreteTypeInfo, EffectiveState = effectiveState }
             : concreteTypeInfo;
         if (!concreteTypeInfo.SupportsWriting)
             AdoSerializerHelpers.ThrowWritingNotSupported(valueType, options, concreteTypeInfo.PgTypeId, resolved: true);
 
         return GetDefault(context.ExpectedPgTypeId);
+    }
+}
+
+file sealed class LateBindingWriteState : IDisposable
+{
+    public required PgConcreteTypeInfo ConcreteTypeInfo { get; init; }
+    public required object? EffectiveState { get; set; }
+    int _disposed;
+
+    // EffectiveState may hold a pooled write state from the underlying concrete converter
+    // (composite, array, etc.). The outer DisposeWriteState on PgTypeInfo only sees this
+    // wrapper, so the wrapper is responsible for cascading disposal to the inner state.
+    public void Dispose()
+    {
+        // Atomic idempotency guard — EffectiveState may be pool-backed; cascading double-dispose
+        // corrupts downstream pools. Atomic catches concurrent disposal too.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            Debug.Assert(false, $"{nameof(LateBindingWriteState)} double-dispose detected — caller violated lifecycle contract.");
+            return;
+        }
+
+        if (EffectiveState is IDisposable disposable)
+            disposable.Dispose();
     }
 }

--- a/src/Npgsql/Internal/Converters/MultirangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/MultirangeConverter.cs
@@ -76,7 +76,7 @@ sealed class MultirangeConverter<T, TRange> : PgStreamingConverter<T>
         var arrayPool = ArrayPool<(Size Size, object? WriteState)>.Shared;
         var data = arrayPool.Rent(value.Count);
         Array.Clear(data, 0, value.Count);
-        var state = new WriteState
+        var state = new MultirangeWriteState
         {
             ArrayPool = arrayPool,
             Data = new(data, 0, value.Count),
@@ -109,7 +109,7 @@ sealed class MultirangeConverter<T, TRange> : PgStreamingConverter<T>
 
     async ValueTask Write(bool async, PgWriter writer, T value, CancellationToken cancellationToken)
     {
-        if (writer.Current.WriteState is not WriteState writeState)
+        if (writer.Current.WriteState is not MultirangeWriteState writeState)
             throw new InvalidCastException($"Invalid state {writer.Current.WriteState?.GetType().FullName}.");
 
         if (writer.ShouldFlush(sizeof(int)))
@@ -140,7 +140,6 @@ sealed class MultirangeConverter<T, TRange> : PgStreamingConverter<T>
         }
     }
 
-    sealed class WriteState : MultiWriteState
-    {
-    }
 }
+
+file sealed class MultirangeWriteState : MultiWriteState;

--- a/src/Npgsql/Internal/Converters/RangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/RangeConverter.cs
@@ -107,12 +107,12 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         // wrapper to writeState so a subsequent inner Bind's throw is caught by the framework wrapper
         // and disposed via WriteState.Dispose, which cascades to any populated bound's inner state.
         var subtypeContext = BindContext.CreateNested(context, _subtypeRequirements);
-        WriteState? state = null;
+        RangeWriteState? state = null;
         if (!value.LowerBoundInfinite && !_subtypeConverter.IsDbNull(value.LowerBound!, null))
         {
             object? subTypeState = null;
             var size = _subtypeConverter.Bind(subtypeContext, value.LowerBound!, ref subTypeState);
-            state = new WriteState();
+            state = new RangeWriteState();
             writeState = state;
             state.LowerBoundSize = size;
             state.LowerBoundWriteState = subTypeState;
@@ -125,7 +125,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
             var size = _subtypeConverter.Bind(subtypeContext, value.UpperBound!, ref subTypeState);
             if (state is null)
             {
-                state = new WriteState();
+                state = new RangeWriteState();
                 writeState = state;
             }
             state.UpperBoundSize = size;
@@ -144,7 +144,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
 
     async ValueTask Write(bool async, PgWriter writer, NpgsqlRange<TSubtype> value, CancellationToken cancellationToken)
     {
-        var writeState = writer.Current.WriteState as WriteState;
+        var writeState = writer.Current.WriteState as RangeWriteState;
         var lowerBoundSize = writeState?.LowerBoundSize ?? -1;
         var upperBoundSize = writeState?.UpperBoundSize ?? -1;
 
@@ -169,7 +169,7 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
 
         // Always need write state from this point.
         if (writeState is null)
-            throw new InvalidCastException($"Invalid write state, expected {typeof(WriteState).FullName}.");
+            throw new InvalidCastException($"Invalid write state, expected {typeof(RangeWriteState).FullName}.");
 
         if (!lowerBoundInfinite)
         {
@@ -208,28 +208,29 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
         }
     }
 
-    sealed class WriteState : IDisposable
+}
+
+file sealed class RangeWriteState : IDisposable
+{
+    // Default to -1 ("treat as infinite/null") so a partially populated WriteState — only one bound
+    // carrying real payload — leaves the unset bound's flag-rewriting in Write working correctly.
+    internal Size LowerBoundSize { get; set; } = -1;
+    internal object? LowerBoundWriteState { get; set; }
+    internal Size UpperBoundSize { get; set; } = -1;
+    internal object? UpperBoundWriteState { get; set; }
+    int _disposed;
+
+    public void Dispose()
     {
-        // Default to -1 ("treat as infinite/null") so a partially populated WriteState — only one bound
-        // carrying real payload — leaves the unset bound's flag-rewriting in Write working correctly.
-        internal Size LowerBoundSize { get; set; } = -1;
-        internal object? LowerBoundWriteState { get; set; }
-        internal Size UpperBoundSize { get; set; } = -1;
-        internal object? UpperBoundWriteState { get; set; }
-        int _disposed;
-
-        public void Dispose()
+        // Atomic idempotency guard — bound states may be pool-backed; cascading double-dispose
+        // corrupts downstream pools. Atomic catches concurrent disposal too.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
-            // Atomic idempotency guard — bound states may be pool-backed; cascading double-dispose
-            // corrupts downstream pools. Atomic catches concurrent disposal too.
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-            {
-                Debug.Assert(false, "RangeConverter.WriteState double-dispose detected — caller violated lifecycle contract.");
-                return;
-            }
-
-            (LowerBoundWriteState as IDisposable)?.Dispose();
-            (UpperBoundWriteState as IDisposable)?.Dispose();
+            Debug.Assert(false, $"{nameof(RangeWriteState)} double-dispose detected — caller violated lifecycle contract.");
+            return;
         }
+
+        (LowerBoundWriteState as IDisposable)?.Dispose();
+        (UpperBoundWriteState as IDisposable)?.Dispose();
     }
 }

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -546,7 +546,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             var mappings = new TypeInfoMappingCollection();
             mappings.AddProviderType<object>(pgElementType.DataTypeName,
-                (options, mapping, includeDataTypeName) => mapping.CreateInfo(options, new LateBoundTypeInfoProvider(options, elementId), includeDataTypeName), MatchRequirement.DataTypeName);
+                (options, mapping, includeDataTypeName) => mapping.CreateInfo(options, new LateBindingTypeInfoProvider(options, elementId), includeDataTypeName), MatchRequirement.DataTypeName);
             mappings.AddProviderArrayType<object>(pgElementType.DataTypeName);
             return mappings.Find(type, dataTypeName, options);
         }

--- a/src/Npgsql/Internal/TypeInfoMapping.cs
+++ b/src/Npgsql/Internal/TypeInfoMapping.cs
@@ -718,7 +718,7 @@ public sealed class TypeInfoMappingCollection
                     converter,
                     // Polymorphism only makes sense over a provider element; if the element provider was erased
                     // to a concrete (pgTypeIdClassified), there's no polymorphism left to express. Today's
-                    // polymorphic elements are unclassified object-shape providers (e.g. LateBoundTypeInfoProvider),
+                    // polymorphic elements are unclassified object-shape providers (e.g. LateBindingTypeInfoProvider),
                     // so this path isn't reached.
                     static (_, _) => throw new InvalidOperationException("Polymorphic provider arrays do not support pgTypeIdClassified element providers."),
                     supportsReading: true, supportsWriting: false))

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -755,7 +755,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         {
             DisposeBindingState();
             // First Bind consumed _providerWriteState into _binding. Re-resolve so the rebuild has
-            // the state late-bound paths (ObjectConverter.BindValue) require — without this the
+            // the state late-bound paths (LateBindingConverter.BindValue) require — without this the
             // re-bind would hit "Invalid state" before the format-mismatch error could surface.
             // Typed-concrete paths re-resolve to default state, harmless.
             if (TypeInfo is not null && _providerWriteState is null)

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -40,11 +40,11 @@ public class WriteStateTests : TestBase
     {
         // Verifies write state propagation through two layers with mixed element shapes:
         //   outer: ArrayTypeInfoProvider<object[], object>
-        //   inner: LateBoundTypeInfoProvider (object -> int or DBNull)
+        //   inner: LateBindingTypeInfoProvider (object -> int or DBNull)
         //            int path  -> WriteStateTrackingProvider<int>         (per-element wrapped WriteState)
         //            null path -> PgSerializerOptions.UnspecifiedDBNullTypeInfo (different concrete info entirely)
         // The tracking int converter's IsDbNullValue and WriteCore must see the provider-produced
-        // write state after passing through the array + ObjectConverter layers, while the DBNull
+        // write state after passing through the array + LateBindingConverter layers, while the DBNull
         // slots must flow through without disturbing the non-null slots.
         var tracker = new WriteStateTracker();
         var options = BuildOptions(b => b.EnableArrays(), new WriteStateTrackingResolverFactory(fixedSize, tracker));
@@ -67,10 +67,10 @@ public class WriteStateTests : TestBase
     public void Object_write_state_upgrades_when_late_bound_inner_produces_at_bind()
     {
         // Verifies the bind-time writeState upgrade path: late-bound resolution returns a converter
-        // whose provider does not pre-populate state, so writeState arrives at ObjectConverter.BindValue
+        // whose provider does not pre-populate state, so writeState arrives at LateBindingConverter.BindValue
         // as a bare PgConcreteTypeInfo (non-IDisposable). The inner converter's BindValue then produces
-        // state during bind, and ObjectConverter must upgrade the outer writeState reference from the
-        // bare PgConcreteTypeInfo to a wrapped ObjectConverter.WriteState (IDisposable).
+        // state during bind, and LateBindingConverter must upgrade the outer writeState reference from the
+        // bare PgConcreteTypeInfo to a wrapped LateBindingConverter.WriteState (IDisposable).
         // Exercises the disposability-conditional lifecycle rule: replacing a non-IDisposable reference
         // with an IDisposable wrapper is allowed because the original carries no disposal obligation.
         var tracker = new WriteStateTracker();
@@ -753,10 +753,10 @@ public class WriteStateTests : TestBase
                 if (dataTypeName == DataTypeNames.Int4 && (type == typeof(int) || type is null))
                     return new PgProviderTypeInfo(options, new WriteStateTrackingProvider(options, fixedSize, tracker, produceProviderState, generatesWriteStateAtBind), DataTypeNames.Int4);
 
-                // object->int4 goes through LateBoundTypeInfoProvider which delegates back to the int resolver above,
+                // object->int4 goes through LateBindingTypeInfoProvider which delegates back to the int resolver above,
                 // letting us exercise write-state propagation across the object (late-bound) element layer.
                 if (dataTypeName == DataTypeNames.Int4 && type == typeof(object))
-                    return new PgProviderTypeInfo(options, new LateBoundTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Int4)), DataTypeNames.Int4);
+                    return new PgProviderTypeInfo(options, new LateBindingTypeInfoProvider(options, options.GetCanonicalTypeId(DataTypeNames.Int4)), DataTypeNames.Int4);
 
                 return null;
             }

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -70,7 +70,7 @@ public class WriteStateTests : TestBase
         // whose provider does not pre-populate state, so writeState arrives at LateBindingConverter.BindValue
         // as a bare PgConcreteTypeInfo (non-IDisposable). The inner converter's BindValue then produces
         // state during bind, and LateBindingConverter must upgrade the outer writeState reference from the
-        // bare PgConcreteTypeInfo to a wrapped LateBindingConverter.WriteState (IDisposable).
+        // bare PgConcreteTypeInfo to a wrapped LateBindingWriteState (IDisposable).
         // Exercises the disposability-conditional lifecycle rule: replacing a non-IDisposable reference
         // with an IDisposable wrapper is allowed because the original carries no disposal obligation.
         var tracker = new WriteStateTracker();


### PR DESCRIPTION
Should reduce generic duplication a bit, and with `file` types we don't give up localized visibility either.