### PR TITLE
Single-pass writing

### DIFF
--- a/src/Npgsql/Internal/BufferRequirements.cs
+++ b/src/Npgsql/Internal/BufferRequirements.cs
@@ -9,9 +9,7 @@ public readonly struct BufferRequirements : IEquatable<BufferRequirements>
 {
     readonly Size _read;
     readonly Size _write;
-    // True when bind can be skipped — the converter has no per-value bind work AND Write is Exact.
-    // Construction is permissive (loose combinations are admissible to keep room for upcoming measuring
-    // work); the invariant is gated at Bind entry, which throws if IsBindOptional=true with non-Exact Write.
+    // True when bind can be skipped — the converter has no per-value bind work, independent of Write Kind.
     readonly bool _optionalBind;
 
     BufferRequirements(Size read, Size write, bool optionalBind)
@@ -34,7 +32,7 @@ public readonly struct BufferRequirements : IEquatable<BufferRequirements>
 
     /// <summary>
     /// True when bind can be skipped for this format — the converter has no per-value bind work
-    /// (sizing, validation, writeState production). Implies <see cref="IsBindFixedSize"/>.
+    /// (sizing, validation, writeState production).
     /// </summary>
     public bool IsBindOptional => _optionalBind;
 

--- a/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
@@ -300,15 +300,16 @@ readonly struct ArrayConverterCore(
                 await writer.Flush(async, cancellationToken).ConfigureAwait(false);
 
             var elem = elemData?[offset + indices.IndicesSum] ?? default;
-            var length = fixedSizeElements
-                ? ElemTypeDbNullable && IsDbNull(values, indices, elem.WriteState, state.NestedObjectDbNullHandling) ? -1 : binaryRequirements.Write.Value
-                : elem.Size.Value;
-
-            writer.WriteInt32(length);
-            if (length is not -1)
+            var size = fixedSizeElements
+                ? ElemTypeDbNullable && IsDbNull(values, indices, elem.WriteState, state.NestedObjectDbNullHandling) ? -1 : binaryRequirements.Write
+                : elem.Size;
+            if (size == -1)
+                writer.WriteInt32(-1);
+            else
             {
-                using var _ = await writer.BeginNestedWrite(async, binaryRequirements.Write,
-                    length, elem.WriteState, cancellationToken).ConfigureAwait(false);
+                // If size is not exact the scope will backpatch the length prefix placeholder on dispose based on writes done inside.
+                using var _ = await writer.BeginLengthPrefixingScope(async, binaryRequirements.Write,
+                    size, elem.WriteState, cancellationToken).ConfigureAwait(false);
                 await elemOps.Write(async, writer, values, indices, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Npgsql/Internal/Converters/CompositeConverter.cs
+++ b/src/Npgsql/Internal/Converters/CompositeConverter.cs
@@ -252,11 +252,13 @@ sealed class CompositeConverter<T> : PgStreamingConverter<T> where T : notnull
                     BufferRequirement = writeRequirement,
                 };
             }
-            var length = elementState.Size.Value;
-            writer.WriteInt32(length);
-            if (length is not -1)
+            if (elementState.Size == -1)
+                writer.WriteInt32(-1);
+            else
             {
-                using var _ = await writer.BeginNestedWrite(async, elementState.BufferRequirement, length, elementState.WriteState, cancellationToken).ConfigureAwait(false);
+                // If size is not exact the scope will backpatch the length prefix placeholder on dispose based on writes done inside.
+                using var _ = await writer.BeginLengthPrefixingScope(async, elementState.BufferRequirement,
+                    elementState.Size, elementState.WriteState, cancellationToken).ConfigureAwait(false);
                 await field.Write(async, elementState.Converter, writer, boxedInstance, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Npgsql/Internal/Converters/JsonConverter.cs
+++ b/src/Npgsql/Internal/Converters/JsonConverter.cs
@@ -34,6 +34,13 @@ sealed class JsonConverter<T, TBase> : PgStreamingConverter<T?> where T: TBase?
             : null;
     }
 
+    public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+    {
+        // Serializing is the only way to size json and we have no validation per value (optionalBind) and no known capacity hint (Size.Unknown).
+        bufferRequirements = BufferRequirements.Create(read: Size.Unknown, write: Size.Unknown, optionalBind: true);
+        return format is DataFormat.Binary;
+    }
+
     public override T? Read(PgReader reader)
         => Read(async: false, reader, CancellationToken.None).GetAwaiter().GetResult();
     public override ValueTask<T?> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
@@ -80,27 +87,30 @@ sealed class JsonConverter<T, TBase> : PgStreamingConverter<T?> where T: TBase?
         return result;
     }
 
-    protected override Size BindValue(in BindContext context, T? value, ref object? writeState)
+    public override void Write(PgWriter writer, T? value)
     {
-        var capacity = 0;
-        if (typeof(T) == typeof(JsonDocument))
-            capacity = ((JsonDocument?)(object?)value)?.RootElement.GetRawText().Length ?? 0;
-        var stream = new MemoryStream(capacity);
+        if (_jsonb)
+            writer.WriteByte(JsonConverter.JsonbProtocolVersion);
+
+        // STJ always emits UTF-8; for any other client encoding, transcode on the way out.
+        var utf8 = _textEncoding.CodePage == Encoding.UTF8.CodePage;
+        using var stream = utf8
+            ? writer.GetStream()
+            : Encoding.CreateTranscodingStream(writer.GetStream(), _textEncoding, Encoding.UTF8, leaveOpen: true);
 
         // Mirroring ASP.NET Core serialization strategy https://github.com/dotnet/aspnetcore/issues/47548
         if (_objectTypeInfo is null)
             JsonSerializer.Serialize(stream, value, (JsonTypeInfo<TBase?>)_jsonTypeInfo);
         else
             JsonSerializer.Serialize(stream, value, _objectTypeInfo);
-
-        return JsonConverter.BindValueCore(_jsonb, stream, _textEncoding, ref writeState);
     }
 
-    public override void Write(PgWriter writer, T? value)
-        => JsonConverter.Write(_jsonb, async: false, writer, CancellationToken.None).GetAwaiter().GetResult();
-
     public override ValueTask WriteAsync(PgWriter writer, T? value, CancellationToken cancellationToken = default)
-        => JsonConverter.Write(_jsonb, async: true, writer, cancellationToken);
+    {
+        Debug.Assert(writer.Current.Size == Size.Unknown, "We expected to be measuring, which is safely sync only.");
+        Write(writer, value);
+        return new();
+    }
 }
 
 // Split out to avoid unnecessary code duplication.
@@ -152,50 +162,5 @@ static class JsonConverter
         encoding.GetChars(buffer.Span, chars);
 
         return (new(chars, 0, charCount), rentedBuffer);
-    }
-
-    public static Size BindValueCore(bool jsonb, MemoryStream stream, Encoding encoding, ref object? writeState)
-    {
-        if (encoding.CodePage == Encoding.UTF8.CodePage)
-        {
-            writeState = stream;
-            return (int)stream.Length + (jsonb ? sizeof(byte) : 0);
-        }
-
-        if (!stream.TryGetBuffer(out var buffer))
-            throw new InvalidOperationException();
-
-        var bytes = encoding.GetBytes(Encoding.UTF8.GetChars(buffer.Array!, buffer.Offset, buffer.Count));
-        writeState = bytes;
-        return bytes.Length + (jsonb ? sizeof(byte) : 0);
-    }
-
-    public static async ValueTask Write(bool jsonb, bool async, PgWriter writer, CancellationToken cancellationToken)
-    {
-        if (jsonb)
-        {
-            if (writer.ShouldFlush(sizeof(byte)))
-                await writer.Flush(async, cancellationToken).ConfigureAwait(false);
-            writer.WriteByte(JsonbProtocolVersion);
-        }
-
-        ArraySegment<byte> buffer;
-        switch (writer.Current.WriteState)
-        {
-        case MemoryStream stream:
-            if (!stream.TryGetBuffer(out buffer))
-                throw new InvalidOperationException();
-            break;
-        case byte[] bytes:
-            buffer = new ArraySegment<byte>(bytes);
-            break;
-        default:
-            throw new InvalidCastException($"Invalid state {writer.Current.WriteState?.GetType().FullName}.");
-        }
-
-        if (async)
-            await writer.WriteBytesAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-        else
-            writer.WriteBytes(buffer.AsSpan());
     }
 }

--- a/src/Npgsql/Internal/Converters/LateBindingConverter.cs
+++ b/src/Npgsql/Internal/Converters/LateBindingConverter.cs
@@ -79,7 +79,7 @@ sealed class LateBindingConverter : PgStreamingConverter<object>
         var found = concreteTypeInfo.Converter.CanConvert(DataFormat.Binary, out var bufferRequirements);
         Debug.Assert(found);
         var writeRequirement = bufferRequirements.Write;
-        using var _ = await writer.BeginNestedWrite(async, writeRequirement, writer.Current.Size.Value, effectiveState, cancellationToken).ConfigureAwait(false);
+        using var _ = await writer.BeginPassthroughScope(async, writeRequirement, writer.Current.Size, effectiveState, cancellationToken).ConfigureAwait(false);
         await concreteTypeInfo.Converter.WriteAsObject(async, writer, value, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Npgsql/Internal/Converters/MultirangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/MultirangeConverter.cs
@@ -123,14 +123,12 @@ sealed class MultirangeConverter<T, TRange> : PgStreamingConverter<T>
                 await writer.Flush(async, cancellationToken).ConfigureAwait(false);
 
             var (size, state) = data[i];
-            if (size.Kind is SizeKind.Unknown)
-                throw new NotImplementedException();
-
-            var length = size.Value;
-            writer.WriteInt32(length);
-            if (length != -1)
+            if (size == -1)
+                writer.WriteInt32(-1);
+            else
             {
-                using var _ = await writer.BeginNestedWrite(async, _rangeRequirements.Write, length, state, cancellationToken).ConfigureAwait(false);
+                // If size is not exact the scope will backpatch the length prefix placeholder on dispose based on writes done inside.
+                using var _ = await writer.BeginLengthPrefixingScope(async, _rangeRequirements.Write, size, state, cancellationToken).ConfigureAwait(false);
                 if (async)
                     await _rangeConverter.WriteAsync(writer, value[i], cancellationToken).ConfigureAwait(false);
                 else

--- a/src/Npgsql/Internal/Converters/RangeConverter.cs
+++ b/src/Npgsql/Internal/Converters/RangeConverter.cs
@@ -173,15 +173,8 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
 
         if (!lowerBoundInfinite)
         {
-            Debug.Assert(lowerBoundSize.Value != -1);
-            if (lowerBoundSize.Kind is SizeKind.Unknown)
-                throw new NotImplementedException();
-
-            var byteCount = lowerBoundSize.Value; // Never -1 so it's a byteCount.
-            if (writer.ShouldFlush(sizeof(int))) // Length
-                await writer.Flush(async, cancellationToken).ConfigureAwait(false);
-            writer.WriteInt32(byteCount);
-            using var _ = await writer.BeginNestedWrite(async, _subtypeRequirements.Write, byteCount,
+            Debug.Assert(lowerBoundSize != -1);
+            using var _ = await writer.BeginLengthPrefixingScope(async, _subtypeRequirements.Write, lowerBoundSize,
                 writeState.LowerBoundWriteState, cancellationToken).ConfigureAwait(false);
             if (async)
                 await _subtypeConverter.WriteAsync(writer, value.LowerBound!, cancellationToken).ConfigureAwait(false);
@@ -191,15 +184,8 @@ sealed class RangeConverter<TSubtype> : PgStreamingConverter<NpgsqlRange<TSubtyp
 
         if (!upperBoundInfinite)
         {
-            Debug.Assert(upperBoundSize.Value != -1);
-            if (upperBoundSize.Kind is SizeKind.Unknown)
-                throw new NotImplementedException();
-
-            var byteCount = upperBoundSize.Value; // Never -1 so it's a byteCount.
-            if (writer.ShouldFlush(sizeof(int))) // Length
-                await writer.Flush(async, cancellationToken).ConfigureAwait(false);
-            writer.WriteInt32(byteCount);
-            using var _ = await writer.BeginNestedWrite(async, _subtypeRequirements.Write, byteCount,
+            Debug.Assert(upperBoundSize != -1);
+            using var _ = await writer.BeginLengthPrefixingScope(async, _subtypeRequirements.Write, upperBoundSize,
                 writeState.UpperBoundWriteState, cancellationToken).ConfigureAwait(false);
             if (async)
                 await _subtypeConverter.WriteAsync(writer, value.UpperBound!, cancellationToken).ConfigureAwait(false);

--- a/src/Npgsql/Internal/NpgsqlConnector.FrontendMessages.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.FrontendMessages.cs
@@ -181,8 +181,8 @@ partial class NpgsqlConnector
         for (var paramIndex = 0; paramIndex < parameters.Count; paramIndex++)
         {
             var param = parameters[paramIndex];
-            param.Bind(out var format, out var size);
-            paramsLength += size.Value > 0 ? size.Value : 0;
+            param.Bind(out var format, out var byteCount);
+            paramsLength += byteCount;
             formatCodesSum += format.ToFormatCode();
         }
 

--- a/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
+++ b/src/Npgsql/Internal/NpgsqlWriteBuffer.cs
@@ -73,7 +73,7 @@ sealed class NpgsqlWriteBuffer : IDisposable
 
     // (Re)init to make sure we'll refetch from the write buffer.
     internal PgWriter GetWriter(NpgsqlDatabaseInfo typeCatalog, FlushMode flushMode = FlushMode.None)
-        => _pgWriter.Init(typeCatalog, flushMode);
+        => _pgWriter.Init(typeCatalog, 0, flushMode);
 
     internal readonly byte[] Buffer;
     readonly Encoder _textEncoder;

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -156,12 +156,7 @@ public abstract class PgConverter
             ThrowInvalidNullValue();
 
         if (context.IsBindOptional)
-        {
-            if (context.BufferRequirement.Kind is not SizeKind.Exact)
-                ThrowHelper.ThrowInvalidOperationException(
-                    $"{nameof(BufferRequirements.IsBindOptional)}=true requires an {nameof(SizeKind.Exact)} buffer requirement.");
             return context.BufferRequirement;
-        }
 
         // writeState identity discipline:
         // - Fixed-size: any change is forbidden (no production, no swap, no clear).
@@ -178,18 +173,6 @@ public abstract class PgConverter
             if ((originalWriteState is not null || context.IsBindFixedSize) && !ReferenceEquals(originalWriteState, writeState)
                 && (context.IsBindFixedSize || writeState is null || originalWriteState is IDisposable))
                 ThrowWriteStateLifecycleViolation(context.IsBindFixedSize);
-
-            // Catches non-Exact sizes from both paths (the IsBindFixedSize Kind check is folded in here —
-            // a converter declaring fixed-size that returned a non-Exact size trips this same throw).
-            switch (size.Kind)
-            {
-            case SizeKind.UpperBound:
-                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.UpperBound)} is not a valid return value for BindValue.");
-                break;
-            case SizeKind.Unknown:
-                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.Unknown)} is not a valid return value for BindValue.");
-                break;
-            }
         }
         catch
         {
@@ -335,12 +318,7 @@ public abstract class PgConverter<T> : PgConverter
         Debug.Assert(TypeAcceptsNull || value is not null);
 
         if (context.IsBindOptional)
-        {
-            if (context.BufferRequirement.Kind is not SizeKind.Exact)
-                ThrowHelper.ThrowInvalidOperationException(
-                    $"{nameof(BufferRequirements.IsBindOptional)}=true requires an {nameof(SizeKind.Exact)} buffer requirement.");
             return context.BufferRequirement;
-        }
 
         // writeState identity discipline:
         // - Fixed-size: any change is forbidden (no production, no swap, no clear).
@@ -357,16 +335,6 @@ public abstract class PgConverter<T> : PgConverter
             if ((originalWriteState is not null || context.IsBindFixedSize) && !ReferenceEquals(originalWriteState, writeState)
                 && (context.IsBindFixedSize || writeState is null || originalWriteState is IDisposable))
                 ThrowWriteStateLifecycleViolation(context.IsBindFixedSize);
-
-            switch (size.Kind)
-            {
-            case SizeKind.UpperBound:
-                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.UpperBound)} is not a valid return value for {nameof(BindValue)}.");
-                break;
-            case SizeKind.Unknown:
-                ThrowHelper.ThrowInvalidOperationException($"{nameof(SizeKind.Unknown)} is not a valid return value for {nameof(BindValue)}.");
-                break;
-            }
         }
         catch
         {

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -149,7 +149,8 @@ public sealed class PgWriter
 
     void Ensure(int count = 1)
     {
-        if (count <= Remaining)
+        // Ensure(0) must still yield a non-empty buffer, so don't early-out on an empty one.
+        if (count <= Remaining && Remaining is not 0)
             return;
 
         Slow(count);
@@ -163,6 +164,22 @@ public sealed class PgWriter
             // GetMemory is expected to throw if count is too large for the remaining space.
             Debug.Assert(count <= Remaining);
         }
+    }
+
+    // Ensures room for `count` bytes: flushes a flushable writer that is low on space, then Ensures —
+    // which grows a FlushMode.None writer (buffered, e.g. a measuring side buffer) that cannot flush.
+    void EnsureWithFlush(int count, bool allowMixedIO = false)
+    {
+        if (ShouldFlush(count))
+            Flush(allowWhenNonBlocking: allowMixedIO);
+        Ensure(count);
+    }
+
+    async ValueTask EnsureWithFlushAsync(int count, bool allowMixedIO, CancellationToken cancellationToken)
+    {
+        if (ShouldFlush(count))
+            await FlushAsync(allowWhenBlocking: allowMixedIO, cancellationToken).ConfigureAwait(false);
+        Ensure(count);
     }
 
     Span<byte> Span => _buffer.AsSpan(_pos, _length - _pos);
@@ -323,8 +340,7 @@ public sealed class PgWriter
                 switch (status)
                 {
                 case OperationStatus.DestinationTooSmall:
-                    Flush();
-                    Ensure(scalarMaxByteCount);
+                    EnsureWithFlush(scalarMaxByteCount);
                     data = data.Slice(charsRead);
                     break;
                 case OperationStatus.InvalidData:
@@ -347,9 +363,7 @@ public sealed class PgWriter
             bool completed;
             do
             {
-                if (ShouldFlush(minBufferSize))
-                    Flush();
-                Ensure(minBufferSize);
+                EnsureWithFlush(minBufferSize);
                 encoder.Convert(data, Span, flush: true, out var charsUsed, out var bytesUsed, out completed);
                 data = data.Slice(charsUsed);
                 Advance(bytesUsed);
@@ -393,8 +407,7 @@ public sealed class PgWriter
                 switch (status)
                 {
                 case OperationStatus.DestinationTooSmall:
-                    await FlushAsync(cancellationToken).ConfigureAwait(false);
-                    Ensure(scalarMaxByteCount);
+                    await EnsureWithFlushAsync(scalarMaxByteCount, allowMixedIO: false, cancellationToken).ConfigureAwait(false);
                     data = data.Slice(charsRead);
                     break;
                 case OperationStatus.InvalidData:
@@ -417,9 +430,7 @@ public sealed class PgWriter
             bool completed;
             do
             {
-                if (ShouldFlush(minBufferSize))
-                    await FlushAsync(cancellationToken).ConfigureAwait(false);
-                Ensure(minBufferSize);
+                await EnsureWithFlushAsync(minBufferSize, allowMixedIO: false, cancellationToken).ConfigureAwait(false);
                 encoder.Convert(data.Span, Span, flush: true, out var charsUsed, out var bytesUsed, out completed);
                 data = data.Slice(charsUsed);
                 Advance(bytesUsed);
@@ -435,7 +446,7 @@ public sealed class PgWriter
         while (!buffer.IsEmpty)
         {
             if (Remaining is 0)
-                Flush(allowWhenNonBlocking: allowMixedIO);
+                EnsureWithFlush(1, allowMixedIO);
             var write = Math.Min(buffer.Length, Remaining);
             buffer.Slice(0, write).CopyTo(Span);
             Advance(write);
@@ -462,7 +473,7 @@ public sealed class PgWriter
             while (!buffer.IsEmpty)
             {
                 if (Remaining is 0)
-                    await FlushAsync(allowWhenBlocking: allowMixedIO, cancellationToken).ConfigureAwait(false);
+                    await EnsureWithFlushAsync(1, allowMixedIO, cancellationToken).ConfigureAwait(false);
                 var write = Math.Min(buffer.Length, Remaining);
                 buffer.Span.Slice(0, write).CopyTo(Span);
                 Advance(write);

--- a/src/Npgsql/Internal/PgWriter.cs
+++ b/src/Npgsql/Internal/PgWriter.cs
@@ -2,6 +2,7 @@ using Npgsql.Internal.Postgres;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -21,81 +22,10 @@ enum FlushMode
     NonBlocking
 }
 
-// A streaming alternative to a System.IO.Stream, instead based on the preferable IBufferWriter.
-interface IStreamingWriter<T> : IBufferWriter<T>
-{
-    void Flush(TimeSpan timeout = default);
-    ValueTask FlushAsync(CancellationToken cancellationToken = default);
-}
-
-sealed class NpgsqlBufferWriter(NpgsqlWriteBuffer buffer) : IStreamingWriter<byte>
-{
-    int? _lastBufferSize;
-
-    public void Advance(int count)
-    {
-        if (_lastBufferSize < count || buffer.WriteSpaceLeft < count)
-            ThrowHelper.ThrowInvalidOperationException("Cannot advance past the end of the current buffer.");
-        _lastBufferSize = null;
-        buffer.WritePosition += count;
-    }
-
-    public Memory<byte> GetMemory(int sizeHint = 0)
-    {
-        var writePosition = buffer.WritePosition;
-        var bufferSize = buffer.Size - writePosition;
-        if (sizeHint > bufferSize)
-            ThrowOutOfMemoryException();
-
-        _lastBufferSize = bufferSize;
-        return buffer.Buffer.AsMemory(writePosition, bufferSize);
-    }
-
-    public Span<byte> GetSpan(int sizeHint = 0)
-    {
-        var writePosition = buffer.WritePosition;
-        var bufferSize = buffer.Size - writePosition;
-        if (sizeHint > bufferSize)
-            ThrowOutOfMemoryException();
-
-        _lastBufferSize = bufferSize;
-        return buffer.Buffer.AsSpan(writePosition, bufferSize);
-    }
-
-    static void ThrowOutOfMemoryException() => throw new OutOfMemoryException("Not enough space left in buffer.");
-
-    public void Flush(TimeSpan timeout = default)
-    {
-        if (timeout == TimeSpan.Zero)
-            buffer.Flush();
-        else
-        {
-            TimeSpan? originalTimeout = null;
-            try
-            {
-                if (timeout != TimeSpan.Zero)
-                {
-                    originalTimeout = buffer.Timeout;
-                    buffer.Timeout = timeout;
-                }
-                buffer.Flush();
-            }
-            finally
-            {
-                if (originalTimeout is { } value)
-                    buffer.Timeout = value;
-            }
-        }
-    }
-
-    public ValueTask FlushAsync(CancellationToken cancellationToken = default)
-        => new(buffer.Flush(async: true, cancellationToken));
-}
-
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public sealed class PgWriter
 {
-    readonly IBufferWriter<byte> _writer;
+    IBufferWriter<byte> _writer;
 
     byte[]? _buffer;
     int _offset;
@@ -107,9 +37,32 @@ public sealed class PgWriter
     ValueMetadata _current;
     NpgsqlDatabaseInfo? _typeCatalog;
 
+    // Per-scope frames for the chained path (variable-length prefix). Each chained scope allocates its own
+    // side buffer because backpatching wouldn't work for variable-length prefixes. The chained path defers
+    // the prefix write until the size is known and the scope is closing.
+    Stack<ChainedFrame>? _chainedFrames;
+
+    struct ChainedFrame
+    {
+        public IBufferWriter<byte> SavedWriter;
+        public byte[]? SavedBuffer;
+        public int SavedOffset;
+        public int SavedPos;
+        public int SavedLength;
+        public int SavedTotalBytesWritten;
+        public ValueMetadata SavedCurrent;
+        public FlushMode SavedFlushMode;
+        public MeasuringSideBufferWriter SideBuffer;
+        public Action<PgWriter, int> PrefixingAction;
+    }
+
     internal PgWriter(IBufferWriter<byte> writer) => _writer = writer;
 
-    internal PgWriter Init(NpgsqlDatabaseInfo typeCatalog, FlushMode flushMode = FlushMode.None)
+    // Cap for the capacityHint. Sits below the LOH threshold (~85KB for byte arrays)
+    // so the underlying storage participates in normal Gen0/Gen1 collection.
+    const int CapacityHintLimit = 64 * 1024;
+
+    internal PgWriter Init(NpgsqlDatabaseInfo typeCatalog, int capacityHint, FlushMode flushMode = FlushMode.None)
     {
         if (_pos != _offset)
             ThrowHelper.ThrowInvalidOperationException("Invalid concurrent use or PgWriter was not committed properly, PgWriter still has uncommitted bytes.");
@@ -120,7 +73,7 @@ public sealed class PgWriter
 
         FlushMode = flushMode;
         _totalBytesWritten = 0;
-        RequestBuffer(count: 0);
+        RequestBuffer(Math.Min(capacityHint, CapacityHintLimit));
         return this;
     }
 
@@ -188,7 +141,7 @@ public sealed class PgWriter
 
     void Advance(int count) => _pos += count;
 
-    void Commit()
+    internal void Commit()
     {
         var written = _pos - _offset;
         _totalBytesWritten += written;
@@ -543,31 +496,249 @@ public sealed class PgWriter
         return new();
     }
 
-    internal ValueTask<NestedWriteScope> BeginNestedWrite(bool async, Size bufferRequirement, int byteCount, object? state, CancellationToken cancellationToken)
+    /// Begins a scope framed by an int4 length prefix. In pre-sized mode the prefix is written with the
+    /// known size and the inner content goes directly into the parent buffer. In measuring mode (size is
+    /// <see cref="SizeKind.Unknown"/> or <see cref="SizeKind.UpperBound"/>) a placeholder is written, the writer is forked to a side buffer for the
+    /// inner content, and the scope's disposal splices the side buffer back into the parent and backpatches the
+    /// placeholder with the measured size.
+    internal ValueTask<NestedWriteScope> BeginLengthPrefixingScope(bool async, Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken)
     {
         Debug.Assert(bufferRequirement != -1);
 
+        // Non-Exact sizes: measure into side buffer and backpatch in place.
+        if (size.Kind is SizeKind.Unknown or SizeKind.UpperBound)
+            return BeginMeasuringLengthPrefixingScope(async, bufferRequirement, size, state, cancellationToken);
+
+        // Exact: write the length directly, content goes directly to the wire.
+        var byteCount = size.Value;
         var bufferRequirementByteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, byteCount);
         _current = new() { Format = _current.Format, Size = byteCount, BufferRequirement = bufferRequirement, WriteState = state };
 
-        if (ShouldFlush(bufferRequirementByteCount))
-            return Core(async, cancellationToken);
+        if (ShouldFlush(sizeof(int) + bufferRequirementByteCount))
+            return Core(async, byteCount, cancellationToken);
 
+        WriteInt32(byteCount);
         return new(new NestedWriteScope());
 
         [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
-        async ValueTask<NestedWriteScope> Core(bool async, CancellationToken cancellationToken)
+        async ValueTask<NestedWriteScope> Core(bool async, int byteCount, CancellationToken cancellationToken)
+        {
+            await Flush(async, cancellationToken).ConfigureAwait(false);
+            WriteInt32(byteCount);
+            return new();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    ValueTask<NestedWriteScope> BeginMeasuringLengthPrefixingScope(bool async, Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken)
+    {
+        if (_writer is not MeasuringSideBufferWriter writer)
+        {
+            // The outermost caller (parameter or test setup) is responsible for putting the writer into measuring mode — i.e.
+            // pointing _writer at a MeasuringSideBufferWriter — before BeginMeasuringScope is called with an Unknown size.
+            // This follows from Bind's depth-first cascade: any element returning Unknown forces composers conversion to report Unknown
+            // By the time Write runs and reaches BeginMeasuringScope(Unknown), the parameter has already set up the measuring writer.
+            ThrowHelper.ThrowInvalidOperationException($"Scope with {nameof(SizeKind.Unknown)} or {nameof(SizeKind.UpperBound)} requires the writer to be in measuring mode.");
+            return default;
+        }
+
+        // Ensure room for the int4 placeholder in the active side buffer; flush first if needed.
+        if (ShouldFlush(sizeof(int)))
+            return FlushAndCore(async, writer, bufferRequirement, size, state, cancellationToken);
+
+        var placeholderOffset = Core(writer, bufferRequirement, size, state);
+        return new(new NestedWriteScope(this, placeholderOffset));
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        async ValueTask<NestedWriteScope> FlushAndCore(bool async, MeasuringSideBufferWriter writer,
+            Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken)
+        {
+            await Flush(async, cancellationToken).ConfigureAwait(false);
+            var placeholderOffset = Core(writer, bufferRequirement, size, state);
+            return new(this, placeholderOffset);
+        }
+
+        int Core(MeasuringSideBufferWriter writer, Size bufferRequirement, Size size, object? state)
+        {
+            // Compute the logical offset where the placeholder will land — stable across side-buffer growth because
+            // ArrayBufferWriter preserves logical content on realloc. After WriteInt32, placeholder is at [offset .. offset+4).
+            var placeholderOffset = writer.WrittenCount + (_pos - _offset);
+            WriteInt32(0);
+
+            // Pre-grow the working buffer for the inner write when an UpperBound capacity hint is available;
+            // Ensure routes through Commit + RequestBuffer, so a side-buffer realloc re-establishes _buffer safely.
+            if (size.Kind is SizeKind.UpperBound)
+                Ensure(Math.Min(size.Value, CapacityHintLimit));
+
+            _current = new() { Format = _current.Format, Size = size, BufferRequirement = bufferRequirement, WriteState = state };
+            return placeholderOffset;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal void EndLengthPrefixingScope(int placeholderOffset)
+    {
+        Commit();
+        var writer = (MeasuringSideBufferWriter)_writer;
+        var measuredSize = writer.WrittenCount - placeholderOffset - sizeof(int);
+
+        Span<byte> backpatchBytes = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(backpatchBytes, measuredSize);
+        writer.Backpatch(placeholderOffset, backpatchBytes);
+    }
+
+    [Obsolete($"Use {nameof(BeginPassthroughScope)}.")]
+    public NestedWriteScope BeginNestedWrite(Size bufferRequirement, int byteCount, object? state)
+        => BeginPassthroughScope(bufferRequirement, byteCount, state);
+
+    [Obsolete($"Use {nameof(BeginPassthroughScopeAsync)}.")]
+    public ValueTask<NestedWriteScope> BeginNestedWriteAsync(Size bufferRequirement, int byteCount, object? state, CancellationToken cancellationToken = default)
+        => BeginPassthroughScopeAsync(bufferRequirement, byteCount, state, cancellationToken);
+
+    // [Obsolete($"Use {nameof(BeginPassthroughScope)}.")]
+    internal ValueTask<NestedWriteScope> BeginNestedWrite(bool async, Size bufferRequirement, int byteCount, object? state, CancellationToken cancellationToken = default)
+        => BeginPassthroughScope(async, bufferRequirement, byteCount, state, cancellationToken);
+
+    public NestedWriteScope BeginPassthroughScope(Size bufferRequirement, Size size, object? state)
+        => BeginPassthroughScope(async: false, bufferRequirement, size, state, CancellationToken.None).GetAwaiter().GetResult();
+
+    public ValueTask<NestedWriteScope> BeginPassthroughScopeAsync(Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken = default)
+        => BeginPassthroughScope(async: true, bufferRequirement, size, state, cancellationToken);
+
+    internal ValueTask<NestedWriteScope> BeginPassthroughScope(bool async, Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken = default)
+    {
+        Debug.Assert(bufferRequirement != -1);
+
+        // No prefix — re-frame _current for a nested write the caller frames itself, or that needs none.
+        _current = new() { Format = _current.Format, Size = size, BufferRequirement = bufferRequirement, WriteState = state };
+        // GetMinimumBufferByteCount needs a concrete size and asserts an Exact requirement matches it;
+        // a measuring inner (Unknown/UpperBound) has no concrete size, so flush on the bare requirement.
+        var minimumByteCount = size.Kind is SizeKind.Exact
+            ? BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, size.Value)
+            : bufferRequirement.GetValueOrDefault();
+        if (ShouldFlush(minimumByteCount))
+            return FlushThenScope(async, cancellationToken);
+        return new(new NestedWriteScope());
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        async ValueTask<NestedWriteScope> FlushThenScope(bool async, CancellationToken cancellationToken)
         {
             await Flush(async, cancellationToken).ConfigureAwait(false);
             return new();
         }
     }
 
-    public NestedWriteScope BeginNestedWrite(Size bufferRequirement, int byteCount, object? state)
-        => BeginNestedWrite(async: false, bufferRequirement, byteCount, state, CancellationToken.None).GetAwaiter().GetResult();
+    public NestedWriteScope BeginLengthPrefixingScope(Size bufferRequirement, Size size, object? state)
+        => BeginLengthPrefixingScope(async: false, bufferRequirement, size, state, CancellationToken.None).Result;
 
-    public ValueTask<NestedWriteScope> BeginNestedWriteAsync(Size bufferRequirement, int byteCount, object? state, CancellationToken cancellationToken = default)
-        => BeginNestedWrite(async: true, bufferRequirement, byteCount, state, cancellationToken);
+    public ValueTask<NestedWriteScope> BeginLengthPrefixingScopeAsync(Size bufferRequirement, Size size, object? state, CancellationToken cancellationToken = default)
+        => BeginLengthPrefixingScope(async: true, bufferRequirement, size, state, cancellationToken);
+
+    public NestedWriteScope BeginLengthPrefixingScope(Size bufferRequirement, Size size, object? state, Action<PgWriter, int> prefixingAction)
+        => BeginLengthPrefixingScope(async: true, bufferRequirement, size, state, prefixingAction, CancellationToken.None).Result;
+
+    public ValueTask<NestedWriteScope> BeginLengthPrefixingScopeAsync(Size bufferRequirement, Size size, object? state,
+        Action<PgWriter, int> prefixingAction, CancellationToken cancellationToken = default)
+        => BeginLengthPrefixingScope(async: true, bufferRequirement, size, state, prefixingAction, cancellationToken);
+
+    // prefixingAction is the prefix writer of last resort; when null the framework writes a plain int4 prefix.
+    internal ValueTask<NestedWriteScope> BeginLengthPrefixingScope(bool async, Size bufferRequirement, Size size, object? state, Action<PgWriter, int> prefixingAction, CancellationToken cancellationToken = default)
+    {
+        Debug.Assert(bufferRequirement != -1);
+
+        // Non-Exact sizes: measure into side buffer and backpatch in place.
+        if (size.Kind is SizeKind.Unknown or SizeKind.UpperBound)
+            return BeginVariableLengthPrefixingScope(async, bufferRequirement, size, state, prefixingAction, cancellationToken);
+
+        // Exact: write the length directly, content goes directly to the wire.
+        var byteCount = size.Value;
+        var bufferRequirementByteCount = BufferRequirements.GetMinimumBufferByteCount(bufferRequirement, byteCount);
+        _current = new() { Format = _current.Format, Size = byteCount, BufferRequirement = bufferRequirement, WriteState = state };
+
+        if (ShouldFlush(sizeof(int) + bufferRequirementByteCount))
+            return Core(async, byteCount, prefixingAction, cancellationToken);
+
+        prefixingAction(this, byteCount);
+        return new(new NestedWriteScope());
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        async ValueTask<NestedWriteScope> Core(bool async, int byteCount, Action<PgWriter, int> prefixingAction, CancellationToken cancellationToken)
+        {
+            await Flush(async, cancellationToken).ConfigureAwait(false);
+            prefixingAction(this, byteCount);
+            return new();
+        }
+
+    }
+
+    ValueTask<NestedWriteScope> BeginVariableLengthPrefixingScope(bool async, Size bufferRequirement, Size size, object? state,
+        Action<PgWriter, int> prefixingAction, CancellationToken cancellationToken = default)
+    {
+        // Allocate a dedicated side buffer for this chained scope.
+        var sideBuffer = new MeasuringSideBufferWriter();
+
+        var frame = new ChainedFrame
+        {
+            SavedWriter = _writer,
+            SavedBuffer = _buffer,
+            SavedOffset = _offset,
+            SavedPos = _pos,
+            SavedLength = _length,
+            SavedTotalBytesWritten = _totalBytesWritten,
+            SavedCurrent = _current,
+            SavedFlushMode = FlushMode,
+            SideBuffer = sideBuffer,
+            PrefixingAction = prefixingAction,
+        };
+
+        (_chainedFrames ??= new Stack<ChainedFrame>()).Push(frame);
+
+        // Fork to the dedicated side buffer.
+        _writer = sideBuffer;
+        _totalBytesWritten = 0;
+        _current = new() { Format = frame.SavedCurrent.Format, Size = Size.Unknown, BufferRequirement = bufferRequirement, WriteState = state };
+        RequestBuffer(0);
+        return new(new NestedWriteScope(this, NestedWriteScope.ChainedScope));
+    }
+
+    // Restores the writer to the parent, emits the prefix via the frame's PrefixingAction, splices the measured
+    // bytes in, and reports the measured size. The dedicated side buffer is per-scope so it's GC'd.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal ValueTask<int> EndVariableLengthPrefixingScope(bool async, CancellationToken cancellationToken)
+    {
+        var frame = _chainedFrames!.Pop();
+
+        // Commit pending writes from the working buffer back to the dedicated side buffer.
+        Commit();
+        var sideBuffer = frame.SideBuffer;
+        var measuredSize = sideBuffer.WrittenCount;
+
+        // Restore parent state.
+        _writer = frame.SavedWriter;
+        _buffer = frame.SavedBuffer;
+        _offset = frame.SavedOffset;
+        _pos = frame.SavedPos;
+        _length = frame.SavedLength;
+        _totalBytesWritten = frame.SavedTotalBytesWritten;
+        _current = frame.SavedCurrent;
+        FlushMode = frame.SavedFlushMode;
+
+        // Emit the length prefix into the restored parent via the caller's prefixingAction.
+        frame.PrefixingAction(this, measuredSize);
+
+        // Splice the dedicated side buffer's accumulated bytes into the parent.
+        if (async)
+            return SpliceAsync(this, sideBuffer, measuredSize, cancellationToken);
+        WriteBytes(sideBuffer.WrittenSpan);
+        return new(measuredSize);
+
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        static async ValueTask<int> SpliceAsync(PgWriter writer, MeasuringSideBufferWriter sideBuffer, int measuredSize, CancellationToken cancellationToken)
+        {
+            await writer.WriteBytesAsync(sideBuffer.WrittenMemory, cancellationToken).ConfigureAwait(false);
+            return measuredSize;
+        }
+    }
 
     sealed class PgWriterStream : Stream
     {
@@ -646,11 +817,123 @@ public sealed class PgWriter
     }
 }
 
-// No-op for now.
-[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
-public struct NestedWriteScope : IDisposable
+sealed class MeasuringSideBufferWriter : IBufferWriter<byte>
 {
+    readonly ArrayBufferWriter<byte> _backing = new();
+    public Memory<byte> GetMemory(int sizeHint = 0) => _backing.GetMemory(sizeHint);
+    public Span<byte> GetSpan(int sizeHint = 0) => _backing.GetSpan(sizeHint);
+    public void Advance(int count) => _backing.Advance(count);
+
+    public ReadOnlySpan<byte> WrittenSpan => _backing.WrittenSpan;
+    public ReadOnlyMemory<byte> WrittenMemory => _backing.WrittenMemory;
+    public int WrittenCount => _backing.WrittenCount;
+
+    internal void Backpatch(int logicalOffset, ReadOnlySpan<byte> bytes)
+    {
+        Debug.Assert(logicalOffset + bytes.Length <= _backing.WrittenCount);
+        var memory = MemoryMarshal.AsMemory(_backing.WrittenMemory);
+        bytes.CopyTo(memory.Span.Slice(logicalOffset, bytes.Length));
+    }
+}
+
+// A streaming alternative to a System.IO.Stream, instead based on the preferable IBufferWriter.
+interface IStreamingWriter<T> : IBufferWriter<T>
+{
+    void Flush(TimeSpan timeout = default);
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
+}
+
+sealed class NpgsqlBufferWriter(NpgsqlWriteBuffer buffer) : IStreamingWriter<byte>
+{
+    int? _lastBufferSize;
+
+    public void Advance(int count)
+    {
+        if (_lastBufferSize < count || buffer.WriteSpaceLeft < count)
+            ThrowHelper.ThrowInvalidOperationException("Cannot advance past the end of the current buffer.");
+        _lastBufferSize = null;
+        buffer.WritePosition += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        var writePosition = buffer.WritePosition;
+        var bufferSize = buffer.Size - writePosition;
+        if (sizeHint > bufferSize)
+            ThrowOutOfMemoryException();
+
+        _lastBufferSize = bufferSize;
+        return buffer.Buffer.AsMemory(writePosition, bufferSize);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        var writePosition = buffer.WritePosition;
+        var bufferSize = buffer.Size - writePosition;
+        if (sizeHint > bufferSize)
+            ThrowOutOfMemoryException();
+
+        _lastBufferSize = bufferSize;
+        return buffer.Buffer.AsSpan(writePosition, bufferSize);
+    }
+
+    static void ThrowOutOfMemoryException() => throw new OutOfMemoryException("Not enough space left in buffer.");
+
+    public void Flush(TimeSpan timeout = default)
+    {
+        if (timeout == TimeSpan.Zero)
+            buffer.Flush();
+        else
+        {
+            TimeSpan? originalTimeout = null;
+            try
+            {
+                if (timeout != TimeSpan.Zero)
+                {
+                    originalTimeout = buffer.Timeout;
+                    buffer.Timeout = timeout;
+                }
+                buffer.Flush();
+            }
+            finally
+            {
+                if (originalTimeout is { } value)
+                    buffer.Timeout = value;
+            }
+        }
+    }
+
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default)
+        => new(buffer.Flush(async: true, cancellationToken));
+}
+
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
+public readonly struct NestedWriteScope : IDisposable
+{
+    // _placeholderOffset >= 0 is a side-buffer placeholder offset; sentinels select the other paths.
+    internal const int ChainedScope = -1;
+
+    readonly PgWriter? _writer;
+    readonly int _placeholderOffset;
+
+    internal NestedWriteScope(PgWriter writer, int placeholderOffset)
+    {
+        _writer = writer;
+        _placeholderOffset = placeholderOffset;
+    }
+
     public void Dispose()
     {
+        if (_writer is null)
+            return;
+        switch (_placeholderOffset)
+        {
+        case ChainedScope:
+            _writer.EndVariableLengthPrefixingScope(async: false, CancellationToken.None).GetAwaiter().GetResult();
+            break;
+        default:
+            _writer.EndLengthPrefixingScope(_placeholderOffset);
+            break;
+        }
     }
 }

--- a/src/Npgsql/NpgsqlParameter.cs
+++ b/src/Npgsql/NpgsqlParameter.cs
@@ -53,6 +53,9 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     private protected PgValueBinding _binding;
     private protected bool _isBound;
 
+    // Set when a measuring parameter materialized its value at Bind — the measured bytes, for Write to replay.
+    private protected MeasuringSideBufferWriter? _materialized;
+
     #endregion
 
     #region Constructors
@@ -743,7 +746,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
     }
 
     /// Bind the current value to the type info, truncate (if applicable), take its size, and do any final validation before writing.
-    internal void Bind(out DataFormat format, out Size size, DataFormat? requiredFormat = null)
+    internal bool Bind(out DataFormat format, out int byteCount, DataFormat? requiredFormat = null)
     {
         if (TypeInfo is null || ConcreteTypeInfo is null)
             ThrowHelper.ThrowInvalidOperationException($"Missing type info, {nameof(ResolveTypeInfo)} needs to be called before {nameof(Bind)}.");
@@ -818,6 +821,10 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
 
                 if (requiredFormat is not null && _binding.DataFormat != requiredFormat.GetValueOrDefault())
                     ThrowHelper.ThrowNotSupportedException($"Parameter '{ParameterName}' must be written in {requiredFormat} format, but does not support this format.");
+
+                // A non-Exact bind size means measuring, the actual byte count isn't known until the value is written.
+                if (!_useSubStream && !_binding.IsDbNullBinding && _binding.Size is { Kind: not SizeKind.Exact })
+                    _materialized = Materialize(concrete);
             }
             catch (Exception ex)
             {
@@ -829,7 +836,27 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
         }
 
         format = Format;
-        size = _binding.Size ?? -1;
+        if (_binding.IsDbNullBinding)
+        {
+            byteCount = default;
+            return false;
+        }
+        byteCount = _materialized?.WrittenCount ?? _binding.Size.GetValueOrDefault().Value;
+        return true;
+
+        // Write a parameter's value into a side buffer at Bind time so its actual byte count is known for the Bind protocol message.
+        MeasuringSideBufferWriter Materialize(PgConcreteTypeInfo concrete)
+        {
+            var buffer = new MeasuringSideBufferWriter();
+            var measureWriter = new PgWriter(buffer).Init(concrete.Options.DatabaseInfo, _binding.Size.GetValueOrDefault().GetValueOrDefault());
+            measureWriter.StartWrite(async: false, _binding, CancellationToken.None).GetAwaiter().GetResult();
+            if (StaticValueType == typeof(object))
+                concrete.Converter.WriteAsObject(measureWriter, Value);
+            else
+                WriteTypedValue(async: false, concrete, measureWriter, CancellationToken.None).GetAwaiter().GetResult();
+            measureWriter.Commit();
+            return buffer;
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         PgValueBinding BindSubStream(object? providerWriteState)
@@ -910,36 +937,51 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             if (writer.ShouldFlush(sizeof(int)))
                 await writer.Flush(async, cancellationToken).ConfigureAwait(false);
 
-            var size = _binding.Size?.Value ?? -1;
-            writer.WriteInt32(size);
-            writer.CommitAndResetTotal(sizeof(int));
-
-            if (!_binding.IsDbNullBinding)
+            if (_materialized is { } materialized)
             {
-                if (_useSubStream)
-                {
-                    Debug.Assert(_subStream is not null);
-                    if (async)
-                        await _subStream.CopyToAsync(writer.GetStream(), cancellationToken).ConfigureAwait(false);
-                    else
-                        _subStream.CopyTo(writer.GetStream());
-                    writer.CommitAndResetTotal(size);
-                }
+                // Measuring parameter: the value was written into a measure buffer at Bind. Emit the field
+                // length prefix from the measured size and splice the materialized bytes.
+                writer.WriteInt32(materialized.WrittenCount);
+                writer.CommitAndResetTotal(sizeof(int));
+                if (async)
+                    await writer.WriteBytesAsync(materialized.WrittenMemory, cancellationToken).ConfigureAwait(false);
                 else
+                    writer.WriteBytes(materialized.WrittenSpan);
+                writer.EndWrite(materialized.WrittenCount);
+            }
+            else
+            {
+                var size = _binding.Size?.Value ?? -1;
+                writer.WriteInt32(size);
+                writer.CommitAndResetTotal(sizeof(int));
+
+                if (!_binding.IsDbNullBinding)
                 {
-                    await writer.StartWrite(async, _binding, cancellationToken).ConfigureAwait(false);
-                    if (StaticValueType == typeof(object))
+                    if (_useSubStream)
                     {
-                        var value = Value;
-                        Debug.Assert(value is not null);
+                        Debug.Assert(_subStream is not null);
                         if (async)
-                            await concrete.Converter.WriteAsObjectAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                            await _subStream.CopyToAsync(writer.GetStream(), cancellationToken).ConfigureAwait(false);
                         else
-                            concrete.Converter.WriteAsObject(writer, value);
+                            _subStream.CopyTo(writer.GetStream());
+                        writer.CommitAndResetTotal(size);
                     }
                     else
-                        await WriteTypedValue(async, concrete, writer, cancellationToken).ConfigureAwait(false);
-                    writer.EndWrite(size);
+                    {
+                        await writer.StartWrite(async, _binding, cancellationToken).ConfigureAwait(false);
+                        if (StaticValueType == typeof(object))
+                        {
+                            var value = Value;
+                            Debug.Assert(value is not null);
+                            if (async)
+                                await concrete.Converter.WriteAsObjectAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                            else
+                                concrete.Converter.WriteAsObject(writer, value);
+                        }
+                        else
+                            await WriteTypedValue(async, concrete, writer, cancellationToken).ConfigureAwait(false);
+                        writer.EndWrite(size);
+                    }
                 }
             }
         }
@@ -1050,6 +1092,7 @@ public class NpgsqlParameter : DbParameter, IDbDataParameter, ICloneable
             // WriteState ref slot for GC.
             _useSubStream = false;
             _subStream = null;
+            _materialized = null;
             _binding = default;
             _isBound = false;
         }

--- a/test/Npgsql.Tests/MeasuringConverterTests.cs
+++ b/test/Npgsql.Tests/MeasuringConverterTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Npgsql.Internal;
+using Npgsql.Internal.Postgres;
+
+namespace Npgsql.Tests;
+
+/// <summary>
+/// Converter-level integration tests for the measuring write protocol. Exercises the dispatch path:
+/// <c>BufferRequirements</c> → <c>BindContext</c> construction → <c>Bind</c>
+/// → <c>Write</c> → <c>Scope (optional)</c> → length-prefix back-patch.
+/// Bypasses the connection layer by composing the options directly, simulating the parameter-level orchestration.
+/// </summary>
+public class MeasuringConverterTests
+{
+    [Test]
+    public void Parameter_writes_measured_value([Values] bool unknownSize, [Values] bool optionalBind)
+    {
+        var param = new NpgsqlParameter<byte[]>
+            { ParameterName = "p", TypedValue = [0xAA, 0xBB, 0xCC], DataTypeName = "bytea" };
+
+        // A converter that requires measuring writes.
+        // Parameter bind materializes the bytes into a side buffer, and yields the exact byte count.
+        // Write then replays the bytes with that prefix.
+        var (written, byteCount) = BindAndWrite(param, BuildOptions(new MeasuringByteaResolverFactory(
+            // Unknown = no hint, UpperBound = arbitrary bound.
+            new MeasuringByteaConverter(unknownSize ? Size.Unknown : Size.CreateUpperBound(1000), optionalBind))));
+
+        Assert.That(byteCount, Is.EqualTo(3));
+        Assert.That(written, Is.EqualTo(new byte[] { 0, 0, 0, 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void Measuring_composer_parameter_materializes_with_nested_length()
+    {
+        var param = new NpgsqlParameter<byte[]>
+            { ParameterName = "p", TypedValue = [0xAA, 0xBB, 0xCC], DataTypeName = "bytea" };
+
+        // A converter that requires measuring writes.
+        // It internally opens another scope and its own measuring resolves in-place there.
+        // Parameter bind materializes the bytes into a side buffer, and yields the exact byte count.
+        // Write then replays the bytes with that prefix.
+        var (written, byteCount) = BindAndWrite(param, BuildOptions(new MeasuringByteaResolverFactory(new MeasuringScopeByteaConverter())));
+
+        Assert.That(byteCount, Is.EqualTo(7));
+        // outer field prefix (7 = nested frame) + nested int4 prefix (3) + content.
+        Assert.That(written, Is.EqualTo(new byte[] { 0, 0, 0, 7, 0, 0, 0, 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    static PgSerializerOptions BuildOptions(PgTypeInfoResolverFactory factory)
+    {
+        var dsb = new NpgsqlSlimDataSourceBuilder("Host=localhost");
+        dsb.AddTypeInfoResolverFactory(factory);
+        using var dataSource = dsb.Build();
+        return new PgSerializerOptions(PostgresMinimalDatabaseInfo.DefaultTypeCatalog, dataSource.Configuration.ResolverChain);
+    }
+
+    // Drives Resolve → Bind → Write against an in-memory buffer; FlushMode.None keeps Write synchronous.
+    // Returns the written bytes and the byte count Bind produced (what the Bind message length is summed from).
+    static (byte[] Written, int ByteCount) BindAndWrite(NpgsqlParameter param, PgSerializerOptions options)
+    {
+        param.ResolveTypeInfo(options, dbTypeResolver: null);
+        param.Bind(out _, out var byteCount);
+
+        var sink = new ArrayBufferWriter<byte>();
+        var task = param.Write(async: false, new PgWriter(sink).Init(PostgresMinimalDatabaseInfo.DefaultTypeCatalog, 0), CancellationToken.None);
+        Debug.Assert(task.IsCompletedSuccessfully, "Write should complete synchronously with FlushMode.None");
+        task.GetAwaiter().GetResult();
+        return (sink.WrittenSpan.ToArray(), byteCount);
+    }
+
+    sealed class MeasuringByteaResolverFactory(PgConverter<byte[]> converter) : PgTypeInfoResolverFactory
+    {
+        public override IPgTypeInfoResolver CreateResolver() => new Resolver(converter);
+        public override IPgTypeInfoResolver? CreateArrayResolver() => null;
+
+        sealed class Resolver(PgConverter<byte[]> converter) : IPgTypeInfoResolver
+        {
+            public PgTypeInfo? GetTypeInfo(Type? type, DataTypeName? dataTypeName, PgSerializerOptions options)
+                => dataTypeName == DataTypeNames.Bytea && (type == typeof(byte[]) || type is null)
+                    ? new PgProviderTypeInfo(options, new MeasuringByteaProvider(options, converter), DataTypeNames.Bytea)
+                    : null;
+        }
+
+        sealed class MeasuringByteaProvider(PgSerializerOptions options, PgConverter<byte[]> converter) : PgConcreteTypeInfoProvider<byte[]>
+        {
+            PgConcreteTypeInfo? _concreteTypeInfo;
+
+            PgConcreteTypeInfo GetOrCreate()
+                => _concreteTypeInfo ??= new(options, converter, options.GetCanonicalTypeId(DataTypeNames.Bytea));
+
+            protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId) => GetOrCreate();
+            protected override PgConcreteTypeInfo GetForValueCore(ProviderValueContext context, byte[]? value, ref object? writeState) => GetOrCreate();
+        }
+    }
+
+    sealed class MeasuringByteaConverter(Size writeSize, bool optionalBind = false) : PgStreamingConverter<byte[]>
+    {
+        public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+        {
+            bufferRequirements = BufferRequirements.Create(Size.Unknown, writeSize, optionalBind);
+            return format is DataFormat.Binary;
+        }
+
+        protected override Size BindValue(in BindContext context, byte[] value, ref object? writeState)
+            => writeSize;
+
+        public override void Write(PgWriter writer, byte[] value)
+            => writer.WriteBytes(value);
+
+        public override byte[] Read(PgReader reader) => throw new NotSupportedException();
+        public override ValueTask<byte[]> ReadAsync(PgReader reader, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override ValueTask WriteAsync(PgWriter writer, byte[] value, CancellationToken cancellationToken = default)
+        {
+            Write(writer, value);
+            return new();
+        }
+    }
+
+    sealed class MeasuringScopeByteaConverter : PgStreamingConverter<byte[]>
+    {
+        public override bool CanConvert(DataFormat format, out BufferRequirements bufferRequirements)
+        {
+            bufferRequirements = BufferRequirements.Streaming;
+            return format is DataFormat.Binary;
+        }
+
+        // Add arbitrary slack to the exact byte count.
+        protected override Size BindValue(in BindContext context, byte[] value, ref object? writeState)
+            => Size.CreateUpperBound(value.Length + 16);
+
+        public override void Write(PgWriter writer, byte[] value)
+        {
+            using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.CreateUpperBound(value.Length), state: null))
+                writer.WriteBytes(value);
+        }
+
+        public override byte[] Read(PgReader reader) => throw new NotSupportedException();
+        public override ValueTask<byte[]> ReadAsync(PgReader reader, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override ValueTask WriteAsync(PgWriter writer, byte[] value, CancellationToken cancellationToken = default)
+        {
+            Write(writer, value);
+            return new();
+        }
+    }
+}

--- a/test/Npgsql.Tests/MeasuringPgWriterTests.cs
+++ b/test/Npgsql.Tests/MeasuringPgWriterTests.cs
@@ -1,0 +1,418 @@
+using System;
+using NUnit.Framework;
+using Npgsql.Internal;
+
+namespace Npgsql.Tests;
+
+/// <summary>
+/// Direct unit tests for <see cref="PgWriter"/>'s measuring mechanisms.
+/// </summary>
+public class MeasuringPgWriterTests
+{
+    static (PgWriter writer, MeasuringSideBufferWriter sink) CreateMeasuringWriter()
+    {
+        var sink = new MeasuringSideBufferWriter();
+        var writer = new PgWriter(sink);
+        writer.Init(new PostgresMinimalDatabaseInfo(), 0);
+        return (writer, sink);
+    }
+
+    [Test]
+    public void Exact_writes_prefix_then_content()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Create(3), size: Size.Create(3), state: null))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        writer.EndWrite(Size.Create(7));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0, 0, 0, 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void Unknown_backpatches_prefix_with_measured_size()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        writer.EndWrite(Size.Create(7));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0, 0, 0, 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void Unknown_with_empty_inner_writes_zero_prefix()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            // no inner writes
+        }
+
+        writer.EndWrite(Size.Create(4));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0, 0, 0, 0 }));
+    }
+
+    [Test]
+    public void UpperBound_routes_through_measuring_mode()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        // UpperBound of 100, actual content is 3 bytes; the prefix should reflect actual size, not the bound.
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.CreateUpperBound(100), size: Size.CreateUpperBound(100), state: null))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        writer.EndWrite(Size.Create(7));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0, 0, 0, 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void Sequential_unknown_scopes_dont_pollute_each_other()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0xAA);
+        }
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        writer.EndWrite(Size.Create(11));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 1, 0xAA,        // first scope
+            0, 0, 0, 2, 0xBB, 0xCC,  // second scope
+        }));
+    }
+
+    [Test]
+    public void Unknown_handles_inner_larger_than_initial_side_buffer_capacity()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        var content = new byte[8192];
+        for (var i = 0; i < content.Length; i++)
+            content[i] = (byte)(i & 0xFF);
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+            writer.WriteBytes(content);
+
+        writer.EndWrite(Size.Create(4 + content.Length));
+        var bytes = sink.WrittenSpan.ToArray();
+        Assert.That(bytes.Length, Is.EqualTo(4 + content.Length));
+        // Prefix should be 8192 in big-endian
+        Assert.That(bytes[0], Is.EqualTo(0));
+        Assert.That(bytes[1], Is.EqualTo(0));
+        Assert.That(bytes[2], Is.EqualTo(0x20));
+        Assert.That(bytes[3], Is.EqualTo(0x00));
+        Assert.That(bytes.AsSpan(4).ToArray(), Is.EqualTo(content));
+    }
+
+    [Test]
+    public void Nested_unknown_scopes_stack_on_shared_side_buffer()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // outer
+        {
+            writer.WriteByte(0x01);  // outer's pre-inner content
+            using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // inner
+            {
+                writer.WriteByte(0xAA);
+                writer.WriteByte(0xBB);
+            }
+            writer.WriteByte(0x02);  // outer's post-inner content
+        }
+
+        // Outer content layout: 0x01 + inner_prefix(4) + 0xAA 0xBB + 0x02 = 8 bytes
+        // Outer prefix = 4 bytes with value 8
+        // Total = 12
+        writer.EndWrite(Size.Create(12));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 8,    // outer prefix (outer content is 8 bytes)
+            0x01,           // outer pre-inner
+            0, 0, 0, 2,    // inner prefix (inner content is 2 bytes)
+            0xAA, 0xBB,    // inner content
+            0x02,           // outer post-inner
+        }));
+    }
+
+    [Test]
+    public void Triple_nested_measuring_scopes()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // L1
+        {
+            using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // L2
+            {
+                using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // L3
+                {
+                    writer.WriteByte(0xFF);
+                }
+            }
+        }
+
+        // L3 content = 1 byte (0xFF), L3 framed = 4 + 1 = 5
+        // L2 content = L3 framed = 5 bytes, L2 framed = 4 + 5 = 9
+        // L1 content = L2 framed = 9 bytes, L1 framed = 4 + 9 = 13
+        writer.EndWrite(Size.Create(13));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 9,     // L1 prefix
+            0, 0, 0, 5,     // L2 prefix
+            0, 0, 0, 1,     // L3 prefix
+            0xFF,            // L3 content
+        }));
+    }
+
+    [Test]
+    public void Chained_variable_prefix_calls_lambda_with_measured_size()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        // Variable-prefix lambda: writes a single-byte length prefix (sufficient for content < 256 bytes).
+        Action<PgWriter, int> writeBytePrefix = static (w, size) => w.WriteByte((byte)size);
+
+        using (writer.BeginLengthPrefixingScope(
+            bufferRequirement: Size.Unknown,
+            size: Size.Unknown,
+            state: null,
+            prefixingAction: writeBytePrefix))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        // 1-byte prefix(value=3) + 3 content bytes = 4
+        writer.EndWrite(Size.Create(4));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 3, 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void Chained_variable_prefix_nested_inside_fixed_prefix_outer()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+        Action<PgWriter, int> writeBytePrefix = static (w, size) => w.WriteByte((byte)size);
+
+        using (writer.BeginLengthPrefixingScope(  // outer: int4 prefix (default)
+            bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0x01);  // outer pre-content
+            using (writer.BeginLengthPrefixingScope(  // inner: variable byte prefix (chained)
+                bufferRequirement: Size.Unknown, size: Size.Unknown, state: null,
+                prefixingAction: writeBytePrefix))
+            {
+                writer.WriteByte(0xAA);
+                writer.WriteByte(0xBB);
+            }
+            writer.WriteByte(0x02);  // outer post-content
+        }
+
+        // outer content: 0x01 + (1-byte prefix(2) + 0xAA 0xBB) + 0x02 = 5 bytes
+        // outer framed: 4 + 5 = 9 bytes
+        writer.EndWrite(Size.Create(9));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 5,    // outer int4 prefix (outer content is 5 bytes)
+            0x01,           // outer pre
+            2,              // inner 1-byte prefix (inner content is 2 bytes)
+            0xAA, 0xBB,    // inner content
+            0x02,           // outer post
+        }));
+    }
+
+    [Test]
+    public void Fixed_inside_chained_tags_along_on_chained_buffer()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+        Action<PgWriter, int> writeBytePrefix = static (w, size) => w.WriteByte((byte)size);
+
+        using (writer.BeginLengthPrefixingScope(  // outer: chained (variable byte prefix)
+            bufferRequirement: Size.Unknown, size: Size.Unknown, state: null,
+            prefixingAction: writeBytePrefix))
+        {
+            writer.WriteByte(0xAA);  // outer pre-content
+            using (writer.BeginLengthPrefixingScope(  // inner: fixed int4 prefix — should tag along on chained's buffer
+                bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+            {
+                writer.WriteByte(0xBB);
+                writer.WriteByte(0xCC);
+            }
+            writer.WriteByte(0xDD);  // outer post-content
+        }
+
+        // outer content: 0xAA + (int4 prefix(2) + 0xBB 0xCC) + 0xDD = 1+4+2+1 = 8 bytes
+        // outer framed: byte_prefix(8) + 8 = 9 bytes total
+        writer.EndWrite(Size.Create(9));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            8,              // outer 1-byte prefix
+            0xAA,           // outer pre
+            0, 0, 0, 2,    // inner int4 prefix
+            0xBB, 0xCC,    // inner content
+            0xDD,           // outer post
+        }));
+    }
+
+    [Test]
+    public void Fixed_chained_fixed_three_level_interleaving()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+        Action<PgWriter, int> writeBytePrefix = static (w, size) => w.WriteByte((byte)size);
+
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null))  // L1 fixed
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null,
+            prefixingAction: writeBytePrefix))  // L2 chained
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null))  // L3 fixed
+        {
+            writer.WriteByte(0xFF);
+        }
+
+        // L3 framed = int4(1) + 0xFF = 5 bytes
+        // L2 framed = byte(5) + 5 = 6 bytes
+        // L1 framed = int4(6) + 6 = 10 bytes
+        writer.EndWrite(Size.Create(10));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 6,    // L1 prefix
+            5,              // L2 prefix
+            0, 0, 0, 1,    // L3 prefix
+            0xFF,           // L3 content
+        }));
+    }
+
+    [Test]
+    public void Chained_fixed_chained_three_level_interleaving()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+        Action<PgWriter, int> writeBytePrefix = static (w, size) => w.WriteByte((byte)size);
+
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null,
+            prefixingAction: writeBytePrefix))  // L1 chained
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null))  // L2 fixed
+        using (writer.BeginLengthPrefixingScope(Size.Unknown, Size.Unknown, state: null,
+            prefixingAction: writeBytePrefix))  // L3 chained
+        {
+            writer.WriteByte(0xFF);
+        }
+
+        // L3 framed = byte(1) + 0xFF = 2 bytes
+        // L2 framed = int4(2) + 2 = 6 bytes
+        // L1 framed = byte(6) + 6 = 7 bytes
+        writer.EndWrite(Size.Create(7));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            6,              // L1 prefix
+            0, 0, 0, 2,    // L2 prefix
+            1,              // L3 prefix
+            0xFF,           // L3 content
+        }));
+    }
+
+    [Test]
+    public void State_correctly_restored_after_measuring_scope()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        // Write some bytes before measuring
+        writer.WriteByte(0x01);
+        writer.WriteByte(0x02);
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0xAA);
+        }
+
+        // Subsequent writes should land directly in the parent buffer, after the measured scope.
+        writer.WriteByte(0xFF);
+
+        writer.EndWrite(Size.Create(8));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0x01, 0x02,           // pre-scope
+            0, 0, 0, 1, 0xAA,     // measuring scope (prefix + content)
+            0xFF,                 // post-scope
+        }));
+    }
+
+    [Test]
+    public void No_prefix_writes_content_without_a_length()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        // lengthByteCount: null — no length prefix; the nested write is framed by the caller, or needs none.
+        using (writer.BeginPassthroughScope(bufferRequirement: Size.Create(3), size: Size.Create(3), state: null))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+            writer.WriteByte(0xCC);
+        }
+
+        writer.EndWrite(Size.Create(3));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0xAA, 0xBB, 0xCC }));
+    }
+
+    [Test]
+    public void No_prefix_with_unknown_size_does_not_throw()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        // Unknown size + no prefix — the LateBindingConverter shape: a transparent wrapper re-framing for a
+        // measuring inner. The Unknown size must flow through without a Size.Value throw, and no prefix lands.
+        using (writer.BeginPassthroughScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))
+        {
+            writer.WriteByte(0xAA);
+            writer.WriteByte(0xBB);
+        }
+
+        writer.EndWrite(Size.Create(2));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[] { 0xAA, 0xBB }));
+    }
+
+    [Test]
+    public void No_prefix_nested_inside_measured_scope()
+    {
+        var (writer, sink) = CreateMeasuringWriter();
+
+        using (writer.BeginLengthPrefixingScope(bufferRequirement: Size.Unknown, size: Size.Unknown, state: null))  // outer int4
+        {
+            writer.WriteByte(0x01);
+            // No-prefix inner — its content joins the outer's measured region with no length of its own.
+            using (writer.BeginPassthroughScope(bufferRequirement: Size.Create(2), size: Size.Create(2), state: null))
+            {
+                writer.WriteByte(0xAA);
+                writer.WriteByte(0xBB);
+            }
+            writer.WriteByte(0x02);
+        }
+
+        // outer content: 0x01 + 0xAA 0xBB + 0x02 = 4 bytes (no inner prefix); outer framed: int4(4) + 4 = 8.
+        writer.EndWrite(Size.Create(8));
+        Assert.That(sink.WrittenSpan.ToArray(), Is.EqualTo(new byte[]
+        {
+            0, 0, 0, 4,
+            0x01, 0xAA, 0xBB, 0x02,
+        }));
+    }
+}

--- a/test/Npgsql.Tests/Types/CompositeTests.cs
+++ b/test/Npgsql.Tests/Types/CompositeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Npgsql.PostgresTypes;
 using NpgsqlTypes;
@@ -383,6 +384,30 @@ CREATE TYPE {compositeType} AS (address inet)");
     }
 
     [Test]
+    public async Task Composite_containing_jsonb()
+    {
+        await using var adminConnection = await OpenConnectionAsync();
+        var compositeType = await GetTempTypeName(adminConnection);
+
+        await adminConnection.ExecuteNonQueryAsync($"CREATE TYPE {compositeType} AS (x int, data jsonb, y int)");
+
+        var dataSourceBuilder = CreateDataSourceBuilder();
+        dataSourceBuilder.MapComposite<SomeCompositeWithJson>(compositeType);
+        await using var dataSource = dataSourceBuilder.Build();
+        await using var connection = await dataSource.OpenConnectionAsync();
+
+        await AssertType(
+            connection,
+            new SomeCompositeWithJson { X = 8, Data = JsonDocument.Parse("42"), Y = 9 },
+            "(8,42,9)",
+            compositeType,
+            dataTypeInference: DataTypeInference.Nothing,
+            comparer: (actual, expected) =>
+                actual.X == expected.X && actual.Y == expected.Y
+                && actual.Data!.RootElement.GetRawText() == expected.Data!.RootElement.GetRawText());
+    }
+
+    [Test]
     public async Task Composite_containing_type_info_provider_type()
     {
         await using var adminConnection = await OpenConnectionAsync();
@@ -745,6 +770,13 @@ CREATE TYPE {type2} AS (comp {type1}, comps {type1}[]);");
     class SomeCompositeWithIPAddress
     {
         public IPAddress? Address { get; set; }
+    }
+
+    class SomeCompositeWithJson
+    {
+        public int X { get; set; }
+        public JsonDocument? Data { get; set; }
+        public int Y { get; set; }
     }
 
     class SomeCompositeWithTypeInfoProviderType

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -89,8 +89,8 @@ public class WriteStateTests : TestBase
     {
         // Verifies write state propagation through a range composition:
         //   RangeConverter<int> -> tracking int subtype (BindValue populates writeState)
-        // The range converter must carry each bound's subtype state into BeginNestedWrite so the subtype's
-        // WriteCore observes the provider-produced sentinel.
+        // The range converter must carry each bound's subtype state into a nested scope
+        // so the subtype's Write observes the provider-produced sentinel.
         var tracker = new WriteStateTracker();
         var options = BuildOptions(b => b.EnableRanges(), new RangeWriteStateTrackingResolverFactory(tracker));
 
@@ -177,7 +177,8 @@ public class WriteStateTests : TestBase
     {
         // Verifies write state propagation through a composite composition:
         //   CompositeConverter<CompositeWithInt> -> tracking int4 field converter
-        // The composite's per-field WriteState storage must carry the subtype's sentinel into BeginNestedWrite.
+        // The composite's per-field WriteState must carry the field's state into a nested scope
+        // so the field converter Write observes the provider-produced sentinel.
         // Uses a real PG CREATE TYPE + MapComposite so the CompositeConverter is constructed by the production path.
         var tracker = new WriteStateTracker();
         await using var adminConnection = await OpenConnectionAsync();
@@ -278,7 +279,7 @@ public class WriteStateTests : TestBase
         param.ResolveTypeInfo(options, dbTypeResolver: null);
         param.Bind(out _, out _);
 
-        var pgWriter = new PgWriter(new ArrayBufferWriter<byte>()).Init(PostgresMinimalDatabaseInfo.DefaultTypeCatalog);
+        var pgWriter = new PgWriter(new ArrayBufferWriter<byte>()).Init(PostgresMinimalDatabaseInfo.DefaultTypeCatalog, 0);
         var task = param.Write(async: false, pgWriter, CancellationToken.None);
         Debug.Assert(task.IsCompletedSuccessfully, "Write should complete synchronously with FlushMode.None");
         task.GetAwaiter().GetResult();


### PR DESCRIPTION
First version of single-pass writing. Which would fix https://github.com/npgsql/npgsql/issues/1727

For now this just gets implemented for JsonConverter (and the composing converters) as it unconditionally requires measuring. This helps in e.g. arrays where currently one measuring element poisons the entire array to require measuring too, even if it was the only element. 

For conditional cases like strings we want to figure out two things:
- What is the cross-over point where the measuring setup and allocs becomes cheaper than the double encode, and switch BindValue based on that (so we would only double encode for small strings).
- What is a decent heuristic for arrays, multiranges and composites to push side buffers into their own state if they believe most elements won't require measuring. It may require some new converter surface to steer the heuristics.

Furthermore this PR still requires benchmarks and perf tuning (and maybe some more cleanup work) but I wanted to get the shape out to show what it means to implement this.