### PR TITLE
Improved provider signatures

### DIFF
--- a/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
+++ b/src/Npgsql/BackendMessages/RowDescriptionMessage.cs
@@ -371,7 +371,8 @@ public sealed class FieldDescription
                 // for any column type. Every pg_catalog.text mapping we own declares text-format support, so a converter that
                 // can't bind to text here throws and surfaces as a missing mapping rather than getting silently reinterpreted.
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(string), _serializerOptions.TextPgTypeId, _serializerOptions);
-                var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
+                var concreteTypeInfo = typeInfo.MakeConcreteForField(
+                    new ProviderFieldContext { Name = Field.Name, TypeModifier = Field.TypeModifier });
                 if (!concreteTypeInfo.SupportsReading)
                     AdoSerializerHelpers.ThrowReadingNotSupported(type, _serializerOptions, _serializerOptions.TextPgTypeId, resolved: true);
 
@@ -382,7 +383,8 @@ public sealed class FieldDescription
             case DataFormat.Binary or DataFormat.Text:
             {
                 var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type ?? typeof(object), _serializerOptions.ToCanonicalTypeId(PostgresType), _serializerOptions);
-                var concreteTypeInfo = typeInfo.MakeConcreteForField(Field);
+                var concreteTypeInfo = typeInfo.MakeConcreteForField(
+                    new ProviderFieldContext { Name = Field.Name, TypeModifier = Field.TypeModifier });
                 if (!concreteTypeInfo.SupportsReading)
                     AdoSerializerHelpers.ThrowReadingNotSupported(type, _serializerOptions, _serializerOptions.ToCanonicalTypeId(PostgresType), resolved: true);
 

--- a/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
+++ b/src/Npgsql/Internal/Composites/Metadata/CompositeFieldInfo.cs
@@ -80,7 +80,7 @@ abstract class CompositeFieldInfo
 
     public PgConverter GetReadInfo(out Size readRequirement)
     {
-        var concreteTypeInfo = ConcreteTypeInfo ?? PgTypeInfo.MakeConcreteForField(new Field(Name, PgTypeInfo.PgTypeId.GetValueOrDefault(), -1));
+        var concreteTypeInfo = ConcreteTypeInfo ?? PgTypeInfo.MakeConcreteForField(new ProviderFieldContext { Name = Name });
         if (!concreteTypeInfo.SupportsReading)
             AdoSerializerHelpers.ThrowReadingNotSupported(PgTypeInfo.Type, PgTypeInfo.Options, concreteTypeInfo.PgTypeId, resolved: true);
 

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -533,16 +533,16 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
     protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, TBase? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
-    protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
+    protected override PgConcreteTypeInfo? GetForFieldCore(in ProviderFieldContext context)
     {
         // When constructed as a same-authoring-unit composition, route directly to inner providers, skipping their
         // wrapping ValidateConcrete on each call.
         var concreteTypeInfo = _isCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(_effectiveTypeInfo).GetForField(field)
-            : _effectiveTypeInfo.GetForField(field);
+            ? PgProviderTypeInfo.GetProvider(_effectiveTypeInfo).GetForField(context)
+            : _effectiveTypeInfo.GetForField(context);
         var concreteNullableTypeInfo = _isCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(_effectiveNullableTypeInfo).GetForField(field)
-            : _effectiveNullableTypeInfo.GetForField(field);
+            ? PgProviderTypeInfo.GetProvider(_effectiveNullableTypeInfo).GetForField(context)
+            : _effectiveNullableTypeInfo.GetForField(context);
 
         return concreteTypeInfo is not null && concreteNullableTypeInfo is not null
             ? GetOrAdd(concreteTypeInfo, concreteNullableTypeInfo)

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -305,7 +305,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         throw new NotSupportedException($"Unknown type T: {typeof(T).FullName}");
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? values, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? values, ref object? writeState)
     {
         PgConcreteTypeInfo? concreteTypeInfo = null;
         PgArrayMetadata metadata;
@@ -313,6 +313,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         (Size, object? WriteState)[]? elemData = null;
 
         var index = 0;
+        ProviderValueContext innerContext;
         switch (values)
         {
         case TElement[] array:
@@ -334,7 +335,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        effectiveContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -363,7 +364,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        effectiveContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -392,7 +393,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        effectiveContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -421,7 +422,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        effectiveContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -529,7 +530,7 @@ sealed class PolymorphicArrayTypeInfoProvider<TBase> : PgConcreteTypeInfoProvide
                 ? PgProviderTypeInfo.GetProvider(_effectiveNullableTypeInfo).GetDefault(pgTypeId)
                 : _effectiveNullableTypeInfo.GetDefault(pgTypeId));
 
-    protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, TBase? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, TBase? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)

--- a/src/Npgsql/Internal/Converters/ArrayConverter.cs
+++ b/src/Npgsql/Internal/Converters/ArrayConverter.cs
@@ -14,22 +14,15 @@ namespace Npgsql.Internal.Converters;
 abstract class ArrayConverter<T> : PgStreamingConverter<T> where T : notnull
 {
     readonly ArrayConverterCore _arrayConverterCore;
-    // Compositional boundary: outward BufferRequirements is always Streaming (doesn't expose the element's
-    // requirements), so this converter's outward descriptor is always Invariant. _elementIsInvariant is
-    // only consulted internally — when false, the cached element BufferRequirements in ArrayConverterCore
-    // would be stale and the runtime per-element paths re-resolve via the element converter using the
-    // PgConversionContext supplied by the carrier (reader/writer/BindContext).
-    readonly bool _elementIsInvariant;
 
     private protected ArrayConverter(int? expectedDimensions, PgConcreteTypeInfo elementTypeInfo, int pgLowerBound = 1)
     {
         // Invariance is context-independent by contract; probe with Empty. The cached BufferRequirements
         // is only valid when invariant — non-invariant elements re-resolve at runtime via the carrier.
         var elementDescriptor = elementTypeInfo.GetConverter(DataFormat.Binary).GetDescriptor(new() { ConversionContext = PgConversionContext.Empty });
-        _elementIsInvariant = elementDescriptor.IsInvariant;
         _arrayConverterCore = new((IElementOperations)this, elementTypeInfo.GetConverter(DataFormat.Binary),
             elementTypeInfo.GetConverter(DataFormat.Binary).IsDbNullable, expectedDimensions,
-            _elementIsInvariant ? elementDescriptor.BufferRequirements : null, elementTypeInfo.PgTypeId, pgLowerBound);
+            elementDescriptor.IsInvariant ? elementDescriptor.BufferRequirements : null, elementTypeInfo.PgTypeId, pgLowerBound);
     }
 
     public override T Read(PgReader reader) => (T)_arrayConverterCore.Read(async: false, reader).Result;
@@ -277,12 +270,12 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         elementTypeInfo)
     where T : notnull
 {
-    PgSerializerOptions Options => EffectiveTypeInfo.Options;
+    PgSerializerOptions Options => InnerTypeInfo.Options;
 
-    protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => Options.GetArrayElementTypeId(pgTypeId);
-    protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => Options.GetArrayTypeId(effectivePgTypeId);
+    protected override PgTypeId GetInnerPgTypeId(PgTypeId pgTypeId) => Options.GetArrayElementTypeId(pgTypeId);
+    protected override PgTypeId GetPgTypeId(PgTypeId innerPgTypeId) => Options.GetArrayTypeId(innerPgTypeId);
 
-    protected override void CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo,
+    protected override void CreateConverter(PgConcreteTypeInfo innerConcreteTypeInfo,
         out PgConverter<T>? binary, out PgConverter<T>? text, out Type? requestedType)
     {
         // Arrays are binary-only on the PG wire. We never produce a text-format array converter; the binary
@@ -291,21 +284,21 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         if (typeof(T) == typeof(Array) || typeof(T).IsArray)
         {
             requestedType = requestedMappingType;
-            binary = ArrayConverter<T>.CreateArrayBased<TElement>(effectiveConcreteTypeInfo, requestedType);
+            binary = ArrayConverter<T>.CreateArrayBased<TElement>(innerConcreteTypeInfo, requestedType);
             return;
         }
 
         if (typeof(T).IsConstructedGenericType && typeof(T).GetGenericTypeDefinition() == typeof(IList<>))
         {
             requestedType = requestedMappingType;
-            binary = ArrayConverter<T>.CreateListBased<TElement>(effectiveConcreteTypeInfo);
+            binary = ArrayConverter<T>.CreateListBased<TElement>(innerConcreteTypeInfo);
             return;
         }
 
         throw new NotSupportedException($"Unknown type T: {typeof(T).FullName}");
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? values, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetInnerTypeInfo(in ProviderValueContext innerContext, T? values, ref object? writeState)
     {
         PgConcreteTypeInfo? concreteTypeInfo = null;
         PgArrayMetadata metadata;
@@ -313,7 +306,8 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         (Size, object? WriteState)[]? elemData = null;
 
         var index = 0;
-        ProviderValueContext innerContext;
+        ProviderValueContext inferredContext;
+        scoped ref readonly var contextRef = ref innerContext;
         switch (values)
         {
         case TElement[] array:
@@ -321,10 +315,10 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in array)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
-                    : GetEffectiveForValue(effectiveContext, value, out state);
+                    ? GetInnerForValueAsNestedObject(contextRef, value, out var state)
+                    : GetInnerForValue(contextRef, value, out state);
                 if (state is not null && elemData is null)
-                    writeState = AllocateElementBuffer(effectiveContext, metadata, out elemData, out elemDataArrayPool);
+                    writeState = AllocateElementBuffer(contextRef, metadata, out elemData, out elemDataArrayPool);
 
                 // Always assign when elemData is allocated to avoid stale pooled array entries.
                 if (elemData is not null)
@@ -335,7 +329,8 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        inferredContext = innerContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        contextRef = ref inferredContext;
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -350,10 +345,10 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in list)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
-                    : GetEffectiveForValue(effectiveContext, value, out state);
+                    ? GetInnerForValueAsNestedObject(contextRef, value, out var state)
+                    : GetInnerForValue(contextRef, value, out state);
                 if (state is not null && elemData is null)
-                    writeState = AllocateElementBuffer(effectiveContext, metadata, out elemData, out elemDataArrayPool);
+                    writeState = AllocateElementBuffer(contextRef, metadata, out elemData, out elemDataArrayPool);
 
                 // Always assign when elemData is allocated to avoid stale pooled array entries.
                 if (elemData is not null)
@@ -364,7 +359,8 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        inferredContext = innerContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        contextRef = ref inferredContext;
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -379,10 +375,10 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in list)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
-                    : GetEffectiveForValue(effectiveContext, value, out state);
+                    ? GetInnerForValueAsNestedObject(contextRef, value, out var state)
+                    : GetInnerForValue(contextRef, value, out state);
                 if (state is not null && elemData is null)
-                    writeState = AllocateElementBuffer(effectiveContext, metadata, out elemData, out elemDataArrayPool);
+                    writeState = AllocateElementBuffer(contextRef, metadata, out elemData, out elemDataArrayPool);
 
                 // Always assign when elemData is allocated to avoid stale pooled array entries.
                 if (elemData is not null)
@@ -393,7 +389,8 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        inferredContext = innerContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        contextRef = ref inferredContext;
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -408,10 +405,10 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
             foreach (var value in array)
             {
                 var result = typeof(TElement) == typeof(object)
-                    ? GetEffectiveForValueAsNestedObject(effectiveContext, value, out var state)
-                    : GetEffectiveForValueAsObject(effectiveContext, value, out state);
+                    ? GetInnerForValueAsNestedObject(contextRef, value, out var state)
+                    : GetInnerForValueAsObject(contextRef, value, out state);
                 if (state is not null && elemData is null)
-                    writeState = AllocateElementBuffer(effectiveContext, metadata, out elemData, out elemDataArrayPool);
+                    writeState = AllocateElementBuffer(contextRef, metadata, out elemData, out elemDataArrayPool);
 
                 // Always assign when elemData is allocated to avoid stale pooled array entries.
                 if (elemData is not null)
@@ -422,7 +419,8 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
                     if (concreteTypeInfo is null)
                     {
                         concreteTypeInfo = result;
-                        innerContext = effectiveContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        inferredContext = innerContext with { ExpectedPgTypeId = concreteTypeInfo.PgTypeId };
+                        contextRef = ref inferredContext;
                     }
                     else if (result != concreteTypeInfo)
                         ThrowHelper.ThrowInvalidOperationException("Array elements resolved to inconsistent concrete type infos. All elements must resolve to the same type info.");
@@ -446,7 +444,7 @@ sealed class ArrayTypeInfoProvider<T, TElement>(PgProviderTypeInfo elementTypeIn
         // happens after Dispose is incidental to the wrapper's disposal contract, not the motivation —
         // it's the inner-state cleanup we're after.
         static ArrayConverterWriteState AllocateElementBuffer(
-            ProviderValueContext effectiveContext, PgArrayMetadata metadata,
+            in ProviderValueContext effectiveContext, PgArrayMetadata metadata,
             out (Size, object? WriteState)[]? elemData, out ArrayPool<(Size, object?)>? elemDataArrayPool)
         {
             var state = new ArrayConverterWriteState

--- a/src/Npgsql/Internal/Converters/BitStringConverters.cs
+++ b/src/Npgsql/Internal/Converters/BitStringConverters.cs
@@ -233,7 +233,7 @@ sealed class PolymorphicBitStringTypeInfoProvider(PgSerializerOptions options, P
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
         => GetConcreteInfo(field: null);
 
-    protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, object? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo GetForFieldCore(Field field)

--- a/src/Npgsql/Internal/Converters/BitStringConverters.cs
+++ b/src/Npgsql/Internal/Converters/BitStringConverters.cs
@@ -231,14 +231,14 @@ sealed class PolymorphicBitStringTypeInfoProvider(PgSerializerOptions options, P
     internal override bool AllowConcreteVariance => true;
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
-        => GetConcreteInfo(field: null);
+        => GetConcreteInfo(typeModifier: -1);
 
     protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
-    protected override PgConcreteTypeInfo GetForFieldCore(Field field)
-        => GetConcreteInfo(field);
+    protected override PgConcreteTypeInfo GetForFieldCore(in ProviderFieldContext context)
+        => GetConcreteInfo(context.TypeModifier);
 
-    PgConcreteTypeInfo GetConcreteInfo(Field? field)
-        => field?.TypeModifier is 1 ? _boolConcreteTypeInfo : _bitArrayConcreteTypeInfo;
+    PgConcreteTypeInfo GetConcreteInfo(int typeModifier)
+        => typeModifier is 1 ? _boolConcreteTypeInfo : _bitArrayConcreteTypeInfo;
 }

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -66,33 +66,33 @@ public sealed class CastingConverter<T> : PgConverter<T>
 // Given there aren't many instantiations of providers (and it's fairly involved to write a fast one) we use the composing base class.
 sealed class CastingTypeInfoProvider<T> : PgComposingTypeInfoProvider<T>
 {
-    public CastingTypeInfoProvider(PgProviderTypeInfo effectiveProviderTypeInfo)
-        : base(effectiveProviderTypeInfo.PgTypeId, effectiveProviderTypeInfo)
+    public CastingTypeInfoProvider(PgProviderTypeInfo innerProviderTypeInfo)
+        : base(innerProviderTypeInfo.PgTypeId, innerProviderTypeInfo)
     {
-        Debug.Assert(!effectiveProviderTypeInfo.HasExactType, "CastingTypeInfoProvider is for wrapping non-exact providers; an exact provider doesn't need the cast.");
+        Debug.Assert(!innerProviderTypeInfo.HasExactType, "CastingTypeInfoProvider is for wrapping non-exact providers; an exact provider doesn't need the cast.");
     }
 
     // Wraps a dynamically-obtained inner — not a same-authoring-unit composition. The inner's contract must still be
     // verified per dispatch.
     protected override bool IsCompositionalUnit => false;
 
-    protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
-    protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
+    protected override PgTypeId GetInnerPgTypeId(PgTypeId pgTypeId) => pgTypeId;
+    protected override PgTypeId GetPgTypeId(PgTypeId innerPgTypeId) => innerPgTypeId;
 
-    protected override void CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo,
+    protected override void CreateConverter(PgConcreteTypeInfo innerConcreteTypeInfo,
         out PgConverter<T>? binary, out PgConverter<T>? text, out Type? requestedType)
     {
         requestedType = null;
-        binary = effectiveConcreteTypeInfo.TryGetConverter(DataFormat.Binary, out var innerBinary)
+        binary = innerConcreteTypeInfo.TryGetConverter(DataFormat.Binary, out var innerBinary)
             ? new CastingConverter<T>(innerBinary)
             : null;
-        text = effectiveConcreteTypeInfo.TryGetConverter(DataFormat.Text, out var innerText)
+        text = innerConcreteTypeInfo.TryGetConverter(DataFormat.Text, out var innerText)
             ? new CastingConverter<T>(innerText)
             : null;
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState)
-        => GetEffectiveForValueAsObject(effectiveContext, value, out writeState);
+    protected override PgConcreteTypeInfo? GetInnerTypeInfo(in ProviderValueContext innerContext, T? value, ref object? writeState)
+        => GetInnerForValueAsObject(innerContext, value, out writeState);
 }
 
 static class CastingTypeInfoExtensions

--- a/src/Npgsql/Internal/Converters/CastingConverter.cs
+++ b/src/Npgsql/Internal/Converters/CastingConverter.cs
@@ -91,7 +91,7 @@ sealed class CastingTypeInfoProvider<T> : PgComposingTypeInfoProvider<T>
             : null;
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => GetEffectiveForValueAsObject(effectiveContext, value, out writeState);
 }
 

--- a/src/Npgsql/Internal/Converters/LateBindingConverter.cs
+++ b/src/Npgsql/Internal/Converters/LateBindingConverter.cs
@@ -130,7 +130,7 @@ sealed class LateBindingTypeInfoProvider : PgConcreteTypeInfoProvider<object>
         return _defaultConcreteTypeInfo;
     }
 
-    protected override PgConcreteTypeInfo GetForValueCore(ProviderValueContext context, object? value, ref object? writeState)
+    protected override PgConcreteTypeInfo GetForValueCore(in ProviderValueContext context, object? value, ref object? writeState)
     {
         if (value is null or DBNull)
         {

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -67,7 +67,7 @@ sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
             : null;
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState)
         => value is not null
             ? GetEffectiveForValue(effectiveContext, value.GetValueOrDefault(), out writeState)
             : null;

--- a/src/Npgsql/Internal/Converters/NullableConverter.cs
+++ b/src/Npgsql/Internal/Converters/NullableConverter.cs
@@ -46,29 +46,29 @@ sealed class NullableConverter<T> : PgConverter<T?>
         => _effectiveConverter.WriteAsObject(async, writer, value, cancellationToken);
 }
 
-sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo effectiveTypeInfo)
-    : PgComposingTypeInfoProvider<T?>(effectiveTypeInfo.PgTypeId, effectiveTypeInfo)
+sealed class NullableTypeInfoProvider<T>(PgProviderTypeInfo innerTypeInfo)
+    : PgComposingTypeInfoProvider<T?>(innerTypeInfo.PgTypeId, innerTypeInfo)
     where T : struct
 {
-    protected override PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId) => pgTypeId;
-    protected override PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId) => effectivePgTypeId;
+    protected override PgTypeId GetInnerPgTypeId(PgTypeId pgTypeId) => pgTypeId;
+    protected override PgTypeId GetPgTypeId(PgTypeId innerPgTypeId) => innerPgTypeId;
 
-    protected override void CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo,
+    protected override void CreateConverter(PgConcreteTypeInfo innerConcreteTypeInfo,
         out PgConverter<T?>? binary, out PgConverter<T?>? text, out Type? requestedType)
     {
         requestedType = null;
         // Nullable wrapping mirrors inner slot fill — wrap each slot independently so a binary-only or
         // text-only inner produces a same-shaped Nullable wrapper.
-        binary = effectiveConcreteTypeInfo.TryGetConverter(DataFormat.Binary, out var innerBinary)
+        binary = innerConcreteTypeInfo.TryGetConverter(DataFormat.Binary, out var innerBinary)
             ? new NullableConverter<T>((PgConverter<T>)innerBinary)
             : null;
-        text = effectiveConcreteTypeInfo.TryGetConverter(DataFormat.Text, out var innerText)
+        text = innerConcreteTypeInfo.TryGetConverter(DataFormat.Text, out var innerText)
             ? new NullableConverter<T>((PgConverter<T>)innerText)
             : null;
     }
 
-    protected override PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetInnerTypeInfo(in ProviderValueContext innerContext, T? value, ref object? writeState)
         => value is not null
-            ? GetEffectiveForValue(effectiveContext, value.GetValueOrDefault(), out writeState)
+            ? GetInnerForValue(innerContext, value.GetValueOrDefault(), out writeState)
             : null;
 }

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -41,13 +41,13 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
     protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
-    protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
+    protected override PgConcreteTypeInfo? GetForFieldCore(in ProviderFieldContext context)
     {
         // When constructed as a same-authoring-unit composition, route directly to the inner provider, skipping the
-        // inner's wrapping ValidateConcrete on each call.
+        // inner's wrapping ValidateConcrete on each call. No id restamp: _elementTypeInfo is decided on the read path.
         var elementConcreteTypeInfo = _isCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(_elementTypeInfo).GetForField(field with { PgTypeId = _elementPgTypeId })
-            : _elementTypeInfo.GetForField(field with { PgTypeId = _elementPgTypeId });
+            ? PgProviderTypeInfo.GetProvider(_elementTypeInfo).GetForField(context)
+            : _elementTypeInfo.GetForField(context);
         return elementConcreteTypeInfo is not null ? GetOrAdd(elementConcreteTypeInfo) : null;
     }
 

--- a/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/PolymorphicArrayTypeInfoProvider.cs
@@ -38,7 +38,7 @@ sealed class PolymorphicArrayTypeInfoProvider : PgConcreteTypeInfoProvider<objec
             ? PgProviderTypeInfo.GetProvider(_elementTypeInfo).GetDefault(_elementPgTypeId)
             : _elementTypeInfo.GetDefault(_elementPgTypeId));
 
-    protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, object? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, object? value, ref object? writeState)
         => throw new NotSupportedException("Polymorphic writing is not supported.");
 
     protected override PgConcreteTypeInfo? GetForFieldCore(Field field)

--- a/src/Npgsql/Internal/Converters/RecordConverter.cs
+++ b/src/Npgsql/Internal/Converters/RecordConverter.cs
@@ -44,7 +44,7 @@ sealed class RecordConverter<T>(PgSerializerOptions options, Func<object[], T>? 
                            ?? throw new NotSupportedException(
                                $"Reading isn't supported for record field {i} (PG type '{postgresType.DisplayName}'");
 
-            var concreteTypeInfo = typeInfo.MakeConcreteForField(Field.CreateUnspecified(pgTypeId));
+            var concreteTypeInfo = typeInfo.MakeConcreteForField();
             if (!concreteTypeInfo.SupportsReading)
                 AdoSerializerHelpers.ThrowReadingNotSupported(IsObjectArrayRecord ? typeof(object) : null, options, pgTypeId, resolved: true);
             var binding = concreteTypeInfo.BindField(DataFormat.Binary);

--- a/src/Npgsql/Internal/Converters/Temporal/DateTimeTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/Converters/Temporal/DateTimeTypeInfoProvider.cs
@@ -41,10 +41,10 @@ sealed class DateTimeTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
         throw new ArgumentOutOfRangeException(nameof(pgTypeId), pgTypeId, "Unsupported PgTypeId.");
     }
 
-    protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, T? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, T? value, ref object? writeState)
         => _provider(this, context, value, ref writeState);
 
-    public PgConcreteTypeInfo? Get(ProviderValueContext context, DateTime value, bool validateOnly = false)
+    public PgConcreteTypeInfo? Get(in ProviderValueContext context, DateTime value, bool validateOnly = false)
     {
         Debug.Assert(!validateOnly || context.ExpectedPgTypeId is not null);
         if (value.Kind is DateTimeKind.Utc)

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -48,10 +48,10 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
             : EffectiveTypeInfo.GetDefault(pgTypeId);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForField(Field field)
+    protected PgConcreteTypeInfo? GetEffectiveForField(in ProviderFieldContext context)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForField(field)
-            : EffectiveTypeInfo.GetForField(field);
+            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForField(context)
+            : EffectiveTypeInfo.GetForField(context);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected PgConcreteTypeInfo? GetEffectiveForValue<TInner>(in ProviderValueContext context, TInner? value, out object? writeState)
@@ -100,10 +100,11 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
         return null;
     }
 
-    protected override PgConcreteTypeInfo? GetForFieldCore(Field field)
+    protected override PgConcreteTypeInfo? GetForFieldCore(in ProviderFieldContext context)
     {
-        var effectiveField = field with { PgTypeId = GetEffectivePgTypeId(field.PgTypeId) };
-        if (GetEffectiveForField(effectiveField) is not { } concreteTypeInfo)
+        // No outer→inner id restamp needed: read-side EffectiveTypeInfo is decided and dispatches off its own
+        // posted id. The context just carries Name/TypeModifier through unchanged.
+        if (GetEffectiveForField(context) is not { } concreteTypeInfo)
             return null;
 
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -9,17 +9,17 @@ namespace Npgsql.Internal;
 abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 {
     readonly PgTypeId? _pgTypeId;
-    protected PgProviderTypeInfo EffectiveTypeInfo { get; }
+    protected PgProviderTypeInfo InnerTypeInfo { get; }
     readonly ConcurrentDictionary<PgConcreteTypeInfo, PgConcreteTypeInfo> _concreteInfoCache = new(ReferenceEqualityComparer.Instance);
 
-    protected PgComposingTypeInfoProvider(PgTypeId? pgTypeId, PgProviderTypeInfo effectiveTypeInfo)
+    protected PgComposingTypeInfoProvider(PgTypeId? pgTypeId, PgProviderTypeInfo innerTypeInfo)
     {
-        ArgumentNullException.ThrowIfNull(effectiveTypeInfo);
-        if (pgTypeId is null && effectiveTypeInfo.PgTypeId is not null)
-            throw new ArgumentNullException(nameof(pgTypeId), $"Cannot be null if {nameof(effectiveTypeInfo)}.{nameof(PgTypeInfo.PgTypeId)} is not null.");
+        ArgumentNullException.ThrowIfNull(innerTypeInfo);
+        if (pgTypeId is null && innerTypeInfo.PgTypeId is not null)
+            throw new ArgumentNullException(nameof(pgTypeId), $"Cannot be null if {nameof(innerTypeInfo)}.{nameof(PgTypeInfo.PgTypeId)} is not null.");
 
         _pgTypeId = pgTypeId;
-        EffectiveTypeInfo = effectiveTypeInfo;
+        InnerTypeInfo = innerTypeInfo;
         IsInternalProvider = true;
     }
 
@@ -38,88 +38,88 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
 
     // Dispatch helpers route to the inner provider directly when this composer is a compositional unit (skipping the
     // inner's wrapping ValidateConcrete) or through the wrapping info otherwise (validated). Composers should call
-    // these instead of EffectiveTypeInfo.GetFor* directly to honor the IsCompositionalUnit contract.
+    // these instead of InnerTypeInfo.GetFor* directly to honor the IsCompositionalUnit contract.
     // AggressiveInlining ensures the virtual IsCompositionalUnit access devirtualizes when called from sealed derived
     // composers, collapsing the branch to a constant at JIT time.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo GetEffectiveDefault(PgTypeId? pgTypeId)
+    protected PgConcreteTypeInfo GetInnerDefault(PgTypeId? pgTypeId)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetDefault(pgTypeId)
-            : EffectiveTypeInfo.GetDefault(pgTypeId);
+            ? PgProviderTypeInfo.GetProvider(InnerTypeInfo).GetDefault(pgTypeId)
+            : InnerTypeInfo.GetDefault(pgTypeId);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForField(in ProviderFieldContext context)
+    protected PgConcreteTypeInfo? GetInnerForField(in ProviderFieldContext context)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForField(context)
-            : EffectiveTypeInfo.GetForField(context);
+            ? PgProviderTypeInfo.GetProvider(InnerTypeInfo).GetForField(context)
+            : InnerTypeInfo.GetForField(context);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValue<TInner>(in ProviderValueContext context, TInner? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetInnerForValue<TInner>(in ProviderValueContext context, TInner? value, out object? writeState)
         => IsCompositionalUnit
-            ? ((PgConcreteTypeInfoProvider<TInner>)PgProviderTypeInfo.GetProvider(EffectiveTypeInfo)).GetForValue(context, value, out writeState)
-            : EffectiveTypeInfo.GetForValue(context, value, out writeState);
+            ? ((PgConcreteTypeInfoProvider<TInner>)PgProviderTypeInfo.GetProvider(InnerTypeInfo)).GetForValue(context, value, out writeState)
+            : InnerTypeInfo.GetForValue(context, value, out writeState);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetInnerForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsObject(context, value, out writeState)
-            : EffectiveTypeInfo.GetForValueAsObject(context, value, out writeState);
+            ? PgProviderTypeInfo.GetProvider(InnerTypeInfo).GetForValueAsObject(context, value, out writeState)
+            : InnerTypeInfo.GetForValueAsObject(context, value, out writeState);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValueAsNestedObject(in ProviderValueContext context, object? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetInnerForValueAsNestedObject(in ProviderValueContext context, object? value, out object? writeState)
         => IsCompositionalUnit
-            ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsNestedObject(context, value, out writeState)
-            : EffectiveTypeInfo.GetForValueAsNestedObject(context, value, out writeState);
+            ? PgProviderTypeInfo.GetProvider(InnerTypeInfo).GetForValueAsNestedObject(context, value, out writeState)
+            : InnerTypeInfo.GetForValueAsNestedObject(context, value, out writeState);
 
-    protected abstract PgTypeId GetEffectivePgTypeId(PgTypeId pgTypeId);
-    protected abstract PgTypeId GetPgTypeId(PgTypeId effectivePgTypeId);
+    protected abstract PgTypeId GetInnerPgTypeId(PgTypeId pgTypeId);
+    protected abstract PgTypeId GetPgTypeId(PgTypeId innerPgTypeId);
 
     /// Produces the per-format converter pair for a composed `PgConcreteTypeInfo`. Either slot may be null
     /// when the composition doesn't support that format, but at least one must be set — the framework
     /// validates this when wrapping the result.
-    protected abstract void CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo,
+    protected abstract void CreateConverter(PgConcreteTypeInfo innerConcreteTypeInfo,
         out PgConverter<T>? binary, out PgConverter<T>? text, out Type? requestedType);
 
-    protected abstract PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState);
+    protected abstract PgConcreteTypeInfo? GetInnerTypeInfo(in ProviderValueContext innerContext, T? value, ref object? writeState);
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
     {
-        PgTypeId? effectiveTypeId = pgTypeId is { } id ? GetEffectiveTypeId(id) : null;
-        var concreteTypeInfo = GetEffectiveDefault(effectiveTypeId);
+        PgTypeId? innerTypeId = pgTypeId is { } id ? GetInnerTypeId(id) : null;
+        var concreteTypeInfo = GetInnerDefault(innerTypeId);
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);
         return GetOrAdd(concreteTypeInfo, composingPgTypeId);
     }
 
     protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, T? value, ref object? writeState)
     {
-        PgTypeId? effectiveTypeId = context.ExpectedPgTypeId is { } id ? GetEffectiveTypeId(id) : null;
-        var effectiveContext = context with { ExpectedPgTypeId = effectiveTypeId };
-        if (GetEffectiveTypeInfo(effectiveContext, value, ref writeState) is { } effectiveTypeInfo)
-            return GetOrAdd(effectiveTypeInfo, context.ExpectedPgTypeId ?? _pgTypeId ?? GetPgTypeId(effectiveTypeInfo.PgTypeId));
+        PgTypeId? innerTypeId = context.ExpectedPgTypeId is { } id ? GetInnerTypeId(id) : null;
+        var innerContext = context with { ExpectedPgTypeId = innerTypeId };
+        if (GetInnerTypeInfo(innerContext, value, ref writeState) is { } innerTypeInfo)
+            return GetOrAdd(innerTypeInfo, context.ExpectedPgTypeId ?? _pgTypeId ?? GetPgTypeId(innerTypeInfo.PgTypeId));
 
         return null;
     }
 
     protected override PgConcreteTypeInfo? GetForFieldCore(in ProviderFieldContext context)
     {
-        // No outer→inner id restamp needed: read-side EffectiveTypeInfo is decided and dispatches off its own
+        // No outer→inner id restamp needed: read-side InnerTypeInfo is decided and dispatches off its own
         // posted id. The context just carries Name/TypeModifier through unchanged.
-        if (GetEffectiveForField(context) is not { } concreteTypeInfo)
+        if (GetInnerForField(context) is not { } concreteTypeInfo)
             return null;
 
         var composingPgTypeId = _pgTypeId ?? GetPgTypeId(concreteTypeInfo.PgTypeId);
         return GetOrAdd(concreteTypeInfo, composingPgTypeId);
     }
 
-    PgTypeId GetEffectiveTypeId(PgTypeId pgTypeId)
+    PgTypeId GetInnerTypeId(PgTypeId pgTypeId)
     {
-        // If we have a _pgTypeId match we already know the effective id, and the constructor has verified it is non-null.
+        // If we have a _pgTypeId match we already know the inner id, and the constructor has verified it is non-null.
         if (pgTypeId == _pgTypeId)
-            return EffectiveTypeInfo.PgTypeId.GetValueOrDefault();
+            return InnerTypeInfo.PgTypeId.GetValueOrDefault();
 
         // We have an undecided type info which is asked to resolve for a specific type id
-        // we'll unfortunately have to look up the effective id, this is rare though.
-        return GetEffectivePgTypeId(pgTypeId);
+        // we'll unfortunately have to look up the inner id, this is rare though.
+        return GetInnerPgTypeId(pgTypeId);
     }
 
     PgConcreteTypeInfo GetOrAdd(PgConcreteTypeInfo concreteTypeInfo, PgTypeId pgTypeId)

--- a/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgComposingTypeInfoProvider.cs
@@ -54,19 +54,19 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
             : EffectiveTypeInfo.GetForField(field);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValue<TInner>(ProviderValueContext context, TInner? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetEffectiveForValue<TInner>(in ProviderValueContext context, TInner? value, out object? writeState)
         => IsCompositionalUnit
             ? ((PgConcreteTypeInfoProvider<TInner>)PgProviderTypeInfo.GetProvider(EffectiveTypeInfo)).GetForValue(context, value, out writeState)
             : EffectiveTypeInfo.GetForValue(context, value, out writeState);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetEffectiveForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
         => IsCompositionalUnit
             ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsObject(context, value, out writeState)
             : EffectiveTypeInfo.GetForValueAsObject(context, value, out writeState);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected PgConcreteTypeInfo? GetEffectiveForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
+    protected PgConcreteTypeInfo? GetEffectiveForValueAsNestedObject(in ProviderValueContext context, object? value, out object? writeState)
         => IsCompositionalUnit
             ? PgProviderTypeInfo.GetProvider(EffectiveTypeInfo).GetForValueAsNestedObject(context, value, out writeState)
             : EffectiveTypeInfo.GetForValueAsNestedObject(context, value, out writeState);
@@ -80,7 +80,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
     protected abstract void CreateConverter(PgConcreteTypeInfo effectiveConcreteTypeInfo,
         out PgConverter<T>? binary, out PgConverter<T>? text, out Type? requestedType);
 
-    protected abstract PgConcreteTypeInfo? GetEffectiveTypeInfo(ProviderValueContext effectiveContext, T? value, ref object? writeState);
+    protected abstract PgConcreteTypeInfo? GetEffectiveTypeInfo(in ProviderValueContext effectiveContext, T? value, ref object? writeState);
 
     protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId)
     {
@@ -90,7 +90,7 @@ abstract class PgComposingTypeInfoProvider<T> : PgConcreteTypeInfoProvider<T>
         return GetOrAdd(concreteTypeInfo, composingPgTypeId);
     }
 
-    protected override PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, T? value, ref object? writeState)
+    protected override PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, T? value, ref object? writeState)
     {
         PgTypeId? effectiveTypeId = context.ExpectedPgTypeId is { } id ? GetEffectiveTypeId(id) : null;
         var effectiveContext = context with { ExpectedPgTypeId = effectiveTypeId };

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -21,15 +21,9 @@ public abstract class PgConcreteTypeInfoProvider
     }
 
     /// <summary>
-    /// Gets the appropriate type info based on the given field info.
+    /// Gets the appropriate type info based on the given field context.
     /// </summary>
-    public PgConcreteTypeInfo? GetForField(Field field)
-    {
-        var result = GetForFieldCore(field);
-        if (result is not null && result.PgTypeId != field.PgTypeId)
-            ThrowPgTypeIdMismatch(nameof(GetForFieldCore));
-        return result;
-    }
+    public PgConcreteTypeInfo? GetForField(in ProviderFieldContext context) => GetForFieldCore(context);
 
     /// <summary>
     /// Gets the appropriate type info based on the given value and expected type id.
@@ -74,13 +68,13 @@ public abstract class PgConcreteTypeInfoProvider
     protected abstract PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId);
 
     /// <summary>
-    /// Gets the concrete type info for a given field.
+    /// Gets the concrete type info for a given field context.
     /// </summary>
     /// <remarks>
     /// Implementations should not return new instances of the possible infos that can be returned, instead its expected these are cached once returned.
     /// Composing providers depend on this to cache their own infos - wrapping the element info - with the cache key being the element info reference.
     /// </remarks>
-    protected virtual PgConcreteTypeInfo? GetForFieldCore(Field field) => null;
+    protected virtual PgConcreteTypeInfo? GetForFieldCore(in ProviderFieldContext context) => null;
 
     internal abstract Type TypeToConvert { get; }
 
@@ -166,6 +160,20 @@ public readonly struct ProviderValueContext
 {
     public PgTypeId? ExpectedPgTypeId { get; init; }
     public NestedObjectDbNullHandling NestedObjectDbNullHandling { get; init; }
+}
+
+/// <summary>
+/// The field metadata a provider dispatches on when resolving a concrete type info for a read. The expected
+/// PG type id is not carried here — read-side resolution always yields a decided info that knows its own id,
+/// so a context copy would be redundant. Providers that need the id at dispatch time read their own posted id.
+/// </summary>
+[Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
+public readonly struct ProviderFieldContext
+{
+    public ProviderFieldContext() { }
+
+    public string? Name { get; init; }
+    public int TypeModifier { get; init; } = -1;
 }
 
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]

--- a/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
+++ b/src/Npgsql/Internal/PgConcreteTypeInfoProvider.cs
@@ -34,7 +34,7 @@ public abstract class PgConcreteTypeInfoProvider
     /// <summary>
     /// Gets the appropriate type info based on the given value and expected type id.
     /// </summary>
-    public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
     {
         writeState = null;
         try
@@ -104,7 +104,7 @@ public abstract class PgConcreteTypeInfoProvider
     /// </remarks>
     internal bool IsInternalProvider { get; private protected init; }
 
-    private protected abstract PgConcreteTypeInfo? GetForValueAsObjectCore(ProviderValueContext context, object? value, ref object? writeState);
+    private protected abstract PgConcreteTypeInfo? GetForValueAsObjectCore(in ProviderValueContext context, object? value, ref object? writeState);
 
     private protected static void ThrowPgTypeIdMismatch(string methodName)
         => throw new InvalidOperationException(
@@ -121,7 +121,7 @@ public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
     /// <summary>
     /// Gets the appropriate type info based on the given value and expected type id.
     /// </summary>
-    public PgConcreteTypeInfo? GetForValue(ProviderValueContext context, T? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValue(in ProviderValueContext context, T? value, out object? writeState)
     {
         writeState = null;
         try
@@ -151,13 +151,13 @@ public abstract class PgConcreteTypeInfoProvider<T> : PgConcreteTypeInfoProvider
     /// Implementations should not return new instances of the possible infos that can be returned, instead its expected these are cached once returned.
     /// Composing providers depend on this to cache their own infos - wrapping the element info - with the cache key being the element info reference.
     /// </remarks>
-    protected abstract PgConcreteTypeInfo? GetForValueCore(ProviderValueContext context, T? value, ref object? writeState);
+    protected abstract PgConcreteTypeInfo? GetForValueCore(in ProviderValueContext context, T? value, ref object? writeState);
 
     internal sealed override Type TypeToConvert => typeof(T);
 
     // If null was passed while it is not a valid value for T we directly return null.
     // This allows concrete info to be produced by falling back to GetDefault afterwards.
-    private protected sealed override PgConcreteTypeInfo? GetForValueAsObjectCore(ProviderValueContext context, object? value, ref object? writeState)
+    private protected sealed override PgConcreteTypeInfo? GetForValueAsObjectCore(in ProviderValueContext context, object? value, ref object? writeState)
         => default(T) is null || value is not null ? GetForValueCore(context, (T?)value, ref writeState) : null;
 }
 
@@ -173,7 +173,7 @@ static class PgConcreteTypeInfoProviderExtensions
 {
     extension(PgConcreteTypeInfoProvider provider)
     {
-        internal PgConcreteTypeInfo? GetForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
+        internal PgConcreteTypeInfo? GetForValueAsNestedObject(in ProviderValueContext context, object? value, out object? writeState)
         {
             writeState = null;
             switch (context.NestedObjectDbNullHandling)

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -41,18 +41,15 @@ public abstract class PgConverter
     protected internal bool HandleDbNull { get; init; }
 
     /// <summary>
-    /// Computes the converter's descriptor under the supplied descriptor context. The framework calls this
-    /// only for formats it knows the converter is registered for; the returned descriptor describes the
-    /// converter's terms for that context (today: buffer requirements; future: dispatch shape, cache keys).
-    /// Text-format converters must read <see cref="PgConversionContext.TextEncoding"/> via
-    /// <see cref="DescriptorContext.ConversionContext"/> for any encoding-dependent sizing rather than
-    /// reaching into <c>PgSerializerOptions</c> directly — that keeps converters insulated from any future
-    /// dynamic-encoding flow.
+    /// Computes the converter's descriptor under the supplied descriptor context.
+    /// The framework calls this in the context of the format this converter is registered for.
+    /// The returned descriptor describes the converter's attributes for that context.
+    /// Encoding dependent text-format converters can read <see cref="PgConversionContext.TextEncoding"/> via
+    /// <see cref="DescriptorContext.ConversionContext"/>.
     /// </summary>
     /// <remarks>
-    /// The virtual default returns <see cref="BufferRequirements.Streaming"/> — the conservative shape an
-    /// uninformed streaming converter would advertise. Override to declare a tighter shape (fixed-size,
-    /// upper-bound, invariant).
+    /// The default implementation returns <see cref="BufferRequirements.Streaming"/>.
+    /// Override to declare a tighter shape (fixed-size, upper-bound, invariant).
     /// </remarks>
     public virtual ConverterDescriptor GetDescriptor(in DescriptorContext context)
     {
@@ -677,13 +674,7 @@ public readonly struct DescriptorContext
     public PgConversionContext ConversionContext { get; init; }
 }
 
-/// <summary>
-/// A converter's description of itself for a given <see cref="DescriptorContext"/>. Today carries
-/// <see cref="BufferRequirements"/>; grows as future converter-static facts (dispatch shape, cache keys,
-/// fallback hints) become useful. No <c>IsSupported</c> flag — format support is registration-time, the
-/// framework only calls <see cref="PgConverter.GetDescriptor"/> for formats it knows the converter is
-/// registered for, so every call returns a meaningful descriptor.
-/// </summary>
+/// A converter's description of itself for a given <see cref="DescriptorContext"/>. An invariant descriptor otherwise.
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct ConverterDescriptor
 {
@@ -695,7 +686,7 @@ public readonly struct ConverterDescriptor
     /// Use only when your <see cref="PgConverter.GetDescriptor"/> implementation does not read any field
     /// from the <see cref="DescriptorContext"/> (or its <see cref="PgConversionContext"/>) and returns the
     /// same descriptor on every call. If any branch of your implementation would return a context-dependent
-    /// descriptor, return a plain <c>new ConverterDescriptor { BufferRequirements = ... }</c> instead — the
+    /// descriptor, return a plain <c>new ConverterDescriptor { BufferRequirements = ... }</c> instead. The
     /// invariant template must apply to all returns from the override, not just some of them.
     /// </remarks>
     public static ConverterDescriptor Invariant { get; } = new() { IsInvariant = true };
@@ -704,9 +695,7 @@ public readonly struct ConverterDescriptor
 
     /// <summary>
     /// True when this descriptor was constructed from <see cref="Invariant"/>. Composers may cache such
-    /// descriptors at construction; otherwise composers must re-resolve per call. The flag is structurally
-    /// gated — the only way to land in the invariant state is via the named template, so a plain
-    /// <c>new ConverterDescriptor { ... }</c> always lands in the safe-by-default (non-invariant) state.
+    /// descriptors at construction, otherwise composers must re-resolve per call.
     /// </summary>
     public bool IsInvariant { get; private init; }
 }

--- a/src/Npgsql/Internal/PgConverter.cs
+++ b/src/Npgsql/Internal/PgConverter.cs
@@ -674,7 +674,7 @@ public readonly struct DescriptorContext
     public PgConversionContext ConversionContext { get; init; }
 }
 
-/// A converter's description of itself for a given <see cref="DescriptorContext"/>. An invariant descriptor otherwise.
+/// A converter's description of itself for a given <see cref="DescriptorContext"/> (or invariant).
 [Experimental(NpgsqlDiagnostics.ConvertersExperimental)]
 public readonly struct ConverterDescriptor
 {

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -94,24 +94,30 @@ public abstract class PgTypeInfo
     }
 
     /// <summary>
-    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field.
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for a field with no metadata hints — equivalent to passing
+    /// an empty <see cref="ProviderFieldContext"/>. Used by call sites that have no name or type modifier
+    /// to thread (nested readers, record fields, binary export).
     /// </summary>
-    /// <param name="field">The field whose metadata drives the concrete type info selection.</param>
+    public PgConcreteTypeInfo MakeConcreteForField() => MakeConcreteForField(new ProviderFieldContext());
+
+    /// <summary>
+    /// Makes a <see cref="PgConcreteTypeInfo"/> for the given field context.
+    /// </summary>
+    /// <param name="context">The field metadata that drives the concrete type info selection.</param>
     /// <returns>The <see cref="PgConcreteTypeInfo"/> to use for the field.</returns>
     /// <remarks>
     /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
-    /// using the field's metadata (e.g. <see cref="Field.PgTypeId"/>) to select the appropriate concrete type info.
+    /// using the field metadata to select the appropriate concrete type info. The provider is assumed to be decided
+    /// (carry a non-null <see cref="PgTypeInfo.PgTypeId"/>) — read-side resolution always produces decided infos.
     /// </remarks>
-    public PgConcreteTypeInfo MakeConcreteForField(Field field)
+    public PgConcreteTypeInfo MakeConcreteForField(in ProviderFieldContext context)
     {
         if (this is PgConcreteTypeInfo concrete)
             return concrete;
 
-        // Decided providers skip GetDefault's validation. The prior GetForField call already validated
-        // the id. Undecided providers thread it so GetDefaultCore can dispatch on it.
+        // The provider's own PgTypeId is the only id input — null to GetDefault uses it.
         var providerTypeInfo = (PgProviderTypeInfo)this;
-        return providerTypeInfo.GetForField(field)
-               ?? providerTypeInfo.GetDefault(providerTypeInfo.PgTypeId is null ? field.PgTypeId : null);
+        return providerTypeInfo.GetForField(context) ?? providerTypeInfo.GetDefault(null);
     }
 
     /// <summary>
@@ -259,12 +265,11 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return _defaultConcrete;
     }
 
-    public PgConcreteTypeInfo? GetForField(Field field)
+    public PgConcreteTypeInfo? GetForField(in ProviderFieldContext context)
     {
-        if (PgTypeId is { } decidedId && field.PgTypeId != decidedId)
-            ThrowUnexpectedPgTypeId(nameof(field));
-
-        var result = _typeInfoProvider.GetForField(field);
+        var result = _typeInfoProvider.GetForField(context);
+        if (result is not null && PgTypeId is { } decidedId && result.PgTypeId != decidedId)
+            ThrowUnexpectedPgTypeId(nameof(result));
         if (result is not null)
         {
             object? writeState = null;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -344,7 +344,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
         }
 
-        return _typeInfoProvider.GetForValueAsNestedObject(context, value, out writeState);
+        return _typeInfoProvider.GetForValueAsNestedObject(contextRef, value, out writeState);
     }
 
     public static PgConcreteTypeInfoProvider GetProvider(PgProviderTypeInfo instance) => instance._typeInfoProvider;

--- a/src/Npgsql/Internal/PgTypeInfo.cs
+++ b/src/Npgsql/Internal/PgTypeInfo.cs
@@ -139,7 +139,7 @@ public abstract class PgTypeInfo
     /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
     /// using the value and the supplied context to select the appropriate concrete type info.
     /// </remarks>
-    public PgConcreteTypeInfo MakeConcreteForValue<T>(ProviderValueContext context, T? value, out object? writeState)
+    public PgConcreteTypeInfo MakeConcreteForValue<T>(in ProviderValueContext context, T? value, out object? writeState)
     {
         if (this is PgConcreteTypeInfo concrete)
         {
@@ -185,7 +185,7 @@ public abstract class PgTypeInfo
     /// When this instance is already concrete it is returned directly; otherwise the underlying provider is consulted
     /// using the value to select the appropriate concrete type info.
     /// </remarks>
-    public PgConcreteTypeInfo MakeConcreteForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
+    public PgConcreteTypeInfo MakeConcreteForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
     {
         if (this is PgConcreteTypeInfo concrete)
         {
@@ -273,13 +273,16 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
         return result;
     }
 
-    public PgConcreteTypeInfo? GetForValue<T>(ProviderValueContext context, T? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValue<T>(in ProviderValueContext context, T? value, out object? writeState)
     {
+        scoped ref readonly var contextRef = ref context;
+        ProviderValueContext effectiveContext;
         if (PgTypeId is { } pgTypeId)
         {
             if (context.ExpectedPgTypeId is not { } expectedId)
             {
-                context = context with { ExpectedPgTypeId = pgTypeId };
+                effectiveContext = context with { ExpectedPgTypeId = pgTypeId };
+                contextRef = ref effectiveContext;
             }
             else if (pgTypeId != expectedId)
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
@@ -287,7 +290,7 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
 
         writeState = null;
         var result = _typeInfoProvider is PgConcreteTypeInfoProvider<T> providerT
-            ? providerT.GetForValue(context, value, out writeState)
+            ? providerT.GetForValue(contextRef, value, out writeState)
             : ThrowNotSupportedType(typeof(T));
 
         if (result is not null)
@@ -300,31 +303,37 @@ public sealed class PgProviderTypeInfo : PgTypeInfo
                 : $"PgProviderTypeInfo is incompatible with type {type}");
     }
 
-    public PgConcreteTypeInfo? GetForValueAsObject(ProviderValueContext context, object? value, out object? writeState)
+    public PgConcreteTypeInfo? GetForValueAsObject(in ProviderValueContext context, object? value, out object? writeState)
     {
+        scoped ref readonly var contextRef = ref context;
+        ProviderValueContext effectiveContext;
         if (PgTypeId is { } pgTypeId)
         {
             if (context.ExpectedPgTypeId is not { } expectedId)
             {
-                context = context with { ExpectedPgTypeId = pgTypeId };
+                effectiveContext = context with { ExpectedPgTypeId = pgTypeId };
+                contextRef = ref effectiveContext;
             }
             else if (pgTypeId != expectedId)
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));
         }
 
-        var result = _typeInfoProvider.GetForValueAsObject(context, value, out writeState);
+        var result = _typeInfoProvider.GetForValueAsObject(contextRef, value, out writeState);
         if (result is not null)
             ValidateConcrete(nameof(PgConcreteTypeInfoProvider.GetForValueAsObject), result, ref writeState);
         return result;
     }
 
-    internal PgConcreteTypeInfo? GetForValueAsNestedObject(ProviderValueContext context, object? value, out object? writeState)
+    internal PgConcreteTypeInfo? GetForValueAsNestedObject(in ProviderValueContext context, object? value, out object? writeState)
     {
+        scoped ref readonly var contextRef = ref context;
+        ProviderValueContext effectiveContext;
         if (PgTypeId is { } pgTypeId)
         {
             if (context.ExpectedPgTypeId is not { } expectedId)
             {
-                context = context with { ExpectedPgTypeId = pgTypeId };
+                effectiveContext = context with { ExpectedPgTypeId = pgTypeId };
+                contextRef = ref effectiveContext;
             }
             else if (pgTypeId != expectedId)
                 ThrowUnexpectedPgTypeId(nameof(context.ExpectedPgTypeId));

--- a/src/Npgsql/Internal/Postgres/Field.cs
+++ b/src/Npgsql/Internal/Postgres/Field.cs
@@ -9,6 +9,4 @@ public readonly struct Field(string name, PgTypeId pgTypeId, int typeModifier)
     public string Name { get; init; } = name;
     public PgTypeId PgTypeId { get; init; } = pgTypeId;
     public int TypeModifier { get; init; } = typeModifier;
-
-    public static Field CreateUnspecified(PgTypeId pgTypeId) => new("?", pgTypeId, -1);
 }

--- a/src/Npgsql/NpgsqlBinaryExporter.cs
+++ b/src/Npgsql/NpgsqlBinaryExporter.cs
@@ -346,9 +346,12 @@ public sealed class NpgsqlBinaryExporter : ICancelable
             var typeInfo = options.GetTypeInfoInternal(type, pgTypeId)
                            ?? throw new NotSupportedException($"Reading is not supported for type '{type}'{(npgsqlDbType is null ? "" : $" and NpgsqlDbType '{npgsqlDbType}'")}");
 
-            // Binary export has no type info so we only do caller-directed interpretation of data.
-            var concreteTypeInfo = typeInfo.MakeConcreteForField(
-                Field.CreateUnspecified(typeInfo.PgTypeId ?? ((PgProviderTypeInfo)typeInfo).GetDefault(null).PgTypeId));
+            // Binary export has no type info so we only do caller-directed interpretation of data. An undecided
+            // provider info (caller didn't supply an NpgsqlDbType for a polymorphic CLR type) has no id for
+            // GetForField to dispatch on; resolve straight to the provider's default.
+            var concreteTypeInfo = typeInfo is PgProviderTypeInfo { PgTypeId: null } undecided
+                ? undecided.GetDefault(null)
+                : typeInfo.MakeConcreteForField();
             if (!concreteTypeInfo.SupportsReading)
                 AdoSerializerHelpers.ThrowReadingNotSupported(type, options, concreteTypeInfo.PgTypeId, resolved: true);
             return new(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat.Binary));

--- a/src/Npgsql/NpgsqlNestedDataReader.cs
+++ b/src/Npgsql/NpgsqlNestedDataReader.cs
@@ -42,18 +42,20 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         public ReadConversionContext LastInfo { get; init; }
         public PgConcreteTypeInfo ObjectTypeInfo { get; }
         public PgFieldBinding ObjectBinding { get; }
+        // Composite columns carry their declared field name; record columns are anonymous (Name is null).
+        // TypeModifier isn't threaded yet — PostgresCompositeType.Field doesn't load attypmod.
+        public ProviderFieldContext FieldContext { get; }
 
-        public NestedColumnInfo(PostgresType postgresType, int bufferPos, PgTypeInfo objectTypeInfo, DataFormat format)
+        public NestedColumnInfo(PostgresType postgresType, int bufferPos, PgTypeInfo objectTypeInfo, DataFormat format, string? fieldName)
         {
             PostgresType = postgresType;
             BufferPos = bufferPos;
-            ObjectTypeInfo = objectTypeInfo.MakeConcreteForField(Field.CreateUnspecified(objectTypeInfo.Options.ToCanonicalTypeId(postgresType)));
+            FieldContext = new ProviderFieldContext { Name = fieldName };
+            ObjectTypeInfo = objectTypeInfo.MakeConcreteForField(FieldContext);
             if (!ObjectTypeInfo.SupportsReading)
                 AdoSerializerHelpers.ThrowReadingNotSupported(typeof(object), objectTypeInfo.Options, ObjectTypeInfo.PgTypeId, resolved: true);
             ObjectBinding = ObjectTypeInfo.BindField(format);
         }
-
-        public Field Field => Field.CreateUnspecified(ObjectTypeInfo.PgTypeId);
     }
 
     PgReader PgReader => _outermostReader.Buffer.PgReader;
@@ -374,12 +376,13 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
         {
             var typeOid = PgReader.ReadUInt32();
             var bufferPos = PgReader.GetFieldOffset(this);
+            var fieldName = _compositeType?.Fields[i].Name;
             if (i >= _columns.Count)
             {
                 var pgType = SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
                 var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
                 _columns.Add(new NestedColumnInfo(pgType, bufferPos,
-                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat));
+                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat, fieldName));
             }
             else
             {
@@ -388,7 +391,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
                     : SerializerOptions.DatabaseInfo.GetPostgresType(typeOid);
                 var pgTypeId = SerializerOptions.ToCanonicalTypeId(pgType);
                 _columns[i] = new NestedColumnInfo(pgType, bufferPos,
-                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat);
+                    AdoSerializerHelpers.GetTypeInfoForReading(typeof(object), pgTypeId, SerializerOptions), DataFormat, fieldName);
             }
 
             var columnLen = PgReader.ReadInt32();
@@ -500,7 +503,7 @@ public sealed class NpgsqlNestedDataReader : DbDataReader
 
         var typeId = SerializerOptions.ToCanonicalTypeId(nestedColumn.PostgresType);
         var typeInfo = AdoSerializerHelpers.GetTypeInfoForReading(type, typeId, SerializerOptions);
-        var concreteTypeInfo = typeInfo.MakeConcreteForField(nestedColumn.Field);
+        var concreteTypeInfo = typeInfo.MakeConcreteForField(nestedColumn.FieldContext);
         if (!concreteTypeInfo.SupportsReading)
             AdoSerializerHelpers.ThrowReadingNotSupported(type, SerializerOptions, typeId, resolved: true);
         var columnInfo = new ReadConversionContext(concreteTypeInfo, concreteTypeInfo.BindField(DataFormat));

--- a/test/Npgsql.Tests/WriteStateTests.cs
+++ b/test/Npgsql.Tests/WriteStateTests.cs
@@ -549,7 +549,7 @@ public class WriteStateTests : TestBase
 
         protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId) => GetOrCreate();
 
-        protected override PgConcreteTypeInfo GetForValueCore(ProviderValueContext context, int value, ref object? writeState)
+        protected override PgConcreteTypeInfo GetForValueCore(in ProviderValueContext context, int value, ref object? writeState)
         {
             writeState = _tracker.NewState();
             return GetOrCreate();
@@ -724,7 +724,7 @@ public class WriteStateTests : TestBase
 
         protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId) => GetOrCreate();
 
-        protected override PgConcreteTypeInfo GetForValueCore(ProviderValueContext context, int value, ref object? writeState)
+        protected override PgConcreteTypeInfo GetForValueCore(in ProviderValueContext context, int value, ref object? writeState)
         {
             if (produceProviderState)
                 writeState = "provider-state";
@@ -807,7 +807,7 @@ public class WriteStateTests : TestBase
 
         protected override PgConcreteTypeInfo GetDefaultCore(PgTypeId? pgTypeId) => GetOrCreate();
 
-        protected override PgConcreteTypeInfo GetForValueCore(ProviderValueContext context, int value, ref object? writeState)
+        protected override PgConcreteTypeInfo GetForValueCore(in ProviderValueContext context, int value, ref object? writeState)
         {
             writeState = tracker;
             return GetOrCreate();


### PR DESCRIPTION
This PR:

- Passes all provider contexts by `in` (this meaningfully moves the needle on provider backed array parameter bindings)
- Renames (internal only) PgComposingTypeInfoProvider apis to better match the actual intent
- Removes Field from the provider apis (since these are net new for 11.0 anyway) in favor of a provider specific context type