### PR TITLE
Fix teardown NRE/ODE in ReplicationConnection's SendStatusUpdate

### DIFF
--- a/src/Npgsql/Replication/ReplicationConnection.cs
+++ b/src/Npgsql/Replication/ReplicationConnection.cs
@@ -587,10 +587,12 @@ public abstract class ReplicationConnection : IAsyncDisposable
 
         // TODO: If the user accidentally does concurrent usage of the connection, the following is vulnerable to race conditions.
         // However, we generally aren't safe for this in Npgsql, leaving as-is for now.
-        if (Connector.State != ConnectorState.Replication)
+        // The connector is null when the connection broke concurrently; report that as "not streaming"
+        // rather than throwing NullReferenceException.
+        if (_npgsqlConnection.Connector is not { State: ConnectorState.Replication } connector)
             throw new InvalidOperationException("Status update can only be sent during replication");
 
-        LogMessages.SendingReplicationStandbyStatusUpdate(ReplicationLogger, nameof(SendStatusUpdate) + "was called", Connector.Id);
+        LogMessages.SendingReplicationStandbyStatusUpdate(ReplicationLogger, nameof(SendStatusUpdate) + "was called", connector.Id);
         await SendFeedback(waitOnSemaphore: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -644,15 +646,29 @@ public abstract class ReplicationConnection : IAsyncDisposable
                     Connector.Id);
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Surface the caller's cancellation (e.g. from SendStatusUpdate) instead of swallowing it below.
+            throw;
+        }
         catch (Exception e)
         {
             LogMessages.ReplicationFeedbackMessageSendingFailed(ReplicationLogger, _npgsqlConnection?.Connector?.Id, e);
         }
         finally
         {
-            _sendFeedbackTimer!.Change(WalReceiverStatusInterval, Timeout.InfiniteTimeSpan);
-            if (requestReply)
-                _requestFeedbackTimer!.Change(_requestFeedbackInterval, Timeout.InfiniteTimeSpan);
+            // Replication may terminate concurrently with an in-flight feedback message (the enumeration
+            // gets cancelled while SendStatusUpdate is being awaited), in which case StartReplicationInternal's
+            // teardown disposes and nulls the timers. Change on a timer disposed after the null check throws ObjectDisposedException.
+            try
+            {
+                _sendFeedbackTimer?.Change(WalReceiverStatusInterval, Timeout.InfiniteTimeSpan);
+                if (requestReply)
+                    _requestFeedbackTimer?.Change(_requestFeedbackInterval, Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException)
+            {
+            }
             _feedbackSemaphore.Release();
         }
     }

--- a/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
+++ b/test/Npgsql.Tests/Replication/CommonReplicationTests.cs
@@ -479,6 +479,61 @@ public class CommonReplicationTests<TConnection> : SafeReplicationTestBase<TConn
                 });
             });
 
+    [Test]
+    [NonParallelizable]
+    public Task SendStatusUpdate_racing_replication_teardown_throws_InvalidOperationException()
+        => SafeReplicationTest(
+            async (slotName, _) =>
+            {
+                await using var rc = await OpenReplicationConnectionAsync();
+                var info = await rc.IdentifySystem();
+                await CreateReplicationSlot(slotName);
+
+                for (var round = 0; round < 10; round++)
+                {
+                    using var streamingCts = new CancellationTokenSource();
+                    await using var enumerator = StartReplication(rc, slotName, info.XLogPos, streamingCts.Token).GetAsyncEnumerator();
+                    var pendingRead = enumerator.MoveNextAsync();
+
+                    var statusUpdates = Task.Run(async () =>
+                    {
+                        // Replication starts lazily on the first MoveNextAsync; retry until the stream is up.
+                        while (true)
+                        {
+                            try
+                            {
+                                await rc.SendStatusUpdate(CancellationToken.None);
+                                break;
+                            }
+                            catch (InvalidOperationException) when (!streamingCts.IsCancellationRequested)
+                            {
+                            }
+                        }
+
+                        while (true)
+                            await rc.SendStatusUpdate(CancellationToken.None);
+                    });
+
+                    // Give the status update loop a moment to get going before tearing down the stream.
+                    await Task.Delay(50);
+                    streamingCts.Cancel();
+
+                    try
+                    {
+                        while (await pendingRead)
+                            pendingRead = enumerator.MoveNextAsync();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    // Once replication has terminated, the loop must end with the documented
+                    // InvalidOperationException ("can only be sent during replication"); anything else
+                    // (in particular NullReferenceException from the feedback timer race) is a bug.
+                    Assert.That(async () => await statusUpdates, Throws.InvalidOperationException);
+                }
+            });
+
     #endregion
 
     async Task CreateReplicationSlot(string slotName)


### PR DESCRIPTION
If the replication connection gets torn down whilst `SendStatusUpdate` is in-flight, you get to spin the wheel on getting an NRE or ODE which isn't ideal:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Npgsql.Replication.ReplicationConnection.SendFeedback(Boolean waitOnSemaphore, Boolean requestReply, CancellationToken cancellationToken)
   at Npgsql.Replication.ReplicationConnection.SendStatusUpdate(CancellationToken cancellationToken)
```

This fixes it so `OperationCanceledException` and `InvalidOperationException` are the only exceptions that show up and should match developer expectations a bit better.