### PR TITLE
Use ThrowHelper for inline exception throws in NpgsqlConnection

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -639,7 +639,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             try
             {
                 if (EnlistedTransaction.TransactionInformation.Status == System.Transactions.TransactionStatus.Active)
-                    throw new InvalidOperationException($"Already enlisted to transaction (localid={EnlistedTransaction.TransactionInformation.LocalIdentifier})");
+                    ThrowHelper.ThrowInvalidOperationException($"Already enlisted to transaction (localid={EnlistedTransaction.TransactionInformation.LocalIdentifier})");
             }
             catch (ObjectDisposedException)
             {
@@ -1085,7 +1085,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         ArgumentNullException.ThrowIfNull(copyFromCommand);
         if (!IsValidCopyCommand(copyFromCommand))
-            throw new ArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
+            ThrowHelper.ThrowArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
 
         CheckReady();
         var connector = Connector!;
@@ -1144,7 +1144,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         ArgumentNullException.ThrowIfNull(copyToCommand);
         if (!IsValidCopyCommand(copyToCommand))
-            throw new ArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
+            ThrowHelper.ThrowArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
 
         CheckReady();
         var connector = Connector!;
@@ -1209,7 +1209,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         ArgumentNullException.ThrowIfNull(copyFromCommand);
         if (!IsValidCopyCommand(copyFromCommand))
-            throw new ArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
+            ThrowHelper.ThrowArgumentException("Must contain a COPY FROM STDIN command!", nameof(copyFromCommand));
 
         CheckReady();
         var connector = Connector!;
@@ -1275,7 +1275,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         ArgumentNullException.ThrowIfNull(copyToCommand);
         if (!IsValidCopyCommand(copyToCommand))
-            throw new ArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
+            ThrowHelper.ThrowArgumentException("Must contain a COPY TO STDOUT command!", nameof(copyToCommand));
 
         CheckReady();
         var connector = Connector!;
@@ -1341,7 +1341,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     {
         ArgumentNullException.ThrowIfNull(copyCommand);
         if (!IsValidCopyCommand(copyCommand))
-            throw new ArgumentException("Must contain a COPY TO STDOUT OR COPY FROM STDIN command!", nameof(copyCommand));
+            ThrowHelper.ThrowArgumentException("Must contain a COPY TO STDOUT OR COPY FROM STDIN command!", nameof(copyCommand));
 
         CheckReady();
         var connector = Connector!;
@@ -1399,7 +1399,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     public bool Wait(int timeout)
     {
         if (timeout != -1 && timeout < 0)
-            throw new ArgumentException("Argument must be -1, 0 or positive", nameof(timeout));
+            ThrowHelper.ThrowArgumentException("Argument must be -1, 0 or positive", nameof(timeout));
 
         CheckReady();
 


### PR DESCRIPTION
Part 2 of #2237. Picking up after vonzshik's #4872.

Replaced 7 inline `throw new ...` calls in `NpgsqlConnection.cs` with the existing `ThrowHelper` helpers. Same exception types and messages, pure mechanical change.

Skipped two:
- The switch in `Close`: `[DoesNotReturn]` doesn't satisfy CS0163, so swapping needs an unreachable `break;` after the call. Felt noisier than just leaving the throw.
- `GetSchema` uses the `ArgumentOutOfRangeException(paramName, actualValue, message)` ctor, and there's no matching ThrowHelper for that overload today.

Easy to widen to other files (NpgsqlCommand etc.) or add the missing helper for that ctor in a follow-up, if useful.
