### PR TITLE
Fix deprecated GitHub Actions outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,10 +335,10 @@ jobs:
         run: |
           if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
               echo "Release tag detected"
-              echo "::set-output name=is_release::true"
+              echo "is_release=true" >> "$GITHUB_OUTPUT"
               if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+.*- ]]; then
                   echo "Prerelease tag detected"
-                  echo "::set-output name=is_prerelease::true"
+                  echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
               fi
           fi
 


### PR DESCRIPTION
## Summary
- replace deprecated `::set-output` commands in the tag analysis step
- write release and prerelease outputs via `$GITHUB_OUTPUT`\n\nThis removes the GitHub Actions outputs deprecation warning while preserving the existing job outputs.