### PR TITLE
Simplify Size and BufferRequirements combine overflow handling

### DIFF
--- a/src/Npgsql/Internal/BufferRequirements.cs
+++ b/src/Npgsql/Internal/BufferRequirements.cs
@@ -63,10 +63,16 @@ public readonly struct BufferRequirements : IEquatable<BufferRequirements>
     // is gated at Bind entry (until measuring lands and the contract loosens).
     public BufferRequirements Combine(BufferRequirements other)
     {
-        return new BufferRequirements(CombineOrUnknown(_read, other._read), CombineOrUnknown(_write, other._write), _optionalBind && other._optionalBind);
+        var read = CombineOrNull(_read, other._read) ?? Size.Unknown;
+        var write = CombineOrNull(_write, other._write);
+        var optionalBind = _optionalBind && other._optionalBind;
+        // Overflowed
+        if (write is null)
+            optionalBind = false;
 
-        // Combine, degrading Exact-overflow into Unknown instead of throwing.
-        static Size CombineOrUnknown(Size left, Size right)
+        return new BufferRequirements(read, write ?? Size.Unknown, optionalBind);
+
+        static Size? CombineOrNull(Size left, Size right)
         {
             try
             {
@@ -74,7 +80,7 @@ public readonly struct BufferRequirements : IEquatable<BufferRequirements>
             }
             catch (OverflowException)
             {
-                return Size.Unknown;
+                return null;
             }
         }
     }

--- a/src/Npgsql/Internal/BufferRequirements.cs
+++ b/src/Npgsql/Internal/BufferRequirements.cs
@@ -59,12 +59,24 @@ public readonly struct BufferRequirements : IEquatable<BufferRequirements>
     /// <summary>Custom requirements with explicit <see cref="IsBindOptional"/>; use when the Kind-derived default is wrong (rare).</summary>
     public static BufferRequirements Create(Size read, Size write, bool optionalBind) => new(read, write, optionalBind);
 
+    // Both sides carry explicit IsBindOptional — AND them. The combined write Kind is independent and
+    // is gated at Bind entry (until measuring lands and the contract loosens).
     public BufferRequirements Combine(BufferRequirements other)
     {
-        // Both sides carry explicit IsBindOptional — AND them. The combined write Kind is independent and
-        // is gated at Bind entry (until measuring lands and the contract loosens).
-        var newWrite = _write.Combine(other._write);
-        return new(_read.Combine(other._read), newWrite, _optionalBind && other._optionalBind);
+        return new BufferRequirements(CombineOrUnknown(_read, other._read), CombineOrUnknown(_write, other._write), _optionalBind && other._optionalBind);
+
+        // Combine, degrading Exact-overflow into Unknown instead of throwing.
+        static Size CombineOrUnknown(Size left, Size right)
+        {
+            try
+            {
+                return left.Combine(right);
+            }
+            catch (OverflowException)
+            {
+                return Size.Unknown;
+            }
+        }
     }
 
     public BufferRequirements Combine(int byteCount)

--- a/src/Npgsql/Internal/Converters/CompositeConverter.cs
+++ b/src/Npgsql/Internal/Converters/CompositeConverter.cs
@@ -27,29 +27,18 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
         // combined with the cumulative Write Kind it produces the composite's IsBindOptional.
         // Provider-backed fields contribute Streaming via GetBinaryRequirements (their cached default's
         // requirements are unsafe to aggregate against — the resolved concrete at bind time may differ).
-        // The aggregation collapses naturally: Streaming fans into Unknown via TryCombine, IsBindOptional
+        // The aggregation collapses naturally: Streaming fans into Unknown via Combine, IsBindOptional
         // ANDs to false, and the final Write Kind becomes non-Exact for any composite with provider fields.
-        var isBindOptional = true;
         var req = BufferRequirements.CreateFixedSize(sizeof(int) + _composite.Fields.Count * (sizeof(uint) + sizeof(int)));
         foreach (var field in _composite.Fields)
         {
             var fieldReqs = field.GetBinaryRequirements();
-            isBindOptional &= fieldReqs.IsBindOptional;
-
-            var readReq = fieldReqs.Read;
-            var writeReq = fieldReqs.Write;
 
             // If field is nullable we cannot depend on its buffer size being fixed.
             if (field.IsDbNullable)
-            {
-                readReq = readReq.Combine(Size.CreateUpperBound(0));
-                writeReq = writeReq.Combine(Size.CreateUpperBound(0));
-            }
+                fieldReqs = fieldReqs.Combine(BufferRequirements.Create(Size.CreateUpperBound(0)));
 
-            var readSuccess = req.Read.TryCombine(readReq, out readReq);
-            var writeSuccess = req.Write.TryCombine(writeReq, out writeReq);
-            // If we fail to combine due to overflow return unknown.
-            req = BufferRequirements.Create(readSuccess ? readReq : Size.Unknown, writeSuccess ? writeReq : Size.Unknown);
+            req = req.Combine(fieldReqs);
         }
 
         // BindValue can return this directly when Exact (no provider field, no nullable, no overflow).
@@ -60,7 +49,7 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
         // (or nullable-shifted) Write means the Bind dispatch can't satisfy the size from the bufreq alone.
         var finalRead = Limit(req.Read);
         var finalWrite = Limit(req.Write);
-        _bufferRequirements = BufferRequirements.Create(finalRead, finalWrite, optionalBind: isBindOptional && finalWrite.Kind is SizeKind.Exact);
+        _bufferRequirements = BufferRequirements.Create(finalRead, finalWrite, optionalBind: req.IsBindOptional && finalWrite.Kind is SizeKind.Exact);
 
         // Return unknown if we hit the limit.
         static Size Limit(Size requirement)

--- a/src/Npgsql/Internal/Size.cs
+++ b/src/Npgsql/Internal/Size.cs
@@ -44,38 +44,18 @@ public readonly struct Size : IEquatable<Size>
     public static Size Unknown { get; } = new(SizeKind.Unknown, 0);
     public static Size Zero { get; } = new(SizeKind.Exact, 0);
 
-    public bool TryCombine(Size other, out Size result)
-    {
-        if (_kind is SizeKind.Unknown || other._kind is SizeKind.Unknown)
-        {
-            result = Unknown;
-            return true;
-        }
-
-        var sum = unchecked(_value + other._value);
-        if ((_value >= 0 && sum < other._value) || (_value < 0 && sum > other._value))
-        {
-            result = default;
-            return false;
-        }
-
-        if (_kind is SizeKind.UpperBound || other._kind is SizeKind.UpperBound)
-        {
-            result = CreateUpperBound(sum);
-            return true;
-        }
-
-        result = Create(sum);
-        return true;
-    }
-
     public Size Combine(Size other)
     {
         if (_kind is SizeKind.Unknown || other._kind is SizeKind.Unknown)
             return Unknown;
 
         if (_kind is SizeKind.UpperBound || other._kind is SizeKind.UpperBound)
-            return CreateUpperBound(checked(_value + other._value));
+        {
+            // An overflowed UpperBound is a ceiling past the representable max, not an error.
+            // Just a bound no longer possible to track, saturate into Unknown.
+            var sum = (long)_value + other._value;
+            return sum > int.MaxValue ? Unknown : CreateUpperBound((int)sum);
+        }
 
         return Create(checked(_value + other._value));
     }


### PR DESCRIPTION
Instead of throwing on UpperBound overflow we saturate it into Unknown. For Exact sizes we still throw on combine. When we're in the context of BufferRequirements however, we can fold it to unknown safely again (and it would be exceedingly rare there, which is why we can remove TryCombine as well).