### PR TITLE
Throw NpgsqlException instead of InvalidOperationException on a broken connection

### DIFF
--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -3115,7 +3115,6 @@ enum ConnectorState
 
     /// <summary>
     /// The connection was broken because an unexpected error occurred which left it in an unknown state.
-    /// This state isn't implemented yet.
     /// </summary>
     Broken,
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -1487,8 +1487,11 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         case ConnectionState.Open | ConnectionState.Fetching:
         case ConnectionState.Connecting:
             return;
-        case ConnectionState.Closed:
         case ConnectionState.Broken:
+            ThrowHelper.ThrowNpgsqlException(
+                "The connection was previously broken because of an exception (see the logs for details).");
+            return;
+        case ConnectionState.Closed:
             ThrowHelper.ThrowInvalidOperationException("Connection is not open");
             return;
         default:
@@ -1518,8 +1521,11 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         case ConnectionState.Open:
         case ConnectionState.Connecting:  // We need to do type loading as part of connecting
             return;
-        case ConnectionState.Closed:
         case ConnectionState.Broken:
+            ThrowHelper.ThrowNpgsqlException(
+                "The connection was previously broken because of an exception (see the logs for details).");
+            return;
+        case ConnectionState.Closed:
             ThrowHelper.ThrowInvalidOperationException("Connection is not open");
             return;
         case ConnectionState.Open | ConnectionState.Executing:

--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -145,6 +145,21 @@ public class ConnectionTests : TestBase
         Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
     }
 
+    [Test]
+    [IssueLink("https://github.com/npgsql/npgsql/issues/5605")]
+    public async Task Broken_connection_throws_NpgsqlException_not_InvalidOperationException()
+    {
+        await using var dataSource = CreateDataSource();
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        conn.Connector!.Break(new IOException("Simulated connection break"));
+        Assert.That(conn.FullState, Is.EqualTo(ConnectionState.Broken));
+
+        // A broken connection must surface as NpgsqlException (catchable as a connection error)
+        // rather than InvalidOperationException. See #5605.
+        Assert.Throws<NpgsqlException>(() => conn.BeginTransaction());
+    }
+
     #region Connection Errors
 
 #if IGNORE


### PR DESCRIPTION
Fixes #5605.

## Problem
When a connection is broken (e.g. by a keepalive failure), `CheckReady` / `CheckOpen` treated the `Broken` state the same as `Closed` and threw `InvalidOperationException("Connection is not open")`. Connection errors are supposed to surface as `NpgsqlException`, so callers can catch them at a higher level, dispose their DB resources and reconnect — `InvalidOperationException` can't reasonably be handled that way.

## Change
- Split the `Broken` case from `Closed` in both `CheckReady` and `CheckOpen`. `Broken` now throws `NpgsqlException`; `Closed` (never opened / closed after normal use) keeps throwing `InvalidOperationException("Connection is not open")`.
- The message points to the logs: as @NinoFloris noted on the issue, the original break reason isn't reachable from the connection (the connector is detached on break), but it is logged when the connector breaks.
- Removed a stale doc note on `ConnectorState.Broken` ("This state isn't implemented yet").

Re: the two questions in my issue comment — the original exception can't be attached as `InnerException` at the connection level without extra plumbing (glad to add that as a follow-up if you'd like), and both `CheckReady` and `CheckOpen` are covered.

## Behavioral change
This changes the exception **type** for operations on a broken connection from `InvalidOperationException` to `NpgsqlException` (`NpgsqlException : DbException`, so `catch (DbException)` now catches it while `catch (InvalidOperationException)` no longer does). Flagging in case it warrants the `breaking change` label / a release-notes entry — it targets 11.0.

## Tests
Added `Broken_connection_throws_NpgsqlException_not_InvalidOperationException` in `ConnectionTests`. Ran it plus the full `ConnectionTests` and transaction test classes against a local PG 17: 224 passed, 0 failed (only the expected platform skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
