### PR TITLE
Use PlatformNames contants for platform exclusions

### DIFF
--- a/test/Npgsql.Tests/ConnectionTests.cs
+++ b/test/Npgsql.Tests/ConnectionTests.cs
@@ -526,7 +526,7 @@ public class ConnectionTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = "MacOsX", Reason = "Fails only on mac, needs to be investigated")]
+    [Platform(Exclude = PlatformNames.MacOSX, Reason = "Fails only on mac, needs to be investigated")]
     public async Task Unix_abstract_domain_socket()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/test/Npgsql.Tests/CopyTests.cs
+++ b/test/Npgsql.Tests/CopyTests.cs
@@ -1326,7 +1326,7 @@ INSERT INTO {table} (field_text, field_int4) VALUES ('HELLO', 1)");
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/5209")]
-    [Platform(Exclude = "MacOsX", Reason = "Write might not throw an exception")]
+    [Platform(Exclude = PlatformNames.MacOSX, Reason = "Write might not throw an exception")]
     public async Task RawBinaryCopy_write_nre([Values] bool async)
     {
         await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -241,7 +241,7 @@ public class MultipleHostsTests : TestBase
             _ = await postmasters[i].WaitForServerConnection();
     }
 
-    [Test, Platform(Exclude = "MacOsX", Reason = "#3786")]
+    [Test, Platform(Exclude = PlatformNames.MacOSX, Reason = "#3786")]
     public void All_hosts_are_down()
     {
         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -241,7 +241,7 @@ public class MultipleHostsTests : TestBase
             _ = await postmasters[i].WaitForServerConnection();
     }
 
-    [Test, Platform(Exclude = PlatformNames.MacOSX, Reason = "#3786")]
+    [Test, Platform(Exclude = PlatformNames.MacOSX, Reason = "https://github.com/npgsql/npgsql/issues/3786")]
     public void All_hosts_are_down()
     {
         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -254,7 +254,7 @@ public class SecurityTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = "Win", Reason = "Postgresql doesn't close connection correctly on windows which might result in missing error message")]
+    [Platform(Exclude = PlatformNames.Win, Reason = "Postgresql doesn't close connection correctly on windows which might result in missing error message")]
     public async Task Connect_with_only_non_ssl_allowed_user([Values] bool keepAlive)
     {
         try
@@ -513,7 +513,7 @@ public class SecurityTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = "MacOsX", Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
+    [Platform(Exclude = PlatformNames.MacOSX, Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
     public async Task Connect_with_verify_and_ca_cert([Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode)
     {
         if (!IsOnBuildServer)
@@ -529,7 +529,7 @@ public class SecurityTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = "MacOsX", Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
+    [Platform(Exclude = PlatformNames.MacOSX, Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
     public async Task Connect_with_verify_check_host([Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode)
     {
         if (!IsOnBuildServer)
@@ -554,7 +554,7 @@ public class SecurityTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = "MacOsX", Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
+    [Platform(Exclude = PlatformNames.MacOSX, Reason = "Mac requires explicit opt-in to receive CA certificate in TLS handshake")]
     public async Task Connect_with_verify_and_multiple_ca_cert([Values(SslMode.VerifyCA, SslMode.VerifyFull)] SslMode sslMode, [Values] bool realCaFirst)
     {
         if (!IsOnBuildServer)

--- a/test/Npgsql.Tests/SecurityTests.cs
+++ b/test/Npgsql.Tests/SecurityTests.cs
@@ -254,7 +254,7 @@ public class SecurityTests : TestBase
     }
 
     [Test]
-    [Platform(Exclude = PlatformNames.Win, Reason = "Postgresql doesn't close connection correctly on windows which might result in missing error message")]
+    [Platform(Exclude = PlatformNames.Win, Reason = "PostgreSQL doesn't close connection correctly on Windows which might result in missing error message")]
     public async Task Connect_with_only_non_ssl_allowed_user([Values] bool keepAlive)
     {
         try


### PR DESCRIPTION
MacOsX with a lowercase s is just too ugly 🙈