### PR TITLE
Remove PgBufferedConverter virtual dispatch hop

### DIFF
--- a/src/Npgsql.NodaTime/Internal/DurationConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/DurationConverter.cs
@@ -13,7 +13,7 @@ sealed class DurationConverter : PgBufferedConverter<Duration>
         return format is DataFormat.Binary;
     }
 
-    protected override Duration ReadCore(PgReader reader)
+    public override Duration Read(PgReader reader)
     {
         var microsecondsInDay = reader.ReadInt64();
         var days = reader.ReadInt32();
@@ -25,7 +25,7 @@ sealed class DurationConverter : PgBufferedConverter<Duration>
         return Duration.FromDays(days) + Duration.FromNanoseconds(microsecondsInDay * 1000);
     }
 
-    protected override void WriteCore(PgWriter writer, Duration value)
+    public override void Write(PgWriter writer, Duration value)
     {
         const long microsecondsPerSecond = 1_000_000;
 

--- a/src/Npgsql.NodaTime/Internal/LegacyConverters.cs
+++ b/src/Npgsql.NodaTime/Internal/LegacyConverters.cs
@@ -14,7 +14,7 @@ sealed class LegacyTimestampTzZonedDateTimeConverter(DateTimeZone dateTimeZone, 
         return format is DataFormat.Binary;
     }
 
-    protected override ZonedDateTime ReadCore(PgReader reader)
+    public override ZonedDateTime Read(PgReader reader)
     {
         var instant = DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions);
         if (dateTimeInfinityConversions && (instant == Instant.MaxValue || instant == Instant.MinValue))
@@ -23,7 +23,7 @@ sealed class LegacyTimestampTzZonedDateTimeConverter(DateTimeZone dateTimeZone, 
         return instant.InZone(dateTimeZone);
     }
 
-    protected override void WriteCore(PgWriter writer, ZonedDateTime value)
+    public override void Write(PgWriter writer, ZonedDateTime value)
     {
         var instant = value.ToInstant();
         if (dateTimeInfinityConversions && (instant == Instant.MaxValue || instant == Instant.MinValue))
@@ -42,7 +42,7 @@ sealed class LegacyTimestampTzOffsetDateTimeConverter(DateTimeZone dateTimeZone,
         return format is DataFormat.Binary;
     }
 
-    protected override OffsetDateTime ReadCore(PgReader reader)
+    public override OffsetDateTime Read(PgReader reader)
     {
         var instant = DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions);
         if (dateTimeInfinityConversions && (instant == Instant.MaxValue || instant == Instant.MinValue))
@@ -51,7 +51,7 @@ sealed class LegacyTimestampTzOffsetDateTimeConverter(DateTimeZone dateTimeZone,
         return instant.InZone(dateTimeZone).ToOffsetDateTime();
     }
 
-    protected override void WriteCore(PgWriter writer, OffsetDateTime value)
+    public override void Write(PgWriter writer, OffsetDateTime value)
     {
         var instant = value.ToInstant();
         if (dateTimeInfinityConversions && (instant == Instant.MaxValue || instant == Instant.MinValue))

--- a/src/Npgsql.NodaTime/Internal/LocalDateConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/LocalDateConverter.cs
@@ -13,7 +13,7 @@ sealed class LocalDateConverter(bool dateTimeInfinityConversions) : PgBufferedCo
         return format is DataFormat.Binary;
     }
 
-    protected override LocalDate ReadCore(PgReader reader)
+    public override LocalDate Read(PgReader reader)
         => reader.ReadInt32() switch
         {
             int.MaxValue => dateTimeInfinityConversions
@@ -25,7 +25,7 @@ sealed class LocalDateConverter(bool dateTimeInfinityConversions) : PgBufferedCo
             var value => new LocalDate().PlusDays(value + 730119)
         };
 
-    protected override void WriteCore(PgWriter writer, LocalDate value)
+    public override void Write(PgWriter writer, LocalDate value)
     {
         if (dateTimeInfinityConversions)
         {

--- a/src/Npgsql.NodaTime/Internal/LocalTimeConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/LocalTimeConverter.cs
@@ -12,9 +12,9 @@ sealed class LocalTimeConverter : PgBufferedConverter<LocalTime>
     }
 
     // PostgreSQL time resolution == 1 microsecond == 10 ticks
-    protected override LocalTime ReadCore(PgReader reader)
+    public override LocalTime Read(PgReader reader)
         => LocalTime.FromTicksSinceMidnight(reader.ReadInt64() * 10);
 
-    protected override void WriteCore(PgWriter writer, LocalTime value)
+    public override void Write(PgWriter writer, LocalTime value)
         => writer.WriteInt64(value.TickOfDay / 10);
 }

--- a/src/Npgsql.NodaTime/Internal/OffsetTimeConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/OffsetTimeConverter.cs
@@ -12,10 +12,10 @@ sealed class OffsetTimeConverter : PgBufferedConverter<OffsetTime>
     }
 
     // Adjust from 1 microsecond to 100ns. Time zone (in seconds) is inverted.
-    protected override OffsetTime ReadCore(PgReader reader)
+    public override OffsetTime Read(PgReader reader)
         => new(LocalTime.FromTicksSinceMidnight(reader.ReadInt64() * 10), Offset.FromSeconds(-reader.ReadInt32()));
 
-    protected override void WriteCore(PgWriter writer, OffsetTime value)
+    public override void Write(PgWriter writer, OffsetTime value)
     {
         writer.WriteInt64(value.TickOfDay / 10);
         writer.WriteInt32(-(int)(value.Offset.Ticks / NodaConstants.TicksPerSecond));

--- a/src/Npgsql.NodaTime/Internal/PeriodConverter.cs
+++ b/src/Npgsql.NodaTime/Internal/PeriodConverter.cs
@@ -13,7 +13,7 @@ sealed class PeriodConverter(bool dateTimeInfinityConversions) : PgBufferedConve
         return format is DataFormat.Binary;
     }
 
-    protected override Period ReadCore(PgReader reader)
+    public override Period Read(PgReader reader)
     {
         var microsecondsInDay = reader.ReadInt64();
         var days = reader.ReadInt32();
@@ -42,7 +42,7 @@ sealed class PeriodConverter(bool dateTimeInfinityConversions) : PgBufferedConve
         }.Build().Normalize();
     }
 
-    protected override void WriteCore(PgWriter writer, Period value)
+    public override void Write(PgWriter writer, Period value)
     {
         if (dateTimeInfinityConversions)
         {

--- a/src/Npgsql.NodaTime/Internal/TimestampConverters.cs
+++ b/src/Npgsql.NodaTime/Internal/TimestampConverters.cs
@@ -13,10 +13,10 @@ sealed class InstantConverter(bool dateTimeInfinityConversions) : PgBufferedConv
         return format is DataFormat.Binary;
     }
 
-    protected override Instant ReadCore(PgReader reader)
+    public override Instant Read(PgReader reader)
         => DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions);
 
-    protected override void WriteCore(PgWriter writer, Instant value)
+    public override void Write(PgWriter writer, Instant value)
         => writer.WriteInt64(EncodeInstant(value, dateTimeInfinityConversions));
 }
 
@@ -28,7 +28,7 @@ sealed class ZonedDateTimeConverter(bool dateTimeInfinityConversions) : PgBuffer
         return format is DataFormat.Binary;
     }
 
-    protected override ZonedDateTime ReadCore(PgReader reader)
+    public override ZonedDateTime Read(PgReader reader)
         => DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions).InUtc();
 
     protected override Size BindValue(in BindContext context, ZonedDateTime value, ref object? writeState)
@@ -44,7 +44,7 @@ sealed class ZonedDateTimeConverter(bool dateTimeInfinityConversions) : PgBuffer
         return context.BufferRequirement;
     }
 
-    protected override void WriteCore(PgWriter writer, ZonedDateTime value)
+    public override void Write(PgWriter writer, ZonedDateTime value)
         => writer.WriteInt64(EncodeInstant(value.ToInstant(), dateTimeInfinityConversions));
 }
 
@@ -56,7 +56,7 @@ sealed class OffsetDateTimeConverter(bool dateTimeInfinityConversions) : PgBuffe
         return format is DataFormat.Binary;
     }
 
-    protected override OffsetDateTime ReadCore(PgReader reader)
+    public override OffsetDateTime Read(PgReader reader)
         => DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions).WithOffset(Offset.Zero);
 
     protected override Size BindValue(in BindContext context, OffsetDateTime value, ref object? writeState)
@@ -72,7 +72,7 @@ sealed class OffsetDateTimeConverter(bool dateTimeInfinityConversions) : PgBuffe
         return context.BufferRequirement;
     }
 
-    protected override void WriteCore(PgWriter writer, OffsetDateTime value)
+    public override void Write(PgWriter writer, OffsetDateTime value)
         => writer.WriteInt64(EncodeInstant(value.ToInstant(), dateTimeInfinityConversions));
 }
 
@@ -84,9 +84,9 @@ sealed class LocalDateTimeConverter(bool dateTimeInfinityConversions) : PgBuffer
         return format is DataFormat.Binary;
     }
 
-    protected override LocalDateTime ReadCore(PgReader reader)
+    public override LocalDateTime Read(PgReader reader)
         => DecodeInstant(reader.ReadInt64(), dateTimeInfinityConversions).InUtc().LocalDateTime;
 
-    protected override void WriteCore(PgWriter writer, LocalDateTime value)
+    public override void Write(PgWriter writer, LocalDateTime value)
         => writer.WriteInt64(EncodeInstant(value.InUtc().ToInstant(), dateTimeInfinityConversions));
 }

--- a/src/Npgsql/Internal/Converters/BitStringConverters.cs
+++ b/src/Npgsql/Internal/Converters/BitStringConverters.cs
@@ -105,7 +105,7 @@ sealed class BitVector32BitStringConverter : PgBufferedConverter<BitVector32>
         return format is DataFormat.Binary;
     }
 
-    protected override BitVector32 ReadCore(PgReader reader)
+    public override BitVector32 Read(PgReader reader)
     {
         if (reader.CurrentRemaining > sizeof(int) + sizeof(int))
             throw new InvalidCastException("Can't read a BIT(N) with more than 32 bits to BitVector32, only up to BIT(32).");
@@ -121,7 +121,7 @@ sealed class BitVector32BitStringConverter : PgBufferedConverter<BitVector32>
         };
     }
 
-    protected override void WriteCore(PgWriter writer, BitVector32 value)
+    public override void Write(PgWriter writer, BitVector32 value)
     {
         writer.WriteInt32(32);
         writer.WriteInt32(value.Data);
@@ -138,7 +138,7 @@ sealed class BoolBitStringConverter : PgBufferedConverter<bool>
         return format is DataFormat.Binary;
     }
 
-    protected override bool ReadCore(PgReader reader)
+    public override bool Read(PgReader reader)
     {
         var bits = reader.ReadInt32();
         return bits switch
@@ -151,7 +151,7 @@ sealed class BoolBitStringConverter : PgBufferedConverter<bool>
     }
 
     protected override Size BindValue(in BindContext context, bool value, ref object? writeState) => MaxSize;
-    protected override void WriteCore(PgWriter writer, bool value)
+    public override void Write(PgWriter writer, bool value)
     {
         writer.WriteInt32(1);
         writer.WriteByte(value ? (byte)128 : (byte)0);

--- a/src/Npgsql/Internal/Converters/EnumConverter.cs
+++ b/src/Npgsql/Internal/Converters/EnumConverter.cs
@@ -47,7 +47,7 @@ sealed class EnumConverter<TEnum> : PgBufferedConverter<TEnum> where TEnum : str
         return _encoding.GetByteCount(str);
     }
 
-    protected override TEnum ReadCore(PgReader reader)
+    public override TEnum Read(PgReader reader)
     {
         var str = _encoding.GetString(reader.ReadBytes(reader.CurrentRemaining));
         var success = _labelToEnum.TryGetValue(str, out var value);
@@ -58,7 +58,7 @@ sealed class EnumConverter<TEnum> : PgBufferedConverter<TEnum> where TEnum : str
         return value;
     }
 
-    protected override void WriteCore(PgWriter writer, TEnum value)
+    public override void Write(PgWriter writer, TEnum value)
     {
         if (!_enumToLabel.TryGetValue(value, out var str))
             throw new InvalidCastException($"Can't write value {value} as enum {typeof(TEnum)}");

--- a/src/Npgsql/Internal/Converters/Geometric/BoxConverter.cs
+++ b/src/Npgsql/Internal/Converters/Geometric/BoxConverter.cs
@@ -11,12 +11,12 @@ sealed class BoxConverter : PgBufferedConverter<NpgsqlBox>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlBox ReadCore(PgReader reader)
+    public override NpgsqlBox Read(PgReader reader)
         => new(
             new NpgsqlPoint(reader.ReadDouble(), reader.ReadDouble()),
             new NpgsqlPoint(reader.ReadDouble(), reader.ReadDouble()));
 
-    protected override void WriteCore(PgWriter writer, NpgsqlBox value)
+    public override void Write(PgWriter writer, NpgsqlBox value)
     {
         writer.WriteDouble(value.Right);
         writer.WriteDouble(value.Top);

--- a/src/Npgsql/Internal/Converters/Geometric/CircleConverter.cs
+++ b/src/Npgsql/Internal/Converters/Geometric/CircleConverter.cs
@@ -11,10 +11,10 @@ sealed class CircleConverter : PgBufferedConverter<NpgsqlCircle>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlCircle ReadCore(PgReader reader)
+    public override NpgsqlCircle Read(PgReader reader)
         => new(reader.ReadDouble(), reader.ReadDouble(), reader.ReadDouble());
 
-    protected override void WriteCore(PgWriter writer, NpgsqlCircle value)
+    public override void Write(PgWriter writer, NpgsqlCircle value)
     {
         writer.WriteDouble(value.X);
         writer.WriteDouble(value.Y);

--- a/src/Npgsql/Internal/Converters/Geometric/LineConverter.cs
+++ b/src/Npgsql/Internal/Converters/Geometric/LineConverter.cs
@@ -11,10 +11,10 @@ sealed class LineConverter : PgBufferedConverter<NpgsqlLine>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlLine ReadCore(PgReader reader)
+    public override NpgsqlLine Read(PgReader reader)
         => new(reader.ReadDouble(), reader.ReadDouble(), reader.ReadDouble());
 
-    protected override void WriteCore(PgWriter writer, NpgsqlLine value)
+    public override void Write(PgWriter writer, NpgsqlLine value)
     {
         writer.WriteDouble(value.A);
         writer.WriteDouble(value.B);

--- a/src/Npgsql/Internal/Converters/Geometric/LineSegmentConverter.cs
+++ b/src/Npgsql/Internal/Converters/Geometric/LineSegmentConverter.cs
@@ -11,10 +11,10 @@ sealed class LineSegmentConverter : PgBufferedConverter<NpgsqlLSeg>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlLSeg ReadCore(PgReader reader)
+    public override NpgsqlLSeg Read(PgReader reader)
         => new(reader.ReadDouble(), reader.ReadDouble(), reader.ReadDouble(), reader.ReadDouble());
 
-    protected override void WriteCore(PgWriter writer, NpgsqlLSeg value)
+    public override void Write(PgWriter writer, NpgsqlLSeg value)
     {
         writer.WriteDouble(value.Start.X);
         writer.WriteDouble(value.Start.Y);

--- a/src/Npgsql/Internal/Converters/Geometric/PointConverter.cs
+++ b/src/Npgsql/Internal/Converters/Geometric/PointConverter.cs
@@ -11,10 +11,10 @@ sealed class PointConverter : PgBufferedConverter<NpgsqlPoint>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlPoint ReadCore(PgReader reader)
+    public override NpgsqlPoint Read(PgReader reader)
         => new(reader.ReadDouble(), reader.ReadDouble());
 
-    protected override void WriteCore(PgWriter writer, NpgsqlPoint value)
+    public override void Write(PgWriter writer, NpgsqlPoint value)
     {
         writer.WriteDouble(value.X);
         writer.WriteDouble(value.Y);

--- a/src/Npgsql/Internal/Converters/Internal/InternalCharConverter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/InternalCharConverter.cs
@@ -12,6 +12,6 @@ sealed class InternalCharConverter<T> : PgBufferedConverter<T> where T : INumber
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadByte());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteByte(byte.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadByte());
+    public override void Write(PgWriter writer, T value) => writer.WriteByte(byte.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Internal/PgLsnConverter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/PgLsnConverter.cs
@@ -10,6 +10,6 @@ sealed class PgLsnConverter : PgBufferedConverter<NpgsqlLogSequenceNumber>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(ulong));
         return format is DataFormat.Binary;
     }
-    protected override NpgsqlLogSequenceNumber ReadCore(PgReader reader) => new(reader.ReadUInt64());
-    protected override void WriteCore(PgWriter writer, NpgsqlLogSequenceNumber value) => writer.WriteUInt64((ulong)value);
+    public override NpgsqlLogSequenceNumber Read(PgReader reader) => new(reader.ReadUInt64());
+    public override void Write(PgWriter writer, NpgsqlLogSequenceNumber value) => writer.WriteUInt64((ulong)value);
 }

--- a/src/Npgsql/Internal/Converters/Internal/TidConverter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/TidConverter.cs
@@ -10,8 +10,8 @@ sealed class TidConverter : PgBufferedConverter<NpgsqlTid>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(uint) + sizeof(ushort));
         return format is DataFormat.Binary;
     }
-    protected override NpgsqlTid ReadCore(PgReader reader) => new(reader.ReadUInt32(), reader.ReadUInt16());
-    protected override void WriteCore(PgWriter writer, NpgsqlTid value)
+    public override NpgsqlTid Read(PgReader reader) => new(reader.ReadUInt32(), reader.ReadUInt16());
+    public override void Write(PgWriter writer, NpgsqlTid value)
     {
         writer.WriteUInt32(value.BlockNumber);
         writer.WriteUInt16(value.OffsetNumber);

--- a/src/Npgsql/Internal/Converters/Internal/UInt32Converter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/UInt32Converter.cs
@@ -8,6 +8,6 @@ sealed class UInt32Converter : PgBufferedConverter<uint>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(uint));
         return format is DataFormat.Binary;
     }
-    protected override uint ReadCore(PgReader reader) => reader.ReadUInt32();
-    protected override void WriteCore(PgWriter writer, uint value) => writer.WriteUInt32(value);
+    public override uint Read(PgReader reader) => reader.ReadUInt32();
+    public override void Write(PgWriter writer, uint value) => writer.WriteUInt32(value);
 }

--- a/src/Npgsql/Internal/Converters/Internal/UInt64Converter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/UInt64Converter.cs
@@ -8,6 +8,6 @@ sealed class UInt64Converter : PgBufferedConverter<ulong>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(ulong));
         return format is DataFormat.Binary;
     }
-    protected override ulong ReadCore(PgReader reader) => reader.ReadUInt64();
-    protected override void WriteCore(PgWriter writer, ulong value) => writer.WriteUInt64(value);
+    public override ulong Read(PgReader reader) => reader.ReadUInt64();
+    public override void Write(PgWriter writer, ulong value) => writer.WriteUInt64(value);
 }

--- a/src/Npgsql/Internal/Converters/Internal/VoidConverter.cs
+++ b/src/Npgsql/Internal/Converters/Internal/VoidConverter.cs
@@ -11,6 +11,6 @@ sealed class VoidConverter : PgBufferedConverter<object?>
         return true;
     }
 
-    protected override object? ReadCore(PgReader reader) => null;
-    protected override void WriteCore(PgWriter writer, object? value) => throw new NotSupportedException();
+    public override object? Read(PgReader reader) => null;
+    public override void Write(PgWriter writer, object? value) => throw new NotSupportedException();
 }

--- a/src/Npgsql/Internal/Converters/MoneyConverter.cs
+++ b/src/Npgsql/Internal/Converters/MoneyConverter.cs
@@ -11,8 +11,8 @@ sealed class MoneyConverter<T> : PgBufferedConverter<T> where T : INumberBase<T>
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => ConvertTo(new PgMoney(reader.ReadInt64()));
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteInt64(ConvertFrom(value).GetValue());
+    public override T Read(PgReader reader) => ConvertTo(new PgMoney(reader.ReadInt64()));
+    public override void Write(PgWriter writer, T value) => writer.WriteInt64(ConvertFrom(value).GetValue());
 
     static PgMoney ConvertFrom(T value) => new(decimal.CreateChecked(value));
     static T ConvertTo(PgMoney money) => T.CreateChecked(money.ToDecimal());

--- a/src/Npgsql/Internal/Converters/Networking/IPAddressConverter.cs
+++ b/src/Npgsql/Internal/Converters/Networking/IPAddressConverter.cs
@@ -12,10 +12,10 @@ sealed class IPAddressConverter : PgBufferedConverter<IPAddress>
     protected override Size BindValue(in BindContext context, IPAddress value, ref object? writeState)
         => NpgsqlInetConverter.BindValueImpl(context, value, ref writeState);
 
-    protected override IPAddress ReadCore(PgReader reader)
+    public override IPAddress Read(PgReader reader)
         => NpgsqlInetConverter.ReadImpl(reader, shouldBeCidr: false).Address;
 
-    protected override void WriteCore(PgWriter writer, IPAddress value)
+    public override void Write(PgWriter writer, IPAddress value)
         => NpgsqlInetConverter.WriteImpl(
             writer,
             (value, (byte)(value.AddressFamily == AddressFamily.InterNetwork ? 32 : 128)),

--- a/src/Npgsql/Internal/Converters/Networking/IPNetworkConverter.cs
+++ b/src/Npgsql/Internal/Converters/Networking/IPNetworkConverter.cs
@@ -12,13 +12,13 @@ sealed class IPNetworkConverter : PgBufferedConverter<IPNetwork>
     protected override Size BindValue(in BindContext context, IPNetwork value, ref object? writeState)
         => NpgsqlInetConverter.BindValueImpl(context, value.BaseAddress, ref writeState);
 
-    protected override IPNetwork ReadCore(PgReader reader)
+    public override IPNetwork Read(PgReader reader)
     {
         var (ip, netmask) = NpgsqlInetConverter.ReadImpl(reader, shouldBeCidr: true);
         return new(ip, netmask);
     }
 
-    protected override void WriteCore(PgWriter writer, IPNetwork value)
+    public override void Write(PgWriter writer, IPNetwork value)
         => NpgsqlInetConverter.WriteImpl(
             writer,
             (

--- a/src/Npgsql/Internal/Converters/Networking/MacaddrConverter.cs
+++ b/src/Npgsql/Internal/Converters/Networking/MacaddrConverter.cs
@@ -16,7 +16,7 @@ sealed class MacaddrConverter(bool macaddr8) : PgBufferedConverter<PhysicalAddre
     protected override Size BindValue(in BindContext context, PhysicalAddress value, ref object? writeState)
         => value.GetAddressBytes().Length;
 
-    protected override PhysicalAddress ReadCore(PgReader reader)
+    public override PhysicalAddress Read(PgReader reader)
     {
         var len = reader.CurrentRemaining;
         Debug.Assert(len is 6 or 8);
@@ -26,7 +26,7 @@ sealed class MacaddrConverter(bool macaddr8) : PgBufferedConverter<PhysicalAddre
         return new PhysicalAddress(bytes);
     }
 
-    protected override void WriteCore(PgWriter writer, PhysicalAddress value)
+    public override void Write(PgWriter writer, PhysicalAddress value)
     {
         var bytes = value.GetAddressBytes();
         if (!macaddr8 && bytes.Length is not 6)

--- a/src/Npgsql/Internal/Converters/Networking/NpgsqlCidrConverter.cs
+++ b/src/Npgsql/Internal/Converters/Networking/NpgsqlCidrConverter.cs
@@ -12,13 +12,13 @@ sealed class NpgsqlCidrConverter : PgBufferedConverter<NpgsqlCidr>
     protected override Size BindValue(in BindContext context, NpgsqlCidr value, ref object? writeState)
         => NpgsqlInetConverter.BindValueImpl(context, value.Address, ref writeState);
 
-    protected override NpgsqlCidr ReadCore(PgReader reader)
+    public override NpgsqlCidr Read(PgReader reader)
     {
         var (ip, netmask) = NpgsqlInetConverter.ReadImpl(reader, shouldBeCidr: true);
         return new(ip, netmask);
     }
 
-    protected override void WriteCore(PgWriter writer, NpgsqlCidr value)
+    public override void Write(PgWriter writer, NpgsqlCidr value)
         => NpgsqlInetConverter.WriteImpl(writer, (value.Address, value.Netmask), isCidr: true);
 }
 #pragma warning restore CS0618

--- a/src/Npgsql/Internal/Converters/Networking/NpgsqlInetConverter.cs
+++ b/src/Npgsql/Internal/Converters/Networking/NpgsqlInetConverter.cs
@@ -33,7 +33,7 @@ sealed class NpgsqlInetConverter : PgBufferedConverter<NpgsqlInet>
                 $"Can't handle IPAddress with AddressFamily {ipAddress.AddressFamily}, only InterNetwork or InterNetworkV6!")
         };
 
-    protected override NpgsqlInet ReadCore(PgReader reader)
+    public override NpgsqlInet Read(PgReader reader)
     {
         var (ip, netmask) = ReadImpl(reader, shouldBeCidr: false);
         return new(ip, netmask);
@@ -53,7 +53,7 @@ sealed class NpgsqlInetConverter : PgBufferedConverter<NpgsqlInet>
         return (new IPAddress(bytes), mask);
     }
 
-    protected override void WriteCore(PgWriter writer, NpgsqlInet value)
+    public override void Write(PgWriter writer, NpgsqlInet value)
         => WriteImpl(writer, (value.Address, value.Netmask), isCidr: false);
 
     internal static void WriteImpl(PgWriter writer, (IPAddress Address, byte Netmask) value, bool isCidr)

--- a/src/Npgsql/Internal/Converters/Primitive/BoolConverter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/BoolConverter.cs
@@ -8,6 +8,6 @@ sealed class BoolConverter : PgBufferedConverter<bool>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(byte));
         return format is DataFormat.Binary;
     }
-    protected override bool ReadCore(PgReader reader) => reader.ReadByte() is not 0;
-    protected override void WriteCore(PgWriter writer, bool value) => writer.WriteByte((byte)(value ? 1 : 0));
+    public override bool Read(PgReader reader) => reader.ReadByte() is not 0;
+    public override void Write(PgWriter writer, bool value) => writer.WriteByte((byte)(value ? 1 : 0));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/DoubleConverter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/DoubleConverter.cs
@@ -12,6 +12,6 @@ sealed class DoubleConverter<T> : PgBufferedConverter<T> where T : INumberBase<T
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadDouble());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteDouble(double.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadDouble());
+    public override void Write(PgWriter writer, T value) => writer.WriteDouble(double.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/GuidUuidConverter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/GuidUuidConverter.cs
@@ -12,10 +12,10 @@ sealed class GuidUuidConverter : PgBufferedConverter<Guid>
         return format is DataFormat.Binary;
     }
 
-    protected override Guid ReadCore(PgReader reader)
+    public override Guid Read(PgReader reader)
         => new(reader.ReadBytes(16).FirstSpan, bigEndian: true);
 
-    protected override void WriteCore(PgWriter writer, Guid value)
+    public override void Write(PgWriter writer, Guid value)
     {
         Span<byte> bytes = stackalloc byte[16];
         value.TryWriteBytes(bytes, bigEndian: true, out _);

--- a/src/Npgsql/Internal/Converters/Primitive/Int2Converter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/Int2Converter.cs
@@ -12,6 +12,6 @@ sealed class Int2Converter<T> : PgBufferedConverter<T> where T : INumberBase<T>
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadInt16());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteInt16(short.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadInt16());
+    public override void Write(PgWriter writer, T value) => writer.WriteInt16(short.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/Int4Converter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/Int4Converter.cs
@@ -12,6 +12,6 @@ sealed class Int4Converter<T> : PgBufferedConverter<T> where T : INumberBase<T>
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadInt32());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteInt32(int.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadInt32());
+    public override void Write(PgWriter writer, T value) => writer.WriteInt32(int.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/Int8Converter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/Int8Converter.cs
@@ -12,6 +12,6 @@ sealed class Int8Converter<T> : PgBufferedConverter<T> where T : INumberBase<T>
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadInt64());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteInt64(long.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadInt64());
+    public override void Write(PgWriter writer, T value) => writer.WriteInt64(long.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/NumericConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/NumericConverters.cs
@@ -98,7 +98,7 @@ sealed class DecimalNumericConverter<T> : PgBufferedConverter<T> where T : INumb
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader)
+    public override T Read(PgReader reader)
     {
         var digitCount = reader.ReadInt16();
         var digits = stackalloc short[StackAllocByteThreshold / sizeof(short)].Slice(0, digitCount);;
@@ -120,7 +120,7 @@ sealed class DecimalNumericConverter<T> : PgBufferedConverter<T> where T : INumb
             _ => throw new NotSupportedException()
         });
 
-    protected override void WriteCore(PgWriter writer, T value)
+    public override void Write(PgWriter writer, T value)
     {
         // We don't know how many digits we need so we allocate enough for the builder to use.
         Span<short> destination = stackalloc short[PgNumeric.Builder.MaxDecimalNumericDigits];

--- a/src/Npgsql/Internal/Converters/Primitive/RealConverter.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/RealConverter.cs
@@ -12,6 +12,6 @@ sealed class RealConverter<T> : PgBufferedConverter<T> where T : INumberBase<T>
         return format is DataFormat.Binary;
     }
 
-    protected override T ReadCore(PgReader reader) => T.CreateChecked(reader.ReadFloat());
-    protected override void WriteCore(PgWriter writer, T value) => writer.WriteFloat(float.CreateChecked(value));
+    public override T Read(PgReader reader) => T.CreateChecked(reader.ReadFloat());
+    public override void Write(PgWriter writer, T value) => writer.WriteFloat(float.CreateChecked(value));
 }

--- a/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
+++ b/src/Npgsql/Internal/Converters/Primitive/TextConverters.cs
@@ -147,7 +147,7 @@ sealed class CharTextConverter(Encoding encoding) : PgBufferedConverter<char>
         return format is DataFormat.Binary or DataFormat.Text;
     }
 
-    protected override char ReadCore(PgReader reader)
+    public override char Read(PgReader reader)
     {
         var byteSeq = reader.ReadBytes(Math.Min(_oneCharMaxByteCount.Value, reader.CurrentRemaining));
         Debug.Assert(byteSeq.IsSingleSegment);
@@ -168,7 +168,7 @@ sealed class CharTextConverter(Encoding encoding) : PgBufferedConverter<char>
         return encoding.GetByteCount(spanValue);
     }
 
-    protected override void WriteCore(PgWriter writer, char value)
+    public override void Write(PgWriter writer, char value)
     {
         Span<char> spanValue = [value];
         writer.WriteChars(spanValue, encoding);

--- a/src/Npgsql/Internal/Converters/Temporal/DateConverters.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/DateConverters.cs
@@ -14,7 +14,7 @@ sealed class DateOnlyDateConverter(bool dateTimeInfinityConversions) : PgBuffere
         return format is DataFormat.Binary;
     }
 
-    protected override DateOnly ReadCore(PgReader reader)
+    public override DateOnly Read(PgReader reader)
         => reader.ReadInt32() switch
         {
             int.MaxValue => dateTimeInfinityConversions
@@ -26,7 +26,7 @@ sealed class DateOnlyDateConverter(bool dateTimeInfinityConversions) : PgBuffere
             var value => BaseValue.AddDays(value)
         };
 
-    protected override void WriteCore(PgWriter writer, DateOnly value)
+    public override void Write(PgWriter writer, DateOnly value)
     {
         if (dateTimeInfinityConversions)
         {
@@ -57,7 +57,7 @@ sealed class DateTimeDateConverter(bool dateTimeInfinityConversions) : PgBuffere
         return format is DataFormat.Binary;
     }
 
-    protected override DateTime ReadCore(PgReader reader)
+    public override DateTime Read(PgReader reader)
         => reader.ReadInt32() switch
         {
             int.MaxValue => dateTimeInfinityConversions
@@ -69,7 +69,7 @@ sealed class DateTimeDateConverter(bool dateTimeInfinityConversions) : PgBuffere
             var value => BaseValue + TimeSpan.FromDays(value)
         };
 
-    protected override void WriteCore(PgWriter writer, DateTime value)
+    public override void Write(PgWriter writer, DateTime value)
     {
         if (dateTimeInfinityConversions)
         {

--- a/src/Npgsql/Internal/Converters/Temporal/DateTimeConverters.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/DateTimeConverters.cs
@@ -44,10 +44,10 @@ sealed class DateTimeConverter : PgBufferedConverter<DateTime>
         return context.BufferRequirement;
     }
 
-    protected override DateTime ReadCore(PgReader reader)
+    public override DateTime Read(PgReader reader)
         => PgTimestamp.Decode(reader.ReadInt64(), _kind, _dateTimeInfinityConversions);
 
-    protected override void WriteCore(PgWriter writer, DateTime value)
+    public override void Write(PgWriter writer, DateTime value)
         => writer.WriteInt64(PgTimestamp.Encode(value, _dateTimeInfinityConversions));
 }
 
@@ -75,9 +75,9 @@ sealed class DateTimeOffsetConverter : PgBufferedConverter<DateTimeOffset>
         return context.BufferRequirement;
     }
 
-    protected override DateTimeOffset ReadCore(PgReader reader)
+    public override DateTimeOffset Read(PgReader reader)
         => new(PgTimestamp.Decode(reader.ReadInt64(), DateTimeKind.Utc, _dateTimeInfinityConversions), TimeSpan.Zero);
 
-    protected override void WriteCore(PgWriter writer, DateTimeOffset value)
+    public override void Write(PgWriter writer, DateTimeOffset value)
         => writer.WriteInt64(PgTimestamp.Encode(value.DateTime, _dateTimeInfinityConversions));
 }

--- a/src/Npgsql/Internal/Converters/Temporal/IntervalConverters.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/IntervalConverters.cs
@@ -12,7 +12,7 @@ sealed class TimeSpanIntervalConverter : PgBufferedConverter<TimeSpan>
         return format is DataFormat.Binary;
     }
 
-    protected override TimeSpan ReadCore(PgReader reader)
+    public override TimeSpan Read(PgReader reader)
     {
         var microseconds = reader.ReadInt64();
         var days = reader.ReadInt32();
@@ -24,7 +24,7 @@ sealed class TimeSpanIntervalConverter : PgBufferedConverter<TimeSpan>
             : new(microseconds * 10 + days * TimeSpan.TicksPerDay);
     }
 
-    protected override void WriteCore(PgWriter writer, TimeSpan value)
+    public override void Write(PgWriter writer, TimeSpan value)
     {
         var ticksInDay = value.Ticks - TimeSpan.TicksPerDay * value.Days;
         writer.WriteInt64(ticksInDay / 10);
@@ -41,7 +41,7 @@ sealed class NpgsqlIntervalConverter : PgBufferedConverter<NpgsqlInterval>
         return format is DataFormat.Binary;
     }
 
-    protected override NpgsqlInterval ReadCore(PgReader reader)
+    public override NpgsqlInterval Read(PgReader reader)
     {
         var ticks = reader.ReadInt64();
         var day = reader.ReadInt32();
@@ -49,7 +49,7 @@ sealed class NpgsqlIntervalConverter : PgBufferedConverter<NpgsqlInterval>
         return new NpgsqlInterval(month, day, ticks);
     }
 
-    protected override void WriteCore(PgWriter writer, NpgsqlInterval value)
+    public override void Write(PgWriter writer, NpgsqlInterval value)
     {
         writer.WriteInt64(value.Time);
         writer.WriteInt32(value.Days);

--- a/src/Npgsql/Internal/Converters/Temporal/LegacyDateTimeConverter.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/LegacyDateTimeConverter.cs
@@ -10,7 +10,7 @@ sealed class LegacyDateTimeConverter(bool dateTimeInfinityConversions, bool time
         return format is DataFormat.Binary;
     }
 
-    protected override DateTime ReadCore(PgReader reader)
+    public override DateTime Read(PgReader reader)
     {
         if (timestamp)
         {
@@ -23,7 +23,7 @@ sealed class LegacyDateTimeConverter(bool dateTimeInfinityConversions, bool time
             : dateTime.ToLocalTime();
     }
 
-    protected override void WriteCore(PgWriter writer, DateTime value)
+    public override void Write(PgWriter writer, DateTime value)
     {
         if (!timestamp && value.Kind is DateTimeKind.Local)
             value = value.ToUniversalTime();
@@ -40,7 +40,7 @@ sealed class LegacyDateTimeOffsetConverter(bool dateTimeInfinityConversions) : P
         return format is DataFormat.Binary;
     }
 
-    protected override DateTimeOffset ReadCore(PgReader reader)
+    public override DateTimeOffset Read(PgReader reader)
     {
         var dateTime = PgTimestamp.Decode(reader.ReadInt64(), DateTimeKind.Utc, dateTimeInfinityConversions);
 
@@ -55,6 +55,6 @@ sealed class LegacyDateTimeOffsetConverter(bool dateTimeInfinityConversions) : P
         return dateTime.ToLocalTime();
     }
 
-    protected override void WriteCore(PgWriter writer, DateTimeOffset value)
+    public override void Write(PgWriter writer, DateTimeOffset value)
         => writer.WriteInt64(PgTimestamp.Encode(value.UtcDateTime, dateTimeInfinityConversions));
 }

--- a/src/Npgsql/Internal/Converters/Temporal/TimeConverters.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/TimeConverters.cs
@@ -10,8 +10,8 @@ sealed class TimeOnlyTimeConverter : PgBufferedConverter<TimeOnly>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(long));
         return format is DataFormat.Binary;
     }
-    protected override TimeOnly ReadCore(PgReader reader) => new(reader.ReadInt64() * 10);
-    protected override void WriteCore(PgWriter writer, TimeOnly value) => writer.WriteInt64(value.Ticks / 10);
+    public override TimeOnly Read(PgReader reader) => new(reader.ReadInt64() * 10);
+    public override void Write(PgWriter writer, TimeOnly value) => writer.WriteInt64(value.Ticks / 10);
 }
 
 sealed class TimeSpanTimeConverter : PgBufferedConverter<TimeSpan>
@@ -21,8 +21,8 @@ sealed class TimeSpanTimeConverter : PgBufferedConverter<TimeSpan>
         bufferRequirements = BufferRequirements.CreateFixedSize(sizeof(long));
         return format is DataFormat.Binary;
     }
-    protected override TimeSpan ReadCore(PgReader reader) => new(reader.ReadInt64() * 10);
-    protected override void WriteCore(PgWriter writer, TimeSpan value) => writer.WriteInt64(value.Ticks / 10);
+    public override TimeSpan Read(PgReader reader) => new(reader.ReadInt64() * 10);
+    public override void Write(PgWriter writer, TimeSpan value) => writer.WriteInt64(value.Ticks / 10);
 }
 
 sealed class DateTimeOffsetTimeTzConverter : PgBufferedConverter<DateTimeOffset>
@@ -34,7 +34,7 @@ sealed class DateTimeOffsetTimeTzConverter : PgBufferedConverter<DateTimeOffset>
         return format is DataFormat.Binary;
     }
 
-    protected override DateTimeOffset ReadCore(PgReader reader)
+    public override DateTimeOffset Read(PgReader reader)
     {
         // Adjust from 1 microsecond to 100ns. Time zone (in seconds) is inverted.
         var ticks = reader.ReadInt64() * 10;
@@ -42,7 +42,7 @@ sealed class DateTimeOffsetTimeTzConverter : PgBufferedConverter<DateTimeOffset>
         return new DateTimeOffset(ticks + TimeSpan.TicksPerDay, offset);
     }
 
-    protected override void WriteCore(PgWriter writer, DateTimeOffset value)
+    public override void Write(PgWriter writer, DateTimeOffset value)
     {
         writer.WriteInt64(value.TimeOfDay.Ticks / 10);
         writer.WriteInt32(-(int)(value.Offset.Ticks / TimeSpan.TicksPerSecond));

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,13 +16,20 @@ public abstract class PgBufferedConverter<T> : PgConverter<T>
     [Obsolete("Call the parameterless constructor and set HandleDbNull directly.")]
     protected PgBufferedConverter(bool customDbNullPredicate) => HandleDbNull = customDbNullPredicate;
 
-    protected abstract T ReadCore(PgReader reader);
-    protected abstract void WriteCore(PgWriter writer, T value);
+    [Obsolete("Override Read instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected virtual T ReadCore(PgReader reader) => throw new NotSupportedException("Override Read instead of ReadCore.");
+
+    [Obsolete("Override Write instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected virtual void WriteCore(PgWriter writer, T value) => throw new NotSupportedException("Override Write instead of WriteCore.");
 
     protected override Size BindValue(in BindContext context, T value, ref object? writeState)
         => throw new NotSupportedException();
 
-    public sealed override T Read(PgReader reader) => ReadCore(reader);
+#pragma warning disable CS0618 // Type or member is obsolete
+    public override T Read(PgReader reader) => ReadCore(reader);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public sealed override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => new(Read(reader));
@@ -29,7 +37,9 @@ public abstract class PgBufferedConverter<T> : PgConverter<T>
     internal sealed override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => new(Read(reader));
 
-    public sealed override void Write(PgWriter writer, T value) => WriteCore(writer, value);
+#pragma warning disable CS0618 // Type or member is obsolete
+    public override void Write(PgWriter writer, T value) => WriteCore(writer, value);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public sealed override ValueTask WriteAsync(PgWriter writer, T value, CancellationToken cancellationToken = default)
     {

--- a/test/Npgsql.Tests/ReaderTests.cs
+++ b/test/Npgsql.Tests/ReaderTests.cs
@@ -2716,10 +2716,10 @@ class ExplodingTypeHandler : PgBufferedConverter<int>
         return format is DataFormat.Binary;
     }
 
-    protected override void WriteCore(PgWriter writer, int value)
+    public override void Write(PgWriter writer, int value)
         => throw new NotSupportedException();
 
-    protected override int ReadCore(PgReader reader)
+    public override int Read(PgReader reader)
     {
         if (_safe)
             throw new Exception("Safe read exception as requested");

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -522,8 +522,8 @@ public class WriteStateTests : TestBase
             return false;
         }
 
-        protected override int ReadCore(PgReader reader) => reader.ReadInt32();
-        protected override void WriteCore(PgWriter writer, int value) => writer.WriteInt32(value);
+        public override int Read(PgReader reader) => reader.ReadInt32();
+        public override void Write(PgWriter writer, int value) => writer.WriteInt32(value);
 
         protected override Size BindValue(in BindContext context, int value, ref object? writeState)
         {
@@ -662,8 +662,8 @@ public class WriteStateTests : TestBase
                 return format is DataFormat.Binary;
             }
 
-            protected override int ReadCore(PgReader reader) => reader.ReadInt32();
-            protected override void WriteCore(PgWriter writer, int value) => writer.WriteInt32(value);
+            public override int Read(PgReader reader) => reader.ReadInt32();
+            public override void Write(PgWriter writer, int value) => writer.WriteInt32(value);
 
             protected override Size BindValue(in BindContext context, int value, ref object? writeState)
             {
@@ -704,9 +704,9 @@ public class WriteStateTests : TestBase
             return false;
         }
 
-        protected override int ReadCore(PgReader reader) => reader.ReadInt32();
+        public override int Read(PgReader reader) => reader.ReadInt32();
 
-        protected override void WriteCore(PgWriter writer, int value)
+        public override void Write(PgWriter writer, int value)
         {
             if (writer.Current.WriteState is not null)
                 _tracker.WriteWriteStateReceived = true;
@@ -806,8 +806,8 @@ public class WriteStateTests : TestBase
             return format is DataFormat.Binary;
         }
 
-        protected override int ReadCore(PgReader reader) => reader.ReadInt32();
-        protected override void WriteCore(PgWriter writer, int value) => writer.WriteInt32(value);
+        public override int Read(PgReader reader) => reader.ReadInt32();
+        public override void Write(PgWriter writer, int value) => writer.WriteInt32(value);
     }
 
     sealed class DisposableWriteStateProvider(PgSerializerOptions options, DisposalTracker tracker) : PgConcreteTypeInfoProvider<int>


### PR DESCRIPTION
PGO generally does a good job eliding it, but AOT can't, and neither does it work well when multiple converters are used for some incoming T.

This PR now allows users to override Read and Write directly (the async methods are still sealed and delegating).

Since we don't do any buffer requirement checks inside Read/Write anymore the outer methods now only delegate to the Core methods, pure waste. There are also no plans to bring back something that would need the outer method to exist again. Even if we hypothetically would, we would just add it inside BeginNestedRead/BeginNestedWrite (and any callers at the edge inside npgsql: data reader etc.). Read{Async}/Write{Async} are the only non template pattern methods remaining on the converter surface, for good reason: wrapping them would be quite expensive, especially for the async side. As a result we'd rather lean on the nesting infra which already amortizes the cost by being part of the caller frame.