### PR TITLE
Add NpgsqlTransactionOptions for read-only/deferrable transactions

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -595,7 +595,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         using var _ = connector.StartUserAction(cancellationToken);
 
         connector.Transaction ??= new NpgsqlTransaction(connector);
-        await connector.Transaction.Init(async, level, options, cancellationToken).ConfigureAwait(false);
+        connector.Transaction.Init(level, options);
         return connector.Transaction;
     }
 

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -560,9 +560,28 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <returns>A <see cref="NpgsqlTransaction"/> object representing the new transaction.</returns>
     /// <remarks>Nested transactions are not supported.</remarks>
     public new NpgsqlTransaction BeginTransaction(IsolationLevel level)
-        => BeginTransaction(async: false, level, CancellationToken.None).GetAwaiter().GetResult();
+        => BeginTransaction(level, NpgsqlTransactionOptions.None);
 
-    async ValueTask<NpgsqlTransaction> BeginTransaction(bool async, IsolationLevel level, CancellationToken cancellationToken)
+    /// <summary>
+    /// Begins a database transaction with the specified options.
+    /// </summary>
+    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
+    /// <returns>A <see cref="NpgsqlTransaction"/> object representing the new transaction.</returns>
+    /// <remarks>Nested transactions are not supported.</remarks>
+    public NpgsqlTransaction BeginTransaction(NpgsqlTransactionOptions options)
+        => BeginTransaction(IsolationLevel.Unspecified, options);
+
+    /// <summary>
+    /// Begins a database transaction with the specified isolation level and options.
+    /// </summary>
+    /// <param name="level">The isolation level under which the transaction should run.</param>
+    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
+    /// <returns>A <see cref="NpgsqlTransaction"/> object representing the new transaction.</returns>
+    /// <remarks>Nested transactions are not supported.</remarks>
+    public NpgsqlTransaction BeginTransaction(IsolationLevel level, NpgsqlTransactionOptions options)
+        => BeginTransaction(async: false, level, options, CancellationToken.None).GetAwaiter().GetResult();
+
+    async ValueTask<NpgsqlTransaction> BeginTransaction(bool async, IsolationLevel level, NpgsqlTransactionOptions options, CancellationToken cancellationToken)
     {
         if (level == IsolationLevel.Chaos)
             ThrowHelper.ThrowNotSupportedException($"Unsupported IsolationLevel: {nameof(IsolationLevel.Chaos)}");
@@ -581,7 +600,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         using var _ = connector.StartUserAction(cancellationToken);
 
         connector.Transaction ??= new NpgsqlTransaction(connector);
-        connector.Transaction.Init(level);
+        connector.Transaction.Init(level, options);
         return connector.Transaction;
     }
 
@@ -625,7 +644,32 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// Nested transactions are not supported.
     /// </remarks>
     public new ValueTask<NpgsqlTransaction> BeginTransactionAsync(IsolationLevel level, CancellationToken cancellationToken = default)
-        => BeginTransaction(async: true, level, cancellationToken);
+        => BeginTransactionAsync(level, NpgsqlTransactionOptions.None, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously begins a database transaction with the specified options.
+    /// </summary>
+    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
+    /// <param name="cancellationToken">
+    /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
+    /// </param>
+    /// <returns>A task whose <see cref="ValueTask{T}.Result"/> property is an object representing the new transaction.</returns>
+    /// <remarks>Nested transactions are not supported.</remarks>
+    public ValueTask<NpgsqlTransaction> BeginTransactionAsync(NpgsqlTransactionOptions options, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(IsolationLevel.Unspecified, options, cancellationToken);
+
+    /// <summary>
+    /// Asynchronously begins a database transaction with the specified isolation level and options.
+    /// </summary>
+    /// <param name="level">The isolation level under which the transaction should run.</param>
+    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
+    /// <param name="cancellationToken">
+    /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
+    /// </param>
+    /// <returns>A task whose <see cref="ValueTask{T}.Result"/> property is an object representing the new transaction.</returns>
+    /// <remarks>Nested transactions are not supported.</remarks>
+    public ValueTask<NpgsqlTransaction> BeginTransactionAsync(IsolationLevel level, NpgsqlTransactionOptions options, CancellationToken cancellationToken = default)
+        => BeginTransaction(async: true, level, options, cancellationToken);
 
     /// <summary>
     /// Enlist transaction.

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -563,21 +563,16 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         => BeginTransaction(level, NpgsqlTransactionOptions.None);
 
     /// <summary>
-    /// Begins a database transaction with the specified options.
-    /// </summary>
-    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
-    /// <returns>A <see cref="NpgsqlTransaction"/> object representing the new transaction.</returns>
-    /// <remarks>Nested transactions are not supported.</remarks>
-    public NpgsqlTransaction BeginTransaction(NpgsqlTransactionOptions options)
-        => BeginTransaction(IsolationLevel.Unspecified, options);
-
-    /// <summary>
     /// Begins a database transaction with the specified isolation level and options.
     /// </summary>
     /// <param name="level">The isolation level under which the transaction should run.</param>
     /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
     /// <returns>A <see cref="NpgsqlTransaction"/> object representing the new transaction.</returns>
-    /// <remarks>Nested transactions are not supported.</remarks>
+    /// <remarks>
+    /// Nested transactions are not supported.
+    /// Note that there's no single-argument <c>options</c>-only overload: combined with the existing <see cref="IsolationLevel"/>
+    /// overloads, that would make calls like <c>BeginTransaction(default)</c> ambiguous.
+    /// </remarks>
     public NpgsqlTransaction BeginTransaction(IsolationLevel level, NpgsqlTransactionOptions options)
         => BeginTransaction(async: false, level, options, CancellationToken.None).GetAwaiter().GetResult();
 
@@ -600,7 +595,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         using var _ = connector.StartUserAction(cancellationToken);
 
         connector.Transaction ??= new NpgsqlTransaction(connector);
-        connector.Transaction.Init(level, options);
+        await connector.Transaction.Init(async, level, options, cancellationToken).ConfigureAwait(false);
         return connector.Transaction;
     }
 
@@ -645,18 +640,6 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// </remarks>
     public new ValueTask<NpgsqlTransaction> BeginTransactionAsync(IsolationLevel level, CancellationToken cancellationToken = default)
         => BeginTransactionAsync(level, NpgsqlTransactionOptions.None, cancellationToken);
-
-    /// <summary>
-    /// Asynchronously begins a database transaction with the specified options.
-    /// </summary>
-    /// <param name="options">Npgsql-specific options under which the transaction should run, e.g. read-only or deferrable.</param>
-    /// <param name="cancellationToken">
-    /// An optional token to cancel the asynchronous operation. The default value is <see cref="CancellationToken.None"/>.
-    /// </param>
-    /// <returns>A task whose <see cref="ValueTask{T}.Result"/> property is an object representing the new transaction.</returns>
-    /// <remarks>Nested transactions are not supported.</remarks>
-    public ValueTask<NpgsqlTransaction> BeginTransactionAsync(NpgsqlTransactionOptions options, CancellationToken cancellationToken = default)
-        => BeginTransactionAsync(IsolationLevel.Unspecified, options, cancellationToken);
 
     /// <summary>
     /// Asynchronously begins a database transaction with the specified isolation level and options.

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -76,35 +77,62 @@ public sealed class NpgsqlTransaction : DbTransaction
         _transactionLogger = connector.TransactionLogger;
     }
 
-    internal void Init(IsolationLevel isolationLevel = DefaultIsolationLevel)
+    internal void Init(IsolationLevel isolationLevel = DefaultIsolationLevel, NpgsqlTransactionOptions options = NpgsqlTransactionOptions.None)
     {
         Debug.Assert(isolationLevel != IsolationLevel.Chaos);
 
         if (!_connector.DatabaseInfo.SupportsTransactions)
             return;
 
-        switch (isolationLevel)
-        {
-        case IsolationLevel.RepeatableRead:
-        case IsolationLevel.Snapshot:
-            _connector.PrependInternalMessage(PregeneratedMessages.BeginTransRepeatableRead, 2);
-            break;
-        case IsolationLevel.Serializable:
-            _connector.PrependInternalMessage(PregeneratedMessages.BeginTransSerializable, 2);
-            break;
-        case IsolationLevel.ReadUncommitted:
-            // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still
-            // send as if.
-            _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadUncommitted, 2);
-            break;
-        case IsolationLevel.ReadCommitted:
-            _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadCommitted, 2);
-            break;
-        case IsolationLevel.Unspecified:
+        if (isolationLevel == IsolationLevel.Unspecified)
             isolationLevel = DefaultIsolationLevel;
-            goto case DefaultIsolationLevel;
-        default:
-            throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
+
+        if (options == NpgsqlTransactionOptions.None)
+        {
+            // Fast path: no Npgsql-specific options were requested, so we can use a pregenerated BEGIN message, avoiding any allocations.
+            switch (isolationLevel)
+            {
+            case IsolationLevel.RepeatableRead:
+            case IsolationLevel.Snapshot:
+                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransRepeatableRead, 2);
+                break;
+            case IsolationLevel.Serializable:
+                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransSerializable, 2);
+                break;
+            case IsolationLevel.ReadUncommitted:
+                // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still
+                // send as if.
+                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadUncommitted, 2);
+                break;
+            case IsolationLevel.ReadCommitted:
+                _connector.PrependInternalMessage(PregeneratedMessages.BeginTransReadCommitted, 2);
+                break;
+            default:
+                throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
+            }
+        }
+        else
+        {
+            var isolationLevelText = isolationLevel switch
+            {
+                IsolationLevel.RepeatableRead or IsolationLevel.Snapshot => "REPEATABLE READ",
+                IsolationLevel.Serializable => "SERIALIZABLE",
+                // PG doesn't really support ReadUncommitted, it's the same as ReadCommitted. But we still send as if.
+                IsolationLevel.ReadUncommitted => "READ UNCOMMITTED",
+                IsolationLevel.ReadCommitted => "READ COMMITTED",
+                _ => throw new NotSupportedException("Isolation level not supported: " + isolationLevel)
+            };
+
+            var sb = new StringBuilder("BEGIN TRANSACTION ISOLATION LEVEL ").Append(isolationLevelText);
+            if ((options & NpgsqlTransactionOptions.ReadOnly) != 0)
+                sb.Append(" READ ONLY");
+            if ((options & NpgsqlTransactionOptions.Deferrable) != 0)
+                sb.Append(" DEFERRABLE");
+
+            // Unlike the isolation levels above, these options can be combined in many ways, making it impractical to pregenerate
+            // messages for all combinations; the BEGIN statement is written out and sent like a regular (prepended) query instead.
+            _connector.WriteQuery(sb.ToString(), async: false).GetAwaiter().GetResult();
+            _connector.PendingPrependedResponses += 2;
         }
 
         _connector.TransactionStatus = TransactionStatus.Pending;

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -77,12 +77,12 @@ public sealed class NpgsqlTransaction : DbTransaction
         _transactionLogger = connector.TransactionLogger;
     }
 
-    internal void Init(IsolationLevel isolationLevel = DefaultIsolationLevel, NpgsqlTransactionOptions options = NpgsqlTransactionOptions.None)
+    internal Task Init(bool async, IsolationLevel isolationLevel, NpgsqlTransactionOptions options, CancellationToken cancellationToken = default)
     {
         Debug.Assert(isolationLevel != IsolationLevel.Chaos);
 
         if (!_connector.DatabaseInfo.SupportsTransactions)
-            return;
+            return Task.CompletedTask;
 
         if (isolationLevel == IsolationLevel.Unspecified)
             isolationLevel = DefaultIsolationLevel;
@@ -110,8 +110,14 @@ public sealed class NpgsqlTransaction : DbTransaction
             default:
                 throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
             }
+
+            FinishInit(isolationLevel);
+            return Task.CompletedTask;
         }
-        else
+
+        return InitWithOptions(async, isolationLevel, options, cancellationToken);
+
+        async Task InitWithOptions(bool async, IsolationLevel isolationLevel, NpgsqlTransactionOptions options, CancellationToken cancellationToken)
         {
             var isolationLevelText = isolationLevel switch
             {
@@ -131,10 +137,15 @@ public sealed class NpgsqlTransaction : DbTransaction
 
             // Unlike the isolation levels above, these options can be combined in many ways, making it impractical to pregenerate
             // messages for all combinations; the BEGIN statement is written out and sent like a regular (prepended) query instead.
-            _connector.WriteQuery(sb.ToString(), async: false).GetAwaiter().GetResult();
+            await _connector.WriteQuery(sb.ToString(), async, cancellationToken).ConfigureAwait(false);
             _connector.PendingPrependedResponses += 2;
-        }
 
+            FinishInit(isolationLevel);
+        }
+    }
+
+    void FinishInit(IsolationLevel isolationLevel)
+    {
         _connector.TransactionStatus = TransactionStatus.Pending;
         _isolationLevel = isolationLevel;
         IsDisposed = false;
@@ -143,6 +154,7 @@ public sealed class NpgsqlTransaction : DbTransaction
     }
 
     #endregion
+
 
     #region Commit
 

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -130,10 +130,8 @@ public sealed class NpgsqlTransaction : DbTransaction
                 sb.Append(" DEFERRABLE");
 
             // Unlike the isolation levels above, these options can be combined in many ways, making it impractical to pregenerate
-            // messages for all combinations. As with PrependInternalMessage above, the (short) BEGIN statement is assumed to
-            // always fit in the write buffer, so this completes synchronously.
-            var writeTask = _connector.WriteQuery(sb.ToString(), async: false);
-            Debug.Assert(writeTask.IsCompleted, "Could not fully write BEGIN message into the buffer");
+            // messages for all combinations; the BEGIN statement is written out and sent like a regular (prepended) query instead.
+            _connector.WriteQuery(sb.ToString(), async: false).GetAwaiter().GetResult();
             _connector.PendingPrependedResponses += 2;
         }
 

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -77,12 +77,12 @@ public sealed class NpgsqlTransaction : DbTransaction
         _transactionLogger = connector.TransactionLogger;
     }
 
-    internal Task Init(bool async, IsolationLevel isolationLevel, NpgsqlTransactionOptions options, CancellationToken cancellationToken = default)
+    internal void Init(IsolationLevel isolationLevel, NpgsqlTransactionOptions options)
     {
         Debug.Assert(isolationLevel != IsolationLevel.Chaos);
 
         if (!_connector.DatabaseInfo.SupportsTransactions)
-            return Task.CompletedTask;
+            return;
 
         if (isolationLevel == IsolationLevel.Unspecified)
             isolationLevel = DefaultIsolationLevel;
@@ -110,14 +110,8 @@ public sealed class NpgsqlTransaction : DbTransaction
             default:
                 throw new NotSupportedException("Isolation level not supported: " + isolationLevel);
             }
-
-            FinishInit(isolationLevel);
-            return Task.CompletedTask;
         }
-
-        return InitWithOptions(async, isolationLevel, options, cancellationToken);
-
-        async Task InitWithOptions(bool async, IsolationLevel isolationLevel, NpgsqlTransactionOptions options, CancellationToken cancellationToken)
+        else
         {
             var isolationLevelText = isolationLevel switch
             {
@@ -136,16 +130,13 @@ public sealed class NpgsqlTransaction : DbTransaction
                 sb.Append(" DEFERRABLE");
 
             // Unlike the isolation levels above, these options can be combined in many ways, making it impractical to pregenerate
-            // messages for all combinations; the BEGIN statement is written out and sent like a regular (prepended) query instead.
-            await _connector.WriteQuery(sb.ToString(), async, cancellationToken).ConfigureAwait(false);
+            // messages for all combinations. As with PrependInternalMessage above, the (short) BEGIN statement is assumed to
+            // always fit in the write buffer, so this completes synchronously.
+            var writeTask = _connector.WriteQuery(sb.ToString(), async: false);
+            Debug.Assert(writeTask.IsCompleted, "Could not fully write BEGIN message into the buffer");
             _connector.PendingPrependedResponses += 2;
-
-            FinishInit(isolationLevel);
         }
-    }
 
-    void FinishInit(IsolationLevel isolationLevel)
-    {
         _connector.TransactionStatus = TransactionStatus.Pending;
         _isolationLevel = isolationLevel;
         IsDisposed = false;

--- a/src/Npgsql/NpgsqlTransaction.cs
+++ b/src/Npgsql/NpgsqlTransaction.cs
@@ -146,7 +146,6 @@ public sealed class NpgsqlTransaction : DbTransaction
 
     #endregion
 
-
     #region Commit
 
     /// <summary>

--- a/src/Npgsql/NpgsqlTransactionOptions.cs
+++ b/src/Npgsql/NpgsqlTransactionOptions.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Npgsql;
+
+#pragma warning disable RS0016
+
+/// <summary>
+/// Specifies additional, Npgsql-specific options to apply when beginning a transaction, avoiding the need for an additional
+/// roundtrip to the server (e.g. via <c>SET TRANSACTION</c>).
+/// </summary>
+[Flags]
+public enum NpgsqlTransactionOptions
+{
+    /// <summary>
+    /// No additional options are set.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The transaction is read-only; no data modifications can be made. Corresponds to <c>READ ONLY</c> in <c>BEGIN</c>.
+    /// </summary>
+    ReadOnly = 1,
+
+    /// <summary>
+    /// The transaction can be deferred. This only has an effect when the transaction is both <see cref="ReadOnly"/> and
+    /// <see cref="System.Data.IsolationLevel.Serializable"/>, in which case it allows the database to wait for a point in time where
+    /// no conflicts can occur before starting the transaction, avoiding the overhead associated with serializable transactions.
+    /// Corresponds to <c>DEFERRABLE</c> in <c>BEGIN</c>.
+    /// </summary>
+    Deferrable = 2,
+}

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -48,9 +48,7 @@ static Microsoft.Extensions.DependencyInjection.NpgsqlServiceCollectionExtension
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Position.get -> long
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Position.set -> void
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Read(byte[]! buffer, int offset, int count) -> int
-Npgsql.NpgsqlConnection.BeginTransaction(Npgsql.NpgsqlTransactionOptions options) -> Npgsql.NpgsqlTransaction!
 Npgsql.NpgsqlConnection.BeginTransaction(System.Data.IsolationLevel level, Npgsql.NpgsqlTransactionOptions options) -> Npgsql.NpgsqlTransaction!
-Npgsql.NpgsqlConnection.BeginTransactionAsync(Npgsql.NpgsqlTransactionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Npgsql.NpgsqlTransaction!>
 Npgsql.NpgsqlConnection.BeginTransactionAsync(System.Data.IsolationLevel level, Npgsql.NpgsqlTransactionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Npgsql.NpgsqlTransaction!>
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.ReadAsync(byte[]! buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Seek(long offset, System.IO.SeekOrigin origin) -> long

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -48,6 +48,10 @@ static Microsoft.Extensions.DependencyInjection.NpgsqlServiceCollectionExtension
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Position.get -> long
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Position.set -> void
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Read(byte[]! buffer, int offset, int count) -> int
+Npgsql.NpgsqlConnection.BeginTransaction(Npgsql.NpgsqlTransactionOptions options) -> Npgsql.NpgsqlTransaction!
+Npgsql.NpgsqlConnection.BeginTransaction(System.Data.IsolationLevel level, Npgsql.NpgsqlTransactionOptions options) -> Npgsql.NpgsqlTransaction!
+Npgsql.NpgsqlConnection.BeginTransactionAsync(Npgsql.NpgsqlTransactionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Npgsql.NpgsqlTransaction!>
+Npgsql.NpgsqlConnection.BeginTransactionAsync(System.Data.IsolationLevel level, Npgsql.NpgsqlTransactionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Npgsql.NpgsqlTransaction!>
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.ReadAsync(byte[]! buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>!
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.Seek(long offset, System.IO.SeekOrigin origin) -> long
 *REMOVED*override Npgsql.NpgsqlLargeObjectStream.SetLength(long value) -> void

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -206,7 +206,7 @@ public class TransactionTests : TestBase
     public async Task ReadOnly_option()
     {
         await using var conn = await OpenConnectionAsync();
-        await using (var tx = conn.BeginTransaction(NpgsqlTransactionOptions.ReadOnly))
+        await using (var tx = conn.BeginTransaction(IsolationLevel.Unspecified, NpgsqlTransactionOptions.ReadOnly))
         {
             Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("on"));
             Assert.That(() => conn.ExecuteNonQuery("CREATE TABLE not_allowed ()"),
@@ -215,8 +215,16 @@ public class TransactionTests : TestBase
             await tx.RollbackAsync();
         }
 
-        await using (var tx = conn.BeginTransaction(NpgsqlTransactionOptions.None))
+        await using (var tx = conn.BeginTransaction(IsolationLevel.Unspecified, NpgsqlTransactionOptions.None))
             Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("off"));
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/867")]
+    public async Task ReadOnly_option_async()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var tx = await conn.BeginTransactionAsync(IsolationLevel.Unspecified, NpgsqlTransactionOptions.ReadOnly);
+        Assert.That(await conn.ExecuteScalarAsync("SHOW transaction_read_only"), Is.EqualTo("on"));
     }
 
     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/867")]
@@ -229,6 +237,18 @@ public class TransactionTests : TestBase
         Assert.That(conn.ExecuteScalar("SHOW TRANSACTION ISOLATION LEVEL"), Is.EqualTo("serializable"));
         Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("on"));
         Assert.That(conn.ExecuteScalar("SHOW transaction_deferrable"), Is.EqualTo("on"));
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/867")]
+    public async Task ReadOnly_and_Deferrable_options_with_isolation_level_async()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var tx = await conn.BeginTransactionAsync(
+            IsolationLevel.Serializable, NpgsqlTransactionOptions.ReadOnly | NpgsqlTransactionOptions.Deferrable);
+
+        Assert.That(await conn.ExecuteScalarAsync("SHOW TRANSACTION ISOLATION LEVEL"), Is.EqualTo("serializable"));
+        Assert.That(await conn.ExecuteScalarAsync("SHOW transaction_read_only"), Is.EqualTo("on"));
+        Assert.That(await conn.ExecuteScalarAsync("SHOW transaction_deferrable"), Is.EqualTo("on"));
     }
 
     [Test, Description("Rollback of an already rolled back transaction")]

--- a/test/Npgsql.Tests/TransactionTests.cs
+++ b/test/Npgsql.Tests/TransactionTests.cs
@@ -202,6 +202,35 @@ public class TransactionTests : TestBase
         Assert.That(() => conn.BeginTransaction(IsolationLevel.Chaos), Throws.Exception.TypeOf<NotSupportedException>());
     }
 
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/867")]
+    public async Task ReadOnly_option()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using (var tx = conn.BeginTransaction(NpgsqlTransactionOptions.ReadOnly))
+        {
+            Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("on"));
+            Assert.That(() => conn.ExecuteNonQuery("CREATE TABLE not_allowed ()"),
+                Throws.Exception.TypeOf<PostgresException>()
+                    .With.Property(nameof(PostgresException.SqlState)).EqualTo(PostgresErrorCodes.ReadOnlySqlTransaction));
+            await tx.RollbackAsync();
+        }
+
+        await using (var tx = conn.BeginTransaction(NpgsqlTransactionOptions.None))
+            Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("off"));
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/867")]
+    public async Task ReadOnly_and_Deferrable_options_with_isolation_level()
+    {
+        await using var conn = await OpenConnectionAsync();
+        await using var tx = conn.BeginTransaction(
+            IsolationLevel.Serializable, NpgsqlTransactionOptions.ReadOnly | NpgsqlTransactionOptions.Deferrable);
+
+        Assert.That(conn.ExecuteScalar("SHOW TRANSACTION ISOLATION LEVEL"), Is.EqualTo("serializable"));
+        Assert.That(conn.ExecuteScalar("SHOW transaction_read_only"), Is.EqualTo("on"));
+        Assert.That(conn.ExecuteScalar("SHOW transaction_deferrable"), Is.EqualTo("on"));
+    }
+
     [Test, Description("Rollback of an already rolled back transaction")]
     public async Task Rollback_twice()
     {


### PR DESCRIPTION
Adds NpgsqlConnection.BeginTransaction(Async) overloads accepting a new NpgsqlTransactionOptions flags enum (ReadOnly, Deferrable), allowing transactions to be started with these options without an extra roundtrip (e.g. SET TRANSACTION READ ONLY).

Ref npgsql/npgsql#867