### PR TITLE
Move string interpolation out of NpgsqlDataReader.ProcessMessage

### DIFF
--- a/src/Npgsql/NpgsqlDataReader.cs
+++ b/src/Npgsql/NpgsqlDataReader.cs
@@ -797,7 +797,7 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
         // We assume that the row's number of columns is identical to the description's
         var numColumns = Buffer.ReadInt16();
         if (ColumnCount != numColumns)
-            ThrowHelper.ThrowArgumentException($"Row's number of columns ({numColumns}) differs from the row description's ({ColumnCount})");
+            ThrowColumnCountMismatch(numColumns);
 
         var readPosition = Buffer.ReadPosition;
         var msgRemainder = dataRow.Length - sizeof(short);
@@ -857,6 +857,10 @@ public sealed class NpgsqlDataReader : DbDataReader, IDbColumnSchemaGenerator
                 break;
             }
         }
+
+        // Moved to separate method to avoid 400 bytes of string interpolation code
+        void ThrowColumnCountMismatch(short columnsCount)
+            => ThrowHelper.ThrowArgumentException($"Row's number of columns ({columnsCount}) differs from the row description's ({ColumnCount})");
     }
 
     #endregion


### PR DESCRIPTION
Saves about 400 bytes of code for that particular method + a bit on the prologue. Something I also noticed is that we have a bounds check on `NpgsqlReadBuffer`'s `Read*` methods. Maybe we can add something like `MemoryMarshal.GetArrayDataReference` there to remove it, no clue whether it makes sense.

<details>
<summary>Before</summary>

```assembly
; Npgsql.NpgsqlDataReader.ProcessMessage(Npgsql.IBackendMessage)
       push      rdi
       push      rsi
       push      rbx
       sub       rsp,50
       xor       eax,eax
       mov       [rsp+28],rax
       vxorps    xmm4,xmm4,xmm4
       vmovdqu   ymmword ptr [rsp+30],ymm4
       mov       rbx,rcx
       mov       rsi,rdx
M30_L00:
       mov       rcx,offset MT_Npgsql.BackendMessages.DataRowMessage
       cmp       [rsi],rcx
       jne       near ptr M30_L05
M30_L01:
       mov       rdi,rsi
       mov       rcx,offset MT_Npgsql.BackendMessages.DataRowMessage
       cmp       [rdi],rcx
       jne       near ptr M30_L09
       mov       rcx,[rbx+28]
       mov       rdx,[rbx+10]
       cmp       rcx,[rdx+50]
       jne       near ptr M30_L06
M30_L02:
       mov       rcx,[rbx+28]
       mov       rdx,[rcx+40]
       cmp       byte ptr [rbx+8B],0
       sete      al
       mov       [rdx+4F],al
       mov       rdx,rcx
       mov       eax,[rdx+64]
       cmp       eax,2
       jl        near ptr M30_L10
       mov       r8,[rdx+48]
       mov       r10d,[rdx+68]
       sub       r10d,eax
       cmp       r10d,[r8+8]
       jae       near ptr M30_L22
       movbe     r8w,[r8+r10+10]
       movsx     rsi,r8w
       add       eax,0FFFFFFFE
       mov       [rdx+64],eax
       mov       rdx,[rbx+40]
       cmp       [rdx+28],esi
       jne       near ptr M30_L11
       mov       rdx,rcx
       mov       edx,[rdx+68]
       sub       edx,eax
       mov       eax,[rdi+8]
       add       eax,0FFFFFFFE
       lea       r8d,[rdx+rax]
       mov       [rbx+84],r8d
       mov       [rbx+7C],edx
       mov       ecx,[rcx+68]
       sub       ecx,edx
       cmp       ecx,eax
       setge     cl
       mov       [rbx+88],cl
       mov       dword ptr [rbx+80],0FFFFFFFF
       mov       rcx,[rbx+38]
       cmp       dword ptr [rcx+10],0
       jg        near ptr M30_L20
M30_L03:
       mov       ecx,[rbx+74]
       cmp       ecx,1
       jne       short M30_L07
M30_L04:
       vzeroupper
       add       rsp,50
       pop       rbx
       pop       rsi
       pop       rdi
       ret
M30_L05:
       mov       rcx,rsi
       mov       r11,7FFE9BA108F8
       call      qword ptr [r11]
       cmp       eax,44
       je        near ptr M30_L01
       jmp       short M30_L08
M30_L06:
       mov       rcx,[rbx+10]
       mov       rdx,[rcx+50]
       lea       rcx,[rbx+28]
       call      CORINFO_HELP_ASSIGN_REF
       jmp       near ptr M30_L02
M30_L07:
       cmp       ecx,2
       ja        near ptr M30_L21
       mov       ecx,ecx
       lea       rdx,[7FFE9C12D880]
       mov       edx,[rdx+rcx*4]
       lea       rax,[M30_L00]
       add       rdx,rax
       jmp       rdx
       mov       byte ptr [rbx+89],1
       xor       ecx,ecx
       mov       [rbx+74],ecx
       jmp       short M30_L04
M30_L08:
       mov       rcx,rbx
       mov       rdx,rsi
       call      qword ptr [7FFE9C0BF9C0]; Npgsql.NpgsqlDataReader.<ProcessMessage>g__HandleUncommon|58_0(Npgsql.IBackendMessage)
       jmp       short M30_L04
M30_L09:
       mov       rdx,rsi
       call      System.Runtime.CompilerServices.CastHelpers.ChkCastClass(Void*, System.Object)
       int       3
M30_L10:
       mov       ecx,143FB
       mov       rdx,7FFE9BE15728
       call      qword ptr [7FFE9BACF228]
       mov       rcx,rax
       call      qword ptr [7FFE9BE2E058]
       int       3
M30_L11:
       lea       rcx,[rsp+28]
       mov       edx,40
       mov       r8d,2
       call      qword ptr [7FFE9BACC270]; System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(Int32, Int32)
       mov       ecx,[rsp+38]
       cmp       ecx,[rsp+48]
       ja        near ptr M30_L16
       mov       rdx,[rsp+40]
       mov       eax,ecx
       lea       rdx,[rdx+rax*2]
       mov       eax,[rsp+48]
       sub       eax,ecx
       cmp       eax,19
       jb        short M30_L12
       vmovups   ymm0,[7FFE9C12D8A0]
       vmovups   [rdx],ymm0
       vmovups   xmm0,[7FFE9C12D8C0]
       vmovups   [rdx+20],xmm0
       mov       word ptr [rdx+30],28
       mov       ecx,[rsp+38]
       add       ecx,19
       mov       [rsp+38],ecx
       jmp       short M30_L13
M30_L12:
       lea       rcx,[rsp+28]
       mov       rdx,20B6FE86288
       call      qword ptr [7FFE9C0BC390]
M30_L13:
       lea       rcx,[rsp+28]
       mov       edx,esi
       call      qword ptr [7FFE9C0BF9A8]
       mov       ecx,[rsp+38]
       cmp       ecx,[rsp+48]
       ja        near ptr M30_L16
       mov       rdx,[rsp+40]
       mov       eax,ecx
       lea       rdx,[rdx+rax*2]
       mov       eax,[rsp+48]
       sub       eax,ecx
       cmp       eax,26
       jb        short M30_L14
       vmovups   ymm0,[7FFE9C12D8E0]
       vmovups   [rdx],ymm0
       vmovups   ymm0,[7FFE9C12D900]
       vmovups   [rdx+20],ymm0
       mov       rcx,730027006E006F
       mov       [rdx+40],rcx
       mov       dword ptr [rdx+48],280020
       mov       ecx,[rsp+38]
       add       ecx,26
       mov       [rsp+38],ecx
       jmp       short M30_L15
M30_L14:
       lea       rcx,[rsp+28]
       mov       rdx,20B6FE862D0
       call      qword ptr [7FFE9C0BC390]
M30_L15:
       mov       rdx,[rbx+40]
       mov       edx,[rdx+28]
       lea       rcx,[rsp+28]
       call      qword ptr [7FFE9BAC7FD8]; System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted[[System.Int32, System.Private.CoreLib]](Int32)
       mov       ecx,[rsp+38]
       cmp       ecx,[rsp+48]
       jbe       short M30_L17
M30_L16:
       call      qword ptr [7FFE9BC97D68]
       int       3
M30_L17:
       mov       rdx,[rsp+40]
       mov       eax,ecx
       lea       rdx,[rdx+rax*2]
       mov       eax,[rsp+48]
       sub       eax,ecx
       je        short M30_L18
       mov       word ptr [rdx],29
       mov       ecx,[rsp+38]
       inc       ecx
       mov       [rsp+38],ecx
       jmp       short M30_L19
M30_L18:
       lea       rcx,[rsp+28]
       mov       rdx,20B6FE72670
       call      qword ptr [7FFE9C0BC390]
M30_L19:
       lea       rcx,[rsp+28]
       call      qword ptr [7FFE9BACC2A0]; System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()
       mov       rcx,rax
       call      qword ptr [7FFE9C0B5C50]
       int       3
M30_L20:
       mov       rcx,[rbx+38]
       inc       dword ptr [rcx+14]
       xor       edx,edx
       mov       [rcx+10],edx
       jmp       near ptr M30_L03
M30_L21:
       mov       rcx,[rbx+10]
       mov       edx,44
       cmp       [rcx],ecx
       call      qword ptr [7FFE9C0B6688]
       int       3
       mov       dword ptr [rbx+74],1
       jmp       near ptr M30_L04
M30_L22:
       call      CORINFO_HELP_RNGCHKFAIL
       int       3
; Total bytes of code 832
```

</details>

<details>
<summary>After</summary>

```assembly
; Npgsql.NpgsqlDataReader.ProcessMessage(Npgsql.IBackendMessage)
       push      rdi
       push      rsi
       push      rbx
       sub       rsp,20
       mov       rbx,rcx
       mov       rsi,rdx
M28_L00:
       mov       rcx,offset MT_Npgsql.BackendMessages.DataRowMessage
       cmp       [rsi],rcx
       jne       near ptr M28_L06
M28_L01:
       mov       rdi,rsi
       mov       rcx,offset MT_Npgsql.BackendMessages.DataRowMessage
       cmp       [rdi],rcx
       jne       near ptr M28_L07
       mov       rcx,[rbx+28]
       mov       rdx,[rbx+10]
       cmp       rcx,[rdx+50]
       jne       near ptr M28_L08
M28_L02:
       mov       rcx,[rbx+28]
       mov       rdx,[rcx+40]
       cmp       byte ptr [rbx+8B],0
       sete      al
       mov       [rdx+4F],al
       mov       edx,[rcx+64]
       cmp       edx,2
       jl        near ptr M28_L09
       mov       rax,[rcx+48]
       mov       r8d,[rcx+68]
       sub       r8d,edx
       cmp       r8d,[rax+8]
       jae       near ptr M28_L14
       movbe     ax,[rax+r8+10]
       cwde
       add       edx,0FFFFFFFE
       mov       [rcx+64],edx
       mov       rcx,[rbx+40]
       cmp       [rcx+28],eax
       jne       near ptr M28_L10
M28_L03:
       mov       rcx,[rbx+28]
       mov       edx,[rcx+68]
       mov       eax,edx
       sub       eax,[rcx+64]
       mov       ecx,[rdi+8]
       add       ecx,0FFFFFFFE
       lea       r8d,[rax+rcx]
       mov       [rbx+84],r8d
       mov       [rbx+7C],eax
       sub       edx,eax
       cmp       edx,ecx
       setge     cl
       mov       [rbx+88],cl
       mov       dword ptr [rbx+80],0FFFFFFFF
       mov       rcx,[rbx+38]
       cmp       dword ptr [rcx+10],0
       jg        near ptr M28_L11
M28_L04:
       mov       ecx,[rbx+74]
       cmp       ecx,1
       jne       near ptr M28_L12
M28_L05:
       add       rsp,20
       pop       rbx
       pop       rsi
       pop       rdi
       ret
M28_L06:
       mov       rcx,rsi
       mov       r11,7FFE9AE80950
       call      qword ptr [r11]
       cmp       eax,44
       je        near ptr M28_L01
       mov       rcx,rbx
       mov       rdx,rsi
       add       rsp,20
       pop       rbx
       pop       rsi
       pop       rdi
       jmp       qword ptr [7FFE9B52F8D0]; Npgsql.NpgsqlDataReader.<ProcessMessage>g__HandleUncommon|58_0(Npgsql.IBackendMessage)
M28_L07:
       mov       rdx,rsi
       call      System.Runtime.CompilerServices.CastHelpers.ChkCastClass(Void*, System.Object)
       int       3
M28_L08:
       mov       rcx,[rbx+10]
       mov       rdx,[rcx+50]
       lea       rcx,[rbx+28]
       call      CORINFO_HELP_ASSIGN_REF
       jmp       near ptr M28_L02
M28_L09:
       mov       ecx,143FB
       mov       rdx,7FFE9B285728
       call      qword ptr [7FFE9AF3F228]
       mov       rcx,rax
       call      qword ptr [7FFE9B29E058]
       int       3
M28_L10:
       mov       rcx,rbx
       mov       edx,eax
       call      qword ptr [7FFE9B52F918]
       jmp       near ptr M28_L03
M28_L11:
       mov       rcx,[rbx+38]
       inc       dword ptr [rcx+14]
       xor       edx,edx
       mov       [rcx+10],edx
       jmp       near ptr M28_L04
M28_L12:
       cmp       ecx,2
       ja        short M28_L13
       mov       ecx,ecx
       lea       rdx,[7FFE9B5AFC80]
       mov       edx,[rdx+rcx*4]
       lea       rax,[M28_L00]
       add       rdx,rax
       jmp       rdx
M28_L13:
       mov       rcx,[rbx+10]
       mov       edx,44
       cmp       [rcx],ecx
       call      qword ptr [7FFE9B526688]
       int       3
       mov       byte ptr [rbx+89],1
       xor       ecx,ecx
       mov       [rbx+74],ecx
       jmp       near ptr M28_L05
       mov       dword ptr [rbx+74],1
       jmp       near ptr M28_L05
M28_L14:
       call      CORINFO_HELP_RNGCHKFAIL
       int       3
; Total bytes of code 464
```

</details>