### PR TITLE
CLR enum underlying type mapping

### DIFF
--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,6 +83,13 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
     {
         readonly PgConverter<TElement> _elemConverter = (PgConverter<TElement>)elementTypeInfo.GetConverter(DataFormat.Binary);
 
+        // When the effective array type's element type differs from TElement (e.g. IntEnum[] with TElement=int),
+        // CreateCollection uses Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's
+        // contract is MethodTable-only: any metadata-reachable Type works, no per-element-type allocator codegen
+        // preservation is required, and no IL3050/DAM annotations are needed.
+        readonly Type? _effectiveType =
+            effectiveType is { IsArray: true } && effectiveType.GetElementType() != typeof(TElement) ? effectiveType : null;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static TElement? GetValue(object collection, IterationIndices indices)
         {
@@ -128,7 +136,16 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
         }
 
         object IElementOperations.CreateCollection(ReadOnlySpan<int> lengths)
-            => lengths.Length switch
+        {
+            if (_effectiveType is { } arrayType)
+                return lengths.Length switch
+                {
+                    0 => Array.CreateInstanceFromArrayType(arrayType, 0),
+                    1 => Array.CreateInstanceFromArrayType(arrayType, lengths[0]),
+                    _ => Array.CreateInstanceFromArrayType(arrayType, lengths.ToArray())
+                };
+
+            return lengths.Length switch
             {
                 0 => Array.Empty<TElement?>(),
                 1 => new TElement?[lengths[0]],
@@ -141,6 +158,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
                 8 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3], lengths[4], lengths[5], lengths[6], lengths[7]],
                 _ => throw new InvalidOperationException("Postgres arrays can have at most 8 dimensions.")
             };
+        }
 
         int IElementOperations.GetCollectionCount(object collection, out int[]? lengths)
             => ArrayConverterCore.GetArrayLengths((Array)collection, out lengths);

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Postgres;
@@ -83,57 +84,32 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
     {
         readonly PgConverter<TElement> _elemConverter = (PgConverter<TElement>)elementTypeInfo.GetConverter(DataFormat.Binary);
 
-        // When the effective array type's element type differs from TElement (e.g. IntEnum[] with TElement=int),
-        // CreateCollection uses Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's
-        // contract is MethodTable-only: any metadata-reachable Type works, no per-element-type allocator codegen
-        // preservation is required, and no IL3050/DAM annotations are needed.
+        // When the effective array type's element type differs from TElement (e.g. IntEnum[] with TElement=int,
+        // or IntEnum?[] with TElement=int?), CreateCollection uses Array.CreateInstanceFromArrayType to produce
+        // the correctly-typed array. Per-element access is a ref-byte-cast over the actual array's data
+        // reference at the row-major flat index — sound for layout-equivalent blittable value-type element
+        // pairs (the resolver gates this at call site), since sizeof(TElement?) matches the actual slot
+        // stride. The cast is on the element slot, not the array instance, so we don't assume the array's
+        // MethodTable matches TElement?[]; that's the part `Unsafe.As<TElement?[]>(actualArray)` would have
+        // gotten wrong for the Nullable<>[] case (no CLR variance through Nullable).
         readonly Type? _effectiveType =
             effectiveType is { IsArray: true } && effectiveType.GetElementType() != typeof(TElement) ? effectiveType : null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static TElement? GetValue(object collection, IterationIndices indices)
+        static ref TElement? GetSlot(object collection, IterationIndices indices)
         {
             Debug.Assert(indices.Rank > 0);
-            switch (indices.Rank)
-            {
-            case 1:
-                // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                Debug.Assert(collection is TElement?[]);
-                return Unsafe.As<TElement?[]>(collection)[indices.One];
-            case 2:
-                // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                Debug.Assert(collection is TElement?[,]);
-                return Unsafe.As<TElement?[,]>(collection)[indices.Many![0], indices.Many![1]];
-            default:
-                // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                Debug.Assert(collection is Array);
-                return (TElement?)Unsafe.As<Array>(collection).GetValue(indices.Many!);
-            }
+            Debug.Assert(collection is Array);
+            ref var first = ref Unsafe.As<byte, TElement?>(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<Array>(collection)));
+            return ref Unsafe.Add(ref first, (nint)indices.IndicesSum);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static TElement? GetValue(object collection, IterationIndices indices) => GetSlot(collection, indices);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void SetValue(object collection, IterationIndices indices, TElement? value)
-        {
-            Debug.Assert(indices.Rank > 0);
-            switch (indices.Rank)
-            {
-                case 1:
-                    // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                    Debug.Assert(collection is TElement?[]);
-                    Unsafe.As<TElement?[]>(collection)[indices.One] = value;
-                    break;
-                case 2:
-                    // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                    Debug.Assert(collection is TElement?[,]);
-                    Unsafe.As<TElement?[,]>(collection)[indices.Many![0], indices.Many![1]] = value;
-                    break;
-                default:
-                    // Justification: exact type Unsafe.As used to avoid the cast overhead for per element calls.
-                    Debug.Assert(collection is Array);
-                    Unsafe.As<Array>(collection).SetValue(value, indices.Many!);
-                    break;
-            }
-        }
+            => GetSlot(collection, indices) = value;
 
         object IElementOperations.CreateCollection(ReadOnlySpan<int> lengths)
         {
@@ -154,9 +130,7 @@ abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
                 4 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3]],
                 5 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3], lengths[4]],
                 6 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3], lengths[4], lengths[5]],
-                7 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3], lengths[4], lengths[5], lengths[6]],
-                8 => new TElement?[lengths[0], lengths[1], lengths[2], lengths[3], lengths[4], lengths[5], lengths[6], lengths[7]],
-                _ => throw new InvalidOperationException("Postgres arrays can have at most 8 dimensions.")
+                _ => throw new InvalidOperationException("Postgres arrays can have at most 6 dimensions.")
             };
         }
 

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -3,7 +3,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverterCore.cs
@@ -411,7 +411,7 @@ sealed class ArrayConverterWriteState : MultiWriteState
 
 readonly struct PgArrayMetadata
 {
-    const int MaxDimensions = 8;
+    const int MaxDimensions = 6;
 
     readonly int _totalElements;
     readonly int[]? _dimensionLengths;

--- a/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
+++ b/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -65,6 +64,31 @@ interface IEnumUnderlyingConverter
             default: throw new NotSupportedException();
         }
     }
+
+    // Known PG wire sizes per .NET underlying type — matches the default Ado mappings. byte/sbyte/short/ushort
+    // → Int2 (2 bytes), int/uint → Int4 (4 bytes), long/ulong → Int8 (8 bytes). PG has no unsigned types, so
+    // unsigned .NET underlyings are bit-reinterpreted onto the signed wire format of the same width.
+    static int WireSize<T>()
+        => Type.GetTypeCode(typeof(T)) switch
+        {
+            TypeCode.Int32 or TypeCode.UInt32 => sizeof(int),
+            TypeCode.Int64 or TypeCode.UInt64 => sizeof(long),
+            TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Byte or TypeCode.SByte => sizeof(short),
+            _ => throw new NotSupportedException()
+        };
+
+    // Typed Enum.ToObject overload — one allocation (the boxed enum), no intermediate boxed underlying.
+    // Used by both the value and nullable converter's AsObject paths.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static object ReadAsBoxedEnum<T>(PgReader reader, Type enumType)
+        => Type.GetTypeCode(typeof(T)) switch
+        {
+            TypeCode.Int32 or TypeCode.UInt32 => Enum.ToObject(enumType, reader.ReadInt32()),
+            TypeCode.Int64 or TypeCode.UInt64 => Enum.ToObject(enumType, reader.ReadInt64()),
+            TypeCode.Int16 or TypeCode.UInt16 => Enum.ToObject(enumType, reader.ReadInt16()),
+            TypeCode.Byte or TypeCode.SByte => Enum.ToObject(enumType, checked((byte)reader.ReadInt16())),
+            _ => throw new NotSupportedException()
+        };
 }
 
 /// <summary>
@@ -79,21 +103,7 @@ sealed class EnumUnderlyingConverter<T>(Type enumType) : PgBufferedConverter<T>,
     where T : unmanaged, IBinaryInteger<T>
 {
     public override ConverterDescriptor GetDescriptor(in DescriptorContext context)
-    {
-        return ConverterDescriptor.Invariant with { BufferRequirements = BufferRequirements.CreateFixedSize(WireSize()) };
-
-        // Known PG wire sizes per .NET underlying type — matches the default Ado mappings. byte/sbyte/short/ushort
-        // → Int2 (2 bytes), int/uint → Int4 (4 bytes), long/ulong → Int8 (8 bytes). PG has no unsigned types, so
-        // unsigned .NET underlyings are bit-reinterpreted onto the signed wire format of the same width.
-        static int WireSize()
-            => Type.GetTypeCode(typeof(T)) switch
-            {
-                TypeCode.Int32 or TypeCode.UInt32 => sizeof(int),
-                TypeCode.Int64 or TypeCode.UInt64 => sizeof(long),
-                TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Byte or TypeCode.SByte => sizeof(short),
-                _ => throw new NotSupportedException()
-            };
-    }
+        => ConverterDescriptor.Invariant with { BufferRequirements = BufferRequirements.CreateFixedSize(IEnumUnderlyingConverter.WireSize<T>()) };
 
     public override T Read(PgReader reader)
         => IEnumUnderlyingConverter.ReadAsEnumUnderlying<T>(reader);
@@ -104,12 +114,27 @@ sealed class EnumUnderlyingConverter<T>(Type enumType) : PgBufferedConverter<T>,
     // Typed Enum.ToObject overload — exactly one allocation per call (the boxed enum), no intermediate boxed
     // underlying. No async machinery: reads are buffered, result is synchronously available.
     internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
-        => Type.GetTypeCode(typeof(T)) switch
-        {
-            TypeCode.Int32 or TypeCode.UInt32 => new(Enum.ToObject(enumType, reader.ReadInt32())),
-            TypeCode.Int64 or TypeCode.UInt64 => new(Enum.ToObject(enumType, reader.ReadInt64())),
-            TypeCode.Int16 or TypeCode.UInt16 => new(Enum.ToObject(enumType, reader.ReadInt16())),
-            TypeCode.Byte or TypeCode.SByte => new(Enum.ToObject(enumType, checked((byte)reader.ReadInt16()))),
-            _ => throw new NotSupportedException()
-        };
+        => new(IEnumUnderlyingConverter.ReadAsBoxedEnum<T>(reader, enumType));
+}
+
+/// <summary>
+/// Nullable sibling of <see cref="EnumUnderlyingConverter{T}"/>. Same wire format, same boxing behavior on the
+/// AsObject path (boxed <see cref="Nullable{T}"/> strips the wrapper, so a boxed enum unboxes to TEnum? at the
+/// caller). Read/Write delegate to the shared <see cref="IEnumUnderlyingConverter"/> helpers; the framework's
+/// null-handling stops at the wire-length check, so Read/Write only see non-null values here.
+/// </summary>
+sealed class EnumUnderlyingNullableConverter<T>(Type enumType) : PgBufferedConverter<T?>, IEnumUnderlyingConverter
+    where T : unmanaged, IBinaryInteger<T>
+{
+    public override ConverterDescriptor GetDescriptor(in DescriptorContext context)
+        => ConverterDescriptor.Invariant with { BufferRequirements = BufferRequirements.CreateFixedSize(IEnumUnderlyingConverter.WireSize<T>()) };
+
+    public override T? Read(PgReader reader)
+        => IEnumUnderlyingConverter.ReadAsEnumUnderlying<T>(reader);
+
+    public override void Write(PgWriter writer, T? value)
+        => IEnumUnderlyingConverter.WriteAsEnumUnderlying(writer, value.GetValueOrDefault());
+
+    internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+        => new(IEnumUnderlyingConverter.ReadAsBoxedEnum<T>(reader, enumType));
 }

--- a/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
+++ b/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Npgsql.Internal.Converters;
+
+/// <summary>
+/// Non-generic marker for <see cref="EnumUnderlyingConverter{T}"/>. Used by <see cref="PgConcreteTypeInfo"/> at
+/// construction time to enforce that only this converter may participate in enum reported-type widening.
+/// </summary>
+interface IEnumUnderlyingConverter
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static bool IsEnumUnderlyingConversion<T>(PgConverter converter)
+        => typeof(T).IsEnum && Enum.GetUnderlyingType(typeof(T)) == converter.TypeToConvert && converter is IEnumUnderlyingConverter;
+
+    // Typed enum-underlying helpers. Reached only via the dispatch sites' RuntimeFeature.IsDynamicCodeSupported gate,
+    // which ILC discharges to false under NAOT — the helpers are therefore unreachable under NAOT and don't get
+    // instantiated per-T (no viral bloat). Under JIT, RyuJIT folds the typecode switch per concrete T at codegen
+    // time, leaving only the matching case live, and the (T)(object)v JIT-elides the box+unbox for layout-compatible
+    // enum/underlying — zero alloc per call.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static T ReadAsEnumUnderlying<T>(PgReader reader)
+    {
+        Debug.Assert(typeof(T).IsEnum);
+        return Type.GetTypeCode(typeof(T)) switch
+        {
+            TypeCode.Int32 or TypeCode.UInt32 => (T)(object)reader.ReadInt32(),
+            TypeCode.Int64 or TypeCode.UInt64 => (T)(object)reader.ReadInt64(),
+            TypeCode.Int16 or TypeCode.UInt16 => (T)(object)reader.ReadInt16(),
+            TypeCode.Byte or TypeCode.SByte => (T)(object)checked((byte)reader.ReadInt16()),
+            _ => throw new NotSupportedException()
+        };
+    }
+
+    static bool IsDbNullAsEnumUnderlying<T>(T? value, object? writeState) => false;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Size BindAsEnumUnderlying<T>(in BindContext context, T value, ref object? writeState)
+    {
+        Debug.Assert(typeof(T).IsEnum);
+        if (context.IsBindOptional)
+            return context.BufferRequirement;
+
+        throw new NotSupportedException();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void WriteAsEnumUnderlying<T>(PgWriter writer, T value)
+    {
+        switch (Type.GetTypeCode(typeof(T)))
+        {
+            case TypeCode.Int32 or TypeCode.UInt32:
+                writer.WriteInt32((int)(object)value!);
+                break;
+            case TypeCode.Int64 or TypeCode.UInt64:
+                writer.WriteInt64((long)(object)value!);
+                break;
+            case TypeCode.Int16 or TypeCode.UInt16:
+                writer.WriteInt16((short)(object)value!);
+                break;
+            case TypeCode.Byte or TypeCode.SByte:
+                writer.WriteInt16((byte)(object)value!);
+                break;
+            default: throw new NotSupportedException();
+        }
+    }
+}
+
+/// <summary>
+/// Converter for a CLR enum's underlying primitive. Reads/writes the primitive directly using the PG wire format
+/// Npgsql's default mappings use for the corresponding .NET type (byte/sbyte/short → smallint, int → integer,
+/// long → bigint), and re-materializes the boxed value as the enum on the AsObject path via
+/// <see cref="Enum.ToObject(Type, object)"/>. Inherits <see cref="PgBufferedConverter{T}"/> so all per-T async
+/// accessor codegen is provided by the base — only the AsObject read needs an override here. Carrying the enum
+/// type here lets callers holding a non-generic <see cref="PgConverter"/> reference get a correctly-boxed enum.
+/// </summary>
+sealed class EnumUnderlyingConverter<T>(Type enumType) : PgBufferedConverter<T>, IEnumUnderlyingConverter
+    where T : unmanaged, IBinaryInteger<T>
+{
+    public override ConverterDescriptor GetDescriptor(in DescriptorContext context)
+    {
+        return ConverterDescriptor.Invariant with { BufferRequirements = BufferRequirements.CreateFixedSize(WireSize()) };
+
+        // Known PG wire sizes per .NET underlying type — matches the default Ado mappings. byte/sbyte/short/ushort
+        // → Int2 (2 bytes), int/uint → Int4 (4 bytes), long/ulong → Int8 (8 bytes). PG has no unsigned types, so
+        // unsigned .NET underlyings ride on the signed wire format with CreateChecked handling range.
+        static int WireSize()
+            => Type.GetTypeCode(typeof(T)) switch
+            {
+                TypeCode.Int32 or TypeCode.UInt32 => sizeof(int),
+                TypeCode.Int64 or TypeCode.UInt64 => sizeof(long),
+                TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Byte or TypeCode.SByte => sizeof(short),
+                _ => throw new NotSupportedException()
+            };
+    }
+
+    public override T Read(PgReader reader)
+        => IEnumUnderlyingConverter.ReadAsEnumUnderlying<T>(reader);
+
+    public override void Write(PgWriter writer, T value)
+        => IEnumUnderlyingConverter.WriteAsEnumUnderlying(writer, value);
+
+    // Typed Enum.ToObject overload — exactly one allocation per call (the boxed enum), no intermediate boxed
+    // underlying. No async machinery: reads are buffered, result is synchronously available.
+    internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+        => Type.GetTypeCode(typeof(T)) switch
+        {
+            TypeCode.Int32 or TypeCode.UInt32 => new(Enum.ToObject(enumType, reader.ReadInt32())),
+            TypeCode.Int64 or TypeCode.UInt64 => new(Enum.ToObject(enumType, reader.ReadInt64())),
+            TypeCode.Int16 or TypeCode.UInt16 => new(Enum.ToObject(enumType, reader.ReadInt16())),
+            TypeCode.Byte or TypeCode.SByte => new(Enum.ToObject(enumType, checked((byte)reader.ReadInt16()))),
+            _ => throw new NotSupportedException()
+        };
+}

--- a/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
+++ b/src/Npgsql/Internal/Converters/EnumUnderlyingConverter.cs
@@ -17,31 +17,28 @@ interface IEnumUnderlyingConverter
     static bool IsEnumUnderlyingConversion<T>(PgConverter converter)
         => typeof(T).IsEnum && Enum.GetUnderlyingType(typeof(T)) == converter.TypeToConvert && converter is IEnumUnderlyingConverter;
 
-    // Typed enum-underlying helpers. Reached only via the dispatch sites' RuntimeFeature.IsDynamicCodeSupported gate,
-    // which ILC discharges to false under NAOT — the helpers are therefore unreachable under NAOT and don't get
-    // instantiated per-T (no viral bloat). Under JIT, RyuJIT folds the typecode switch per concrete T at codegen
-    // time, leaving only the matching case live, and the (T)(object)v JIT-elides the box+unbox for layout-compatible
-    // enum/underlying — zero alloc per call.
+    // Typed enum-underlying helpers. The enum-typed instantiations are reached only via the dispatch sites'
+    // RuntimeFeature.IsDynamicCodeSupported gate, which ILC discharges to false under NAOT — so they don't get
+    // instantiated per enum-T (no viral bloat). Under JIT, RyuJIT folds the typecode switch per concrete T at
+    // codegen time, leaving only the matching case live. T is the enum or (via the converter's own Read/Write)
+    // its underlying primitive; Unsafe.BitCast reinterprets the layout-identical bits — signed and unsigned
+    // alike — without boxing.
     [MethodImpl(MethodImplOptions.NoInlining)]
     static T ReadAsEnumUnderlying<T>(PgReader reader)
-    {
-        Debug.Assert(typeof(T).IsEnum);
-        return Type.GetTypeCode(typeof(T)) switch
+        => Type.GetTypeCode(typeof(T)) switch
         {
-            TypeCode.Int32 or TypeCode.UInt32 => (T)(object)reader.ReadInt32(),
-            TypeCode.Int64 or TypeCode.UInt64 => (T)(object)reader.ReadInt64(),
-            TypeCode.Int16 or TypeCode.UInt16 => (T)(object)reader.ReadInt16(),
-            TypeCode.Byte or TypeCode.SByte => (T)(object)checked((byte)reader.ReadInt16()),
+            TypeCode.Int32 or TypeCode.UInt32 => Unsafe.BitCast<int, T>(reader.ReadInt32()),
+            TypeCode.Int64 or TypeCode.UInt64 => Unsafe.BitCast<long, T>(reader.ReadInt64()),
+            TypeCode.Int16 or TypeCode.UInt16 => Unsafe.BitCast<short, T>(reader.ReadInt16()),
+            TypeCode.Byte or TypeCode.SByte => Unsafe.BitCast<byte, T>(checked((byte)reader.ReadInt16())),
             _ => throw new NotSupportedException()
         };
-    }
 
     static bool IsDbNullAsEnumUnderlying<T>(T? value, object? writeState) => false;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Size BindAsEnumUnderlying<T>(in BindContext context, T value, ref object? writeState)
     {
-        Debug.Assert(typeof(T).IsEnum);
         if (context.IsBindOptional)
             return context.BufferRequirement;
 
@@ -54,16 +51,16 @@ interface IEnumUnderlyingConverter
         switch (Type.GetTypeCode(typeof(T)))
         {
             case TypeCode.Int32 or TypeCode.UInt32:
-                writer.WriteInt32((int)(object)value!);
+                writer.WriteInt32(Unsafe.BitCast<T, int>(value));
                 break;
             case TypeCode.Int64 or TypeCode.UInt64:
-                writer.WriteInt64((long)(object)value!);
+                writer.WriteInt64(Unsafe.BitCast<T, long>(value));
                 break;
             case TypeCode.Int16 or TypeCode.UInt16:
-                writer.WriteInt16((short)(object)value!);
+                writer.WriteInt16(Unsafe.BitCast<T, short>(value));
                 break;
             case TypeCode.Byte or TypeCode.SByte:
-                writer.WriteInt16((byte)(object)value!);
+                writer.WriteInt16(Unsafe.BitCast<T, byte>(value));
                 break;
             default: throw new NotSupportedException();
         }
@@ -87,7 +84,7 @@ sealed class EnumUnderlyingConverter<T>(Type enumType) : PgBufferedConverter<T>,
 
         // Known PG wire sizes per .NET underlying type — matches the default Ado mappings. byte/sbyte/short/ushort
         // → Int2 (2 bytes), int/uint → Int4 (4 bytes), long/ulong → Int8 (8 bytes). PG has no unsigned types, so
-        // unsigned .NET underlyings ride on the signed wire format with CreateChecked handling range.
+        // unsigned .NET underlyings are bit-reinterpreted onto the signed wire format of the same width.
         static int WireSize()
             => Type.GetTypeCode(typeof(T)) switch
             {

--- a/src/Npgsql/Internal/Converters/PgEnumConverter.cs
+++ b/src/Npgsql/Internal/Converters/PgEnumConverter.cs
@@ -6,13 +6,13 @@ using System.Text;
 namespace Npgsql.Internal.Converters;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-sealed class EnumConverter<TEnum> : PgBufferedConverter<TEnum> where TEnum : struct, Enum
+sealed class PgEnumConverter<TEnum> : PgBufferedConverter<TEnum> where TEnum : struct, Enum
 {
     readonly Dictionary<TEnum, string> _enumToLabel;
     readonly Dictionary<string, TEnum> _labelToEnum;
 
     // Unmapped enums
-    public EnumConverter(Dictionary<Enum, string> enumToLabel, Dictionary<string, Enum> labelToEnum)
+    public PgEnumConverter(Dictionary<Enum, string> enumToLabel, Dictionary<string, Enum> labelToEnum)
     {
         _enumToLabel = new(enumToLabel.Count);
         foreach (var kv in enumToLabel)
@@ -23,7 +23,7 @@ sealed class EnumConverter<TEnum> : PgBufferedConverter<TEnum> where TEnum : str
             _labelToEnum.Add(kv.Key, (TEnum)kv.Value);
     }
 
-    public EnumConverter(Dictionary<TEnum, string> enumToLabel, Dictionary<string, TEnum> labelToEnum)
+    public PgEnumConverter(Dictionary<TEnum, string> enumToLabel, Dictionary<string, TEnum> labelToEnum)
     {
         _enumToLabel = enumToLabel;
         _labelToEnum = labelToEnum;

--- a/src/Npgsql/Internal/PgBufferedConverter.cs
+++ b/src/Npgsql/Internal/PgBufferedConverter.cs
@@ -34,7 +34,7 @@ public abstract class PgBufferedConverter<T> : PgConverter<T>
     public sealed override ValueTask<T> ReadAsync(PgReader reader, CancellationToken cancellationToken = default)
         => new(Read(reader));
 
-    internal sealed override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
+    internal override ValueTask<object?> ReadAsObject(bool async, PgReader reader, CancellationToken cancellationToken)
         => new(Read(reader));
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -47,7 +47,7 @@ public abstract class PgBufferedConverter<T> : PgConverter<T>
         return new();
     }
 
-    internal sealed override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
+    internal override ValueTask WriteAsObject(bool async, PgWriter writer, object? value, CancellationToken cancellationToken)
     {
         Write(writer, (T)value!);
         return new();

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Util;
+using static Npgsql.Internal.Converters.IEnumUnderlyingConverter;
 
 namespace Npgsql.Internal;
 
@@ -107,7 +108,9 @@ public abstract class PgConverter
     Read<T>(PgReader reader)
         => typeof(T) == TypeToConvert
             ? UnsafeAs<T>().Read(reader)
-            : (T)ReadAsObject(reader)!;
+            : IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported
+                ? ReadAsEnumUnderlying<T>(reader)
+                : (T)ReadAsObject(reader)!;
 
     /// <summary>Asynchronously reads a value from the reader as <typeparamref name="T"/>.</summary>
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
@@ -121,12 +124,43 @@ public abstract class PgConverter
         if (typeof(T) == TypeToConvert)
             return UnsafeAs<T>().ReadAsync(reader, cancellationToken);
 
+        if (IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported)
+            return new(ReadAsEnumUnderlying<T>(reader));
+
         var task = ReadAsObjectAsync(reader, cancellationToken);
         return task.IsCompletedSuccessfully ? new((T)task.Result!) : ReadAndUnboxAsync(task);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static async ValueTask<T> ReadAndUnboxAsync(ValueTask<object?> task)
             => (T)(await task.ConfigureAwait(false))!;
+    }
+
+    /// <summary>Db-null check for <typeparamref name="T"/>.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsDbNull<T>(T? value, object? writeState)
+    {
+        if (typeof(T) == TypeToConvert)
+            return UnsafeAs<T>().IsDbNull(value, writeState);
+
+        if (IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported)
+            return IsDbNullAsEnumUnderlying(value, writeState);
+
+        return IsDbNullAsObject(value, writeState);
+    }
+
+    /// <summary>Computes the serialized size for <paramref name="value"/>, producing any required <paramref name="writeState"/>.</summary>
+    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Size Bind<T>(in BindContext context, T value, ref object? writeState)
+    {
+        if (typeof(T) == TypeToConvert)
+            return UnsafeAs<T>().Bind(context, value, ref writeState);
+
+        if (IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported)
+            return BindAsEnumUnderlying(context, value, ref writeState);
+
+        return BindAsObject(context, value, ref writeState);
     }
 
     /// <summary>Writes a <typeparamref name="T"/> value to the writer.</summary>
@@ -139,6 +173,13 @@ public abstract class PgConverter
             UnsafeAs<T>().Write(writer, value);
             return;
         }
+
+        if (IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported)
+        {
+            WriteAsEnumUnderlying(writer, value);
+            return;
+        }
+
         WriteAsObject(writer, value);
     }
 
@@ -146,25 +187,18 @@ public abstract class PgConverter
     /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask WriteAsync<T>(PgWriter writer, T value, CancellationToken cancellationToken = default)
-        => typeof(T) == TypeToConvert
-            ? UnsafeAs<T>().WriteAsync(writer, value, cancellationToken)
-            : WriteAsObjectAsync(writer, value, cancellationToken);
+    {
+        if (typeof(T) == TypeToConvert)
+            return UnsafeAs<T>().WriteAsync(writer, value, cancellationToken);
 
-    /// <summary>Db-null check for <typeparamref name="T"/>.</summary>
-    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsDbNull<T>(T? value, object? writeState)
-        => typeof(T) == TypeToConvert
-            ? UnsafeAs<T>().IsDbNull(value, writeState)
-            : IsDbNullAsObject(value, writeState);
+        if (IsEnumUnderlyingConversion<T>(this) && RuntimeFeature.IsDynamicCodeSupported)
+        {
+            WriteAsEnumUnderlying(writer, value);
+            return new();
+        }
 
-    /// <summary>Computes the serialized size for <paramref name="value"/>, producing any required <paramref name="writeState"/>.</summary>
-    /// <remarks>Dispatches to the typed converter when <typeparamref name="T"/> matches <see cref="TypeToConvert"/>; otherwise routes through the object-erased path.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Size Bind<T>(in BindContext context, T value, ref object? writeState)
-        => typeof(T) == TypeToConvert
-            ? UnsafeAs<T>().Bind(context, value, ref writeState)
-            : BindAsObject(context, value, ref writeState);
+        return WriteAsObjectAsync(writer, value, cancellationToken);
+    }
 
     /// Checks whether <paramref name="value"/> is considered a database null by this converter.
     public bool IsDbNullAsObject(object? value, object? writeState)

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql.Internal.Converters;
 using Npgsql.Internal.Postgres;
 
 namespace Npgsql.Internal;
@@ -22,7 +23,8 @@ public abstract class PgTypeInfo
     /// Resolves the type the info should advertise. <paramref name="requestedType"/> must be on the same subtype
     /// chain as <paramref name="type"/>: when narrower (or equal) it is returned as-is (the under-reporting case);
     /// when wider <paramref name="type"/> is returned (the polymorphic-alias case, the info advertises the
-    /// converter's type back to a wider query). Throws when the two types are not in any subtype relationship.
+    /// converter's type back to a wider query). An enum requestedType over its underlying-type converter is also
+    /// accepted (representation-identical); throws when the types share none of these relationships.
     /// </summary>
     private protected static Type ResolveType(Type type, Type? requestedType)
     {
@@ -32,6 +34,9 @@ public abstract class PgTypeInfo
             return requestedType;
         if (type.IsAssignableTo(requestedType))
             return type;
+        // Enum and underlying type are representation-identical: accept the enum requestedType as a narrower report.
+        if (requestedType.IsEnum && requestedType.GetEnumUnderlyingType() == type)
+            return requestedType;
         throw new ArgumentException(
             $"The requested type {requestedType} is not in a subtype relationship with the converter's type {type}.",
             nameof(requestedType));
@@ -359,7 +364,7 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     // <paramref name="binary"/> fills the binary slot, <paramref name="text"/> fills the text slot.
     // Both slots may carry the same instance (multi-format converter), different instances (single-format per
     // slot), or — only one of them may be null when the format isn't supported. At least one slot must be filled.
-    internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter? binary, PgConverter? text, PgTypeId pgTypeId, Type? requestedType = null)
+    internal PgConcreteTypeInfo(PgSerializerOptions options, PgConverter? binary, PgConverter? text, PgTypeId pgTypeId, Type? requestedType = null, bool? supportsReading = null, bool? supportsWriting = null)
         : base(options, (binary ?? text ?? ThrowNoSlot()).TypeToConvert, pgTypeId, requestedType)
     {
         if (binary is not null && text is not null && binary.TypeToConvert != text.TypeToConvert)
@@ -378,8 +383,20 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         }
 
         var canonical = binary ?? text!;
-        _supportsReading = GetDefaultSupportsReading(canonical.TypeToConvert, requestedType);
-        _supportsWriting = GetDefaultSupportsWriting(canonical.TypeToConvert, requestedType);
+
+        // Enum-over-underlying is representation-identical via IEnumUnderlyingConverter's reinterpret;
+        // surface that internally without touching the general GetDefault* helpers (which would let
+        // arbitrary external converters claim the same compatibility unsafely). Callers can still
+        // override either direction via the explicit args.
+        var enumUnderlying = canonical is IEnumUnderlyingConverter
+            && requestedType is { IsEnum: true }
+            && requestedType.GetEnumUnderlyingType() == canonical.TypeToConvert;
+
+        // Set fields directly to bypass init guards on default values; init props enforce directional widen-to-true.
+        _supportsReading = supportsReading
+            ?? (enumUnderlying ? true : GetDefaultSupportsReading(canonical.TypeToConvert, requestedType));
+        _supportsWriting = supportsWriting
+            ?? (enumUnderlying ? true : GetDefaultSupportsWriting(canonical.TypeToConvert, requestedType));
     }
 
     [DoesNotReturn]
@@ -398,11 +415,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         DataFormat? preferredFormat = null,
         bool? supportsReading = null,
         bool? supportsWriting = null)
-        => new(options, binary, null, pgTypeId, requestedType)
+        => new(options, binary, null, pgTypeId, requestedType, supportsReading, supportsWriting)
         {
             PreferredFormat = preferredFormat,
-            SupportsReading = supportsReading ?? GetDefaultSupportsReading(binary.TypeToConvert, requestedType),
-            SupportsWriting = supportsWriting ?? GetDefaultSupportsWriting(binary.TypeToConvert, requestedType),
         };
 
     /// <summary>
@@ -418,11 +433,9 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         DataFormat? preferredFormat = null,
         bool? supportsReading = null,
         bool? supportsWriting = null)
-        => new(options, binary, text, pgTypeId, requestedType)
+        => new(options, binary, text, pgTypeId, requestedType, supportsReading, supportsWriting)
         {
             PreferredFormat = preferredFormat,
-            SupportsReading = supportsReading ?? GetDefaultSupportsReading(binary.TypeToConvert, requestedType),
-            SupportsWriting = supportsWriting ?? GetDefaultSupportsWriting(binary.TypeToConvert, requestedType),
         };
 
     /// <summary>

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal.Converters;
 using Npgsql.Internal.Postgres;
+using static Npgsql.Internal.Converters.IEnumUnderlyingConverter;
 
 namespace Npgsql.Internal;
 
@@ -580,11 +581,15 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
     {
         await reader.StartReadAsync(binding, cancellationToken).ConfigureAwait(false);
 
-        // Inline copy of converter.ReadAsync<T> to keep everything in one async frame.
+        // Inline copy of converter.ReadAsync<T> to keep everything in one async frame. The enum-underlying branch
+        // mirrors PgConverter.ReadAsync<T>'s fast path so async reads don't fall through to the boxing
+        // ReadAsObjectAsync route on CoreCLR. The helper is synchronous because EnumUnderlyingConverter is buffered.
         var converter = binding.Converter;
         var result = typeof(T) == converter.TypeToConvert
             ? await Unsafe.As<PgConverter<T>>(converter).ReadAsync(reader, cancellationToken).ConfigureAwait(false)
-            : (T)(await converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false))!;
+            : IsEnumUnderlyingConversion<T>(converter) && RuntimeFeature.IsDynamicCodeSupported
+                ? ReadAsEnumUnderlying<T>(reader)
+                : (T)(await converter.ReadAsObjectAsync(reader, cancellationToken).ConfigureAwait(false))!;
 
         await reader.EndReadAsync().ConfigureAwait(false);
         return result;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -34,12 +34,33 @@ public abstract class PgTypeInfo
             return requestedType;
         if (type.IsAssignableTo(requestedType))
             return type;
-        // Enum and underlying type are representation-identical: accept the enum requestedType as a narrower report.
-        if (requestedType.IsEnum && requestedType.GetEnumUnderlyingType() == type)
+        // Enum and underlying type (both their bare and Nullable<> forms) are representation-identical:
+        // accept the enum requestedType as a narrower report.
+        if (IsEnumUnderlyingPair(requestedType, type))
             return requestedType;
         throw new ArgumentException(
             $"The requested type {requestedType} is not in a subtype relationship with the converter's type {type}.",
             nameof(requestedType));
+    }
+
+    // True when (requestedType, converterType) is an enum-over-its-underlying-primitive pair (or the parallel
+    // Nullable<> forms). Used by ResolveType to accept the narrower enum report and by PgConcreteTypeInfo's
+    // ctor to gate the SupportsReading/SupportsWriting special-case for IEnumUnderlyingConverter.
+    private protected static bool IsEnumUnderlyingPair(Type? requestedType, Type converterType)
+    {
+        if (requestedType is null)
+            return false;
+
+        var requestedNullable = Nullable.GetUnderlyingType(requestedType);
+        var converterNullable = Nullable.GetUnderlyingType(converterType);
+        // Both sides must agree on the nullable wrapper — mixing bare and Nullable<> would mean different
+        // value-shape contracts on the typed dispatch path.
+        if ((requestedNullable is null) != (converterNullable is null))
+            return false;
+
+        var requestedEnum = requestedNullable ?? requestedType;
+        var converterPrimitive = converterNullable ?? converterType;
+        return requestedEnum.IsEnum && requestedEnum.GetEnumUnderlyingType() == converterPrimitive;
     }
 
     private protected PgTypeInfo(PgSerializerOptions options, Type type, PgTypeId? pgTypeId, Type? requestedType = null)
@@ -387,10 +408,10 @@ public sealed class PgConcreteTypeInfo : PgTypeInfo
         // Enum-over-underlying is representation-identical via IEnumUnderlyingConverter's reinterpret;
         // surface that internally without touching the general GetDefault* helpers (which would let
         // arbitrary external converters claim the same compatibility unsafely). Callers can still
-        // override either direction via the explicit args.
+        // override either direction via the explicit args. Both bare-enum (Underlying) and Nullable<TEnum>
+        // (Nullable<Underlying>) pairs qualify — see IsEnumUnderlyingPair.
         var enumUnderlying = canonical is IEnumUnderlyingConverter
-            && requestedType is { IsEnum: true }
-            && requestedType.GetEnumUnderlyingType() == canonical.TypeToConvert;
+            && IsEnumUnderlyingPair(requestedType, canonical.TypeToConvert);
 
         // Set fields directly to bypass init guards on default values; init props enforce directional widen-to-true.
         _supportsReading = supportsReading

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -35,7 +35,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 info = GetPgEnumTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
             if (info is null && type is not null && dataTypeName is not null)
                 info = GetStreamTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
-            if (info is null && type is not null && type.IsEnum)
+            if (info is null && type is not null)
                 info = GetEnumTypeInfo(type, dataTypeName, options);
 
             return info;
@@ -50,43 +50,38 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             return PgConcreteTypeInfo.Create(options, binary: converter, text: converter, dataTypeName, supportsWriting: false);
         }
 
-        static PgTypeInfo? GetEnumTypeInfo(Type type, DataTypeName? dataTypeName, PgSerializerOptions options)
+        protected static PgTypeInfo? GetEnumTypeInfo(Type type, DataTypeName? dataTypeName, PgSerializerOptions options)
         {
-            Debug.Assert(type.IsEnum);
-
-            var underlyingType = type.GetEnumUnderlyingType();
-
-            // Resolve the underlying type's info just to derive the PgTypeId and validate that the resolver chain
-            // recognizes the underlying mapped to this dataTypeName. The wire format knowledge is baked into
-            // EnumUnderlyingConverter itself (matching the default Ado mappings: byte/sbyte/short → Int2, int → Int4,
-            // long → Int8), so no inner converter reference is needed.
-            var underlyingInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, dataTypeName, options);
-            if (underlyingInfo?.PgTypeId is not { } pgTypeId)
+            if (!type.IsEnum)
                 return null;
 
-            var wrappedConverter = CreateEnumUnderlyingConverter(type, underlyingType);
-            if (wrappedConverter is null)
-                return null;
-
-            return PgConcreteTypeInfo.Create(options, binary: wrappedConverter, pgTypeId, requestedType: type);
-        }
-
-        static PgConverter? CreateEnumUnderlyingConverter(Type enumType, Type underlyingType)
-            => Type.GetTypeCode(underlyingType) switch
+            // EnumUnderlyingConverter reads/writes the underlying primitive at a fixed PG wire format, so the enum
+            // maps to exactly one canonical PG type: byte/sbyte/short/ushort → int2, int/uint → int4, long/ulong →
+            // int8. (PG has no unsigned types; unsigned .NET underlyings are bit-reinterpreted onto the signed wire
+            // format of the same width.) Deriving the PgTypeId by resolving the underlying through the chain would let
+            // ExtraConversions numeric cross-mappings (e.g. int→int8) through, pairing a mismatched PG type with the
+            // fixed-format converter and corrupting the wire — so the canonical type is paired with the converter here.
+            (PgConverter, DataTypeName)? mapping = Type.GetTypeCode(type) switch
             {
-                // PG has no unsigned integer types; unsigned .NET underlyings ride on the same wire format as their
-                // signed counterparts (ushort → smallint, uint → integer, ulong → bigint) with CreateChecked handling
-                // out-of-range values at read/write time.
-                TypeCode.Int32 => new EnumUnderlyingConverter<int>(enumType),
-                TypeCode.Int64 => new EnumUnderlyingConverter<long>(enumType),
-                TypeCode.Int16 => new EnumUnderlyingConverter<short>(enumType),
-                TypeCode.Byte => new EnumUnderlyingConverter<byte>(enumType),
-                TypeCode.SByte => new EnumUnderlyingConverter<sbyte>(enumType),
-                TypeCode.UInt32 => new EnumUnderlyingConverter<uint>(enumType),
-                TypeCode.UInt64 => new EnumUnderlyingConverter<ulong>(enumType),
-                TypeCode.UInt16 => new EnumUnderlyingConverter<ushort>(enumType),
+                TypeCode.Int16 => (new EnumUnderlyingConverter<short>(type), DataTypeNames.Int2),
+                TypeCode.UInt16 => (new EnumUnderlyingConverter<ushort>(type), DataTypeNames.Int2),
+                TypeCode.Byte => (new EnumUnderlyingConverter<byte>(type), DataTypeNames.Int2),
+                TypeCode.SByte => (new EnumUnderlyingConverter<sbyte>(type), DataTypeNames.Int2),
+                TypeCode.Int32 => (new EnumUnderlyingConverter<int>(type), DataTypeNames.Int4),
+                TypeCode.UInt32 => (new EnumUnderlyingConverter<uint>(type), DataTypeNames.Int4),
+                TypeCode.Int64 => (new EnumUnderlyingConverter<long>(type), DataTypeNames.Int8),
+                TypeCode.UInt64 => (new EnumUnderlyingConverter<ulong>(type), DataTypeNames.Int8),
                 _ => null
             };
+            if (mapping is not ({ } converter, var canonicalDataTypeName))
+                return null;
+
+            // On the read path the column's type must be exactly the enum's canonical PG type; no cross-conversion.
+            if (dataTypeName is { } requested && canonicalDataTypeName != requested)
+                return null;
+
+            return PgConcreteTypeInfo.Create(options, binary: converter, canonicalDataTypeName, requestedType: type);
+        }
 
         static PgTypeInfo? GetPgEnumTypeInfo(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
@@ -731,23 +726,15 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (type is not null && !type.IsArray)
                 return null;
 
-            // Resolve the underlying type's element info through the full chain.
-            var underlyingType = elementType.GetEnumUnderlyingType();
-            var elementDataTypeName = pgElementType.DataTypeName;
-            var elemInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, elementDataTypeName, options);
-            if (elemInfo is null)
-                return null;
-
-            var concreteElemInfo = elemInfo as PgConcreteTypeInfo ?? elemInfo.MakeConcreteForField(
-                Field.CreateUnspecified(elemInfo.PgTypeId!.Value));
-
-            if (concreteElemInfo.GetConverter(DataFormat.Binary).TypeToConvert != underlyingType)
+            // Resolve the element enum's canonical info (EnumUnderlyingConverter + canonical PG type). Going through
+            // the scalar path also rejects a cross-convertible column type, keeping arrays consistent with scalars.
+            if (GetEnumTypeInfo(elementType, pgElementType.DataTypeName, options) is not PgConcreteTypeInfo concreteElemInfo)
                 return null;
 
             // Build array converter using the underlying type; storage is produced as type (MyEnum[]) via
             // Array.CreateInstanceFromArrayType. IntEnum[] and int[] are layout-identical for value types with
             // the same underlying representation, so Unsafe.As<int?[]> access is bit-safe.
-            var arrayConverter = CreateEnumArrayConverter(underlyingType, concreteElemInfo, type);
+            var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, type);
             if (arrayConverter is null)
                 return null;
 
@@ -763,31 +750,20 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (!arrayType.IsArray)
                 return null;
 
-            // Resolve the underlying type's element info.
-            var underlyingType = elementType.GetEnumUnderlyingType();
-            var elemInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, null, options);
-            if (elemInfo is null || elemInfo.PgTypeId is null)
+            // Resolve the element enum's canonical info (EnumUnderlyingConverter + canonical PG type).
+            if (GetEnumTypeInfo(elementType, null, options) is not PgConcreteTypeInfo concreteElemInfo)
                 return null;
 
-            var concreteElemInfo = elemInfo as PgConcreteTypeInfo ?? elemInfo.MakeConcreteForField(
-                Field.CreateUnspecified(elemInfo.PgTypeId.Value));
-
-            if (concreteElemInfo.GetConverter(DataFormat.Binary).TypeToConvert != underlyingType)
+            // Find the array PG type for the element's canonical PG type.
+            var elementDataTypeName = options.DatabaseInfo.GetDataTypeName(concreteElemInfo.PgTypeId);
+            if (options.DatabaseInfo.GetPostgresType(elementDataTypeName) is not PostgresBaseType { Array: { } arrayPgType })
                 return null;
 
-            // Find the array PG type for the element's PG type.
-            var elementPgTypeId = concreteElemInfo.PgTypeId;
-            var elementDataTypeName = options.DatabaseInfo.GetDataTypeName(elementPgTypeId);
-            var pgType = options.DatabaseInfo.GetPostgresType(elementDataTypeName);
-            if (pgType is not PostgresBaseType { Array: { } arrayPgType })
-                return null;
-
-            var arrayDataTypeName = arrayPgType.DataTypeName;
-            var arrayConverter = CreateEnumArrayConverter(underlyingType, concreteElemInfo, arrayType);
+            var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, arrayType);
             if (arrayConverter is null)
                 return null;
 
-            return PgConcreteTypeInfo.Create(options, arrayConverter, arrayDataTypeName, requestedType: arrayType, supportsReading: true);
+            return PgConcreteTypeInfo.Create(options, binary: arrayConverter, arrayPgType.DataTypeName, requestedType: arrayType, supportsReading: true);
         }
 
         static PgConverter? CreateEnumArrayConverter(Type underlyingType, PgConcreteTypeInfo elemInfo, Type? arrayType)

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -52,7 +52,11 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
         protected static PgTypeInfo? GetEnumTypeInfo(Type type, DataTypeName? dataTypeName, PgSerializerOptions options)
         {
-            if (!type.IsEnum)
+            // Only resolve the underlying-mapping when the caller has named the PG type explicitly — without a
+            // dataTypeName the resolver would silently route arbitrary enums to int2/int4/int8, masking the
+            // common case of a missing PgEnum/EnumMapping registration. Requiring the explicit ask makes the
+            // underlying-type fallback an opt-in path rather than a default.
+            if (!type.IsEnum || dataTypeName is not { } requested)
                 return null;
 
             // EnumUnderlyingConverter reads/writes the underlying primitive at a fixed PG wire format, so the enum
@@ -76,8 +80,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (mapping is not ({ } converter, var canonicalDataTypeName))
                 return null;
 
-            // On the read path the column's type must be exactly the enum's canonical PG type; no cross-conversion.
-            if (dataTypeName is { } requested && canonicalDataTypeName != requested)
+            // The requested PG type must be exactly the enum's canonical match; no cross-conversion.
+            if (canonicalDataTypeName != requested)
                 return null;
 
             return PgConcreteTypeInfo.Create(options, binary: converter, canonicalDataTypeName, requestedType: type);
@@ -520,16 +524,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 && (type is null || type == typeof(object) || TypeInfoMappingCollection.IsArrayLikeType(type, out elementType)))
             {
                 info = GetPgEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
-                       GetEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
+                       GetEnumArrayTypeInfo(elementType, type, dataTypeName.GetValueOrDefault(), options) ??
                        GetObjectArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options);
-            }
-
-            // CLR enum array write path: type is known (e.g. IntEnum[]) but no dataTypeName.
-            if (info is null && type is not null && dataTypeName is null
-                && TypeInfoMappingCollection.IsArrayLikeType(type, out elementType)
-                && elementType.IsEnum)
-            {
-                info = GetEnumArrayTypeInfoForWrite(elementType, type, options);
             }
 
             return info;
@@ -713,7 +709,11 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             return mappings.Find(type, dataTypeName, options);
         }
 
-        static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, PostgresType pgElementType, Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
+        // Array mirror of GetEnumTypeInfo: requires an explicit array DataTypeName (same opt-in rule as the
+        // scalar case) and delegates the element-canonical-match check to GetEnumTypeInfo. Decomposes the
+        // array PG type into its element to feed the scalar path; rejection there (cross-conversion or
+        // unsupported underlying) propagates up here too.
+        static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, Type? type, DataTypeName arrayDataTypeName, PgSerializerOptions options)
         {
             if (elementType is null || !elementType.IsEnum)
                 return null;
@@ -726,44 +726,22 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (type is not null && !type.IsArray)
                 return null;
 
-            // Resolve the element enum's canonical info (EnumUnderlyingConverter + canonical PG type). Going through
-            // the scalar path also rejects a cross-convertible column type, keeping arrays consistent with scalars.
-            if (GetEnumTypeInfo(elementType, pgElementType.DataTypeName, options) is not PgConcreteTypeInfo concreteElemInfo)
+            if (options.DatabaseInfo.GetPostgresType(arrayDataTypeName) is not PostgresArrayType { Element: var pgElement })
                 return null;
 
-            // Build array converter using the underlying type; storage is produced as type (MyEnum[]) via
-            // Array.CreateInstanceFromArrayType. IntEnum[] and int[] are layout-identical for value types with
-            // the same underlying representation, so Unsafe.As<int?[]> access is bit-safe.
+            // Delegate the canonical-match check to the scalar path — if the requested element type isn't the
+            // enum's canonical PG type, GetEnumTypeInfo returns null and we propagate.
+            if (GetEnumTypeInfo(elementType, pgElement.DataTypeName, options) is not PgConcreteTypeInfo concreteElemInfo)
+                return null;
+
+            // Storage is produced as type (MyEnum[]) via Array.CreateInstanceFromArrayType. IntEnum[] and int[]
+            // are layout-identical for value types with the same underlying representation, so the inner
+            // converter's Unsafe.As<int?[]> access is bit-safe.
             var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, type);
             if (arrayConverter is null)
                 return null;
 
-            return PgConcreteTypeInfo.Create(options, binary: arrayConverter, dataTypeName, requestedType: type, supportsReading: true);
-        }
-
-        static PgTypeInfo? GetEnumArrayTypeInfoForWrite(Type elementType, Type arrayType, PgSerializerOptions options)
-        {
-            Debug.Assert(elementType.IsEnum);
-
-            // Same restriction as the read path: only actual array types are supported for enum underlying-type
-            // collections. See the matching comment on GetEnumArrayTypeInfo and dotnet/runtime#127249.
-            if (!arrayType.IsArray)
-                return null;
-
-            // Resolve the element enum's canonical info (EnumUnderlyingConverter + canonical PG type).
-            if (GetEnumTypeInfo(elementType, null, options) is not PgConcreteTypeInfo concreteElemInfo)
-                return null;
-
-            // Find the array PG type for the element's canonical PG type.
-            var elementDataTypeName = options.DatabaseInfo.GetDataTypeName(concreteElemInfo.PgTypeId);
-            if (options.DatabaseInfo.GetPostgresType(elementDataTypeName) is not PostgresBaseType { Array: { } arrayPgType })
-                return null;
-
-            var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, arrayType);
-            if (arrayConverter is null)
-                return null;
-
-            return PgConcreteTypeInfo.Create(options, binary: arrayConverter, arrayPgType.DataTypeName, requestedType: arrayType, supportsReading: true);
+            return PgConcreteTypeInfo.Create(options, binary: arrayConverter, arrayDataTypeName, requestedType: type, supportsReading: true);
         }
 
         static PgConverter? CreateEnumArrayConverter(Type underlyingType, PgConcreteTypeInfo elemInfo, Type? arrayType)

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
 using Npgsql.Internal.Converters;
 using Npgsql.Internal.Converters.Internal;

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -727,13 +727,22 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
         // Array mirror of GetEnumTypeInfo: requires an explicit array DataTypeName (same opt-in rule as the
         // scalar case) and delegates the element-canonical-match check to GetEnumTypeInfo. Decomposes the
         // array PG type into its element to feed the scalar path; rejection there (cross-conversion or
-        // unsupported underlying) propagates up here too. Nullable<TEnum>[] elements aren't supported here —
-        // even though Nullable<TEnum>[] is layout-identical to Nullable<TUnderlying>[], the CLR's enum-array
-        // covariance only covers bare enum arrays, so ArrayConverter's exact-type reinterpret would fail.
+        // unsupported underlying) propagates up here too. Supports both MyEnum[] (CLR enum-array covariance
+        // handles IntEnum[]↔int[] at the array level) and MyEnum?[] of any rank — for the nullable case we
+        // route the sibling converter EnumUnderlyingNullableConverter<T> through CreateArrayBased<T?>, and
+        // per-element access in ArrayBased uses a ref-byte-cast indexed by the row-major flat index, which
+        // is sound across all dimensions because sizeof(Nullable<T>) matches the user's Nullable<TEnum>
+        // slot stride (no per-enum generic codegen; closed generic stays one-per-underlying primitive).
         static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, Type? type, DataTypeName arrayDataTypeName, PgSerializerOptions options)
         {
-            if (elementType is null || !elementType.IsEnum)
+            if (elementType is null)
                 return null;
+            var enumElementType = elementType.IsEnum
+                ? elementType
+                : Nullable.GetUnderlyingType(elementType) is { IsEnum: true } nullableEnum ? nullableEnum : null;
+            if (enumElementType is null)
+                return null;
+            var isNullable = enumElementType != elementType;
 
             // Enum underlying-type support is limited to actual array types (T[], T[,]). The runtime doesn't root T[]
             // when only generic interfaces arrays implement (IList<T>, etc.) reach metadata, and there's no
@@ -746,36 +755,45 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             if (options.DatabaseInfo.GetPostgresType(arrayDataTypeName) is not PostgresArrayType { Element: var pgElement })
                 return null;
 
-            // Delegate the canonical-match check to the scalar path — if the requested element type isn't the
-            // enum's canonical PG type, GetEnumTypeInfo returns null and we propagate.
+            // Delegate the canonical-match check to the scalar path. For the nullable case we pass the user's
+            // Nullable<TEnum> element type so GetEnumTypeInfo returns the nullable sibling
+            // EnumUnderlyingNullableConverter<TUnderlying> — that's what ArrayBased<Nullable<TUnderlying>>
+            // expects, and its element-slot size matches the actual Nullable<TEnum>[] slot stride.
             if (GetEnumTypeInfo(elementType, pgElement.DataTypeName, options) is not PgConcreteTypeInfo concreteElemInfo)
                 return null;
 
-            // Storage is produced as type (MyEnum[]) via Array.CreateInstanceFromArrayType. IntEnum[] and int[]
-            // are layout-identical for value types with the same underlying representation, so the inner
-            // converter's Unsafe.As<int[]> access is bit-safe.
-            var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, type);
+            var arrayConverter = CreateEnumArrayConverter(enumElementType.GetEnumUnderlyingType(), isNullable, concreteElemInfo, type);
             if (arrayConverter is null)
                 return null;
 
             return PgConcreteTypeInfo.Create(options, binary: arrayConverter, arrayDataTypeName, requestedType: type, supportsReading: true);
         }
 
-        static PgConverter? CreateEnumArrayConverter(Type underlyingType, PgConcreteTypeInfo elemInfo, Type? arrayType)
-            // TElement is the underlying primitive; effectiveType (arrayType) is e.g. IntEnum[] which drives
-            // Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's contract is
-            // MethodTable-only, so any metadata-reachable array Type works without IL3050 suppression or DAM
-            // annotations.
-            => Type.GetTypeCode(underlyingType) switch
+        // TElement is the underlying primitive (or its Nullable<> form for nullable arrays); effectiveType
+        // (arrayType) is the user's array type, e.g. IntEnum[] or IntEnum?[,,]. Bare arrays use CLR enum-
+        // array covariance for the IntEnum[]↔int[] identity. Nullable arrays of any rank go through the
+        // ref-byte slot cast in ArrayBased — sizeof(Nullable<T>) matches the actual slot stride, so the
+        // per-element ref read/write lands on slot boundaries. No per-(TEnum) generic codegen — closed
+        // generic stays one-per-underlying primitive, NAOT-stable.
+        static PgConverter? CreateEnumArrayConverter(Type underlyingType, bool nullable, PgConcreteTypeInfo elemInfo, Type? arrayType)
+            => (Type.GetTypeCode(underlyingType), nullable) switch
             {
-                TypeCode.Int32 => ArrayConverter<Array>.CreateArrayBased<int>(elemInfo, arrayType),
-                TypeCode.Int64 => ArrayConverter<Array>.CreateArrayBased<long>(elemInfo, arrayType),
-                TypeCode.Int16 => ArrayConverter<Array>.CreateArrayBased<short>(elemInfo, arrayType),
-                TypeCode.Byte => ArrayConverter<Array>.CreateArrayBased<byte>(elemInfo, arrayType),
-                TypeCode.SByte => ArrayConverter<Array>.CreateArrayBased<sbyte>(elemInfo, arrayType),
-                TypeCode.UInt32 => ArrayConverter<Array>.CreateArrayBased<uint>(elemInfo, arrayType),
-                TypeCode.UInt64 => ArrayConverter<Array>.CreateArrayBased<ulong>(elemInfo, arrayType),
-                TypeCode.UInt16 => ArrayConverter<Array>.CreateArrayBased<ushort>(elemInfo, arrayType),
+                (TypeCode.Int32, false) => ArrayConverter<Array>.CreateArrayBased<int>(elemInfo, arrayType),
+                (TypeCode.Int64, false) => ArrayConverter<Array>.CreateArrayBased<long>(elemInfo, arrayType),
+                (TypeCode.Int16, false) => ArrayConverter<Array>.CreateArrayBased<short>(elemInfo, arrayType),
+                (TypeCode.Byte, false) => ArrayConverter<Array>.CreateArrayBased<byte>(elemInfo, arrayType),
+                (TypeCode.SByte, false) => ArrayConverter<Array>.CreateArrayBased<sbyte>(elemInfo, arrayType),
+                (TypeCode.UInt32, false) => ArrayConverter<Array>.CreateArrayBased<uint>(elemInfo, arrayType),
+                (TypeCode.UInt64, false) => ArrayConverter<Array>.CreateArrayBased<ulong>(elemInfo, arrayType),
+                (TypeCode.UInt16, false) => ArrayConverter<Array>.CreateArrayBased<ushort>(elemInfo, arrayType),
+                (TypeCode.Int32, true) => ArrayConverter<Array>.CreateArrayBased<int?>(elemInfo, arrayType),
+                (TypeCode.Int64, true) => ArrayConverter<Array>.CreateArrayBased<long?>(elemInfo, arrayType),
+                (TypeCode.Int16, true) => ArrayConverter<Array>.CreateArrayBased<short?>(elemInfo, arrayType),
+                (TypeCode.Byte, true) => ArrayConverter<Array>.CreateArrayBased<byte?>(elemInfo, arrayType),
+                (TypeCode.SByte, true) => ArrayConverter<Array>.CreateArrayBased<sbyte?>(elemInfo, arrayType),
+                (TypeCode.UInt32, true) => ArrayConverter<Array>.CreateArrayBased<uint?>(elemInfo, arrayType),
+                (TypeCode.UInt64, true) => ArrayConverter<Array>.CreateArrayBased<ulong?>(elemInfo, arrayType),
+                (TypeCode.UInt16, true) => ArrayConverter<Array>.CreateArrayBased<ushort?>(elemInfo, arrayType),
                 _ => null
             };
 

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -31,7 +31,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
         {
             var info = Mappings.Find(type, dataTypeName, options);
             if (info is null && dataTypeName is not null)
-                info = GetEnumTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
+                info = GetPgEnumTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
             if (info is null && type is not null && dataTypeName is not null)
                 info = GetStreamTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
 
@@ -47,7 +47,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             return PgConcreteTypeInfo.Create(options, binary: converter, text: converter, dataTypeName, supportsWriting: false);
         }
 
-        static PgTypeInfo? GetEnumTypeInfo(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
+        static PgTypeInfo? GetPgEnumTypeInfo(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
             if (type is not null && type != typeof(object) && type != typeof(string)
                 || options.DatabaseInfo.GetPostgresType(dataTypeName) is not PostgresEnumType)
@@ -483,7 +483,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 && options.DatabaseInfo.GetPostgresType(dataTypeName) is PostgresArrayType { Element: var pgElementType }
                 && (type is null || type == typeof(object) || TypeInfoMappingCollection.IsArrayLikeType(type, out elementType)))
             {
-                info = GetEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
+                info = GetPgEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
                        GetObjectArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options);
             }
             return info;
@@ -667,7 +667,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             return mappings.Find(type, dataTypeName, options);
         }
 
-        static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, PostgresType pgElementType, Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
+        static PgTypeInfo? GetPgEnumArrayTypeInfo(Type? elementType, PostgresType pgElementType, Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
             if ((type is not null && type != typeof(object) && elementType != typeof(string))
                 || pgElementType is not PostgresEnumType enumType)

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.IO;
 using Npgsql.Internal.Converters;
 using Npgsql.Internal.Converters.Internal;
@@ -34,6 +35,8 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 info = GetPgEnumTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
             if (info is null && type is not null && dataTypeName is not null)
                 info = GetStreamTypeInfo(type, dataTypeName.GetValueOrDefault(), options);
+            if (info is null && type is not null && type.IsEnum)
+                info = GetEnumTypeInfo(type, dataTypeName, options);
 
             return info;
         }
@@ -46,6 +49,44 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             var converter = new StreamConverter(supportsTextFormat: true);
             return PgConcreteTypeInfo.Create(options, binary: converter, text: converter, dataTypeName, supportsWriting: false);
         }
+
+        static PgTypeInfo? GetEnumTypeInfo(Type type, DataTypeName? dataTypeName, PgSerializerOptions options)
+        {
+            Debug.Assert(type.IsEnum);
+
+            var underlyingType = type.GetEnumUnderlyingType();
+
+            // Resolve the underlying type's info just to derive the PgTypeId and validate that the resolver chain
+            // recognizes the underlying mapped to this dataTypeName. The wire format knowledge is baked into
+            // EnumUnderlyingConverter itself (matching the default Ado mappings: byte/sbyte/short → Int2, int → Int4,
+            // long → Int8), so no inner converter reference is needed.
+            var underlyingInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, dataTypeName, options);
+            if (underlyingInfo?.PgTypeId is not { } pgTypeId)
+                return null;
+
+            var wrappedConverter = CreateEnumUnderlyingConverter(type, underlyingType);
+            if (wrappedConverter is null)
+                return null;
+
+            return PgConcreteTypeInfo.Create(options, binary: wrappedConverter, pgTypeId, requestedType: type);
+        }
+
+        static PgConverter? CreateEnumUnderlyingConverter(Type enumType, Type underlyingType)
+            => Type.GetTypeCode(underlyingType) switch
+            {
+                // PG has no unsigned integer types; unsigned .NET underlyings ride on the same wire format as their
+                // signed counterparts (ushort → smallint, uint → integer, ulong → bigint) with CreateChecked handling
+                // out-of-range values at read/write time.
+                TypeCode.Int32 => new EnumUnderlyingConverter<int>(enumType),
+                TypeCode.Int64 => new EnumUnderlyingConverter<long>(enumType),
+                TypeCode.Int16 => new EnumUnderlyingConverter<short>(enumType),
+                TypeCode.Byte => new EnumUnderlyingConverter<byte>(enumType),
+                TypeCode.SByte => new EnumUnderlyingConverter<sbyte>(enumType),
+                TypeCode.UInt32 => new EnumUnderlyingConverter<uint>(enumType),
+                TypeCode.UInt64 => new EnumUnderlyingConverter<ulong>(enumType),
+                TypeCode.UInt16 => new EnumUnderlyingConverter<ushort>(enumType),
+                _ => null
+            };
 
         static PgTypeInfo? GetPgEnumTypeInfo(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
@@ -484,8 +525,18 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
                 && (type is null || type == typeof(object) || TypeInfoMappingCollection.IsArrayLikeType(type, out elementType)))
             {
                 info = GetPgEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
+                       GetEnumArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options) ??
                        GetObjectArrayTypeInfo(elementType, pgElementType, type, dataTypeName.GetValueOrDefault(), options);
             }
+
+            // CLR enum array write path: type is known (e.g. IntEnum[]) but no dataTypeName.
+            if (info is null && type is not null && dataTypeName is null
+                && TypeInfoMappingCollection.IsArrayLikeType(type, out elementType)
+                && elementType.IsEnum)
+            {
+                info = GetEnumArrayTypeInfoForWrite(elementType, type, options);
+            }
+
             return info;
         }
 
@@ -666,6 +717,96 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             mappings.AddProviderArrayType<object>(pgElementType.DataTypeName);
             return mappings.Find(type, dataTypeName, options);
         }
+
+        static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, PostgresType pgElementType, Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
+        {
+            if (elementType is null || !elementType.IsEnum)
+                return null;
+
+            // Enum underlying-type support is limited to actual array types (T[], T[,]). The runtime doesn't root T[]
+            // when only generic interfaces arrays implement (IList<T>, etc.) reach metadata, and there's no
+            // trim-safe API for producing an array from one of those interfaces. Users who want IList<MyEnum>
+            // assign the array at the call site: `IList<MyEnum> list = reader.GetFieldValue<MyEnum[]>(...)`.
+            // See dotnet/runtime#127249 for the discussion that established this constraint.
+            if (type is not null && !type.IsArray)
+                return null;
+
+            // Resolve the underlying type's element info through the full chain.
+            var underlyingType = elementType.GetEnumUnderlyingType();
+            var elementDataTypeName = pgElementType.DataTypeName;
+            var elemInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, elementDataTypeName, options);
+            if (elemInfo is null)
+                return null;
+
+            var concreteElemInfo = elemInfo as PgConcreteTypeInfo ?? elemInfo.MakeConcreteForField(
+                Field.CreateUnspecified(elemInfo.PgTypeId!.Value));
+
+            if (concreteElemInfo.GetConverter(DataFormat.Binary).TypeToConvert != underlyingType)
+                return null;
+
+            // Build array converter using the underlying type; storage is produced as type (MyEnum[]) via
+            // Array.CreateInstanceFromArrayType. IntEnum[] and int[] are layout-identical for value types with
+            // the same underlying representation, so Unsafe.As<int?[]> access is bit-safe.
+            var arrayConverter = CreateEnumArrayConverter(underlyingType, concreteElemInfo, type);
+            if (arrayConverter is null)
+                return null;
+
+            return PgConcreteTypeInfo.Create(options, binary: arrayConverter, dataTypeName, requestedType: type, supportsReading: true);
+        }
+
+        static PgTypeInfo? GetEnumArrayTypeInfoForWrite(Type elementType, Type arrayType, PgSerializerOptions options)
+        {
+            Debug.Assert(elementType.IsEnum);
+
+            // Same restriction as the read path: only actual array types are supported for enum underlying-type
+            // collections. See the matching comment on GetEnumArrayTypeInfo and dotnet/runtime#127249.
+            if (!arrayType.IsArray)
+                return null;
+
+            // Resolve the underlying type's element info.
+            var underlyingType = elementType.GetEnumUnderlyingType();
+            var elemInfo = options.TypeInfoResolver.GetTypeInfo(underlyingType, null, options);
+            if (elemInfo is null || elemInfo.PgTypeId is null)
+                return null;
+
+            var concreteElemInfo = elemInfo as PgConcreteTypeInfo ?? elemInfo.MakeConcreteForField(
+                Field.CreateUnspecified(elemInfo.PgTypeId.Value));
+
+            if (concreteElemInfo.GetConverter(DataFormat.Binary).TypeToConvert != underlyingType)
+                return null;
+
+            // Find the array PG type for the element's PG type.
+            var elementPgTypeId = concreteElemInfo.PgTypeId;
+            var elementDataTypeName = options.DatabaseInfo.GetDataTypeName(elementPgTypeId);
+            var pgType = options.DatabaseInfo.GetPostgresType(elementDataTypeName);
+            if (pgType is not PostgresBaseType { Array: { } arrayPgType })
+                return null;
+
+            var arrayDataTypeName = arrayPgType.DataTypeName;
+            var arrayConverter = CreateEnumArrayConverter(underlyingType, concreteElemInfo, arrayType);
+            if (arrayConverter is null)
+                return null;
+
+            return PgConcreteTypeInfo.Create(options, arrayConverter, arrayDataTypeName, requestedType: arrayType, supportsReading: true);
+        }
+
+        static PgConverter? CreateEnumArrayConverter(Type underlyingType, PgConcreteTypeInfo elemInfo, Type? arrayType)
+            => Type.GetTypeCode(underlyingType) switch
+            {
+                // TElement is the underlying type; effectiveType (arrayType) is e.g. IntEnum[] which drives
+                // Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's contract
+                // is MethodTable-only, so any metadata-reachable array Type works without IL3050 suppression
+                // or DAM annotations.
+                TypeCode.Int32 => ArrayConverter<Array>.CreateArrayBased<int>(elemInfo, arrayType),
+                TypeCode.Int64 => ArrayConverter<Array>.CreateArrayBased<long>(elemInfo, arrayType),
+                TypeCode.Int16 => ArrayConverter<Array>.CreateArrayBased<short>(elemInfo, arrayType),
+                TypeCode.Byte => ArrayConverter<Array>.CreateArrayBased<byte>(elemInfo, arrayType),
+                TypeCode.SByte => ArrayConverter<Array>.CreateArrayBased<sbyte>(elemInfo, arrayType),
+                TypeCode.UInt32 => ArrayConverter<Array>.CreateArrayBased<uint>(elemInfo, arrayType),
+                TypeCode.UInt64 => ArrayConverter<Array>.CreateArrayBased<ulong>(elemInfo, arrayType),
+                TypeCode.UInt16 => ArrayConverter<Array>.CreateArrayBased<ushort>(elemInfo, arrayType),
+                _ => null
+            };
 
         static PgTypeInfo? GetPgEnumArrayTypeInfo(Type? elementType, PostgresType pgElementType, Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {

--- a/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/AdoTypeInfoResolverFactory.cs
@@ -56,8 +56,15 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // dataTypeName the resolver would silently route arbitrary enums to int2/int4/int8, masking the
             // common case of a missing PgEnum/EnumMapping registration. Requiring the explicit ask makes the
             // underlying-type fallback an opt-in path rather than a default.
-            if (!type.IsEnum || dataTypeName is not { } requested)
+            if (dataTypeName is not { } requested)
                 return null;
+
+            // Recognize both the bare enum and Nullable<TEnum> as the same shape; the nullable variant just
+            // routes through the parallel converter (PgConverter<T?> sibling).
+            var enumType = type.IsEnum ? type : Nullable.GetUnderlyingType(type) is { IsEnum: true } nullableEnum ? nullableEnum : null;
+            if (enumType is null)
+                return null;
+            var isNullable = enumType != type;
 
             // EnumUnderlyingConverter reads/writes the underlying primitive at a fixed PG wire format, so the enum
             // maps to exactly one canonical PG type: byte/sbyte/short/ushort → int2, int/uint → int4, long/ulong →
@@ -65,16 +72,24 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
             // format of the same width.) Deriving the PgTypeId by resolving the underlying through the chain would let
             // ExtraConversions numeric cross-mappings (e.g. int→int8) through, pairing a mismatched PG type with the
             // fixed-format converter and corrupting the wire — so the canonical type is paired with the converter here.
-            (PgConverter, DataTypeName)? mapping = Type.GetTypeCode(type) switch
+            (PgConverter, DataTypeName)? mapping = (Type.GetTypeCode(enumType), isNullable) switch
             {
-                TypeCode.Int16 => (new EnumUnderlyingConverter<short>(type), DataTypeNames.Int2),
-                TypeCode.UInt16 => (new EnumUnderlyingConverter<ushort>(type), DataTypeNames.Int2),
-                TypeCode.Byte => (new EnumUnderlyingConverter<byte>(type), DataTypeNames.Int2),
-                TypeCode.SByte => (new EnumUnderlyingConverter<sbyte>(type), DataTypeNames.Int2),
-                TypeCode.Int32 => (new EnumUnderlyingConverter<int>(type), DataTypeNames.Int4),
-                TypeCode.UInt32 => (new EnumUnderlyingConverter<uint>(type), DataTypeNames.Int4),
-                TypeCode.Int64 => (new EnumUnderlyingConverter<long>(type), DataTypeNames.Int8),
-                TypeCode.UInt64 => (new EnumUnderlyingConverter<ulong>(type), DataTypeNames.Int8),
+                (TypeCode.Int16, false) => (new EnumUnderlyingConverter<short>(enumType), DataTypeNames.Int2),
+                (TypeCode.UInt16, false) => (new EnumUnderlyingConverter<ushort>(enumType), DataTypeNames.Int2),
+                (TypeCode.Byte, false) => (new EnumUnderlyingConverter<byte>(enumType), DataTypeNames.Int2),
+                (TypeCode.SByte, false) => (new EnumUnderlyingConverter<sbyte>(enumType), DataTypeNames.Int2),
+                (TypeCode.Int32, false) => (new EnumUnderlyingConverter<int>(enumType), DataTypeNames.Int4),
+                (TypeCode.UInt32, false) => (new EnumUnderlyingConverter<uint>(enumType), DataTypeNames.Int4),
+                (TypeCode.Int64, false) => (new EnumUnderlyingConverter<long>(enumType), DataTypeNames.Int8),
+                (TypeCode.UInt64, false) => (new EnumUnderlyingConverter<ulong>(enumType), DataTypeNames.Int8),
+                (TypeCode.Int16, true) => (new EnumUnderlyingNullableConverter<short>(enumType), DataTypeNames.Int2),
+                (TypeCode.UInt16, true) => (new EnumUnderlyingNullableConverter<ushort>(enumType), DataTypeNames.Int2),
+                (TypeCode.Byte, true) => (new EnumUnderlyingNullableConverter<byte>(enumType), DataTypeNames.Int2),
+                (TypeCode.SByte, true) => (new EnumUnderlyingNullableConverter<sbyte>(enumType), DataTypeNames.Int2),
+                (TypeCode.Int32, true) => (new EnumUnderlyingNullableConverter<int>(enumType), DataTypeNames.Int4),
+                (TypeCode.UInt32, true) => (new EnumUnderlyingNullableConverter<uint>(enumType), DataTypeNames.Int4),
+                (TypeCode.Int64, true) => (new EnumUnderlyingNullableConverter<long>(enumType), DataTypeNames.Int8),
+                (TypeCode.UInt64, true) => (new EnumUnderlyingNullableConverter<ulong>(enumType), DataTypeNames.Int8),
                 _ => null
             };
             if (mapping is not ({ } converter, var canonicalDataTypeName))
@@ -712,7 +727,9 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
         // Array mirror of GetEnumTypeInfo: requires an explicit array DataTypeName (same opt-in rule as the
         // scalar case) and delegates the element-canonical-match check to GetEnumTypeInfo. Decomposes the
         // array PG type into its element to feed the scalar path; rejection there (cross-conversion or
-        // unsupported underlying) propagates up here too.
+        // unsupported underlying) propagates up here too. Nullable<TEnum>[] elements aren't supported here —
+        // even though Nullable<TEnum>[] is layout-identical to Nullable<TUnderlying>[], the CLR's enum-array
+        // covariance only covers bare enum arrays, so ArrayConverter's exact-type reinterpret would fail.
         static PgTypeInfo? GetEnumArrayTypeInfo(Type? elementType, Type? type, DataTypeName arrayDataTypeName, PgSerializerOptions options)
         {
             if (elementType is null || !elementType.IsEnum)
@@ -736,7 +753,7 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
             // Storage is produced as type (MyEnum[]) via Array.CreateInstanceFromArrayType. IntEnum[] and int[]
             // are layout-identical for value types with the same underlying representation, so the inner
-            // converter's Unsafe.As<int?[]> access is bit-safe.
+            // converter's Unsafe.As<int[]> access is bit-safe.
             var arrayConverter = CreateEnumArrayConverter(elementType.GetEnumUnderlyingType(), concreteElemInfo, type);
             if (arrayConverter is null)
                 return null;
@@ -745,12 +762,12 @@ sealed partial class AdoTypeInfoResolverFactory : PgTypeInfoResolverFactory
         }
 
         static PgConverter? CreateEnumArrayConverter(Type underlyingType, PgConcreteTypeInfo elemInfo, Type? arrayType)
+            // TElement is the underlying primitive; effectiveType (arrayType) is e.g. IntEnum[] which drives
+            // Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's contract is
+            // MethodTable-only, so any metadata-reachable array Type works without IL3050 suppression or DAM
+            // annotations.
             => Type.GetTypeCode(underlyingType) switch
             {
-                // TElement is the underlying type; effectiveType (arrayType) is e.g. IntEnum[] which drives
-                // Array.CreateInstanceFromArrayType to produce the correctly-typed array. The API's contract
-                // is MethodTable-only, so any metadata-reachable array Type works without IL3050 suppression
-                // or DAM annotations.
                 TypeCode.Int32 => ArrayConverter<Array>.CreateArrayBased<int>(elemInfo, arrayType),
                 TypeCode.Int64 => ArrayConverter<Array>.CreateArrayBased<long>(elemInfo, arrayType),
                 TypeCode.Int16 => ArrayConverter<Array>.CreateArrayBased<short>(elemInfo, arrayType),

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -13,8 +13,8 @@ namespace Npgsql.Internal.ResolverFactories;
 [RequiresDynamicCode("The use of unmapped enums, ranges or multiranges requires dynamic code usage which is incompatible with NativeAOT.")]
 sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
 {
-    public override IPgTypeInfoResolver CreateResolver() => new EnumResolver();
-    public override IPgTypeInfoResolver CreateArrayResolver() => new EnumArrayResolver();
+    public override IPgTypeInfoResolver CreateResolver() => new PgEnumResolver();
+    public override IPgTypeInfoResolver CreateArrayResolver() => new PgEnumArrayResolver();
 
     public override IPgTypeInfoResolver CreateRangeResolver() => new RangeResolver();
     public override IPgTypeInfoResolver CreateRangeArrayResolver() => new RangeArrayResolver();
@@ -24,7 +24,7 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
     [RequiresUnreferencedCode("The use of unmapped enums, ranges or multiranges requires reflection usage which is incompatible with trimming.")]
     [RequiresDynamicCode("The use of unmapped enums, ranges or multiranges requires dynamic code usage which is incompatible with NativeAOT.")]
-    class EnumResolver : DynamicTypeInfoResolver
+    class PgEnumResolver : DynamicTypeInfoResolver
     {
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
         {
@@ -45,18 +45,17 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
                         labelToEnum[enumName] = enumValue;
                     }
 
-                    // EnumConverter is format-agnostic — register the same instance for both binary and
+                    // PgEnumConverter is format-agnostic — register the same instance for both binary and
                     // text so historical text-format binding paths continue to work.
-                    var converter = (PgConverter)Activator.CreateInstance(typeof(EnumConverter<>).MakeGenericType(mapping.Type),
-                        enumToLabel, labelToEnum)!;
-                    return mapping.CreateInfo(options, converter, converter);
+                    return mapping.CreateInfo(options, (PgConverter)Activator.CreateInstance(typeof(PgEnumConverter<>).MakeGenericType(mapping.Type),
+                        enumToLabel, labelToEnum)!);
                 });
         }
     }
 
     [RequiresUnreferencedCode("The use of unmapped enums, ranges or multiranges requires reflection usage which is incompatible with trimming.")]
     [RequiresDynamicCode("The use of unmapped enums, ranges or multiranges requires dynamic code usage which is incompatible with NativeAOT.")]
-    sealed class EnumArrayResolver : EnumResolver
+    sealed class PgEnumArrayResolver : PgEnumResolver
     {
         protected override DynamicMappingCollection? GetMappings(Type? type, DataTypeName dataTypeName, PgSerializerOptions options)
             => type is not null && IsArrayLikeType(type, out var elementType) && IsArrayDataTypeName(dataTypeName, options, out var elementDataTypeName)

--- a/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
+++ b/src/Npgsql/Internal/ResolverFactories/UnmappedTypeInfoResolverFactory.cs
@@ -47,8 +47,9 @@ sealed class UnmappedTypeInfoResolverFactory : PgTypeInfoResolverFactory
 
                     // PgEnumConverter is format-agnostic — register the same instance for both binary and
                     // text so historical text-format binding paths continue to work.
-                    return mapping.CreateInfo(options, (PgConverter)Activator.CreateInstance(typeof(PgEnumConverter<>).MakeGenericType(mapping.Type),
-                        enumToLabel, labelToEnum)!);
+                    var converter = (PgConverter)Activator.CreateInstance(typeof(PgEnumConverter<>).MakeGenericType(mapping.Type),
+                        enumToLabel, labelToEnum)!;
+                    return mapping.CreateInfo(options, binary: converter, text: converter);
                 });
         }
     }

--- a/src/Npgsql/TypeMapping/UserTypeMapper.cs
+++ b/src/Npgsql/TypeMapping/UserTypeMapper.cs
@@ -268,10 +268,10 @@ sealed class UserTypeMapper : PgTypeInfoResolverFactory
         internal override void AddMapping(TypeInfoMappingCollection mappings)
             => mappings.AddStructType<TEnum>(PgTypeName, (options, mapping, _) =>
             {
-                // EnumConverter is format-agnostic (encodes the label via TextEncoding for both wire formats);
+                // PgEnumConverter is format-agnostic (encodes the label via TextEncoding for both wire formats);
                 // expose it on both slots so text-format binds/reads work, and prefer text since the wire
                 // representation of enum values is the label string.
-                var converter = new EnumConverter<TEnum>(_enumToLabel, _labelToEnum);
+                var converter = new PgEnumConverter<TEnum>(_enumToLabel, _labelToEnum);
                 return mapping.CreateInfo(options, converter, converter, preferredFormat: DataFormat.Text);
             }, isDefault: true);
 

--- a/src/Npgsql/Util/IterationIndices.cs
+++ b/src/Npgsql/Util/IterationIndices.cs
@@ -10,6 +10,9 @@ struct IterationIndices
 {
     long _indicesSum;
 
+    // Row-major flattened element index, maintained incrementally by TryAdvance. Equivalent to
+    // ArrayExtensions.GetFlattenedIndex(indices, lengths) on each step but without the per-element
+    // stride multiplication.
     public long IndicesSum => _indicesSum;
 
     public int Rank { get; private init; }
@@ -102,6 +105,18 @@ struct IterationIndices
                 Many = new int[dimensions],
             };
         }
+    }
+
+    // Copy of the proposed Array.GetFlattenedIndex (dotnet/runtime#125325) until it ships, kept as the
+    // single owner of the row-major stride formula. TryAdvance/IncrementOrCarry produce the same value
+    // incrementally as IndicesSum.
+    public static long GetFlattenedIndex(ReadOnlySpan<int> indices, ReadOnlySpan<int> lengths)
+    {
+        Debug.Assert(indices.Length == lengths.Length);
+        long flatIndex = 0;
+        for (var dim = 0; dim < indices.Length; dim++)
+            flatIndex = flatIndex * lengths[dim] + indices[dim];
+        return flatIndex;
     }
 
     static ref int GetIntRefFromLong(ref long value)

--- a/test/Npgsql.Tests/BugTests.cs
+++ b/test/Npgsql.Tests/BugTests.cs
@@ -1173,7 +1173,8 @@ CREATE TEMP TABLE ""OrganisatieQmo_Organisatie_QueryModelObjects_Imp""
         await using var adminConnection = await OpenConnectionAsync();
         var type = await GetTempTypeName(adminConnection);
         var func = await GetTempFunctionName(adminConnection);
-        await adminConnection.ExecuteNonQueryAsync($"CREATE TYPE {type} as (x int, some_text text, test int)");
+        // The TestEnum field is 'point' on the pg side, far from any plausible future enum fallback mapping.
+        await adminConnection.ExecuteNonQueryAsync($"CREATE TYPE {type} as (x int, some_text text, test point)");
 
         var dataSourceBuilder = CreateDataSourceBuilder();
         dataSourceBuilder.MapComposite<SomeComposite>(type);
@@ -1185,8 +1186,8 @@ CREATE OR REPLACE FUNCTION {func}(id int, out comp1 {type}, OUT comp2 {type}[])
 LANGUAGE plpgsql AS
 $$
 BEGIN
-    comp1 = ROW(9, 'bar', 1)::{type};
-    comp2 = ARRAY[ROW(9, 'bar', 1)::{type}];
+    comp1 = ROW(9, 'bar', '(0,0)'::point)::{type};
+    comp2 = ARRAY[ROW(9, 'bar', '(0,0)'::point)::{type}];
 END;
 $$;");
 

--- a/test/Npgsql.Tests/GlobalTypeMapperTests.cs
+++ b/test/Npgsql.Tests/GlobalTypeMapperTests.cs
@@ -33,15 +33,19 @@ public class GlobalTypeMapperTests : TestBase
         NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Mood>(type);
 
         // Global mapping changes have no effect on already-built data sources
-        await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource1, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32)
+        );
         await AssertType(dataSource1, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
         // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy",
-            type, dataTypeInference: DataTypeInference.Nothing));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32)));
         await AssertType(dataSource2, "happy", "happy", "text", dbType: DbType.String);
     }
 
@@ -67,14 +71,19 @@ public class GlobalTypeMapperTests : TestBase
             NpgsqlConnection.GlobalTypeMapper.UnmapEnum(typeof(Mood), type);
 
             // Global mapping changes have no effect on already-built data sources
-            await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
+            await AssertType(dataSource1, Mood.Happy, "happy", type,
+                dataTypeInference: DataTypeInference.Mismatch,
+                dbType: new(DbType.Object, DbType.Int32)
+                );
             await AssertType(dataSource1, "happy", "happy",
                 type, dataTypeInference: DataTypeInference.Mismatch,
                 dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
             // But they do affect new data sources
             await using var dataSource2 = CreateDataSource();
-            Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
+            Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
+                dataTypeInference: DataTypeInference.Mismatch,
+                dbType: new(DbType.Object, DbType.Int32)));
             await AssertType(dataSource2, "happy", "happy", "text", dbType: DbType.String);
         }
         finally
@@ -104,14 +113,18 @@ public class GlobalTypeMapperTests : TestBase
         NpgsqlConnection.GlobalTypeMapper.Reset();
 
         // Global mapping changes have no effect on already-built data sources
-        await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource1, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
         await AssertType(dataSource1, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
         // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32)));
         await AssertType(dataSource2, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String));

--- a/test/Npgsql.Tests/GlobalTypeMapperTests.cs
+++ b/test/Npgsql.Tests/GlobalTypeMapperTests.cs
@@ -33,19 +33,14 @@ public class GlobalTypeMapperTests : TestBase
         NpgsqlConnection.GlobalTypeMapper.UnmapEnum<Mood>(type);
 
         // Global mapping changes have no effect on already-built data sources
-        await AssertType(dataSource1, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32)
-        );
+        await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
         await AssertType(dataSource1, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
         // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32)));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
         await AssertType(dataSource2, "happy", "happy", "text", dbType: DbType.String);
     }
 
@@ -71,19 +66,14 @@ public class GlobalTypeMapperTests : TestBase
             NpgsqlConnection.GlobalTypeMapper.UnmapEnum(typeof(Mood), type);
 
             // Global mapping changes have no effect on already-built data sources
-            await AssertType(dataSource1, Mood.Happy, "happy", type,
-                dataTypeInference: DataTypeInference.Mismatch,
-                dbType: new(DbType.Object, DbType.Int32)
-                );
+            await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
             await AssertType(dataSource1, "happy", "happy",
                 type, dataTypeInference: DataTypeInference.Mismatch,
                 dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
             // But they do affect new data sources
             await using var dataSource2 = CreateDataSource();
-            Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
-                dataTypeInference: DataTypeInference.Mismatch,
-                dbType: new(DbType.Object, DbType.Int32)));
+            Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
             await AssertType(dataSource2, "happy", "happy", "text", dbType: DbType.String);
         }
         finally
@@ -113,18 +103,14 @@ public class GlobalTypeMapperTests : TestBase
         NpgsqlConnection.GlobalTypeMapper.Reset();
 
         // Global mapping changes have no effect on already-built data sources
-        await AssertType(dataSource1, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource1, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
         await AssertType(dataSource1, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String), valueTypeEqualsFieldType: false);
 
         // But they do affect new data sources
         await using var dataSource2 = CreateDataSource();
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32)));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource2, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
         await AssertType(dataSource2, "happy", "happy",
             type, dataTypeInference: DataTypeInference.Mismatch,
             dbType: new(DbType.Object, DbType.String));

--- a/test/Npgsql.Tests/Types/ArrayTests.cs
+++ b/test/Npgsql.Tests/Types/ArrayTests.cs
@@ -67,10 +67,10 @@ public class ArrayTests : TestBase
         await using var conn = CreateConnection();
         await conn.OpenAsync();
         await using var cmd = new NpgsqlCommand("SELECT 1", conn);
-        cmd.Parameters.AddWithValue("p", new int[1, 1, 1, 1, 1, 1, 1, 1, 1]); // 9 dimensions
+        cmd.Parameters.AddWithValue("p", new int[1, 1, 1, 1, 1, 1, 1]); // 7 dimensions
         var ex = Assert.ThrowsAsync<InvalidCastException>(async () => await cmd.ExecuteScalarAsync());
         Assert.That(ex!.InnerException, Is.TypeOf<ArgumentException>()
-            .And.Message.EqualTo("Postgres arrays can have at most 8 dimensions. (Parameter 'dimensionLengths')"));
+            .And.Message.EqualTo("Postgres arrays can have at most 6 dimensions. (Parameter 'dimensionLengths')"));
     }
 
     [Test, Description("Checks that PG arrays containing nulls are returned as set via ValueTypeArrayMode.")]

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -21,35 +21,43 @@ public class EnumTests : TestBase
 
     [Test]
     public Task Int_enum()
-        => AssertType(IntEnum.FortyTwo, "42", "integer", dbType: DbType.Int32, valueTypeEqualsFieldType: false);
+        => AssertType(IntEnum.FortyTwo, "42", "integer", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int32, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Short_enum()
-        => AssertType(ShortEnum.B, "2", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+        => AssertType(ShortEnum.B, "2", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Long_enum()
-        => AssertType(LongEnum.Big, "100000000000", "bigint", dbType: DbType.Int64, valueTypeEqualsFieldType: false);
+        => AssertType(LongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Byte_enum()
-        => AssertType(ByteEnum.X, "255", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+        => AssertType(ByteEnum.X, "255", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task SByte_enum()
-        => AssertType(SByteEnum.B, "100", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+        => AssertType(SByteEnum.B, "100", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task UShort_enum()
-        => AssertType(UShortEnum.B, "30000", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+        => AssertType(UShortEnum.B, "30000", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task UInt_enum()
-        => AssertType(UIntEnum.B, "100000", "integer", dbType: DbType.Int32, valueTypeEqualsFieldType: false);
+        => AssertType(UIntEnum.B, "100000", "integer", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int32, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task ULong_enum()
-        => AssertType(ULongEnum.Big, "100000000000", "bigint", dbType: DbType.Int64, valueTypeEqualsFieldType: false);
+        => AssertType(ULongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Enum_rejects_non_canonical_column()

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -1,0 +1,33 @@
+using System.Data;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Npgsql.Tests.Types;
+
+/// <summary>
+/// Tests for CLR enum types read and written through their underlying integer PG types
+/// (enum underlying-type converter support).
+/// </summary>
+public class EnumTests : TestBase
+{
+    enum IntEnum { Zero = 0, One = 1, FortyTwo = 42 }
+    enum ShortEnum : short { A = 1, B = 2 }
+    enum LongEnum : long { Big = 100_000_000_000 }
+    enum ByteEnum : byte { X = 255 }
+
+    [Test]
+    public Task Int_enum()
+        => AssertType(IntEnum.FortyTwo, "42", "integer", dbType: DbType.Int32, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task Short_enum()
+        => AssertType(ShortEnum.B, "2", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task Long_enum()
+        => AssertType(LongEnum.Big, "100000000000", "bigint", dbType: DbType.Int64, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task Byte_enum()
+        => AssertType(ByteEnum.X, "255", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+}

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -14,6 +14,10 @@ public class EnumTests : TestBase
     enum ShortEnum : short { A = 1, B = 2 }
     enum LongEnum : long { Big = 100_000_000_000 }
     enum ByteEnum : byte { X = 255 }
+    enum SByteEnum : sbyte { A = 1, B = 100 }
+    enum UShortEnum : ushort { A = 1, B = 30000 }
+    enum UIntEnum : uint { A = 1, B = 100_000 }
+    enum ULongEnum : ulong { Big = 100_000_000_000 }
 
     [Test]
     public Task Int_enum()
@@ -30,4 +34,26 @@ public class EnumTests : TestBase
     [Test]
     public Task Byte_enum()
         => AssertType(ByteEnum.X, "255", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task SByte_enum()
+        => AssertType(SByteEnum.B, "100", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task UShort_enum()
+        => AssertType(UShortEnum.B, "30000", "smallint", dbType: DbType.Int16, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task UInt_enum()
+        => AssertType(UIntEnum.B, "100000", "integer", dbType: DbType.Int32, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task ULong_enum()
+        => AssertType(ULongEnum.Big, "100000000000", "bigint", dbType: DbType.Int64, valueTypeEqualsFieldType: false);
+
+    [Test]
+    public Task Enum_rejects_non_canonical_column()
+        // The converter is fixed to the underlying's canonical wire format (int → integer); cross-converting to a
+        // mismatched PG type would corrupt the wire. Both scalar and array paths reject it.
+        => AssertTypeUnsupported(IntEnum.FortyTwo, "42", "bigint");
 }

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -59,6 +59,30 @@ public class EnumTests : TestBase
         => AssertType(ULongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
             dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false);
 
+    // Nullable scalar tests skip the auto-derived array check: Nullable<TEnum>[] is layout-identical to
+    // Nullable<TUnderlying>[] but the CLR's enum-array covariance doesn't extend to Nullable<>[], so the
+    // ArrayConverter's exact-type assertion can't reinterpret IntEnum?[] as int?[] at runtime. The scalar
+    // path is what's contracted here; nullable-enum-array support is a separate generalization.
+    [Test]
+    public Task Nullable_int_enum()
+        => AssertType<IntEnum?>(IntEnum.FortyTwo, "42", "integer", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int32, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+
+    [Test]
+    public Task Nullable_short_enum()
+        => AssertType<ShortEnum?>(ShortEnum.B, "2", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+
+    [Test]
+    public Task Nullable_long_enum()
+        => AssertType<LongEnum?>(LongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+
+    [Test]
+    public Task Nullable_byte_enum()
+        => AssertType<ByteEnum?>(ByteEnum.X, "255", "smallint", dataTypeInference: DataTypeInference.Nothing,
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+
     [Test]
     public Task Enum_rejects_non_canonical_column()
         // The converter is fixed to the underlying's canonical wire format (int → integer); cross-converting to a

--- a/test/Npgsql.Tests/Types/EnumTests.cs
+++ b/test/Npgsql.Tests/Types/EnumTests.cs
@@ -59,33 +59,49 @@ public class EnumTests : TestBase
         => AssertType(ULongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
             dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false);
 
-    // Nullable scalar tests skip the auto-derived array check: Nullable<TEnum>[] is layout-identical to
-    // Nullable<TUnderlying>[] but the CLR's enum-array covariance doesn't extend to Nullable<>[], so the
-    // ArrayConverter's exact-type assertion can't reinterpret IntEnum?[] as int?[] at runtime. The scalar
-    // path is what's contracted here; nullable-enum-array support is a separate generalization.
     [Test]
     public Task Nullable_int_enum()
         => AssertType<IntEnum?>(IntEnum.FortyTwo, "42", "integer", dataTypeInference: DataTypeInference.Nothing,
-            dbType: new DbTypes(DbType.Int32, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+            dbType: new DbTypes(DbType.Int32, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Nullable_short_enum()
         => AssertType<ShortEnum?>(ShortEnum.B, "2", "smallint", dataTypeInference: DataTypeInference.Nothing,
-            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Nullable_long_enum()
         => AssertType<LongEnum?>(LongEnum.Big, "100000000000", "bigint", dataTypeInference: DataTypeInference.Nothing,
-            dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+            dbType: new DbTypes(DbType.Int64, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Nullable_byte_enum()
         => AssertType<ByteEnum?>(ByteEnum.X, "255", "smallint", dataTypeInference: DataTypeInference.Nothing,
-            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false, skipArrayCheck: true);
+            dbType: new DbTypes(DbType.Int16, DbType.Object), valueTypeEqualsFieldType: false);
 
     [Test]
     public Task Enum_rejects_non_canonical_column()
         // The converter is fixed to the underlying's canonical wire format (int → integer); cross-converting to a
         // mismatched PG type would corrupt the wire. Both scalar and array paths reject it.
         => AssertTypeUnsupported(IntEnum.FortyTwo, "42", "bigint");
+
+    [Test]
+    public Task Int_enum_max_dim_array()
+    {
+        var arr = new IntEnum[1, 1, 1, 1, 1, 2];
+        arr[0, 0, 0, 0, 0, 0] = IntEnum.FortyTwo;
+        arr[0, 0, 0, 0, 0, 1] = IntEnum.One;
+        return AssertType(arr, "{{{{{{42,1}}}}}}", "integer[]",
+            dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
+    }
+
+    [Test]
+    public Task Nullable_int_enum_max_dim_array()
+    {
+        var arr = new IntEnum?[1, 1, 1, 1, 1, 2];
+        arr[0, 0, 0, 0, 0, 0] = IntEnum.FortyTwo;
+        arr[0, 0, 0, 0, 0, 1] = null;
+        return AssertType(arr, "{{{{{{42,NULL}}}}}}", "integer[]",
+            dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
+    }
 }

--- a/test/Npgsql.Tests/Types/PgEnumTests.cs
+++ b/test/Npgsql.Tests/Types/PgEnumTests.cs
@@ -27,7 +27,9 @@ public class PgEnumTests : TestBase
         dataSourceBuilder.MapEnum<Mood>(type);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
     }
 
     [Test]
@@ -44,7 +46,9 @@ public class PgEnumTests : TestBase
         await using var dataSource = dataSourceBuilder.Build();
 
         Assert.That(isUnmapSuccessful);
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32)));
     }
 
     [Test]
@@ -57,7 +61,9 @@ public class PgEnumTests : TestBase
         var dataSourceBuilder = CreateDataSourceBuilder();
         dataSourceBuilder.MapEnum(typeof(Mood), type);
         await using var dataSource = dataSourceBuilder.Build();
-        await AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
     }
 
     [Test]
@@ -74,7 +80,9 @@ public class PgEnumTests : TestBase
         await using var dataSource = dataSourceBuilder.Build();
 
         Assert.That(isUnmapSuccessful);
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32)));
     }
 
     [Test]
@@ -92,7 +100,7 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<TestEnum>(type2);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, new[] { Mood.Ok, Mood.Sad }, "{ok,sad}", type1 + "[]", dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, new[] { Mood.Ok, Mood.Sad }, "{ok,sad}", type1 + "[]", dataTypeInference: DataTypeInference.Mismatch);
     }
 
     [Test]
@@ -106,7 +114,7 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<Mood>(type);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, new[] { Mood.Ok, Mood.Happy }, "{ok,happy}", type + "[]", dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, new[] { Mood.Ok, Mood.Happy }, "{ok,happy}", type + "[]", dataTypeInference: DataTypeInference.Mismatch);
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/859")]
@@ -120,9 +128,15 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<NameTranslationEnum>(enumName1);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, NameTranslationEnum.Simple, "simple", enumName1, dataTypeInference: DataTypeInference.Nothing);
-        await AssertType(dataSource, NameTranslationEnum.TwoWords, "two_words", enumName1, dataTypeInference: DataTypeInference.Nothing);
-        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", enumName1, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.Simple, "simple", enumName1,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.TwoWords, "two_words", enumName1,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", enumName1,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/859")]
@@ -136,9 +150,15 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<NameTranslationEnum>(type, nameTranslator: new NpgsqlNullNameTranslator());
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, NameTranslationEnum.Simple, "Simple", type, dataTypeInference: DataTypeInference.Nothing);
-        await AssertType(dataSource, NameTranslationEnum.TwoWords, "TwoWords", type, dataTypeInference: DataTypeInference.Nothing);
-        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.Simple, "Simple", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.TwoWords, "TwoWords", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", type,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
     }
 
     [Test]
@@ -153,8 +173,12 @@ CREATE TYPE {type1} AS ENUM ('sad', 'ok', 'happy');
 CREATE TYPE {type2} AS ENUM ('value1', 'value2');");
         await connection.ReloadTypesAsync();
 
-        await AssertType(connection, Mood.Happy, "happy", type1, dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
-        await AssertType(connection, AnotherEnum.Value2, "value2", type2, dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
+        await AssertType(connection, Mood.Happy, "happy", type1,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32), valueTypeEqualsFieldType: false);
+        await AssertType(connection, AnotherEnum.Value2, "value2", type2,
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32), valueTypeEqualsFieldType: false);
     }
 
     [Test]
@@ -215,8 +239,12 @@ CREATE TYPE {schema2}.my_enum AS ENUM ('alpha');");
         dataSourceBuilder.MapEnum<Enum2>($"{schema2}.my_enum");
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, Enum1.One, "one", $"{schema1}.my_enum", dataTypeInference: DataTypeInference.Nothing);
-        await AssertType(dataSource, Enum2.Alpha, "alpha", $"{schema2}.my_enum", dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, Enum1.One, "one", $"{schema1}.my_enum",
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, Enum2.Alpha, "alpha", $"{schema2}.my_enum",
+            dataTypeInference: DataTypeInference.Mismatch,
+            dbType: new(DbType.Object, DbType.Int32));
     }
 
     enum Enum1 { One }

--- a/test/Npgsql.Tests/Types/PgEnumTests.cs
+++ b/test/Npgsql.Tests/Types/PgEnumTests.cs
@@ -27,9 +27,7 @@ public class PgEnumTests : TestBase
         dataSourceBuilder.MapEnum<Mood>(type);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test]
@@ -46,9 +44,7 @@ public class PgEnumTests : TestBase
         await using var dataSource = dataSourceBuilder.Build();
 
         Assert.That(isUnmapSuccessful);
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32)));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
     }
 
     [Test]
@@ -61,9 +57,7 @@ public class PgEnumTests : TestBase
         var dataSourceBuilder = CreateDataSourceBuilder();
         dataSourceBuilder.MapEnum(typeof(Mood), type);
         await using var dataSource = dataSourceBuilder.Build();
-        await AssertType(dataSource, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test]
@@ -80,9 +74,7 @@ public class PgEnumTests : TestBase
         await using var dataSource = dataSourceBuilder.Build();
 
         Assert.That(isUnmapSuccessful);
-        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32)));
+        Assert.ThrowsAsync<InvalidCastException>(() => AssertType(dataSource, Mood.Happy, "happy", type, dataTypeInference: DataTypeInference.Nothing));
     }
 
     [Test]
@@ -100,7 +92,7 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<TestEnum>(type2);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, new[] { Mood.Ok, Mood.Sad }, "{ok,sad}", type1 + "[]", dataTypeInference: DataTypeInference.Mismatch);
+        await AssertType(dataSource, new[] { Mood.Ok, Mood.Sad }, "{ok,sad}", type1 + "[]", dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test]
@@ -114,7 +106,7 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<Mood>(type);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, new[] { Mood.Ok, Mood.Happy }, "{ok,happy}", type + "[]", dataTypeInference: DataTypeInference.Mismatch);
+        await AssertType(dataSource, new[] { Mood.Ok, Mood.Happy }, "{ok,happy}", type + "[]", dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/859")]
@@ -128,15 +120,9 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<NameTranslationEnum>(enumName1);
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, NameTranslationEnum.Simple, "simple", enumName1,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
-        await AssertType(dataSource, NameTranslationEnum.TwoWords, "two_words", enumName1,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
-        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", enumName1,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.Simple, "simple", enumName1, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.TwoWords, "two_words", enumName1, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", enumName1, dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/859")]
@@ -150,15 +136,9 @@ CREATE TYPE {type2} AS ENUM ('label1', 'label2', 'label3')");
         dataSourceBuilder.MapEnum<NameTranslationEnum>(type, nameTranslator: new NpgsqlNullNameTranslator());
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, NameTranslationEnum.Simple, "Simple", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
-        await AssertType(dataSource, NameTranslationEnum.TwoWords, "TwoWords", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
-        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", type,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, NameTranslationEnum.Simple, "Simple", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.TwoWords, "TwoWords", type, dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, NameTranslationEnum.SomeClrName, "some_database_name", type, dataTypeInference: DataTypeInference.Nothing);
     }
 
     [Test]
@@ -173,12 +153,8 @@ CREATE TYPE {type1} AS ENUM ('sad', 'ok', 'happy');
 CREATE TYPE {type2} AS ENUM ('value1', 'value2');");
         await connection.ReloadTypesAsync();
 
-        await AssertType(connection, Mood.Happy, "happy", type1,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32), valueTypeEqualsFieldType: false);
-        await AssertType(connection, AnotherEnum.Value2, "value2", type2,
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32), valueTypeEqualsFieldType: false);
+        await AssertType(connection, Mood.Happy, "happy", type1, dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
+        await AssertType(connection, AnotherEnum.Value2, "value2", type2, dataTypeInference: DataTypeInference.Nothing, valueTypeEqualsFieldType: false);
     }
 
     [Test]
@@ -239,12 +215,8 @@ CREATE TYPE {schema2}.my_enum AS ENUM ('alpha');");
         dataSourceBuilder.MapEnum<Enum2>($"{schema2}.my_enum");
         await using var dataSource = dataSourceBuilder.Build();
 
-        await AssertType(dataSource, Enum1.One, "one", $"{schema1}.my_enum",
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
-        await AssertType(dataSource, Enum2.Alpha, "alpha", $"{schema2}.my_enum",
-            dataTypeInference: DataTypeInference.Mismatch,
-            dbType: new(DbType.Object, DbType.Int32));
+        await AssertType(dataSource, Enum1.One, "one", $"{schema1}.my_enum", dataTypeInference: DataTypeInference.Nothing);
+        await AssertType(dataSource, Enum2.Alpha, "alpha", $"{schema2}.my_enum", dataTypeInference: DataTypeInference.Nothing);
     }
 
     enum Enum1 { One }

--- a/test/Npgsql.Tests/Types/PgEnumTests.cs
+++ b/test/Npgsql.Tests/Types/PgEnumTests.cs
@@ -11,7 +11,7 @@ using static Npgsql.Tests.TestUtil;
 
 namespace Npgsql.Tests.Types;
 
-public class EnumTests : TestBase
+public class PgEnumTests : TestBase
 {
     enum Mood { Sad, Ok, Happy }
     enum AnotherEnum { Value1, Value2 }


### PR DESCRIPTION
Solves half of https://github.com/npgsql/npgsql/issues/3303 and fixes https://github.com/npgsql/npgsql/issues/5591.

This brings NativeAOT compatible \*unmapped* CLR enum support for reads and writes. Once merged we begin to map (by default, inferred) to the closest pg type based on the enum's underlying type:
- int, uint => int4
- long, ulong => int8
- byte, sbyte, short, ushort => int2

We don't support any primitive conversions like we have for raw primitives. We can leave those until people actually ask for them. This means if users want to map an int enum into an int8 (and so on) that we do not yet support this.

Arrays are supported but not fully, see: https://github.com/dotnet/runtime/issues/127249. We could consider adding these mappings on CoreCLR only. So far I've kept the functionality symmetrical, as we try to do with most mappings.

A lot of the recent work was required to land this feature:
- Cleaning up the provider/concrete split that proliferated 'AsObject' logic all over the codebase.
- Getting all non-generic converter dispatching to use the centralized PgConverter.Read<T> (and so on) methods.
- Rationalizing all PgTypeInfo variance logic to be able to confidently add the enum <-> underlying exemptions.

This PR just really threads the needle through CLR and NativeAOT quirks. The enum <-> underlying "reduced-type equivalence" is one big, weird, exception in the type system: array covariance carries it through, though generic instantiation stays invariant. Given our infra is generic it requires full manual mapping to faithfully resurface the relationship, rather than simply relying on the (allocating) boxing/unboxing helpers to do it for us. 

Once past the IL stage NativeAOT brings its own problems. Its aggressive trimming does not carve out any real exceptions for these historical equivalences beyond the absolute simplest cases (nevertheless working with enums through their underlying type is the recommended way). Then just as I was rounding off the work I noticed a classic bloat issue, one that has surfaced a few times before in our NativeAOT journey. In short, there are fundamental limitations in the current IL scanner, and we are still waiting for a more capable one (https://github.com/dotnet/runtime/issues/83021). 

More concretely: we cannot make unmapped enum reading and writing \*allocation free* on NativeAOT without incurring massive code bloat. The essential issue is that the scanner cannot clean up code blocks that were found dead or under vacuous conditionals after scanning completed. This applies to typeof(T).IsX branches, isinst branches over types that didn't get instantiated, and so forth. All of that knowledge requires the whole program view the scanner itself is building (and potentially the generic specialization view that codegen has) which all happens after it has decided the methods and types must be kept.

If we do not fortify our typeof(T).IsEnum check with `RuntimeFeature.IsDynamicCodeSupported` we would root all that enum dispatching logic for every T that flows through, and as they are dispatching stubs, that's basically everything. We can't use any of our usual tricks here - like putting the code behind virtual dispatch - because there are no actual rooted instantations over the user's TEnum. The entire point was that we didn't need to know about those types in Npgsql. Finally, on the more exotic end there is no 'unsafe but guaranteed' equivalence of virtual table layout between T = enum and its underlying T = int either. Which means we cannot 'safely' do `Unsafe.As<PgConverter<IntEnum>(PgConverter<int>)` and be guaranteed their virtual slots line up such that we end up in the virtual method we intended to call. As a result NativeAOT support is a bit worse than I would have wanted, but it sits on the edge of what's reasonably possible.

Suffice to say this ended up being an even more hilariously painful feature to land than I initially assumed, but it's type safe, trim safe, and complete with as much compositional support as the runtime provides guarantees for.