### PR TITLE
Fix off-by-one in ThrowColumnMismatch exception message

### DIFF
--- a/src/Npgsql/NpgsqlBinaryImporter.cs
+++ b/src/Npgsql/NpgsqlBinaryImporter.cs
@@ -606,7 +606,7 @@ public sealed class NpgsqlBinaryImporter : ICancelable
     #endregion Enums
 
     void ThrowColumnMismatch()
-        => throw new InvalidOperationException($"The binary import operation was started with {NumColumns} column(s), but {_column + 1} value(s) were provided.");
+        => throw new InvalidOperationException($"The binary import operation was started with {NumColumns} column(s), but {_column} value(s) were provided.");
 
     #region Tracing
 

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -949,6 +949,22 @@ INSERT INTO {table} (bits, bitvector, bitarray) VALUES (B'00000001101', B'000000
         Assert.Throws<InvalidOperationException>(() => writer.WriteRow("Hello", 8, "I should not be here"));
     }
 
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/6583")]
+    public async Task Write_column_out_of_bounds_exception_message()
+    {
+        using var conn = await OpenConnectionAsync();
+        var table = await CreateTempTable(conn, "foo INT, bar TEXT");
+
+        using var writer = conn.BeginBinaryImport($"COPY {table} (foo, bar) FROM STDIN BINARY");
+
+        writer.StartRow();
+        writer.Write(1);
+        
+        var ex = Assert.Throws<InvalidOperationException>(() => writer.StartRow());
+        Assert.That(ex!.Message, Does.Contain("2 column(s)"));
+        Assert.That(ex!.Message, Does.Contain("1 value(s)"));
+    }
+
     [Test]
     public async Task Cancel_raw_binary_export_when_not_consumed_and_then_Dispose()
     {


### PR DESCRIPTION
Fixes #6583

## Problem
`ThrowColumnMismatch` was using `_column + 1` in the exception message, 
but `_column` already holds the correct number of values written when the 
method is called from `StartRow`. This caused the reported value count to 
always be off by one.

For example, with a 3-column table where only 2 values were written:
> "started with 3 column(s), but **3** value(s) were provided"

when it should say:
> "started with 3 column(s), but **2** value(s) were provided"

## Fix
Removed the `+ 1` from the interpolated string in `ThrowColumnMismatch`.

## Test
Added `Write_column_out_of_bounds_exception_message` to `CopyTests.cs` 
to verify the exception message reports the correct value count.