### PR TITLE
Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,6 +378,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' && startsWith(github.repository, 'npgsql/') && needs.build.outputs.is_release == 'true'
     environment: nuget.org
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -397,6 +400,12 @@ jobs:
 
       # TODO: Create a release
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: Npgsql
+
       - name: Publish to nuget.org
-        run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_ORG_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "*.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
         working-directory: nupkgs


### PR DESCRIPTION
## Summary
- switch the nuget.org release job from the long-lived `NUGET_ORG_API_KEY` secret to NuGet Trusted Publishing via `NuGet/login@v1`
- grant the release job `id-token: write` so GitHub Actions can mint the OIDC token
- publish with the short-lived API key returned by NuGet.org

## Required NuGet.org setup
Before the next tag release, add a NuGet.org Trusted Publishing policy for the `Npgsql` owner matching:

| Field | Value |
| --- | --- |
| Repository owner | `npgsql` |
| Repository | `npgsql` |
| Workflow file | `build.yml` |
| Environment | `nuget.org` |

The workflow uses `user: Npgsql` for the NuGet login action.
