### PR TITLE
reduce allocations in NpgsqlParameterCollection.AddRange

### DIFF
--- a/src/Npgsql/NpgsqlParameterCollection.cs
+++ b/src/Npgsql/NpgsqlParameterCollection.cs
@@ -589,6 +589,7 @@ public sealed class NpgsqlParameterCollection : DbParameterCollection, IList<Npg
     public override void AddRange(Array values)
     {
         ArgumentNullException.ThrowIfNull(values);
+        InternalList.EnsureCapacity(InternalList.Count + values.Length);
 
         foreach (var parameter in values)
             Add(Cast(parameter));

--- a/test/Npgsql.Benchmarks/ParameterCollection.cs
+++ b/test/Npgsql.Benchmarks/ParameterCollection.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace Npgsql.Benchmarks;
+
+[MemoryDiagnoser]
+public class ParameterCollection
+{
+    private NpgsqlParameter[] manyParameters = [];
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        List<NpgsqlParameter> parameters = [];
+
+        for (var i = 0; i < 2000; i++)
+        {
+            parameters.Add(new NpgsqlParameter());
+        }
+
+        manyParameters = parameters.ToArray();
+    }
+
+    [Benchmark]
+    public void AddRange()
+    {
+        NpgsqlParameterCollection parameterCollection = [];
+        parameterCollection.AddRange(manyParameters);
+    }
+}


### PR DESCRIPTION
Call `EnsureCapacity` before inserting the items to avoid the list being resized multiple times. We noticed this in a GC trace with a query that has a lot of parameters for an `IN()` clause.

Benchmark before:

| Method   | Mean     | Error    | StdDev   | Allocated |
|--------- |---------:|---------:|---------:|----------:|
| AddRange | 41.69 us | 0.335 us | 0.297 us |   40.3 KB |

Benchmark after:

| Method   | Mean     | Error    | StdDev   | Allocated |
|--------- |---------:|---------:|---------:|----------:|
| AddRange | 40.19 us | 0.441 us | 0.345 us |  15.82 KB |